### PR TITLE
ci(release): trigger only for main CI runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: [ "CI" ]
     types: [ completed ]
+    branches: [ main ]
 
 # Prevent concurrent releases
 concurrency:


### PR DESCRIPTION
Avoid creating skipped Release workflow runs for PR CI executions by filtering workflow_run to main.

🤖 Generated with [Firebender](https://firebender.com)