### PR TITLE
fix: parse WORKFLOW_STORAGE_PATH env var in EnhancedMultiSourceWorkfl…

### DIFF
--- a/src/infrastructure/storage/enhanced-multi-source-workflow-storage.ts
+++ b/src/infrastructure/storage/enhanced-multi-source-workflow-storage.ts
@@ -121,6 +121,14 @@ export class EnhancedMultiSourceWorkflowStorage implements IWorkflowStorage {
       gracefulDegradation: config.gracefulDegradation ?? true
     };
     
+    // Parse WORKFLOW_STORAGE_PATH environment variable
+    const customPathsEnv = process.env['WORKFLOW_STORAGE_PATH'];
+    if (customPathsEnv) {
+      const paths = customPathsEnv.split(path.delimiter).map(p => p.trim()).filter(p => p.length > 0);
+      config.customPaths = [...(config.customPaths || []), ...paths];
+      logger.info('Added custom paths from WORKFLOW_STORAGE_PATH', { paths });
+    }
+    
     this.storageInstances = this.initializeStorageSources(config);
   }
 


### PR DESCRIPTION
…owStorage

The WORKFLOW_STORAGE_PATH environment variable was not being parsed in EnhancedMultiSourceWorkflowStorage, though it was documented as supported and worked in the older MultiDirectoryWorkflowStorage.

The issue was that the DI container uses registerSingleton which calls the constructor directly, not the factory function where env var parsing was happening.

Fix: Parse WORKFLOW_STORAGE_PATH in the constructor itself, splitting by path delimiter and adding to customPaths config.

This enables users to specify custom workflow directories via: WORKFLOW_STORAGE_PATH=/path/to/workflows

Matches the behavior documented in docs/configuration.md.