### PR TITLE
ci(release): upgrade npm for trusted publishing

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -24,6 +24,13 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
+      # npm Trusted Publishing (OIDC) requires npm >= 11.5.1
+      - name: Upgrade npm (Trusted Publishing)
+        run: |
+          npm --version
+          npm install -g npm@11.6.2
+          npm --version
+
       - name: Install dependencies (no lifecycle scripts)
         run: npm ci --ignore-scripts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,13 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
+      # npm Trusted Publishing (OIDC) requires npm >= 11.5.1
+      - name: Upgrade npm (Trusted Publishing)
+        run: |
+          npm --version
+          npm install -g npm@11.6.2
+          npm --version
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
 


### PR DESCRIPTION
Ensure the release workflows use an npm version that supports OIDC trusted publishing so npm publish --provenance can authenticate without an npm token.

🤖 Generated with [Firebender](https://firebender.com)