### PR TITLE
ci: provide NPM_TOKEN to semantic-release dry-runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
       - name: semantic-release dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release --dry-run --no-ci
 
   # ============================================================================

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  # semantic-release dry-run verifies it can push tags/commits; requires write access.
+  contents: write
 
 jobs:
   dry-run:
@@ -29,4 +30,5 @@ jobs:
       - name: semantic-release dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release --dry-run --no-ci


### PR DESCRIPTION
Pass NPM_TOKEN to semantic-release dry-run jobs so verifyConditions for @semantic-release/npm succeeds on main. Also grant contents: write to the manual Release (dry-run) workflow since semantic-release validates push permissions.

🤖 Generated with [Firebender](https://firebender.com)