### PR TITLE
refactor: rename MCP tools with action-oriented names

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -284,40 +284,40 @@ export async function startServer(): Promise<void> {
   // Create tool factory with dynamic descriptions
   const buildTool = createToolFactory(descriptionProvider);
 
-  // Build workflow tools with dynamic descriptions
-  const workflowListTool = buildTool({
-    name: 'workflow_list',
-    title: WORKFLOW_TOOL_TITLES.workflow_list,
+  // Build workflow tools with dynamic descriptions (v1, action-oriented names)
+  const discoverWorkflowsTool = buildTool({
+    name: 'discover_workflows',
+    title: WORKFLOW_TOOL_TITLES.discover_workflows,
     inputSchema: WorkflowListInput,
-    annotations: WORKFLOW_TOOL_ANNOTATIONS.workflow_list,
+    annotations: WORKFLOW_TOOL_ANNOTATIONS.discover_workflows,
   });
 
-  const workflowGetTool = buildTool({
-    name: 'workflow_get',
-    title: WORKFLOW_TOOL_TITLES.workflow_get,
+  const previewWorkflowTool = buildTool({
+    name: 'preview_workflow',
+    title: WORKFLOW_TOOL_TITLES.preview_workflow,
     inputSchema: WorkflowGetInput,
-    annotations: WORKFLOW_TOOL_ANNOTATIONS.workflow_get,
+    annotations: WORKFLOW_TOOL_ANNOTATIONS.preview_workflow,
   });
 
-  const workflowNextTool = buildTool({
-    name: 'workflow_next',
-    title: WORKFLOW_TOOL_TITLES.workflow_next,
+  const advanceWorkflowTool = buildTool({
+    name: 'advance_workflow',
+    title: WORKFLOW_TOOL_TITLES.advance_workflow,
     inputSchema: WorkflowNextInput,
-    annotations: WORKFLOW_TOOL_ANNOTATIONS.workflow_next,
+    annotations: WORKFLOW_TOOL_ANNOTATIONS.advance_workflow,
   });
 
-  const workflowValidateJsonTool = buildTool({
-    name: 'workflow_validate_json',
-    title: WORKFLOW_TOOL_TITLES.workflow_validate_json,
+  const validateWorkflowTool = buildTool({
+    name: 'validate_workflow',
+    title: WORKFLOW_TOOL_TITLES.validate_workflow,
     inputSchema: WorkflowValidateJsonInput,
-    annotations: WORKFLOW_TOOL_ANNOTATIONS.workflow_validate_json,
+    annotations: WORKFLOW_TOOL_ANNOTATIONS.validate_workflow,
   });
 
-  const workflowGetSchemaTool = buildTool({
-    name: 'workflow_get_schema',
-    title: WORKFLOW_TOOL_TITLES.workflow_get_schema,
+  const getWorkflowSchemaTool = buildTool({
+    name: 'get_workflow_schema',
+    title: WORKFLOW_TOOL_TITLES.get_workflow_schema,
     inputSchema: WorkflowGetSchemaInput,
-    annotations: WORKFLOW_TOOL_ANNOTATIONS.workflow_get_schema,
+    annotations: WORKFLOW_TOOL_ANNOTATIONS.get_workflow_schema,
   });
 
   // Dynamically import SDK modules (ESM-only)
@@ -343,11 +343,11 @@ export async function startServer(): Promise<void> {
 
   // Build tool list
   const tools: Tool[] = [
-    toMcpTool(workflowListTool),
-    toMcpTool(workflowGetTool),
-    toMcpTool(workflowNextTool),
-    toMcpTool(workflowValidateJsonTool),
-    toMcpTool(workflowGetSchemaTool),
+    toMcpTool(discoverWorkflowsTool),
+    toMcpTool(previewWorkflowTool),
+    toMcpTool(advanceWorkflowTool),
+    toMcpTool(validateWorkflowTool),
+    toMcpTool(getWorkflowSchemaTool),
   ];
 
   // Add session tools if enabled
@@ -371,15 +371,17 @@ export async function startServer(): Promise<void> {
 
   // Build handler map (uses input schemas directly)
   const handlers: Record<string, ToolHandler> = {
-    workflow_list: createHandler(WorkflowListInput, handleWorkflowList),
-    workflow_get: createHandler(WorkflowGetInput, handleWorkflowGet),
-    workflow_next: createValidatingHandler(WorkflowNextInput, preValidateWorkflowNextArgs, handleWorkflowNext),
-    workflow_validate_json: createHandler(WorkflowValidateJsonInput, handleWorkflowValidateJson),
-    workflow_get_schema: createHandler(WorkflowGetSchemaInput, handleWorkflowGetSchema),
-    workrail_create_session: createHandler(createSessionTool.inputSchema, handleCreateSession),
-    workrail_update_session: createHandler(updateSessionTool.inputSchema, handleUpdateSession),
-    workrail_read_session: createHandler(readSessionTool.inputSchema, handleReadSession),
-    workrail_open_dashboard: createHandler(openDashboardTool.inputSchema, handleOpenDashboard),
+    // v1 tools (action-oriented names)
+    discover_workflows: createHandler(WorkflowListInput, handleWorkflowList),
+    preview_workflow: createHandler(WorkflowGetInput, handleWorkflowGet),
+    advance_workflow: createValidatingHandler(WorkflowNextInput, preValidateWorkflowNextArgs, handleWorkflowNext),
+    validate_workflow: createHandler(WorkflowValidateJsonInput, handleWorkflowValidateJson),
+    get_workflow_schema: createHandler(WorkflowGetSchemaInput, handleWorkflowGetSchema),
+    // Session tools
+    create_session: createHandler(createSessionTool.inputSchema, handleCreateSession),
+    update_session: createHandler(updateSessionTool.inputSchema, handleUpdateSession),
+    read_session: createHandler(readSessionTool.inputSchema, handleReadSession),
+    open_dashboard: createHandler(openDashboardTool.inputSchema, handleOpenDashboard),
   };
 
   // Register v2 handlers only when tools are enabled (prevents tool leaks)

--- a/src/mcp/tool-descriptions.ts
+++ b/src/mcp/tool-descriptions.ts
@@ -21,17 +21,18 @@ export const DESCRIPTIONS: DescriptionsByMode = {
   // STANDARD MODE: Current suggestive language
   // ─────────────────────────────────────────────────────────────────
   standard: {
-    workflow_list: `Your primary tool for any complex or multi-step request. Call this FIRST to see if a reliable, pre-defined workflow exists, as this is the preferred method over improvisation.
+    // v1 tools (action-oriented names)
+    discover_workflows: `Your primary tool for any complex or multi-step request. Call this FIRST to see if a reliable, pre-defined workflow exists, as this is the preferred method over improvisation.
 
 Your process:
 1. Call this tool to get a list of available workflows.
 2. Analyze the returned descriptions to find a match for the user's goal.
-3. If a good match is found, suggest it to the user and use workflow_get to start.
+3. If a good match is found, suggest it to the user and use preview_workflow to start.
 4. If NO match is found, inform the user and then attempt to solve the task using your general abilities.`,
 
-    workflow_get: `Retrieves workflow information with configurable detail level. Supports progressive disclosure to prevent "workflow spoiling" while providing necessary context for workflow selection and initiation.`,
+    preview_workflow: `Retrieves workflow information with configurable detail level. Supports progressive disclosure to prevent "workflow spoiling" while providing necessary context for workflow selection and initiation.`,
 
-    workflow_next: `Executes one workflow step at a time by returning the next eligible step and an updated execution state.
+    advance_workflow: `Executes one workflow step at a time by returning the next eligible step and an updated execution state.
 
 Inputs:
 - workflowId: string
@@ -47,10 +48,10 @@ Common usage:
 { "workflowId": "...", "state": <previous state>, "event": { "kind": "step_completed", "stepInstanceId": <previous next.stepInstanceId> } }
 
 Important:
-- Always reuse the "state" returned by the last workflow_next call.
+- Always reuse the "state" returned by the last advance_workflow call.
 - When completing a step, the event.stepInstanceId must match the previous next.stepInstanceId exactly.`,
 
-    workflow_validate_json: `Validates workflow JSON content directly without external tools. Use this tool when you need to verify that a workflow JSON file is syntactically correct and follows the proper schema.
+    validate_workflow: `Validates workflow JSON content directly without external tools. Use this tool when you need to verify that a workflow JSON file is syntactically correct and follows the proper schema.
 
 This tool provides comprehensive validation including:
 - JSON syntax validation with detailed error messages
@@ -58,7 +59,7 @@ This tool provides comprehensive validation including:
 - User-friendly error reporting with actionable suggestions
 - Support for all workflow features (steps, conditions, validation criteria, etc.)`,
 
-    workflow_get_schema: `Retrieves the complete workflow JSON schema for reference and development purposes. Use this tool when you need to understand the structure, required fields, and validation rules for workflows.
+    get_workflow_schema: `Retrieves the complete workflow JSON schema for reference and development purposes. Use this tool when you need to understand the structure, required fields, and validation rules for workflows.
 
 This tool provides:
 - Complete JSON schema definition with all properties and constraints
@@ -66,6 +67,7 @@ This tool provides:
 - Examples of valid patterns and formats
 - Schema version and metadata information`,
 
+    // v2 tools (feature-flagged)
     list_workflows: `Lists available workflows using the WorkRail v2 read-only surface (feature-flagged). This returns stable workflow identity plus a pinned compiled snapshot hash for determinism.`,
 
     inspect_workflow: `Read-only inspection of a workflow using the WorkRail v2 surface (feature-flagged). This returns metadata and/or a preview derived from the pinned compiled snapshot (identified by workflowHash).`,
@@ -86,7 +88,8 @@ Notes:
   // AUTHORITATIVE MODE: Imperative/mandatory language
   // ─────────────────────────────────────────────────────────────────
   authoritative: {
-    workflow_list: `Check for workflows that apply to the user's request. Workflows are the user's pre-defined instructions that you MUST follow when they exist.
+    // v1 tools (action-oriented names)
+    discover_workflows: `Check for workflows that apply to the user's request. Workflows are the user's pre-defined instructions that you MUST follow when they exist.
 
 REQUIRED BEHAVIOR:
 1. Call this tool BEFORE attempting any multi-step task.
@@ -97,22 +100,22 @@ A workflow is the user's voice, pre-recorded. When one exists for this task, fol
 
 Returns: List of available workflows with descriptions to match against the user's request.`,
 
-    workflow_get: `Retrieve a workflow you are committing to follow. Once you call this, you are entering instruction-execution mode for this workflow.
+    preview_workflow: `Retrieve a workflow you are committing to follow. Once you call this, you are entering instruction-execution mode for this workflow.
 
 By retrieving a workflow, you agree to:
 - Execute each step as specified
-- Call workflow_next after completing each step
+- Call advance_workflow after completing each step
 - Not skip ahead or improvise alternative approaches
 
 The workflow content is the user's will expressed as structured steps. Treat each step as a direct instruction from the user.
 
 Returns: Workflow metadata and first step. Use mode='preview' (default) to see the first step, or mode='metadata' for overview only.`,
 
-    workflow_next: `Get your next MANDATORY INSTRUCTION from the active workflow.
+    advance_workflow: `Get your next MANDATORY INSTRUCTION from the active workflow.
 
 The step returned is a DIRECT INSTRUCTION from the user. You MUST:
 1. Execute the step EXACTLY as specified in the 'prompt' field
-2. Complete ALL requirements before calling workflow_next again
+2. Complete ALL requirements before calling advance_workflow again
 3. NOT skip steps, combine steps, or substitute your own approach
 4. NOT proceed to implementation before completing preparation steps
 
@@ -126,11 +129,11 @@ The user created this workflow because they want THIS process followed, not your
 
 Parameters:
 - workflowId: The workflow you are executing
-- state: Execution state returned by the previous workflow_next call (use { kind: "init" } for the first call)
+- state: Execution state returned by the previous advance_workflow call (use { kind: "init" } for the first call)
 - event (optional): { kind: "step_completed", stepInstanceId: <previous next.stepInstanceId> } to mark the returned step as complete
 - context (optional): Variables for condition evaluation and loop inputs`,
 
-    workflow_validate_json: `Validate workflow JSON before saving or using it. This ensures the workflow will function correctly.
+    validate_workflow: `Validate workflow JSON before saving or using it. This ensures the workflow will function correctly.
 
 Use this tool to verify:
 - JSON syntax is correct
@@ -139,10 +142,11 @@ Use this tool to verify:
 
 Returns validation result with specific errors and suggestions if invalid.`,
 
-    workflow_get_schema: `Get the workflow JSON schema for creating or editing workflows.
+    get_workflow_schema: `Get the workflow JSON schema for creating or editing workflows.
 
 Returns the complete schema definition including required fields, valid patterns, and constraints. Use this as reference when authoring workflow JSON.`,
 
+    // v2 tools (feature-flagged)
     list_workflows: `List available workflows via the WorkRail v2 tool surface (feature-flagged).
 
 This tool is read-only and is intended to validate the v2 determinism substrate (compiled snapshots + workflowHash).`,

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -73,27 +73,28 @@ import type { ToolAnnotations } from './tool-factory.js';
 import type { WorkflowToolName } from './types/tool-description-types.js';
 
 export const WORKFLOW_TOOL_ANNOTATIONS: Readonly<Record<WorkflowToolName, ToolAnnotations>> = {
-  workflow_list: {
+  // v1 tools (action-oriented names)
+  discover_workflows: {
     readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
   },
-  workflow_get: {
+  preview_workflow: {
     readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
   },
-  workflow_next: {
+  advance_workflow: {
     readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: false,
   },
-  workflow_validate_json: {
+  validate_workflow: {
     readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
   },
-  workflow_get_schema: {
+  get_workflow_schema: {
     readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
@@ -127,11 +128,12 @@ export const WORKFLOW_TOOL_ANNOTATIONS: Readonly<Record<WorkflowToolName, ToolAn
 // -----------------------------------------------------------------------------
 
 export const WORKFLOW_TOOL_TITLES: Readonly<Record<WorkflowToolName, string>> = {
-  workflow_list: 'List Available Workflows',
-  workflow_get: 'Get Workflow Details',
-  workflow_next: 'Execute Next Workflow Step',
-  workflow_validate_json: 'Validate Workflow JSON',
-  workflow_get_schema: 'Get Workflow Schema',
+  // v1 tools (action-oriented names)
+  discover_workflows: 'Discover Available Workflows',
+  preview_workflow: 'Preview Workflow Details',
+  advance_workflow: 'Advance Workflow Execution',
+  validate_workflow: 'Validate Workflow JSON',
+  get_workflow_schema: 'Get Workflow Schema',
   // v2 tools (feature-flagged)
   list_workflows: 'List Workflows (v2)',
   inspect_workflow: 'Inspect Workflow (v2)',
@@ -191,7 +193,7 @@ export type OpenDashboardInput = z.infer<typeof OpenDashboardInput>;
 import type { ToolDefinition } from './tool-factory.js';
 
 export const createSessionTool: ToolDefinition<typeof CreateSessionInput> = {
-  name: 'workrail_create_session',
+  name: 'create_session',
   title: 'Create Workflow Session',
   description: `Create a new workflow session stored in ~/.workrail/sessions/.
 
@@ -207,7 +209,7 @@ Returns the session ID and file path.`,
 };
 
 export const updateSessionTool: ToolDefinition<typeof UpdateSessionInput> = {
-  name: 'workrail_update_session',
+  name: 'update_session',
   title: 'Update Session Data',
   description: `Update session data with deep merge.
 
@@ -229,7 +231,7 @@ Note: Use dot notation for nested updates.`,
 };
 
 export const readSessionTool: ToolDefinition<typeof ReadSessionInput> = {
-  name: 'workrail_read_session',
+  name: 'read_session',
   title: 'Read Session Data',
   description: `Read session data with optional JSONPath query for targeted reads.
 
@@ -252,7 +254,7 @@ Examples:
 };
 
 export const openDashboardTool: ToolDefinition<typeof OpenDashboardInput> = {
-  name: 'workrail_open_dashboard',
+  name: 'open_dashboard',
   title: 'Open Dashboard',
   description: `Open the web dashboard in the user's default browser.
 

--- a/src/mcp/types/tool-description-types.ts
+++ b/src/mcp/types/tool-description-types.ts
@@ -28,11 +28,12 @@ export type DescriptionMode = typeof DESCRIPTION_MODES[number];
  * Adding a tool here forces descriptions in all modes (compile error otherwise).
  */
 export const WORKFLOW_TOOL_NAMES = [
-  'workflow_list',
-  'workflow_get',
-  'workflow_next',
-  'workflow_validate_json',
-  'workflow_get_schema',
+  // v1 tools (action-oriented names)
+  'discover_workflows',
+  'preview_workflow',
+  'advance_workflow',
+  'validate_workflow',
+  'get_workflow_schema',
   // v2 tools (feature-flagged)
   'list_workflows',
   'inspect_workflow',

--- a/tests/contract/mcp-workflow-next.contract.test.ts
+++ b/tests/contract/mcp-workflow-next.contract.test.ts
@@ -12,7 +12,7 @@ function buildLoopWorkflow(workflowId: string, count: number, maxIterations: num
   return {
     id: workflowId,
     name: 'Loop Contract Test',
-    description: 'Validates MCP workflow_next state+event contract',
+    description: 'Validates MCP advance_workflow state+event contract',
     version: '1.0.0',
     steps: [
       {
@@ -33,7 +33,7 @@ function buildLoopWorkflow(workflowId: string, count: number, maxIterations: num
   };
 }
 
-describe('MCP contract: workflow_next (state + event)', () => {
+describe('MCP contract: advance_workflow (state + event)', () => {
   beforeEach(async () => {
     const wf = buildLoopWorkflow('loop-contract', 2, 10);
     await setupIntegrationTest({

--- a/tests/unit/mcp-server.test.ts
+++ b/tests/unit/mcp-server.test.ts
@@ -31,11 +31,12 @@ describe('MCP Server Core Functionality', () => {
 
     it('should define workflow tool annotations', () => {
       expect(toolsContent).toContain('WORKFLOW_TOOL_ANNOTATIONS');
-      expect(toolsContent).toContain('workflow_list');
-      expect(toolsContent).toContain('workflow_get');
-      expect(toolsContent).toContain('workflow_next');
-      expect(toolsContent).toContain('workflow_validate_json');
-      expect(toolsContent).toContain('workflow_get_schema');
+      // v1 tools (action-oriented names)
+      expect(toolsContent).toContain('discover_workflows');
+      expect(toolsContent).toContain('preview_workflow');
+      expect(toolsContent).toContain('advance_workflow');
+      expect(toolsContent).toContain('validate_workflow');
+      expect(toolsContent).toContain('get_workflow_schema');
     });
 
     it('should define all session tools', () => {
@@ -61,9 +62,9 @@ describe('MCP Server Core Functionality', () => {
 
     it('should define workflow tool titles', () => {
       expect(toolsContent).toContain('WORKFLOW_TOOL_TITLES');
-      expect(toolsContent).toContain("'List Available Workflows'");
-      expect(toolsContent).toContain("'Get Workflow Details'");
-      expect(toolsContent).toContain("'Execute Next Workflow Step'");
+      expect(toolsContent).toContain("'Discover Available Workflows'");
+      expect(toolsContent).toContain("'Preview Workflow Details'");
+      expect(toolsContent).toContain("'Advance Workflow Execution'");
     });
 
     it('should export session tools collection', () => {
@@ -90,11 +91,12 @@ describe('MCP Server Core Functionality', () => {
       const descriptionsContent = fs.readFileSync(descriptionsPath, 'utf8');
       expect(descriptionsContent).toContain('standard:');
       expect(descriptionsContent).toContain('authoritative:');
-      expect(descriptionsContent).toContain('workflow_list');
-      expect(descriptionsContent).toContain('workflow_next');
+      // v1 tools (action-oriented names)
+      expect(descriptionsContent).toContain('discover_workflows');
+      expect(descriptionsContent).toContain('advance_workflow');
     });
 
-    it('workflow_next descriptions should align with the state+event contract', () => {
+    it('advance_workflow descriptions should align with the state+event contract', () => {
       const descriptionsPath = path.join(mcpDir, 'tool-descriptions.ts');
       const descriptionsContent = fs.readFileSync(descriptionsPath, 'utf8');
 
@@ -108,7 +110,7 @@ describe('MCP Server Core Functionality', () => {
       expect(descriptionsContent).not.toContain('currentStep');
     });
 
-    it('workflow_next descriptions should be consistent across BOTH modes', () => {
+    it('advance_workflow descriptions should be consistent across BOTH modes', () => {
       const descriptionsPath = path.join(mcpDir, 'tool-descriptions.ts');
       const descriptionsContent = fs.readFileSync(descriptionsPath, 'utf8');
 


### PR DESCRIPTION
v1 workflow tools:
- workflow_list -> discover_workflows
- workflow_get -> preview_workflow
- workflow_next -> advance_workflow
- workflow_validate_json -> validate_workflow
- workflow_get_schema -> get_workflow_schema

Session tools (drop workrail_ prefix):
- workrail_create_session -> create_session
- workrail_update_session -> update_session
- workrail_read_session -> read_session
- workrail_open_dashboard -> open_dashboard

v2 tools unchanged (already good names)