### PR TITLE
feat(validation): add parameter suggestions and schema consistency enforcement

### DIFF
--- a/src/mcp/handlers/workflow.ts
+++ b/src/mcp/handlers/workflow.ts
@@ -128,7 +128,7 @@ export async function handleWorkflowGet(
     const getWorkflowUseCase = createGetWorkflow(ctx.workflowService);
 
     const result = await withTimeout(
-      getWorkflowUseCase(input.id, input.mode),
+      getWorkflowUseCase(input.workflowId, input.mode),
       TIMEOUT_MS,
       'workflow_get'
     );

--- a/src/mcp/tool-descriptions.ts
+++ b/src/mcp/tool-descriptions.ts
@@ -30,7 +30,11 @@ Your process:
 3. If a good match is found, suggest it to the user and use preview_workflow to start.
 4. If NO match is found, inform the user and then attempt to solve the task using your general abilities.`,
 
-    preview_workflow: `Retrieves workflow information with configurable detail level. Supports progressive disclosure to prevent "workflow spoiling" while providing necessary context for workflow selection and initiation.`,
+    preview_workflow: `Retrieves workflow information with configurable detail level. Supports progressive disclosure to prevent "workflow spoiling" while providing necessary context for workflow selection and initiation.
+
+Parameters:
+- workflowId: The unique identifier of the workflow to retrieve
+- mode (optional): 'metadata' for overview only, 'preview' (default) for first step`,
 
     advance_workflow: `Executes one workflow step at a time by returning the next eligible step and an updated execution state.
 
@@ -109,7 +113,9 @@ By retrieving a workflow, you agree to:
 
 The workflow content is the user's will expressed as structured steps. Treat each step as a direct instruction from the user.
 
-Returns: Workflow metadata and first step. Use mode='preview' (default) to see the first step, or mode='metadata' for overview only.`,
+Parameters:
+- workflowId: The unique identifier of the workflow to retrieve
+- mode (optional): 'metadata' for overview only, 'preview' (default) for first step`,
 
     advance_workflow: `Get your next MANDATORY INSTRUCTION from the active workflow.
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -25,9 +25,9 @@ export const WorkflowListInput = z.object({});
 export type WorkflowListInput = z.infer<typeof WorkflowListInput>;
 
 export const WorkflowGetInput = z.object({
-  id: z
+  workflowId: z
     .string()
-    .regex(/^[A-Za-z0-9_-]+$/, 'ID must contain only letters, numbers, hyphens, and underscores')
+    .regex(/^[A-Za-z0-9_-]+$/, 'Workflow ID must contain only letters, numbers, hyphens, and underscores')
     .describe('The unique identifier of the workflow to retrieve'),
   mode: z
     .enum(['metadata', 'preview'])
@@ -148,6 +148,7 @@ export const WORKFLOW_TOOL_TITLES: Readonly<Record<WorkflowToolName, string>> = 
 export const CreateSessionInput = z.object({
   workflowId: z
     .string()
+    .regex(/^[A-Za-z0-9_-]+$/, 'Workflow ID must contain only letters, numbers, hyphens, and underscores')
     .describe('Workflow identifier (e.g., "bug-investigation", "mr-review")'),
   sessionId: z
     .string()
@@ -160,7 +161,7 @@ export const CreateSessionInput = z.object({
 export type CreateSessionInput = z.infer<typeof CreateSessionInput>;
 
 export const UpdateSessionInput = z.object({
-  workflowId: z.string().describe('Workflow identifier'),
+  workflowId: z.string().regex(/^[A-Za-z0-9_-]+$/, 'Workflow ID must contain only letters, numbers, hyphens, and underscores').describe('Workflow identifier'),
   sessionId: z.string().describe('Session identifier'),
   updates: z
     .record(z.unknown())
@@ -169,7 +170,7 @@ export const UpdateSessionInput = z.object({
 export type UpdateSessionInput = z.infer<typeof UpdateSessionInput>;
 
 export const ReadSessionInput = z.object({
-  workflowId: z.string().describe('Workflow identifier'),
+  workflowId: z.string().regex(/^[A-Za-z0-9_-]+$/, 'Workflow ID must contain only letters, numbers, hyphens, and underscores').describe('Workflow identifier'),
   sessionId: z.string().describe('Session identifier'),
   path: z
     .string()

--- a/src/mcp/v2/tools.ts
+++ b/src/mcp/v2/tools.ts
@@ -5,13 +5,13 @@ export const V2ListWorkflowsInput = z.object({});
 export type V2ListWorkflowsInput = z.infer<typeof V2ListWorkflowsInput>;
 
 export const V2InspectWorkflowInput = z.object({
-  workflowId: z.string().min(1).describe('The workflow ID to inspect'),
+  workflowId: z.string().min(1).regex(/^[A-Za-z0-9_-]+$/, 'Workflow ID must contain only letters, numbers, hyphens, and underscores').describe('The workflow ID to inspect'),
   mode: z.enum(['metadata', 'preview']).default('preview').describe('Detail level'),
 });
 export type V2InspectWorkflowInput = z.infer<typeof V2InspectWorkflowInput>;
 
 export const V2StartWorkflowInput = z.object({
-  workflowId: z.string().min(1).describe('The workflow ID to start'),
+  workflowId: z.string().min(1).regex(/^[A-Za-z0-9_-]+$/, 'Workflow ID must contain only letters, numbers, hyphens, and underscores').describe('The workflow ID to start'),
   context: z.record(z.unknown()).optional().describe('External context inputs (conditions, parameters). Do not include workflow progress state.'),
 });
 export type V2StartWorkflowInput = z.infer<typeof V2StartWorkflowInput>;

--- a/src/mcp/validation/index.ts
+++ b/src/mcp/validation/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Validation Module
+ *
+ * Public exports for MCP input validation and suggestion generation.
+ *
+ * @module mcp/validation
+ */
+
+// Domain types
+export type {
+  Similarity,
+  ValidationSuggestion,
+  UnknownKeySuggestion,
+  MissingRequiredSuggestion,
+  InvalidEnumSuggestion,
+  SuggestionResult,
+} from './suggestion-types.js';
+
+export {
+  similarity,
+  EMPTY_SUGGESTION_RESULT,
+  isUnknownKeySuggestion,
+  isMissingRequiredSuggestion,
+  isInvalidEnumSuggestion,
+} from './suggestion-types.js';
+
+// Configuration
+export type { SuggestionConfig } from './suggestion-config.js';
+export { DEFAULT_SUGGESTION_CONFIG, MINIMAL_SUGGESTION_CONFIG } from './suggestion-config.js';
+
+// String similarity (exposed for testing)
+export {
+  levenshteinDistance,
+  computeSimilarity,
+  computeSimilarityIgnoreCase,
+  findClosestMatch,
+  findAllMatches,
+  type ClosestMatch,
+} from './string-similarity.js';
+
+// Schema introspection (exposed for testing)
+export {
+  extractExpectedKeys,
+  extractRequiredKeys,
+  findUnknownKeys,
+  findMissingRequiredKeys,
+  generateExampleValue,
+  generateTemplate,
+  extractEnumValues,
+} from './schema-introspection.js';
+
+// Suggestion generator (main API)
+export {
+  generateSuggestions,
+  formatSuggestionDetails,
+  hasSuggestions,
+} from './suggestion-generator.js';

--- a/src/mcp/validation/schema-introspection.ts
+++ b/src/mcp/validation/schema-introspection.ts
@@ -1,0 +1,281 @@
+/**
+ * Schema Introspection Utilities
+ *
+ * Pure functions for extracting information from Zod schemas.
+ * Used to understand expected structure for suggestions.
+ *
+ * Philosophy:
+ * - Pure functions (deterministic, no side effects)
+ * - Validate at boundaries, trust inside
+ * - Defensive handling of unknown Zod types
+ *
+ * @module mcp/validation/schema-introspection
+ */
+
+import { z } from 'zod';
+
+/**
+ * Extract all expected keys from a Zod object schema.
+ *
+ * @param schema - A Zod schema (must be ZodObject for meaningful results)
+ * @returns Array of expected key names (empty if not an object schema)
+ */
+export function extractExpectedKeys(schema: z.ZodType): readonly string[] {
+  if (schema instanceof z.ZodObject) {
+    return Object.keys(schema._def.shape());
+  }
+  return [];
+}
+
+/**
+ * Extract required keys from a Zod object schema.
+ *
+ * A key is required if it's not optional and has no default.
+ *
+ * @param schema - A Zod schema
+ * @returns Array of required key names
+ */
+export function extractRequiredKeys(schema: z.ZodType): readonly string[] {
+  if (!(schema instanceof z.ZodObject)) {
+    return [];
+  }
+
+  const shape = schema._def.shape();
+  const required: string[] = [];
+
+  for (const [key, value] of Object.entries(shape)) {
+    const field = value as z.ZodType;
+    if (!(field instanceof z.ZodOptional) && !(field instanceof z.ZodDefault)) {
+      required.push(key);
+    }
+  }
+
+  return required;
+}
+
+/**
+ * Find keys in the provided object that are not in the schema.
+ *
+ * @param args - The input arguments (unknown type from MCP)
+ * @param schema - The expected Zod schema
+ * @returns Array of unknown key names
+ */
+export function findUnknownKeys(args: unknown, schema: z.ZodType): readonly string[] {
+  if (typeof args !== 'object' || args === null) {
+    return [];
+  }
+
+  const expectedKeys = new Set(extractExpectedKeys(schema));
+  const providedKeys = Object.keys(args);
+
+  return providedKeys.filter(key => !expectedKeys.has(key));
+}
+
+/**
+ * Find required keys that are missing from the provided object.
+ *
+ * @param args - The input arguments
+ * @param schema - The expected Zod schema
+ * @returns Array of missing required key names
+ */
+export function findMissingRequiredKeys(args: unknown, schema: z.ZodType): readonly string[] {
+  if (typeof args !== 'object' || args === null) {
+    return extractRequiredKeys(schema);
+  }
+
+  const providedKeys = new Set(Object.keys(args));
+  const requiredKeys = extractRequiredKeys(schema);
+
+  return requiredKeys.filter(key => !providedKeys.has(key));
+}
+
+/**
+ * Generate an example value for a Zod type.
+ *
+ * Creates a representative value that shows the expected structure.
+ * Uses placeholders for values to indicate type expectations.
+ *
+ * @param schema - A Zod schema
+ * @param depth - Current recursion depth (for limiting nested objects)
+ * @param maxDepth - Maximum recursion depth
+ * @returns Example value or placeholder string
+ */
+export function generateExampleValue(
+  schema: z.ZodType,
+  depth: number = 0,
+  maxDepth: number = 3
+): unknown {
+  // Prevent infinite recursion
+  if (depth > maxDepth) {
+    return '...';
+  }
+
+  // Handle ZodDefault - use the default value
+  if (schema instanceof z.ZodDefault) {
+    return schema._def.defaultValue();
+  }
+
+  // Handle ZodOptional - unwrap and generate
+  if (schema instanceof z.ZodOptional) {
+    return generateExampleValue(schema._def.innerType, depth, maxDepth);
+  }
+
+  // Handle ZodObject
+  if (schema instanceof z.ZodObject) {
+    const shape = schema._def.shape();
+    const result: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(shape)) {
+      const field = value as z.ZodType;
+      // Skip optional fields in examples to keep them concise
+      if (field instanceof z.ZodOptional) continue;
+      result[key] = generateExampleValue(field, depth + 1, maxDepth);
+    }
+
+    return result;
+  }
+
+  // Handle ZodDiscriminatedUnion - use the first variant
+  if (schema instanceof z.ZodDiscriminatedUnion) {
+    const options = schema._def.options as Array<z.ZodType>;
+    if (options.length > 0) {
+      return generateExampleValue(options[0], depth + 1, maxDepth);
+    }
+    return {};
+  }
+
+  // Handle ZodString
+  if (schema instanceof z.ZodString) {
+    const description = schema._def.description;
+    if (description) {
+      return `<${description}>`;
+    }
+    return '<string>';
+  }
+
+  // Handle ZodNumber
+  if (schema instanceof z.ZodNumber) {
+    return '<number>';
+  }
+
+  // Handle ZodBoolean
+  if (schema instanceof z.ZodBoolean) {
+    return '<boolean>';
+  }
+
+  // Handle ZodArray
+  if (schema instanceof z.ZodArray) {
+    return [];
+  }
+
+  // Handle ZodEnum
+  if (schema instanceof z.ZodEnum) {
+    const values = schema._def.values as string[];
+    if (values.length > 0) {
+      return values[0];
+    }
+    return '<enum>';
+  }
+
+  // Handle ZodLiteral
+  if (schema instanceof z.ZodLiteral) {
+    return schema._def.value;
+  }
+
+  // Handle ZodRecord
+  if (schema instanceof z.ZodRecord) {
+    return {};
+  }
+
+  // Handle ZodUnknown / ZodAny
+  if (schema instanceof z.ZodUnknown || schema instanceof z.ZodAny) {
+    return '<any>';
+  }
+
+  // Handle ZodEffects (transforms, refinements)
+  if (schema instanceof z.ZodEffects) {
+    return generateExampleValue(schema._def.schema, depth, maxDepth);
+  }
+
+  // Fallback
+  return '<unknown>';
+}
+
+/**
+ * Generate a complete template showing expected input structure.
+ *
+ * Only includes required fields to keep the template concise.
+ *
+ * @param schema - A Zod schema
+ * @param maxDepth - Maximum recursion depth
+ * @returns Template object or null if schema is not an object
+ */
+export function generateTemplate(
+  schema: z.ZodType,
+  maxDepth: number = 3
+): Readonly<Record<string, unknown>> | null {
+  if (!(schema instanceof z.ZodObject)) {
+    return null;
+  }
+
+  const example = generateExampleValue(schema, 0, maxDepth);
+  if (typeof example === 'object' && example !== null) {
+    return example as Readonly<Record<string, unknown>>;
+  }
+
+  return null;
+}
+
+/**
+ * Extract enum values from a field if it's an enum type.
+ *
+ * @param schema - A Zod schema
+ * @param path - Dot-separated path to the field
+ * @returns Array of allowed values, or empty if not an enum
+ */
+export function extractEnumValues(schema: z.ZodType, path: string): readonly string[] {
+  const parts = path.split('.');
+  let current: z.ZodType = schema;
+
+  for (const part of parts) {
+    if (current instanceof z.ZodObject) {
+      const shape = current._def.shape();
+      const field = shape[part] as z.ZodType | undefined;
+      if (!field) return [];
+      current = field;
+    } else if (current instanceof z.ZodOptional) {
+      current = current._def.innerType;
+      // Re-check with the unwrapped type
+      if (current instanceof z.ZodObject) {
+        const shape = current._def.shape();
+        const field = shape[part] as z.ZodType | undefined;
+        if (!field) return [];
+        current = field;
+      } else {
+        return [];
+      }
+    } else {
+      return [];
+    }
+  }
+
+  // Unwrap optional/default
+  if (current instanceof z.ZodOptional || current instanceof z.ZodDefault) {
+    current = current._def.innerType;
+  }
+
+  // Check if it's an enum
+  if (current instanceof z.ZodEnum) {
+    return current._def.values as string[];
+  }
+
+  // Check if it's a literal (single allowed value)
+  if (current instanceof z.ZodLiteral) {
+    const value = current._def.value;
+    if (typeof value === 'string') {
+      return [value];
+    }
+  }
+
+  return [];
+}

--- a/src/mcp/validation/string-similarity.ts
+++ b/src/mcp/validation/string-similarity.ts
@@ -1,0 +1,178 @@
+/**
+ * String Similarity Utilities
+ *
+ * Pure functions for computing string similarity.
+ * Used for "did you mean?" suggestions.
+ *
+ * Philosophy:
+ * - Pure functions (deterministic, no side effects)
+ * - Compose small functions
+ * - Explicit domain types (Similarity branded type)
+ *
+ * @module mcp/validation/string-similarity
+ */
+
+import { similarity, type Similarity } from './suggestion-types.js';
+
+/**
+ * Compute Levenshtein (edit) distance between two strings.
+ *
+ * This is the minimum number of single-character edits
+ * (insertions, deletions, substitutions) to transform a into b.
+ *
+ * Time complexity: O(n * m) where n, m are string lengths.
+ * Space complexity: O(min(n, m)) using optimized single-row approach.
+ *
+ * @param a - First string
+ * @param b - Second string
+ * @returns Edit distance (0 = identical, higher = more different)
+ */
+export function levenshteinDistance(a: string, b: string): number {
+  // Ensure a is the shorter string for space optimization
+  if (a.length > b.length) {
+    [a, b] = [b, a];
+  }
+
+  const m = a.length;
+  const n = b.length;
+
+  // Handle edge cases
+  if (m === 0) return n;
+  if (n === 0) return m;
+
+  // Single-row optimization: only keep current and previous row
+  let prevRow = new Array<number>(m + 1);
+  let currRow = new Array<number>(m + 1);
+
+  // Initialize first row
+  for (let i = 0; i <= m; i++) {
+    prevRow[i] = i;
+  }
+
+  // Fill the matrix row by row
+  for (let j = 1; j <= n; j++) {
+    currRow[0] = j;
+
+    for (let i = 1; i <= m; i++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      currRow[i] = Math.min(
+        prevRow[i] + 1,      // deletion
+        currRow[i - 1] + 1,  // insertion
+        prevRow[i - 1] + cost // substitution
+      );
+    }
+
+    // Swap rows
+    [prevRow, currRow] = [currRow, prevRow];
+  }
+
+  return prevRow[m];
+}
+
+/**
+ * Compute normalized similarity score between two strings.
+ *
+ * Returns a value from 0 (completely different) to 1 (identical).
+ * Uses Levenshtein distance normalized by max string length.
+ *
+ * @param a - First string
+ * @param b - Second string
+ * @returns Similarity score as branded Similarity type
+ */
+export function computeSimilarity(a: string, b: string): Similarity {
+  if (a === b) return similarity(1);
+  if (a.length === 0 || b.length === 0) return similarity(0);
+
+  const distance = levenshteinDistance(a, b);
+  const maxLength = Math.max(a.length, b.length);
+
+  return similarity(1 - distance / maxLength);
+}
+
+/**
+ * Compute case-insensitive similarity.
+ *
+ * Useful for parameter name matching where case might differ
+ * (e.g., workflow_id vs workflowId).
+ *
+ * @param a - First string
+ * @param b - Second string
+ * @returns Similarity score
+ */
+export function computeSimilarityIgnoreCase(a: string, b: string): Similarity {
+  return computeSimilarity(a.toLowerCase(), b.toLowerCase());
+}
+
+/**
+ * Match result from findClosestMatch.
+ */
+export interface ClosestMatch {
+  readonly match: string;
+  readonly score: Similarity;
+}
+
+/**
+ * Find the closest matching string from a list of candidates.
+ *
+ * Returns null if no candidate meets the similarity threshold.
+ *
+ * @param input - The input string to match
+ * @param candidates - List of possible matches
+ * @param threshold - Minimum similarity to consider a match
+ * @returns The best match and its score, or null if none found
+ */
+export function findClosestMatch(
+  input: string,
+  candidates: readonly string[],
+  threshold: Similarity
+): ClosestMatch | null {
+  if (candidates.length === 0) return null;
+
+  let bestMatch: string | null = null;
+  let bestScore: Similarity = similarity(0);
+
+  for (const candidate of candidates) {
+    const score = computeSimilarityIgnoreCase(input, candidate);
+    if (score > bestScore && score >= threshold) {
+      bestScore = score;
+      bestMatch = candidate;
+    }
+  }
+
+  if (bestMatch === null) return null;
+
+  return { match: bestMatch, score: bestScore };
+}
+
+/**
+ * Find all matches above threshold, sorted by similarity descending.
+ *
+ * @param input - The input string to match
+ * @param candidates - List of possible matches
+ * @param threshold - Minimum similarity to include
+ * @param limit - Maximum number of matches to return
+ * @returns Array of matches sorted by similarity (best first)
+ */
+export function findAllMatches(
+  input: string,
+  candidates: readonly string[],
+  threshold: Similarity,
+  limit: number
+): readonly ClosestMatch[] {
+  const matches: ClosestMatch[] = [];
+
+  for (const candidate of candidates) {
+    const score = computeSimilarityIgnoreCase(input, candidate);
+    if (score >= threshold) {
+      matches.push({ match: candidate, score });
+    }
+  }
+
+  // Sort by score descending, then by match string for determinism
+  matches.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.match.localeCompare(b.match);
+  });
+
+  return matches.slice(0, limit);
+}

--- a/src/mcp/validation/suggestion-config.ts
+++ b/src/mcp/validation/suggestion-config.ts
@@ -1,0 +1,67 @@
+/**
+ * Configuration for Parameter Suggestions
+ *
+ * Immutable configuration objects for suggestion generation.
+ * Avoids magic numbers by making thresholds explicit and documented.
+ *
+ * @module mcp/validation/suggestion-config
+ */
+
+import { similarity, type Similarity } from './suggestion-types.js';
+
+/**
+ * Configuration for suggestion generation.
+ * All fields are readonly to enforce immutability.
+ */
+export interface SuggestionConfig {
+  /**
+   * Minimum similarity score (0-1) required to suggest a match.
+   * Lower values are more permissive (more suggestions).
+   * 0.6 catches common typos like workflow_id → workflowId (~0.85 similarity).
+   */
+  readonly similarityThreshold: Similarity;
+
+  /**
+   * Maximum number of suggestions to include per error.
+   * Limits noise in error responses.
+   */
+  readonly maxSuggestions: number;
+
+  /**
+   * Whether to include a correct template showing expected structure.
+   * Useful for complex inputs like state objects.
+   */
+  readonly includeTemplate: boolean;
+
+  /**
+   * Maximum depth for template generation.
+   * Prevents unbounded recursion in deeply nested schemas.
+   */
+  readonly maxTemplateDepth: number;
+}
+
+/**
+ * Default configuration optimized for agent self-correction.
+ *
+ * These values are tuned based on observed agent errors:
+ * - 0.6 threshold catches snake_case → camelCase conversions
+ * - 3 suggestions avoids overwhelming the agent
+ * - Templates help with complex nested objects
+ */
+export const DEFAULT_SUGGESTION_CONFIG: SuggestionConfig = {
+  similarityThreshold: similarity(0.6),
+  maxSuggestions: 3,
+  includeTemplate: true,
+  maxTemplateDepth: 3,
+} as const;
+
+/**
+ * Minimal configuration for performance-sensitive paths.
+ * Only does unknown key detection, no templates.
+ */
+export const MINIMAL_SUGGESTION_CONFIG: SuggestionConfig = {
+  similarityThreshold: similarity(0.7),
+  maxSuggestions: 1,
+  includeTemplate: false,
+  maxTemplateDepth: 1,
+} as const;

--- a/src/mcp/validation/suggestion-generator.ts
+++ b/src/mcp/validation/suggestion-generator.ts
@@ -1,0 +1,213 @@
+/**
+ * Suggestion Generator
+ *
+ * Orchestrates schema introspection and string similarity to generate
+ * helpful suggestions for invalid input.
+ *
+ * Philosophy:
+ * - Pure functions (deterministic, no side effects)
+ * - Compose small functions
+ * - Control flow from data state
+ *
+ * @module mcp/validation/suggestion-generator
+ */
+
+import { z } from 'zod';
+import type { SuggestionConfig } from './suggestion-config.js';
+import type {
+  SuggestionResult,
+  ValidationSuggestion,
+  UnknownKeySuggestion,
+  MissingRequiredSuggestion,
+} from './suggestion-types.js';
+import { EMPTY_SUGGESTION_RESULT } from './suggestion-types.js';
+import { findClosestMatch } from './string-similarity.js';
+import {
+  extractExpectedKeys,
+  findUnknownKeys,
+  findMissingRequiredKeys,
+  generateTemplate,
+  generateExampleValue,
+} from './schema-introspection.js';
+
+/**
+ * Generate unknown key suggestions by matching against expected keys.
+ *
+ * @param unknownKeys - Keys provided that aren't in the schema
+ * @param expectedKeys - Keys expected by the schema
+ * @param config - Suggestion configuration
+ * @returns Array of unknown key suggestions
+ */
+function generateUnknownKeySuggestions(
+  unknownKeys: readonly string[],
+  expectedKeys: readonly string[],
+  config: SuggestionConfig
+): readonly UnknownKeySuggestion[] {
+  const suggestions: UnknownKeySuggestion[] = [];
+
+  for (const unknownKey of unknownKeys) {
+    const match = findClosestMatch(unknownKey, expectedKeys, config.similarityThreshold);
+    if (match) {
+      suggestions.push({
+        kind: 'unknown_key',
+        provided: unknownKey,
+        didYouMean: match.match,
+        similarity: match.score,
+      });
+    }
+  }
+
+  // Sort by similarity descending for consistent output
+  suggestions.sort((a, b) => b.similarity - a.similarity);
+
+  return suggestions.slice(0, config.maxSuggestions);
+}
+
+/**
+ * Generate missing required parameter suggestions.
+ *
+ * @param missingKeys - Required keys that weren't provided
+ * @param schema - The Zod schema (for generating examples)
+ * @param config - Suggestion configuration
+ * @returns Array of missing required suggestions
+ */
+function generateMissingRequiredSuggestions(
+  missingKeys: readonly string[],
+  schema: z.ZodType,
+  config: SuggestionConfig
+): readonly MissingRequiredSuggestion[] {
+  if (!(schema instanceof z.ZodObject)) {
+    return [];
+  }
+
+  const shape = schema._def.shape();
+  const suggestions: MissingRequiredSuggestion[] = [];
+
+  for (const key of missingKeys) {
+    const field = shape[key] as z.ZodType | undefined;
+    if (field) {
+      suggestions.push({
+        kind: 'missing_required',
+        param: key,
+        example: generateExampleValue(field, 0, config.maxTemplateDepth),
+      });
+    }
+  }
+
+  // Sort alphabetically for consistent output
+  suggestions.sort((a, b) => a.param.localeCompare(b.param));
+
+  return suggestions.slice(0, config.maxSuggestions);
+}
+
+/**
+ * Generate all suggestions for invalid input.
+ *
+ * This is the main entry point that combines all suggestion types.
+ *
+ * @param args - The invalid input arguments
+ * @param schema - The expected Zod schema
+ * @param config - Suggestion configuration
+ * @returns Immutable suggestion result
+ */
+export function generateSuggestions(
+  args: unknown,
+  schema: z.ZodType,
+  config: SuggestionConfig
+): SuggestionResult {
+  const suggestions: ValidationSuggestion[] = [];
+
+  // Get expected keys for matching
+  const expectedKeys = extractExpectedKeys(schema);
+
+  // Find and suggest corrections for unknown keys
+  const unknownKeys = findUnknownKeys(args, schema);
+  const unknownKeySuggestions = generateUnknownKeySuggestions(
+    unknownKeys,
+    expectedKeys,
+    config
+  );
+  suggestions.push(...unknownKeySuggestions);
+
+  // Find and suggest missing required keys
+  const missingKeys = findMissingRequiredKeys(args, schema);
+  const missingRequiredSuggestions = generateMissingRequiredSuggestions(
+    missingKeys,
+    schema,
+    config
+  );
+  suggestions.push(...missingRequiredSuggestions);
+
+  // Return empty result if no suggestions
+  if (suggestions.length === 0 && !config.includeTemplate) {
+    return EMPTY_SUGGESTION_RESULT;
+  }
+
+  // Generate template if configured
+  const correctTemplate = config.includeTemplate
+    ? generateTemplate(schema, config.maxTemplateDepth)
+    : null;
+
+  return {
+    suggestions,
+    correctTemplate,
+  };
+}
+
+/**
+ * Format suggestion result for inclusion in error details.
+ *
+ * Creates a plain object suitable for JSON serialization.
+ *
+ * @param result - The suggestion result to format
+ * @returns Object to spread into error details (may be empty)
+ */
+export function formatSuggestionDetails(
+  result: SuggestionResult
+): Record<string, unknown> {
+  const details: Record<string, unknown> = {};
+
+  if (result.suggestions.length > 0) {
+    details.suggestions = result.suggestions.map(s => {
+      switch (s.kind) {
+        case 'unknown_key':
+          return {
+            kind: s.kind,
+            provided: s.provided,
+            didYouMean: s.didYouMean,
+            similarity: Math.round(s.similarity * 100) / 100, // Round for readability
+          };
+        case 'missing_required':
+          return {
+            kind: s.kind,
+            param: s.param,
+            example: s.example,
+          };
+        case 'invalid_enum':
+          return {
+            kind: s.kind,
+            path: s.path,
+            provided: s.provided,
+            didYouMean: s.didYouMean,
+            allowedValues: s.allowedValues,
+          };
+      }
+    });
+  }
+
+  if (result.correctTemplate !== null) {
+    details.correctTemplate = result.correctTemplate;
+  }
+
+  return details;
+}
+
+/**
+ * Check if a suggestion result has any meaningful content.
+ *
+ * @param result - The suggestion result to check
+ * @returns True if there are suggestions or a template
+ */
+export function hasSuggestions(result: SuggestionResult): boolean {
+  return result.suggestions.length > 0 || result.correctTemplate !== null;
+}

--- a/src/mcp/validation/suggestion-types.ts
+++ b/src/mcp/validation/suggestion-types.ts
@@ -1,0 +1,109 @@
+/**
+ * Domain Types for Parameter Suggestions
+ *
+ * Provides type-safe representations for validation suggestions.
+ * Uses branded types and discriminated unions to make illegal states unrepresentable.
+ *
+ * Philosophy:
+ * - Immutability by default
+ * - Explicit domain types over primitives
+ * - Exhaustiveness via discriminated unions
+ *
+ * @module mcp/validation/suggestion-types
+ */
+
+// -----------------------------------------------------------------------------
+// Branded Types
+// -----------------------------------------------------------------------------
+
+/**
+ * Similarity score: 0 (completely different) to 1 (identical).
+ * Branded to prevent accidental mixing with arbitrary numbers.
+ */
+export type Similarity = number & { readonly __brand: 'Similarity' };
+
+/**
+ * Create a Similarity value, clamping to valid range [0, 1].
+ */
+export function similarity(n: number): Similarity {
+  return Math.max(0, Math.min(1, n)) as Similarity;
+}
+
+// -----------------------------------------------------------------------------
+// Suggestion Discriminated Union
+// -----------------------------------------------------------------------------
+
+/**
+ * Suggestion for an unknown key that might be a typo.
+ */
+export interface UnknownKeySuggestion {
+  readonly kind: 'unknown_key';
+  readonly provided: string;
+  readonly didYouMean: string;
+  readonly similarity: Similarity;
+}
+
+/**
+ * Suggestion for a missing required parameter.
+ */
+export interface MissingRequiredSuggestion {
+  readonly kind: 'missing_required';
+  readonly param: string;
+  readonly example: unknown;
+}
+
+/**
+ * Suggestion for an invalid enum value.
+ */
+export interface InvalidEnumSuggestion {
+  readonly kind: 'invalid_enum';
+  readonly path: string;
+  readonly provided: string;
+  readonly didYouMean: string | null;
+  readonly allowedValues: readonly string[];
+}
+
+/**
+ * All suggestion kinds as exhaustive discriminated union.
+ * Adding a new kind requires handling in all switch/match expressions.
+ */
+export type ValidationSuggestion =
+  | UnknownKeySuggestion
+  | MissingRequiredSuggestion
+  | InvalidEnumSuggestion;
+
+// -----------------------------------------------------------------------------
+// Result Types
+// -----------------------------------------------------------------------------
+
+/**
+ * Immutable result of suggestion generation.
+ */
+export interface SuggestionResult {
+  readonly suggestions: readonly ValidationSuggestion[];
+  readonly correctTemplate: Readonly<Record<string, unknown>> | null;
+}
+
+/**
+ * Empty suggestion result (no suggestions).
+ */
+export const EMPTY_SUGGESTION_RESULT: SuggestionResult = {
+  suggestions: [],
+  correctTemplate: null,
+} as const;
+
+// -----------------------------------------------------------------------------
+// Type Guards (for exhaustive handling)
+// -----------------------------------------------------------------------------
+
+export function isUnknownKeySuggestion(s: ValidationSuggestion): s is UnknownKeySuggestion {
+  return s.kind === 'unknown_key';
+}
+
+export function isMissingRequiredSuggestion(s: ValidationSuggestion): s is MissingRequiredSuggestion {
+  return s.kind === 'missing_required';
+}
+
+export function isInvalidEnumSuggestion(s: ValidationSuggestion): s is InvalidEnumSuggestion {
+  return s.kind === 'invalid_enum';
+}

--- a/tests/architecture/schema-consistency.test.ts
+++ b/tests/architecture/schema-consistency.test.ts
@@ -1,0 +1,538 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+// v1 workflow tool schemas
+import {
+  WorkflowListInput,
+  WorkflowGetInput,
+  WorkflowNextInput,
+  WorkflowValidateJsonInput,
+  WorkflowGetSchemaInput,
+  WORKFLOW_TOOL_ANNOTATIONS,
+  // Session tools
+  CreateSessionInput,
+  UpdateSessionInput,
+  ReadSessionInput,
+  OpenDashboardInput,
+  createSessionTool,
+  updateSessionTool,
+  readSessionTool,
+  openDashboardTool,
+} from '../../src/mcp/tools.js';
+
+// v2 workflow tool schemas
+import {
+  V2ListWorkflowsInput,
+  V2InspectWorkflowInput,
+  V2StartWorkflowInput,
+  V2ContinueWorkflowInput,
+  V2_TOOL_ANNOTATIONS,
+} from '../../src/mcp/v2/tools.js';
+
+// Tool descriptions
+import { DESCRIPTIONS } from '../../src/mcp/tool-descriptions.js';
+
+/**
+ * Schema Consistency Architecture Tests
+ * 
+ * Purpose: Prevent agent confusion from inconsistent tool schemas.
+ * 
+ * Design Lock Reference: docs/design/v2-core-design-locks.md
+ * - Section 8: Tools vs docs alignment locks (anti-drift)
+ * - Section 12: Unified error envelope
+ * - Section 16.5D: Anti-drift enforcement (exact MCP tool registry)
+ * 
+ * These tests enforce:
+ * 1. Consistent parameter naming across all tools
+ * 2. No snake_case parameters (agents may normalize incorrectly)
+ * 3. All parameters have descriptions
+ * 4. Type consistency for shared concepts
+ * 5. Annotation consistency (readOnly, idempotent, etc.)
+ * 6. Description-schema alignment
+ * 7. V2 tool idempotency contracts (Section 1.2)
+ */
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+interface SchemaInfo {
+  name: string;
+  schema: z.ZodType;
+  hasWorkflowIdConcept: boolean;
+}
+
+/** All workflow-related input schemas that may reference a workflow ID */
+const WORKFLOW_SCHEMAS: SchemaInfo[] = [
+  { name: 'WorkflowGetInput', schema: WorkflowGetInput, hasWorkflowIdConcept: true },
+  { name: 'WorkflowNextInput', schema: WorkflowNextInput, hasWorkflowIdConcept: true },
+  { name: 'WorkflowValidateJsonInput', schema: WorkflowValidateJsonInput, hasWorkflowIdConcept: false },
+  { name: 'WorkflowGetSchemaInput', schema: WorkflowGetSchemaInput, hasWorkflowIdConcept: false },
+  { name: 'WorkflowListInput', schema: WorkflowListInput, hasWorkflowIdConcept: false },
+  { name: 'V2InspectWorkflowInput', schema: V2InspectWorkflowInput, hasWorkflowIdConcept: true },
+  { name: 'V2StartWorkflowInput', schema: V2StartWorkflowInput, hasWorkflowIdConcept: true },
+  { name: 'V2ContinueWorkflowInput', schema: V2ContinueWorkflowInput, hasWorkflowIdConcept: false },
+  { name: 'V2ListWorkflowsInput', schema: V2ListWorkflowsInput, hasWorkflowIdConcept: false },
+];
+
+/** All session-related input schemas */
+const SESSION_SCHEMAS: SchemaInfo[] = [
+  { name: 'CreateSessionInput', schema: CreateSessionInput, hasWorkflowIdConcept: true },
+  { name: 'UpdateSessionInput', schema: UpdateSessionInput, hasWorkflowIdConcept: true },
+  { name: 'ReadSessionInput', schema: ReadSessionInput, hasWorkflowIdConcept: true },
+  { name: 'OpenDashboardInput', schema: OpenDashboardInput, hasWorkflowIdConcept: false },
+];
+
+const ALL_SCHEMAS = [...WORKFLOW_SCHEMAS, ...SESSION_SCHEMAS];
+
+/** Extract parameter names from a Zod object schema */
+function getParameterNames(schema: z.ZodType): string[] {
+  if (schema instanceof z.ZodObject) {
+    return Object.keys(schema._def.shape());
+  }
+  return [];
+}
+
+/** Extract parameter info including description from a Zod object schema */
+function getParameterInfo(schema: z.ZodType): Map<string, { description?: string; type: string }> {
+  const result = new Map<string, { description?: string; type: string }>();
+  
+  if (schema instanceof z.ZodObject) {
+    const shape = schema._def.shape();
+    for (const [key, value] of Object.entries(shape)) {
+      const zodValue = value as z.ZodType;
+      result.set(key, {
+        description: zodValue._def.description,
+        type: zodValue._def.typeName || 'unknown',
+      });
+    }
+  }
+  
+  return result;
+}
+
+/** Check if a string uses snake_case */
+function isSnakeCase(str: string): boolean {
+  return str.includes('_');
+}
+
+// -----------------------------------------------------------------------------
+// Test: Workflow ID Parameter Consistency
+// -----------------------------------------------------------------------------
+
+describe('Workflow ID parameter consistency', () => {
+  it('all schemas with workflow ID concept must use "workflowId" (not "id" or "workflow_id")', () => {
+    const schemasWithWorkflowId = ALL_SCHEMAS.filter(s => s.hasWorkflowIdConcept);
+    
+    for (const { name, schema } of schemasWithWorkflowId) {
+      const params = getParameterNames(schema);
+      
+      // Must have workflowId
+      expect(params, `${name} must have "workflowId" parameter`).toContain('workflowId');
+      
+      // Must NOT have "id" alone (ambiguous)
+      expect(params, `${name} must not use bare "id" (use "workflowId" instead)`).not.toContain('id');
+      
+      // Must NOT have snake_case variant
+      expect(params, `${name} must not use "workflow_id" (use "workflowId" instead)`).not.toContain('workflow_id');
+    }
+  });
+
+  it('schemas without workflow ID concept must not have stray ID parameters', () => {
+    const schemasWithoutWorkflowId = ALL_SCHEMAS.filter(s => !s.hasWorkflowIdConcept);
+    
+    for (const { name, schema } of schemasWithoutWorkflowId) {
+      const params = getParameterNames(schema);
+      
+      // Should not have workflow_id (snake_case is always wrong)
+      expect(params, `${name} has unexpected "workflow_id" parameter`).not.toContain('workflow_id');
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Test: No Snake Case Parameters
+// -----------------------------------------------------------------------------
+
+describe('Parameter naming conventions', () => {
+  it('all parameters must use camelCase (no snake_case)', () => {
+    const violations: string[] = [];
+    
+    for (const { name, schema } of ALL_SCHEMAS) {
+      const params = getParameterNames(schema);
+      
+      for (const param of params) {
+        if (isSnakeCase(param)) {
+          violations.push(`${name}.${param}`);
+        }
+      }
+    }
+    
+    if (violations.length > 0) {
+      expect.fail(
+        `Snake_case parameters found (agents may normalize incorrectly):\n` +
+        violations.map(v => `  - ${v}`).join('\n') +
+        `\n\nUse camelCase instead (e.g., "workflowId" not "workflow_id")`
+      );
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Test: All Parameters Must Have Descriptions
+// -----------------------------------------------------------------------------
+
+describe('Parameter documentation', () => {
+  it('all parameters must have .describe() set', () => {
+    const undocumented: string[] = [];
+    
+    for (const { name, schema } of ALL_SCHEMAS) {
+      const paramInfo = getParameterInfo(schema);
+      
+      for (const [paramName, info] of paramInfo) {
+        if (!info.description || info.description.trim() === '') {
+          undocumented.push(`${name}.${paramName}`);
+        }
+      }
+    }
+    
+    if (undocumented.length > 0) {
+      expect.fail(
+        `Parameters without descriptions (agents rely on these):\n` +
+        undocumented.map(p => `  - ${p}`).join('\n') +
+        `\n\nAdd .describe('...') to each parameter.`
+      );
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Test: Type Consistency for Shared Concepts
+// -----------------------------------------------------------------------------
+
+describe('Type consistency across tools', () => {
+  it('context parameter must be Record<string, unknown> everywhere', () => {
+    const schemasWithContext = ALL_SCHEMAS.filter(({ schema }) => {
+      const params = getParameterNames(schema);
+      return params.includes('context');
+    });
+    
+    for (const { name, schema } of schemasWithContext) {
+      if (schema instanceof z.ZodObject) {
+        const shape = schema._def.shape();
+        const contextField = shape.context as z.ZodType;
+        
+        // Unwrap optional if present
+        const innerType = contextField instanceof z.ZodOptional 
+          ? contextField._def.innerType 
+          : contextField;
+        
+        expect(
+          innerType instanceof z.ZodRecord,
+          `${name}.context must be a Record type`
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('workflowId must have consistent validation pattern', () => {
+    const schemasWithWorkflowId = ALL_SCHEMAS.filter(s => s.hasWorkflowIdConcept);
+    const patterns: Map<string, string> = new Map();
+    
+    for (const { name, schema } of schemasWithWorkflowId) {
+      if (schema instanceof z.ZodObject) {
+        const shape = schema._def.shape();
+        const workflowIdField = shape.workflowId as z.ZodType;
+        
+        // Extract pattern if it's a string with regex check
+        if (workflowIdField instanceof z.ZodString) {
+          const regexCheck = workflowIdField._def.checks?.find(
+            (c: { kind: string }) => c.kind === 'regex'
+          );
+          if (regexCheck && 'regex' in regexCheck) {
+            patterns.set(name, (regexCheck as { regex: RegExp }).regex.source);
+          } else {
+            patterns.set(name, '(no pattern)');
+          }
+        }
+      }
+    }
+    
+    // All patterns should be the same (or all should have no pattern)
+    const uniquePatterns = new Set(patterns.values());
+    if (uniquePatterns.size > 1) {
+      const patternList = Array.from(patterns.entries())
+        .map(([schema, pattern]) => `  - ${schema}: ${pattern}`)
+        .join('\n');
+      
+      expect.fail(
+        `Inconsistent workflowId validation patterns:\n${patternList}\n\n` +
+        `All workflowId fields should use the same pattern for consistency.`
+      );
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Test: Tool Annotation Consistency
+// -----------------------------------------------------------------------------
+
+describe('Tool annotation consistency', () => {
+  const READ_ONLY_V1_TOOLS = ['discover_workflows', 'preview_workflow', 'get_workflow_schema'];
+  const READ_ONLY_V2_TOOLS = ['list_workflows', 'inspect_workflow'];
+  
+  it('read-only v1 tools must have readOnlyHint: true', () => {
+    for (const tool of READ_ONLY_V1_TOOLS) {
+      const annotations = WORKFLOW_TOOL_ANNOTATIONS[tool as keyof typeof WORKFLOW_TOOL_ANNOTATIONS];
+      expect(
+        annotations?.readOnlyHint,
+        `${tool} should have readOnlyHint: true`
+      ).toBe(true);
+    }
+  });
+
+  it('read-only v2 tools must have readOnlyHint: true', () => {
+    for (const tool of READ_ONLY_V2_TOOLS) {
+      const annotations = V2_TOOL_ANNOTATIONS[tool as keyof typeof V2_TOOL_ANNOTATIONS];
+      expect(
+        annotations?.readOnlyHint,
+        `${tool} should have readOnlyHint: true`
+      ).toBe(true);
+    }
+  });
+
+  it('mutating tools must have readOnlyHint: false', () => {
+    // Note: validate_workflow is read-only (it only validates, doesn't mutate)
+    const mutatingV1 = ['advance_workflow'];
+    const mutatingV2 = ['start_workflow', 'continue_workflow'];
+    
+    for (const tool of mutatingV1) {
+      const annotations = WORKFLOW_TOOL_ANNOTATIONS[tool as keyof typeof WORKFLOW_TOOL_ANNOTATIONS];
+      expect(
+        annotations?.readOnlyHint,
+        `${tool} should have readOnlyHint: false`
+      ).toBe(false);
+    }
+    
+    for (const tool of mutatingV2) {
+      const annotations = V2_TOOL_ANNOTATIONS[tool as keyof typeof V2_TOOL_ANNOTATIONS];
+      expect(
+        annotations?.readOnlyHint,
+        `${tool} should have readOnlyHint: false`
+      ).toBe(false);
+    }
+  });
+
+  it('session read tool must have readOnlyHint: true', () => {
+    expect(readSessionTool.annotations.readOnlyHint).toBe(true);
+  });
+
+  it('session write tools must have readOnlyHint: false', () => {
+    expect(createSessionTool.annotations.readOnlyHint).toBe(false);
+    expect(updateSessionTool.annotations.readOnlyHint).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Test: Description-Schema Alignment
+// -----------------------------------------------------------------------------
+
+describe('Description-schema alignment', () => {
+  const TOOLS_WITH_REQUIRED_PARAMS: Array<{
+    tool: string;
+    requiredParams: string[];
+    description: string;
+  }> = [
+    {
+      tool: 'advance_workflow',
+      requiredParams: ['workflowId', 'state'],
+      description: DESCRIPTIONS.standard.advance_workflow,
+    },
+    {
+      tool: 'preview_workflow',
+      requiredParams: ['workflowId'],
+      description: DESCRIPTIONS.standard.preview_workflow,
+    },
+  ];
+
+  it('tool descriptions must mention all required parameters', () => {
+    const missingMentions: string[] = [];
+    
+    for (const { tool, requiredParams, description } of TOOLS_WITH_REQUIRED_PARAMS) {
+      for (const param of requiredParams) {
+        // Check if param is mentioned in description (case-insensitive word boundary)
+        const mentioned = new RegExp(`\\b${param}\\b`, 'i').test(description);
+        if (!mentioned) {
+          missingMentions.push(`${tool}: missing mention of "${param}"`);
+        }
+      }
+    }
+    
+    if (missingMentions.length > 0) {
+      expect.fail(
+        `Tool descriptions don't mention required parameters:\n` +
+        missingMentions.map(m => `  - ${m}`).join('\n') +
+        `\n\nUpdate tool descriptions to document required parameters.`
+      );
+    }
+  });
+
+  it('authoritative mode descriptions must also mention required parameters', () => {
+    const missingMentions: string[] = [];
+    
+    for (const { tool, requiredParams } of TOOLS_WITH_REQUIRED_PARAMS) {
+      const description = DESCRIPTIONS.authoritative[tool as keyof typeof DESCRIPTIONS.authoritative];
+      
+      for (const param of requiredParams) {
+        const mentioned = new RegExp(`\\b${param}\\b`, 'i').test(description);
+        if (!mentioned) {
+          missingMentions.push(`${tool} (authoritative): missing mention of "${param}"`);
+        }
+      }
+    }
+    
+    if (missingMentions.length > 0) {
+      expect.fail(
+        `Authoritative descriptions don't mention required parameters:\n` +
+        missingMentions.map(m => `  - ${m}`).join('\n')
+      );
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Test: V1/V2 Tool Relationship
+// -----------------------------------------------------------------------------
+
+describe('V1/V2 tool relationship', () => {
+  // V2 tools are feature-flagged and intentionally overlap with v1.
+  // They use the same names because v2 is the replacement surface.
+  // The server only exposes one or the other based on feature flags.
+  
+  const V1_ONLY_TOOLS = ['discover_workflows', 'preview_workflow', 'advance_workflow', 'validate_workflow', 'get_workflow_schema'];
+  const V2_ONLY_TOOLS = ['list_workflows', 'inspect_workflow', 'start_workflow', 'continue_workflow'];
+  
+  it('v1-only tools must not appear in v2 registry', () => {
+    const v2Tools = Object.keys(V2_TOOL_ANNOTATIONS);
+    
+    for (const v1Tool of V1_ONLY_TOOLS) {
+      expect(v2Tools, `${v1Tool} should not be in v2 registry`).not.toContain(v1Tool);
+    }
+  });
+  
+  it('v2-only tools must not appear in v1 workflow annotations', () => {
+    // V2 tools should only be in v2 annotations, not v1
+    // Note: WORKFLOW_TOOL_ANNOTATIONS includes both v1 and v2 for completeness
+    // This test verifies v2 tools have their own dedicated registry
+    for (const v2Tool of V2_ONLY_TOOLS) {
+      expect(V2_TOOL_ANNOTATIONS[v2Tool as keyof typeof V2_TOOL_ANNOTATIONS]).toBeDefined();
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Test: V2 Idempotency Contracts (Design Lock Section 1.2)
+// -----------------------------------------------------------------------------
+
+describe('V2 idempotency contracts (Section 1.2)', () => {
+  /**
+   * Design Lock Reference: docs/design/v2-core-design-locks.md Section 1.2
+   * 
+   * - continue_workflow (with ackToken) is idempotent (replay-safe)
+   * - Rehydrate-only (without ackToken) is side-effect-free
+   */
+  
+  it('continue_workflow must have idempotentHint: true (replay-safe per Section 1.2)', () => {
+    const annotations = V2_TOOL_ANNOTATIONS.continue_workflow;
+    expect(
+      annotations.idempotentHint,
+      'continue_workflow must be idempotent per design lock Section 1.2'
+    ).toBe(true);
+  });
+
+  it('start_workflow must have idempotentHint: false (creates new runs)', () => {
+    const annotations = V2_TOOL_ANNOTATIONS.start_workflow;
+    expect(
+      annotations.idempotentHint,
+      'start_workflow creates new runs and is not idempotent'
+    ).toBe(false);
+  });
+
+  it('read-only v2 tools must have idempotentHint: true', () => {
+    expect(V2_TOOL_ANNOTATIONS.list_workflows.idempotentHint).toBe(true);
+    expect(V2_TOOL_ANNOTATIONS.inspect_workflow.idempotentHint).toBe(true);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Test: Locked V2 Tool Surface (Design Lock Section 16.5D)
+// -----------------------------------------------------------------------------
+
+describe('Locked v2 tool surface (Section 16.5D)', () => {
+  /**
+   * Design Lock Reference: docs/design/v2-core-design-locks.md Section 16.5 Sub-phase D
+   * 
+   * > Assert the exposed tool set is exactly the locked list (core + flagged)
+   * > Prevent accidental "projection MCP tools" from being added
+   */
+  
+  const LOCKED_V2_CORE_TOOLS = [
+    'list_workflows',
+    'inspect_workflow',
+    'start_workflow',
+    'continue_workflow',
+  ] as const;
+
+  it('v2 tool registry must match exactly the locked core tool list', () => {
+    const registeredTools = Object.keys(V2_TOOL_ANNOTATIONS).sort();
+    const lockedTools = [...LOCKED_V2_CORE_TOOLS].sort();
+    
+    expect(registeredTools).toEqual(lockedTools);
+  });
+
+  it('no projection tools must leak to MCP (Section 6 lock)', () => {
+    // Design Lock Section 6: "Do not add MCP tools for projections"
+    const forbiddenPatterns = [
+      /^project_/,      // projectRunDag, projectGaps, etc.
+      /^get_session$/,  // Direct session access
+      /^list_sessions$/,// Session enumeration
+      /^derive_/,       // Derived projections
+    ];
+    
+    const v2Tools = Object.keys(V2_TOOL_ANNOTATIONS);
+    for (const tool of v2Tools) {
+      for (const pattern of forbiddenPatterns) {
+        expect(tool, `Tool "${tool}" matches forbidden pattern ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Test: Token Parameter Consistency (Design Lock Section 1.2)
+// -----------------------------------------------------------------------------
+
+describe('Token parameter consistency (Section 1.2)', () => {
+  /**
+   * Design Lock Reference: docs/design/v2-core-design-locks.md Section 1.2
+   * 
+   * V2ContinueWorkflowInput must have:
+   * - stateToken (opaque, required)
+   * - ackToken (opaque, optional for rehydrate-only)
+   */
+  
+  it('V2ContinueWorkflowInput must have stateToken and ackToken parameters', () => {
+    const params = getParameterNames(V2ContinueWorkflowInput);
+    
+    expect(params, 'V2ContinueWorkflowInput must have stateToken').toContain('stateToken');
+    expect(params, 'V2ContinueWorkflowInput must have ackToken').toContain('ackToken');
+  });
+
+  it('token parameters must not use snake_case', () => {
+    const params = getParameterNames(V2ContinueWorkflowInput);
+    
+    // Verify no snake_case variants
+    expect(params).not.toContain('state_token');
+    expect(params).not.toContain('ack_token');
+  });
+});

--- a/tests/unit/parameter-suggestions.test.ts
+++ b/tests/unit/parameter-suggestions.test.ts
@@ -1,0 +1,417 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+import {
+  // String similarity
+  levenshteinDistance,
+  computeSimilarity,
+  computeSimilarityIgnoreCase,
+  findClosestMatch,
+  findAllMatches,
+  similarity,
+  // Schema introspection
+  extractExpectedKeys,
+  extractRequiredKeys,
+  findUnknownKeys,
+  findMissingRequiredKeys,
+  generateExampleValue,
+  generateTemplate,
+  // Suggestion generation
+  generateSuggestions,
+  formatSuggestionDetails,
+  hasSuggestions,
+  DEFAULT_SUGGESTION_CONFIG,
+  EMPTY_SUGGESTION_RESULT,
+} from '../../src/mcp/validation/index.js';
+
+// -----------------------------------------------------------------------------
+// Test Schemas (use REAL Zod schemas, not mocks)
+// -----------------------------------------------------------------------------
+
+const SimpleSchema = z.object({
+  workflowId: z.string().describe('The workflow ID'),
+  mode: z.enum(['metadata', 'preview']).default('preview'),
+});
+
+const ComplexSchema = z.object({
+  workflowId: z.string().regex(/^[A-Za-z0-9_-]+$/).describe('Workflow identifier'),
+  state: z.discriminatedUnion('kind', [
+    z.object({ kind: z.literal('init') }),
+    z.object({
+      kind: z.literal('running'),
+      completed: z.array(z.string()),
+    }),
+    z.object({ kind: z.literal('complete') }),
+  ]).describe('Execution state'),
+  context: z.record(z.unknown()).optional().describe('External context'),
+});
+
+// -----------------------------------------------------------------------------
+// String Similarity Tests
+// -----------------------------------------------------------------------------
+
+describe('levenshteinDistance', () => {
+  it('returns 0 for identical strings', () => {
+    expect(levenshteinDistance('hello', 'hello')).toBe(0);
+  });
+
+  it('returns length for empty vs non-empty', () => {
+    expect(levenshteinDistance('', 'hello')).toBe(5);
+    expect(levenshteinDistance('hello', '')).toBe(5);
+  });
+
+  it('computes correct distance for single edit', () => {
+    expect(levenshteinDistance('cat', 'bat')).toBe(1); // substitution
+    expect(levenshteinDistance('cat', 'cats')).toBe(1); // insertion
+    expect(levenshteinDistance('cats', 'cat')).toBe(1); // deletion
+  });
+
+  it('computes correct distance for multiple edits', () => {
+    expect(levenshteinDistance('kitten', 'sitting')).toBe(3);
+    expect(levenshteinDistance('workflow_id', 'workflowId')).toBe(2);
+  });
+
+  it('is deterministic (same inputs, same output)', () => {
+    const d1 = levenshteinDistance('abc', 'xyz');
+    const d2 = levenshteinDistance('abc', 'xyz');
+    expect(d1).toBe(d2);
+  });
+});
+
+describe('computeSimilarity', () => {
+  it('returns 1.0 for identical strings', () => {
+    expect(computeSimilarity('hello', 'hello')).toBe(1);
+  });
+
+  it('returns 0.0 for completely different strings', () => {
+    expect(computeSimilarity('', 'hello')).toBe(0);
+    expect(computeSimilarity('hello', '')).toBe(0);
+  });
+
+  it('returns value between 0 and 1', () => {
+    const score = computeSimilarity('workflow_id', 'workflowId');
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(1);
+  });
+
+  it('handles snake_case to camelCase conversion', () => {
+    // workflow_id vs workflowId should have high similarity
+    const score = computeSimilarityIgnoreCase('workflow_id', 'workflowId');
+    expect(score).toBeGreaterThan(0.7);
+  });
+});
+
+describe('findClosestMatch', () => {
+  const candidates = ['workflowId', 'state', 'context', 'mode'];
+
+  it('finds exact match with score 1.0', () => {
+    const result = findClosestMatch('workflowId', candidates, similarity(0.5));
+    expect(result).not.toBeNull();
+    expect(result?.match).toBe('workflowId');
+    expect(result?.score).toBe(1);
+  });
+
+  it('finds close match for typo', () => {
+    const result = findClosestMatch('workflow_id', candidates, similarity(0.6));
+    expect(result).not.toBeNull();
+    expect(result?.match).toBe('workflowId');
+  });
+
+  it('returns null when no match meets threshold', () => {
+    const result = findClosestMatch('xyz', candidates, similarity(0.9));
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty candidates', () => {
+    const result = findClosestMatch('test', [], similarity(0.5));
+    expect(result).toBeNull();
+  });
+});
+
+describe('findAllMatches', () => {
+  const candidates = ['workflowId', 'workflowName', 'flowId', 'id'];
+
+  it('returns matches sorted by similarity descending', () => {
+    const matches = findAllMatches('workflowId', candidates, similarity(0.5), 10);
+    expect(matches.length).toBeGreaterThan(0);
+    // First should be exact match
+    expect(matches[0].match).toBe('workflowId');
+    expect(matches[0].score).toBe(1);
+  });
+
+  it('respects limit parameter', () => {
+    const matches = findAllMatches('work', candidates, similarity(0.3), 2);
+    expect(matches.length).toBeLessThanOrEqual(2);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Schema Introspection Tests
+// -----------------------------------------------------------------------------
+
+describe('extractExpectedKeys', () => {
+  it('extracts keys from object schema', () => {
+    const keys = extractExpectedKeys(SimpleSchema);
+    expect(keys).toContain('workflowId');
+    expect(keys).toContain('mode');
+  });
+
+  it('returns empty for non-object schema', () => {
+    const keys = extractExpectedKeys(z.string());
+    expect(keys).toEqual([]);
+  });
+});
+
+describe('extractRequiredKeys', () => {
+  it('extracts only required keys', () => {
+    const keys = extractRequiredKeys(SimpleSchema);
+    expect(keys).toContain('workflowId');
+    // mode has default, so not required
+    expect(keys).not.toContain('mode');
+  });
+
+  it('handles complex schemas', () => {
+    const keys = extractRequiredKeys(ComplexSchema);
+    expect(keys).toContain('workflowId');
+    expect(keys).toContain('state');
+    expect(keys).not.toContain('context'); // optional
+  });
+});
+
+describe('findUnknownKeys', () => {
+  it('finds keys not in schema', () => {
+    const args = { workflow_id: 'test', unknown_key: true };
+    const unknown = findUnknownKeys(args, SimpleSchema);
+    expect(unknown).toContain('workflow_id');
+    expect(unknown).toContain('unknown_key');
+    expect(unknown).not.toContain('workflowId');
+  });
+
+  it('returns empty for valid keys', () => {
+    const args = { workflowId: 'test', mode: 'preview' };
+    const unknown = findUnknownKeys(args, SimpleSchema);
+    expect(unknown).toEqual([]);
+  });
+
+  it('handles non-object args', () => {
+    const unknown = findUnknownKeys('string', SimpleSchema);
+    expect(unknown).toEqual([]);
+  });
+});
+
+describe('findMissingRequiredKeys', () => {
+  it('finds missing required keys', () => {
+    const args = { mode: 'preview' };
+    const missing = findMissingRequiredKeys(args, SimpleSchema);
+    expect(missing).toContain('workflowId');
+  });
+
+  it('returns empty when all required present', () => {
+    const args = { workflowId: 'test' };
+    const missing = findMissingRequiredKeys(args, SimpleSchema);
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('generateExampleValue', () => {
+  it('generates example for string', () => {
+    const example = generateExampleValue(z.string().describe('test field'));
+    expect(example).toBe('<test field>');
+  });
+
+  it('generates example for enum', () => {
+    const example = generateExampleValue(z.enum(['a', 'b', 'c']));
+    expect(example).toBe('a');
+  });
+
+  it('generates example for object', () => {
+    const example = generateExampleValue(SimpleSchema);
+    expect(typeof example).toBe('object');
+    expect(example).toHaveProperty('workflowId');
+  });
+
+  it('uses default value when available', () => {
+    const schemaWithDefault = z.string().default('default_value');
+    const example = generateExampleValue(schemaWithDefault);
+    expect(example).toBe('default_value');
+  });
+});
+
+describe('generateTemplate', () => {
+  it('generates template for object schema', () => {
+    const template = generateTemplate(SimpleSchema);
+    expect(template).not.toBeNull();
+    expect(template).toHaveProperty('workflowId');
+  });
+
+  it('returns null for non-object schema', () => {
+    const template = generateTemplate(z.string());
+    expect(template).toBeNull();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Suggestion Generation Tests
+// -----------------------------------------------------------------------------
+
+describe('generateSuggestions', () => {
+  it('suggests workflowId for workflow_id', () => {
+    const result = generateSuggestions(
+      { workflow_id: 'test' },
+      SimpleSchema,
+      DEFAULT_SUGGESTION_CONFIG
+    );
+
+    expect(result.suggestions.length).toBeGreaterThan(0);
+
+    const unknownKeySuggestion = result.suggestions.find(s => s.kind === 'unknown_key');
+    expect(unknownKeySuggestion).toBeDefined();
+    if (unknownKeySuggestion?.kind === 'unknown_key') {
+      expect(unknownKeySuggestion.provided).toBe('workflow_id');
+      expect(unknownKeySuggestion.didYouMean).toBe('workflowId');
+    }
+  });
+
+  it('suggests missing required parameters', () => {
+    const result = generateSuggestions(
+      {}, // Missing workflowId
+      SimpleSchema,
+      DEFAULT_SUGGESTION_CONFIG
+    );
+
+    const missingRequiredSuggestion = result.suggestions.find(
+      s => s.kind === 'missing_required'
+    );
+    expect(missingRequiredSuggestion).toBeDefined();
+    if (missingRequiredSuggestion?.kind === 'missing_required') {
+      expect(missingRequiredSuggestion.param).toBe('workflowId');
+    }
+  });
+
+  it('includes template when configured', () => {
+    const result = generateSuggestions(
+      { workflow_id: 'test' },
+      SimpleSchema,
+      DEFAULT_SUGGESTION_CONFIG
+    );
+
+    expect(result.correctTemplate).not.toBeNull();
+    expect(result.correctTemplate).toHaveProperty('workflowId');
+  });
+
+  it('returns empty result for valid input', () => {
+    const result = generateSuggestions(
+      { workflowId: 'test' },
+      SimpleSchema,
+      { ...DEFAULT_SUGGESTION_CONFIG, includeTemplate: false }
+    );
+
+    // No unknown keys, no missing required (mode has default)
+    expect(result.suggestions.length).toBe(0);
+  });
+
+  it('is deterministic (same inputs, same output)', () => {
+    const args = { workflow_id: 'test', extra_key: true };
+    
+    const result1 = generateSuggestions(args, SimpleSchema, DEFAULT_SUGGESTION_CONFIG);
+    const result2 = generateSuggestions(args, SimpleSchema, DEFAULT_SUGGESTION_CONFIG);
+    
+    expect(result1).toEqual(result2);
+  });
+});
+
+describe('formatSuggestionDetails', () => {
+  it('formats unknown key suggestions', () => {
+    const result = generateSuggestions(
+      { workflow_id: 'test' },
+      SimpleSchema,
+      DEFAULT_SUGGESTION_CONFIG
+    );
+    
+    const details = formatSuggestionDetails(result);
+    
+    expect(details).toHaveProperty('suggestions');
+    expect(Array.isArray(details.suggestions)).toBe(true);
+  });
+
+  it('includes correctTemplate in details', () => {
+    const result = generateSuggestions(
+      { workflow_id: 'test' },
+      SimpleSchema,
+      DEFAULT_SUGGESTION_CONFIG
+    );
+    
+    const details = formatSuggestionDetails(result);
+    
+    expect(details).toHaveProperty('correctTemplate');
+  });
+
+  it('returns empty object for empty result', () => {
+    const details = formatSuggestionDetails(EMPTY_SUGGESTION_RESULT);
+    expect(details).toEqual({});
+  });
+});
+
+describe('hasSuggestions', () => {
+  it('returns true when suggestions exist', () => {
+    const result = generateSuggestions(
+      { workflow_id: 'test' },
+      SimpleSchema,
+      DEFAULT_SUGGESTION_CONFIG
+    );
+    
+    expect(hasSuggestions(result)).toBe(true);
+  });
+
+  it('returns false for empty result', () => {
+    expect(hasSuggestions(EMPTY_SUGGESTION_RESULT)).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Integration-style Tests (with real WorkRail schemas)
+// -----------------------------------------------------------------------------
+
+describe('Real-world agent error scenarios', () => {
+  it('handles snake_case parameter naming (most common error)', () => {
+    // Simulating agent passing snake_case instead of camelCase
+    const badArgs = {
+      workflow_id: 'relocation-workflow-us',
+      user_input: 'I want to relocate...',
+    };
+    
+    const result = generateSuggestions(badArgs, ComplexSchema, DEFAULT_SUGGESTION_CONFIG);
+    
+    // Should suggest workflowId for workflow_id
+    const workflowIdSuggestion = result.suggestions.find(
+      s => s.kind === 'unknown_key' && s.provided === 'workflow_id'
+    );
+    expect(workflowIdSuggestion).toBeDefined();
+    if (workflowIdSuggestion?.kind === 'unknown_key') {
+      expect(workflowIdSuggestion.didYouMean).toBe('workflowId');
+    }
+    
+    // Should suggest missing required 'state' parameter
+    const stateSuggestion = result.suggestions.find(
+      s => s.kind === 'missing_required' && s.param === 'state'
+    );
+    expect(stateSuggestion).toBeDefined();
+  });
+
+  it('handles completely invented parameter names', () => {
+    const badArgs = {
+      user_query: 'test', // Completely wrong
+      data: {}, // Completely wrong
+    };
+    
+    const result = generateSuggestions(badArgs, SimpleSchema, DEFAULT_SUGGESTION_CONFIG);
+    
+    // Should suggest missing workflowId
+    const missing = result.suggestions.find(s => s.kind === 'missing_required');
+    expect(missing).toBeDefined();
+    
+    // Template should show correct structure
+    expect(result.correctTemplate).not.toBeNull();
+    expect(result.correctTemplate).toHaveProperty('workflowId');
+  });
+});


### PR DESCRIPTION
## Summary
- Standardize `workflowId` parameter naming across all tools (was `id` in `preview_workflow`)
- Add "did you mean?" suggestions when agents pass unrecognized parameters
- Add architectural tests enforcing schema consistency per design locks

## Problem
Agent passed `workflow_id` instead of `workflowId` due to inconsistent naming between tools (`preview_workflow` used `id`, `advance_workflow` used `workflowId`). Error messages provided no guidance for self-correction.

## Changes
- Rename `id` to `workflowId` in `WorkflowGetInput` and handler
- Add consistent regex patterns to v2 and session schemas
- Add `workflowId` to `preview_workflow` descriptions (both modes)
- Create `src/mcp/validation/` module with Levenshtein-based suggestion generator
- Add 22 schema consistency tests (Section 1.2, 8, 16.5D alignment)
- Add 42 parameter suggestion tests