### PR TITLE
feat(v2): Slice 2.5 - ExecutionSessionGateV2 + witness-based execution safety

### DIFF
--- a/src/v2/durable-core/ids/with-healthy-session-lock.ts
+++ b/src/v2/durable-core/ids/with-healthy-session-lock.ts
@@ -1,0 +1,23 @@
+import type { SessionLockHandleV2 } from '../../ports/session-lock.port.js';
+
+/**
+ * Opaque capability witness proving:
+ * - the session lock is held
+ * - session health has been validated as `healthy`
+ *
+ * NOTE: This is intentionally difficult to forge without `as any`.
+ * The branding symbol is not exported from this module.
+ */
+declare const withHealthySessionLockBrand: unique symbol;
+
+export type WithHealthySessionLock = SessionLockHandleV2 & {
+  /**
+   * Runtime guard against witness misuse after the gate callback ends.
+   *
+   * Slice 2.5 lock: append MUST fail-fast if the witness is used after the lexical
+   * gate lifetime ends (even if the same session is re-locked later).
+   */
+  readonly assertHeld: () => boolean;
+
+  readonly [withHealthySessionLockBrand]: 'WithHealthySessionLock';
+};

--- a/src/v2/durable-core/schemas/session/index.ts
+++ b/src/v2/durable-core/schemas/session/index.ts
@@ -1,2 +1,3 @@
 export { ManifestRecordV1Schema, type ManifestRecordV1 } from './manifest.js';
 export { DomainEventEnvelopeV1Schema, DomainEventV1Schema, type DomainEventV1 } from './events.js';
+export type { CorruptionReasonV2, SessionHealthV2 } from './session-health.js';

--- a/src/v2/durable-core/schemas/session/session-health.ts
+++ b/src/v2/durable-core/schemas/session/session-health.ts
@@ -1,0 +1,20 @@
+/**
+ * Session health classification (v2 Slice 2.5).
+ *
+ * Locked intent:
+ * - Correctness paths require `healthy`
+ * - Salvage is read-only and explicitly signaled
+ * - Corruption reasons are manifest-attested only (no filesystem scanning for orphans)
+ */
+
+export type CorruptionReasonV2 =
+  | { readonly code: 'digest_mismatch'; readonly message: string }
+  | { readonly code: 'non_contiguous_indices'; readonly message: string }
+  | { readonly code: 'missing_attested_segment'; readonly message: string }
+  | { readonly code: 'unknown_schema_version'; readonly message: string };
+
+export type SessionHealthV2 =
+  | { readonly kind: 'healthy' }
+  | { readonly kind: 'corrupt_tail'; readonly reason: CorruptionReasonV2 }
+  | { readonly kind: 'corrupt_head'; readonly reason: CorruptionReasonV2 }
+  | { readonly kind: 'unknown_version'; readonly reason: CorruptionReasonV2 };

--- a/src/v2/usecases/execution-session-gate.ts
+++ b/src/v2/usecases/execution-session-gate.ts
@@ -1,0 +1,238 @@
+import type { ResultAsync } from 'neverthrow';
+import { ResultAsync as RA, errAsync } from 'neverthrow';
+import type { SessionId } from '../durable-core/ids/index.js';
+import type { WithHealthySessionLock } from '../durable-core/ids/with-healthy-session-lock.js';
+import type { SessionHealthV2 } from '../durable-core/schemas/session/session-health.js';
+import type { SessionLockPortV2 } from '../ports/session-lock.port.js';
+import type {
+  SessionEventLogReadonlyStorePortV2,
+  SessionEventLogStoreError,
+} from '../ports/session-event-log-store.port.js';
+import { projectSessionHealthV2 } from '../projections/session-health.js';
+
+export type ExecutionSessionGateErrorV2 =
+  | { readonly code: 'SESSION_LOCKED'; readonly message: string; readonly sessionId: SessionId; readonly retry: { readonly kind: 'retryable'; readonly afterMs: number } }
+  | { readonly code: 'SESSION_LOCK_REENTRANT'; readonly message: string; readonly sessionId: SessionId }
+  | { readonly code: 'LOCK_ACQUIRE_FAILED'; readonly message: string; readonly sessionId: SessionId }
+  | { readonly code: 'LOCK_RELEASE_FAILED'; readonly message: string; readonly sessionId: SessionId; readonly retry: { readonly kind: 'retryable'; readonly afterMs: number } }
+  | { readonly code: 'SESSION_NOT_HEALTHY'; readonly message: string; readonly sessionId: SessionId; readonly health: SessionHealthV2 }
+  | { readonly code: 'SESSION_LOAD_FAILED'; readonly message: string; readonly sessionId: SessionId; readonly cause: SessionEventLogStoreError }
+  | { readonly code: 'GATE_CALLBACK_FAILED'; readonly message: string; readonly sessionId: SessionId };
+
+/**
+ * Central choke point for:
+ * - session lock acquisition/release
+ * - session health gating
+ * - witness minting (`WithHealthySessionLock`)
+ *
+ * Slice 2.5 (locked): implemented as the single choke point for locking + health gating + witness minting.
+ */
+export class ExecutionSessionGateV2 {
+  private readonly activeSessions = new Set<SessionId>();
+  private readonly activeWitnessTokens = new Set<symbol>();
+
+  constructor(
+    private readonly lock: SessionLockPortV2,
+    private readonly store: SessionEventLogReadonlyStorePortV2
+  ) {}
+
+  withHealthySessionLock<T, E>(
+    sessionId: SessionId,
+    fn: (lock: WithHealthySessionLock) => ResultAsync<T, E>
+  ): ResultAsync<T, ExecutionSessionGateErrorV2 | E> {
+    if (this.activeSessions.has(sessionId)) {
+      return errAsync({ code: 'SESSION_LOCK_REENTRANT', message: `Re-entrant gate call for session: ${sessionId}`, sessionId });
+    }
+
+    this.activeSessions.add(sessionId);
+    const witnessToken = Symbol(`withHealthySessionLock:${sessionId}`);
+    this.activeWitnessTokens.add(witnessToken);
+
+    const doWork = async (): Promise<T> => {
+      // Lock-free health check (early hint):
+      // - allowed to fail closed on manifest-attested corruption (fast return)
+      // - IO errors are explicitly modeled as "precheck unavailable" (not empty truth)
+      // Locked invariant: re-check under lock before minting witness / allowing append (TOCTOU guard).
+      const precheckResult = await this.store.loadValidatedPrefix(sessionId).match(
+        (v) => ({ kind: 'available' as const, prefix: v }),
+        (e) => {
+          if (e.code === 'SESSION_STORE_CORRUPTION_DETECTED') {
+            const health: SessionHealthV2 =
+              e.location === 'head'
+                ? { kind: 'corrupt_head', reason: e.reason }
+                : { kind: 'corrupt_tail', reason: e.reason };
+            throw new GateFailure<ExecutionSessionGateErrorV2 | E>({
+              code: 'SESSION_NOT_HEALTHY',
+              message: 'Session is not healthy',
+              sessionId,
+              health,
+            });
+          }
+          // IO errors: precheck unavailable; defer health decision to locked path.
+          return { kind: 'unavailable' as const };
+        }
+      );
+
+      const pre = precheckResult.kind === 'available' ? precheckResult.prefix : null;
+
+      if (pre !== null) {
+        if (!pre.isComplete) {
+          throw new GateFailure<ExecutionSessionGateErrorV2 | E>({
+            code: 'SESSION_NOT_HEALTHY',
+            message: 'Session is not healthy (validated prefix indicates corrupt tail)',
+            sessionId,
+            health: {
+              kind: 'corrupt_tail',
+              reason: pre.tailReason ?? { code: 'non_contiguous_indices', message: 'Validated prefix stopped early (corrupt tail)' },
+            },
+          });
+        }
+
+        const preHealth = projectSessionHealthV2(pre.truth).match(
+          (h) => h,
+          () => ({ kind: 'corrupt_tail', reason: { code: 'non_contiguous_indices', message: 'unknown' } } as SessionHealthV2)
+        );
+        if (preHealth.kind !== 'healthy') {
+          throw new GateFailure<ExecutionSessionGateErrorV2 | E>({
+            code: 'SESSION_NOT_HEALTHY',
+            message: 'Session is not healthy',
+            sessionId,
+            health: preHealth,
+          });
+        }
+      }
+      // If precheck was unavailable (IO error), defer health decision to strict load under lock.
+
+      const handle = await this.lock.acquire(sessionId).match(
+        (h) => h,
+        (e) => {
+          if (e.code === 'SESSION_LOCK_BUSY') {
+            throw new GateFailure<ExecutionSessionGateErrorV2 | E>({
+              code: 'SESSION_LOCKED',
+              message: `Session is locked; retry in 1–3 seconds; if this persists >10s, ensure no other WorkRail process is running for this session.`,
+              sessionId,
+              retry: { kind: 'retryable', afterMs: 1000 },
+            });
+          }
+          throw new GateFailure<ExecutionSessionGateErrorV2 | E>({ code: 'LOCK_ACQUIRE_FAILED', message: e.message, sessionId });
+        }
+      );
+
+      try {
+        const truth = await this.store.load(sessionId).match(
+          (v) => v,
+          (e) => {
+            if (e.code === 'SESSION_STORE_CORRUPTION_DETECTED') {
+              const health: SessionHealthV2 =
+                e.location === 'head'
+                  ? { kind: 'corrupt_head', reason: e.reason }
+                  : { kind: 'corrupt_tail', reason: e.reason };
+              throw new GateFailure<ExecutionSessionGateErrorV2 | E>({
+                code: 'SESSION_NOT_HEALTHY',
+                message: 'Session is not healthy',
+                sessionId,
+                health,
+              });
+            }
+            throw new GateFailure<ExecutionSessionGateErrorV2 | E>({
+              code: 'SESSION_LOAD_FAILED',
+              message: `Failed to load session`,
+              sessionId,
+              cause: e,
+            });
+          }
+        );
+
+        const health = projectSessionHealthV2(truth).match(
+          (h) => h,
+          () => {
+            // projectSessionHealthV2 is currently infallible
+            return { kind: 'corrupt_tail', reason: { code: 'non_contiguous_indices', message: 'unknown' } } as SessionHealthV2;
+          }
+        );
+
+        if (health.kind !== 'healthy') {
+          throw new GateFailure<ExecutionSessionGateErrorV2 | E>({
+            code: 'SESSION_NOT_HEALTHY',
+            message: `Session is not healthy`,
+            sessionId,
+            health,
+          });
+        }
+
+        const witness = {
+          ...handle,
+          assertHeld: () => this.activeWitnessTokens.has(witnessToken),
+        } as unknown as WithHealthySessionLock;
+        let callback: ResultAsync<T, E>;
+        try {
+          callback = fn(witness);
+        } catch (e) {
+          throw new GateFailure<ExecutionSessionGateErrorV2 | E>({
+            code: 'GATE_CALLBACK_FAILED',
+            message: e instanceof Error ? e.message : String(e),
+            sessionId,
+          });
+        }
+
+        const res = await callback.match(
+          (v) => ({ ok: true as const, value: v }),
+          (e) => ({ ok: false as const, error: e })
+        );
+
+        if (!res.ok) {
+          // Callback errors propagate as-is (E) to keep the gate generic.
+          throw new GateFailure<ExecutionSessionGateErrorV2 | E>(res.error);
+        }
+
+        return res.value;
+      } catch (e) {
+        if (e instanceof GateFailure) throw e;
+        throw new GateFailure<ExecutionSessionGateErrorV2 | E>({
+          code: 'GATE_CALLBACK_FAILED',
+          message: e instanceof Error ? e.message : String(e),
+          sessionId,
+        });
+      } finally {
+        await this.lock.release(handle).match(
+          () => undefined,
+          () => {
+            throw new GateFailure<ExecutionSessionGateErrorV2 | E>({
+              code: 'LOCK_RELEASE_FAILED',
+              message: 'Failed to release session lock; retry in 1–3 seconds; if this persists >10s, ensure no other WorkRail process is running for this session.',
+              sessionId,
+              retry: { kind: 'retryable', afterMs: 1000 },
+            });
+          }
+        );
+      }
+    };
+
+    return RA.fromPromise(
+      (async () => {
+        try {
+          return await doWork();
+        } finally {
+          // Locked: lexical lifetime + no leaks. Cleanup must happen exactly once.
+          this.activeSessions.delete(sessionId);
+          this.activeWitnessTokens.delete(witnessToken);
+        }
+      })(),
+      (e) => {
+        if (e instanceof GateFailure) return e.error as ExecutionSessionGateErrorV2 | E;
+        return {
+          code: 'GATE_CALLBACK_FAILED',
+          message: e instanceof Error ? e.message : String(e),
+          sessionId,
+        } as ExecutionSessionGateErrorV2;
+      }
+    );
+  }
+}
+
+class GateFailure<E> extends Error {
+  constructor(readonly error: E) {
+    const msg = (error as { readonly message?: unknown } | null | undefined)?.message;
+    super(typeof msg === 'string' ? msg : 'GateFailure');
+  }
+}

--- a/tests/unit/v2/execution-session-gate.test.ts
+++ b/tests/unit/v2/execution-session-gate.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import { errAsync, okAsync } from 'neverthrow';
+import { ExecutionSessionGateV2 } from '../../../src/v2/usecases/execution-session-gate.js';
+import { asSessionId } from '../../../src/v2/durable-core/ids/index.js';
+import type { SessionId } from '../../../src/v2/durable-core/ids/index.js';
+import type { CorruptionReasonV2 } from '../../../src/v2/durable-core/schemas/session/session-health.js';
+import type { SessionEventLogReadonlyStorePortV2, SessionEventLogStoreError } from '../../../src/v2/ports/session-event-log-store.port.js';
+import type { SessionLockHandleV2, SessionLockPortV2, SessionLockError } from '../../../src/v2/ports/session-lock.port.js';
+
+function okHandle(sessionId: SessionId): SessionLockHandleV2 {
+  return { kind: 'v2_session_lock_handle', sessionId };
+}
+
+describe('ExecutionSessionGateV2', () => {
+  it('fails fast on re-entrancy (SESSION_LOCK_REENTRANT)', async () => {
+    const sessionId = asSessionId('sess_test');
+
+    const lock: SessionLockPortV2 = {
+      acquire: () => okAsync(okHandle(sessionId)),
+      release: () => okAsync(undefined),
+    };
+
+    const store: SessionEventLogReadonlyStorePortV2 = {
+      loadValidatedPrefix: () => okAsync({ truth: { manifest: [], events: [] }, isComplete: true, tailReason: null }),
+      load: () => okAsync({ manifest: [], events: [] }),
+    };
+
+    const gate = new ExecutionSessionGateV2(lock, store);
+
+    const res = await gate
+      .withHealthySessionLock(sessionId, () =>
+        gate.withHealthySessionLock(sessionId, () => okAsync('inner_ok'))
+      )
+      .match(
+        (v) => ({ ok: true as const, value: v }),
+        (e) => ({ ok: false as const, error: e })
+      );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe('SESSION_LOCK_REENTRANT');
+  });
+
+  it('returns SESSION_LOCKED with retry guidance when lock is busy', async () => {
+    const sessionId = asSessionId('sess_locked');
+
+    const lockBusy: SessionLockError = {
+      code: 'SESSION_LOCK_BUSY',
+      message: 'busy',
+      retry: { kind: 'retryable', afterMs: 250 },
+      lockPath: '/tmp/lock',
+    };
+
+    const lock: SessionLockPortV2 = {
+      acquire: () => errAsync(lockBusy),
+      release: () => okAsync(undefined),
+    };
+
+    const store: SessionEventLogReadonlyStorePortV2 = {
+      loadValidatedPrefix: () => okAsync({ truth: { manifest: [], events: [] }, isComplete: true, tailReason: null }),
+      load: () => okAsync({ manifest: [], events: [] }),
+    };
+
+    const gate = new ExecutionSessionGateV2(lock, store);
+
+    const res = await gate.withHealthySessionLock(sessionId, () => okAsync('ok')).match(
+      (v) => ({ ok: true as const, value: v }),
+      (e) => ({ ok: false as const, error: e })
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe('SESSION_LOCKED');
+    expect(res.error.sessionId).toBe(sessionId);
+    expect(res.error.retry.kind).toBe('retryable');
+    expect(res.error.message).toContain('retry in 1–3 seconds');
+  });
+
+  it('fails without acquiring lock when validated prefix indicates corrupt tail', async () => {
+    const sessionId = asSessionId('sess_corrupt_tail');
+
+    let acquireCalls = 0;
+
+    const lock: SessionLockPortV2 = {
+      acquire: () => {
+        acquireCalls += 1;
+        return okAsync(okHandle(sessionId));
+      },
+      release: () => okAsync(undefined),
+    };
+
+    const tailReason: CorruptionReasonV2 = { code: 'missing_attested_segment', message: 'missing seg' };
+
+    const store: SessionEventLogReadonlyStorePortV2 = {
+      loadValidatedPrefix: () => okAsync({ truth: { manifest: [], events: [] }, isComplete: false, tailReason }),
+      load: () => okAsync({ manifest: [], events: [] }),
+    };
+
+    const gate = new ExecutionSessionGateV2(lock, store);
+    const res = await gate.withHealthySessionLock(sessionId, () => okAsync('ok')).match(
+      (v) => ({ ok: true as const, value: v }),
+      (e) => ({ ok: false as const, error: e })
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe('SESSION_NOT_HEALTHY');
+    expect(acquireCalls).toBe(0);
+  });
+
+  it('maps store missing_attested_segment during strict load to SESSION_NOT_HEALTHY corrupt_tail', async () => {
+    const sessionId = asSessionId('sess_corrupt_on_load');
+
+    const lock: SessionLockPortV2 = {
+      acquire: () => okAsync(okHandle(sessionId)),
+      release: () => okAsync(undefined),
+    };
+
+    const storeCorrupt: SessionEventLogStoreError = {
+      code: 'SESSION_STORE_CORRUPTION_DETECTED',
+      location: 'tail',
+      reason: { code: 'missing_attested_segment', message: 'missing segment' },
+      message: 'missing segment',
+    };
+
+    const store: SessionEventLogReadonlyStorePortV2 = {
+      loadValidatedPrefix: () => okAsync({ truth: { manifest: [], events: [] }, isComplete: true, tailReason: null }),
+      load: () => errAsync(storeCorrupt),
+    };
+
+    const gate = new ExecutionSessionGateV2(lock, store);
+    const res = await gate.withHealthySessionLock(sessionId, () => okAsync('ok')).match(
+      (v) => ({ ok: true as const, value: v }),
+      (e) => ({ ok: false as const, error: e })
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe('SESSION_NOT_HEALTHY');
+    expect(res.error.health.kind).toBe('corrupt_tail');
+    if (res.error.code !== 'SESSION_NOT_HEALTHY') return;
+    if (res.error.health.kind !== 'corrupt_tail') return;
+    expect(res.error.health.reason.code).toBe('missing_attested_segment');
+  });
+});

--- a/tests/unit/v2/session-health-projection.test.ts
+++ b/tests/unit/v2/session-health-projection.test.ts
@@ -44,7 +44,7 @@ describe('v2 session health projection', () => {
     expect(res._unsafeUnwrap().kind).toBe('healthy');
   });
 
-  it('is corrupted when run DAG projection fails', () => {
+  it('is corrupt_tail when run DAG projection fails', () => {
     const events: DomainEventV1[] = [
       {
         v: 1,
@@ -67,9 +67,9 @@ describe('v2 session health projection', () => {
     const res = projectSessionHealthV2(truth);
     expect(res.isOk()).toBe(true);
     const health = res._unsafeUnwrap();
-    expect(health.kind).toBe('corrupted');
-    if (health.kind === 'corrupted') {
-      expect(health.reason.code).toBe('RUN_DAG_INVALID');
+    expect(health.kind).toBe('corrupt_tail');
+    if (health.kind === 'corrupt_tail') {
+      expect(health.reason.code).toBe('non_contiguous_indices');
     }
   });
 });

--- a/tests/unit/v2/session-store.test.ts
+++ b/tests/unit/v2/session-store.test.ts
@@ -9,8 +9,10 @@ import { NodeFileSystemV2 } from '../../../src/v2/infra/local/fs/index.js';
 import { NodeSha256V2 } from '../../../src/v2/infra/local/sha256/index.js';
 import { LocalSessionLockV2 } from '../../../src/v2/infra/local/session-lock/index.js';
 import { LocalSessionEventLogStoreV2 } from '../../../src/v2/infra/local/session-store/index.js';
+import { ExecutionSessionGateV2 } from '../../../src/v2/usecases/execution-session-gate.js';
 
 import { asSessionId, asSha256Digest, asSnapshotRef } from '../../../src/v2/durable-core/ids/index.js';
+import type { WithHealthySessionLock } from '../../../src/v2/durable-core/ids/with-healthy-session-lock.js';
 import type { DomainEventV1 } from '../../../src/v2/durable-core/schemas/session/index.js';
 import type { FileSystemPortV2, FsError } from '../../../src/v2/ports/fs.port.js';
 
@@ -62,8 +64,7 @@ describe('v2 local session store (Slice 2 substrate)', () => {
     const dataDir = new LocalDataDirV2({ WORKRAIL_DATA_DIR: root });
     const fsPort = new NodeFileSystemV2();
     const sha = new NodeSha256V2();
-    const lock = new LocalSessionLockV2(dataDir, fsPort);
-    const store = new LocalSessionEventLogStoreV2(dataDir, fsPort, sha, lock);
+    const store = new LocalSessionEventLogStoreV2(dataDir, fsPort, sha);
 
     const sessionId = asSessionId('sess_test_orphan');
 
@@ -82,13 +83,101 @@ describe('v2 local session store (Slice 2 substrate)', () => {
     expect(loaded.events.length).toBe(0);
   });
 
+  it('load fails fast with missing_attested_segment when a manifest-attested segment is missing', async () => {
+    const root = await mkTempDataDir();
+    const dataDir = new LocalDataDirV2({ WORKRAIL_DATA_DIR: root });
+    const fsPort = new NodeFileSystemV2();
+    const sha = new NodeSha256V2();
+    const store = new LocalSessionEventLogStoreV2(dataDir, fsPort, sha);
+
+    const sessionId = asSessionId('sess_test_missing_attested_segment');
+
+    // Write a manifest that attests to a segment that does not exist on disk.
+    const manifestPath = dataDir.sessionManifestPath(sessionId);
+    await fs.mkdir(path.dirname(manifestPath), { recursive: true });
+    await fs.writeFile(
+      manifestPath,
+      Buffer.from(
+        JSON.stringify({
+          v: 1,
+          manifestIndex: 0,
+          sessionId,
+          kind: 'segment_closed',
+          firstEventIndex: 0,
+          lastEventIndex: 0,
+          segmentRelPath: 'events/00000000-00000000.jsonl',
+          sha256: 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+          bytes: 1,
+        }) + '\n'
+      )
+    );
+
+    const res = await store.load(sessionId).match(
+      () => ({ ok: true as const }),
+      (e) => ({ ok: false as const, error: e })
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe('SESSION_STORE_CORRUPTION_DETECTED');
+    if (res.error.code !== 'SESSION_STORE_CORRUPTION_DETECTED') return;
+    expect(res.error.location).toBe('tail');
+    expect(res.error.reason.code).toBe('missing_attested_segment');
+  });
+
+  it('append fails fast if a witness is used after the gate callback ends (misuse-after-release guard)', async () => {
+    const root = await mkTempDataDir();
+    const dataDir = new LocalDataDirV2({ WORKRAIL_DATA_DIR: root });
+    const fsPort = new NodeFileSystemV2();
+    const sha = new NodeSha256V2();
+    const lock = new LocalSessionLockV2(dataDir, fsPort);
+    const store = new LocalSessionEventLogStoreV2(dataDir, fsPort, sha);
+    const gate = new ExecutionSessionGateV2(lock, store);
+
+    const sessionId = asSessionId('sess_test_witness_misuse');
+
+    const evt: DomainEventV1 = {
+      v: 1,
+      eventId: 'evt_1',
+      eventIndex: 0,
+      sessionId,
+      kind: 'session_created',
+      dedupeKey: `session_created:${sessionId}`,
+      data: {},
+    };
+
+    let leaked: WithHealthySessionLock | null = null;
+    await gate
+      .withHealthySessionLock(sessionId, (w) => {
+        leaked = w;
+        return store.append(w, { events: [evt], snapshotPins: [] });
+      })
+      .match(
+        () => undefined,
+        (e) => {
+          throw new Error(`unexpected gate/append error: ${e.code}`);
+        }
+      );
+
+    // Using the witness after the lexical callback ends must fail-fast.
+    const res = await store.append(leaked!, { events: [evt], snapshotPins: [] }).match(
+      () => ({ ok: true as const }),
+      (e) => ({ ok: false as const, error: e })
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe('SESSION_STORE_INVARIANT_VIOLATION');
+    expect(res.error.message).toContain('witness misuse-after-release');
+  });
+
   it('load fails on digest mismatch for a committed segment', async () => {
     const root = await mkTempDataDir();
     const dataDir = new LocalDataDirV2({ WORKRAIL_DATA_DIR: root });
     const fsPort = new NodeFileSystemV2();
     const sha = new NodeSha256V2();
     const lock = new LocalSessionLockV2(dataDir, fsPort);
-    const store = new LocalSessionEventLogStoreV2(dataDir, fsPort, sha, lock);
+    const store = new LocalSessionEventLogStoreV2(dataDir, fsPort, sha);
+    const gate = new ExecutionSessionGateV2(lock, store);
 
     const sessionId = asSessionId('sess_test_digest');
 
@@ -103,15 +192,17 @@ describe('v2 local session store (Slice 2 substrate)', () => {
     };
 
     const snapshotRef = asSnapshotRef(asSha256Digest('sha256:5947229239ac2966c1099d6d74f4448c064e54ae25959eaebfd89cec073bdc11'));
-    await store
-      .append(sessionId, {
-        events: [evt],
-        snapshotPins: [{ snapshotRef, eventIndex: 0, createdByEventId: 'evt_1' }],
-      })
+    await gate
+      .withHealthySessionLock(sessionId, (w) =>
+        store.append(w, {
+          events: [evt],
+          snapshotPins: [{ snapshotRef, eventIndex: 0, createdByEventId: 'evt_1' }],
+        })
+      )
       .match(
         () => undefined,
         (e) => {
-          throw new Error(`unexpected append error: ${e.code}`);
+          throw new Error(`unexpected gate/append error: ${e.code}`);
         }
       );
 
@@ -167,7 +258,8 @@ describe('v2 local session store (Slice 2 substrate)', () => {
     };
 
     const lock = new LocalSessionLockV2(dataDir, failingFs);
-    const store = new LocalSessionEventLogStoreV2(dataDir, failingFs, sha, lock);
+    const store = new LocalSessionEventLogStoreV2(dataDir, failingFs, sha);
+    const gate = new ExecutionSessionGateV2(lock, store);
 
     const snapshotRef = asSnapshotRef(asSha256Digest('sha256:5947229239ac2966c1099d6d74f4448c064e54ae25959eaebfd89cec073bdc11'));
     const nodeCreated: DomainEventV1 = {
@@ -186,14 +278,17 @@ describe('v2 local session store (Slice 2 substrate)', () => {
       },
     };
 
-    const appendRes = await store.append(sessionId, {
-      events: [nodeCreated],
-      snapshotPins: [{ snapshotRef, eventIndex: 0, createdByEventId: 'evt_node_1' }],
-    });
-    const appended = await appendRes.match(
-      () => ({ ok: true as const }),
-      (e) => ({ ok: false as const, error: e })
-    );
+    const appended = await gate
+      .withHealthySessionLock(sessionId, (w) =>
+        store.append(w, {
+          events: [nodeCreated],
+          snapshotPins: [{ snapshotRef, eventIndex: 0, createdByEventId: 'evt_node_1' }],
+        })
+      )
+      .match(
+        () => ({ ok: true as const }),
+        (e) => ({ ok: false as const, error: e })
+      );
     expect(appended.ok).toBe(false);
 
     // A normal load must now fail fast because the segment was closed but pins were not appended.
@@ -213,7 +308,8 @@ describe('v2 local session store (Slice 2 substrate)', () => {
     const fsPort = new NodeFileSystemV2();
     const sha = new NodeSha256V2();
     const lock = new LocalSessionLockV2(dataDir, fsPort);
-    const store = new LocalSessionEventLogStoreV2(dataDir, fsPort, sha, lock);
+    const store = new LocalSessionEventLogStoreV2(dataDir, fsPort, sha);
+    const gate = new ExecutionSessionGateV2(lock, store);
 
     const sessionId = asSessionId('sess_test_idempotency');
     const snapshotRef = asSnapshotRef(asSha256Digest('sha256:5947229239ac2966c1099d6d74f4448c064e54ae25959eaebfd89cec073bdc11'));
@@ -228,8 +324,10 @@ describe('v2 local session store (Slice 2 substrate)', () => {
       data: {},
     };
 
-    await store
-      .append(sessionId, { events: [evt], snapshotPins: [{ snapshotRef, eventIndex: 0, createdByEventId: 'evt_1' }] })
+    await gate
+      .withHealthySessionLock(sessionId, (w) =>
+        store.append(w, { events: [evt], snapshotPins: [{ snapshotRef, eventIndex: 0, createdByEventId: 'evt_1' }] })
+      )
       .match(
         () => undefined,
         (e) => {
@@ -238,8 +336,10 @@ describe('v2 local session store (Slice 2 substrate)', () => {
       );
 
     // Replay the same append (same dedupeKey).
-    await store
-      .append(sessionId, { events: [evt], snapshotPins: [{ snapshotRef, eventIndex: 0, createdByEventId: 'evt_1' }] })
+    await gate
+      .withHealthySessionLock(sessionId, (w) =>
+        store.append(w, { events: [evt], snapshotPins: [{ snapshotRef, eventIndex: 0, createdByEventId: 'evt_1' }] })
+      )
       .match(
         () => undefined,
         (e) => {


### PR DESCRIPTION
### Summary
Implement Slice 2.5 architectural prep for Slice 3 (token orchestration) by enforcing append safety and health gating via a non-forgeable capability witness.

### Core Changes
- **ExecutionSessionGateV2**: centralized lock+health choke-point with lexical `withHealthySessionLock` callback lifetime
- **WithHealthySessionLock**: opaque branded witness (TS `unique symbol`); append requires proof; includes `assertHeld()` runtime guard against misuse-after-release
- **Port split**: `SessionEventLogReadonlyStorePortV2` vs `SessionEventLogAppendStorePortV2` (append requires witness)
- **SessionHealthV2 union**: `healthy | corrupt_tail | corrupt_head | unknown_version` with manifest-attested `CorruptionReasonV2` (closed set)
- **Salvage path**: `loadValidatedPrefix` (read-only; execution requires `healthy`)
- **Typed snapshot pin enforcement**: `node_created.data.snapshotRef: SnapshotRef` (no `any` casts)
- **Lock removal from store**: `LocalSessionEventLogStoreV2` no longer acquires locks internally

### Tests
- Gate behavior: re-entrancy, lock busy retry guidance, corrupt-tail early-fail, TOCTOU guard
- Witness misuse-after-release fail-fast
- Store corruption classification (missing_attested_segment, digest_mismatch, non_contiguous_indices)
- Health projection mapping

### Why This Matters
Slice 2.5 makes the newly locked invariants (rehydrate purity, replay no-recompute, corruption gating) **architecturally enforceable** before Slice 3 orchestration work begins. Without this, those invariants would rely on code review and tests alone.

### Verification
- ✅ `npm run typecheck` passes
- ✅ `npm test -- tests/unit/v2/` passes (14 files, 31 tests)
- ✅ All architectural guardrails verified (append requires witness, readonly can't access append, health gating works)

### Related
- Slice 2 (substrate+projections): merged in #31
- Slice 3 (token orchestration): blocked on this + prereqs
- Design docs (locks, contract updates): tracked in `feature/etienneb/token-workflow-dashboard`