### PR TITLE
fix: remove deprecated createFeatureFlagProvider() usage

### DIFF
--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -84,7 +84,12 @@ async function registerStorageChain(): Promise<void> {
   );
 
   // Layer 1: Base storage (singleton)
-  container.registerSingleton(DI.Storage.Base, EnhancedMultiSourceWorkflowStorage);
+  container.register(DI.Storage.Base, {
+    useFactory: instanceCachingFactory((c: DependencyContainer) => {
+      const featureFlags = c.resolve<any>(DI.Infra.FeatureFlags);
+      return new EnhancedMultiSourceWorkflowStorage(featureFlags);
+    }),
+  });
 
   // Layer 2: Schema validation decorator (singleton via instanceCachingFactory)
   container.register(DI.Storage.Validated, {


### PR DESCRIPTION
- Inject IFeatureFlagProvider into EnhancedMultiSourceWorkflowStorage via DI
- Pass feature flags to FileWorkflowStorage instances to avoid deprecated fallback
- Register FeatureFlags early in DI container before storage chain
- Update factory function to handle new constructor signature