### PR TITLE
ci: grant semantic-release dry-run push permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ lockfile, build-artifact ]
     permissions:
-      contents: read
+      # semantic-release dry-run verifies it can push tags/commits; requires write access.
+      contents: write
 
     steps:
       - name: Checkout code (full history)


### PR DESCRIPTION
semantic-release dry-run verifies the repository is pushable; allow contents: write for that job so CI on main doesn’t fail with EGITNOPERMISSION.

🤖 Generated with [Firebender](https://firebender.com)