### PR TITLE
fix(v2): Agent-friendly error messages, JCS undefined handling, and MCP boundary safety net

### DIFF
--- a/src/mcp/handlers/v2-advance-core/index.ts
+++ b/src/mcp/handlers/v2-advance-core/index.ts
@@ -41,6 +41,7 @@ import { EnhancedLoopValidator } from '../../../application/services/enhanced-lo
 
 import type { InternalError } from '../v2-error-mapping.js';
 import { toV1ExecutionState } from '../v2-state-conversion.js';
+import { internalSuggestion } from '../v2-execution-helpers.js';
 import { withTimeout } from '../shared/with-timeout.js';
 import { validateAdvanceInputs, type ValidatedAdvanceInputs } from './input-validation.js';
 import { buildBlockedOutcome } from './outcome-blocked.js';
@@ -214,8 +215,8 @@ export function executeAdvanceCore(args: {
       const outputRequirement = { kind: 'not_required' as const };
       const evalValidation: ValidationResult = {
         valid: false,
-        issues: [`Validation evaluation failed: ${phase.message}`],
-        suggestions: ['Check validation criteria for malformed rules or invalid schemas.'],
+        issues: ['WorkRail could not evaluate the validation criteria for this step. This is not caused by your output.'],
+        suggestions: [internalSuggestion('Retry your submission with the same output.', 'The validation criteria for this step may be misconfigured.')],
       };
 
       const ctx: AdvanceContext = { truth, sessionId, runId, currentNodeId, attemptId, workflowHash, inputOutput, pinnedWorkflow, engineState, pendingStep };

--- a/src/mcp/handlers/v2-execution/continue-advance.ts
+++ b/src/mcp/handlers/v2-execution/continue-advance.ts
@@ -183,8 +183,7 @@ export function handleAdvanceIntent(args: {
           if (isInternalError(cause)) {
             return {
               kind: 'invariant_violation' as const,
-              message: `Advance failed due to internal invariant violation: ${cause.kind}`,
-              suggestion: 'Retry; if this persists, treat as invariant violation.',
+              message: `Advance failed due to internal error: ${cause.kind}`,
             };
           }
           if (typeof cause === 'object' && cause !== null && 'code' in cause) {
@@ -196,8 +195,7 @@ export function handleAdvanceIntent(args: {
           }
           return {
             kind: 'invariant_violation' as const,
-            message: 'Advance failed with an unknown error shape (invariant violation).',
-            suggestion: 'Retry; if this persists, treat as invariant violation.',
+            message: 'Advance failed with an unknown error shape.',
           };
         })
         .andThen((res) => {
@@ -212,8 +210,7 @@ export function handleAdvanceIntent(args: {
           if (!recordedEvent) {
             return neErrorAsync({
               kind: 'invariant_violation' as const,
-              message: 'Missing recorded advance outcome after successful append (invariant violation).',
-              suggestion: 'Retry; if this persists, treat as invariant violation.',
+              message: 'Missing recorded advance outcome after successful append.',
             });
           }
 

--- a/src/mcp/handlers/v2-execution/continue-rehydrate.ts
+++ b/src/mcp/handlers/v2-execution/continue-rehydrate.ts
@@ -168,7 +168,6 @@ export function handleRehydrateIntent(args: {
             return neErrorAsync({
               kind: 'invariant_violation' as const,
               message: `Prompt rendering failed: ${metaRes.error.message}`,
-              suggestion: 'Retry; if this persists, treat as invariant violation.',
             });
           }
           

--- a/src/mcp/handlers/v2-execution/replay.ts
+++ b/src/mcp/handlers/v2-execution/replay.ts
@@ -316,8 +316,7 @@ export function replayFromRecordedAdvance(args: {
   if (!toNode) {
     return neErrorAsync({
       kind: 'invariant_violation' as const,
-      message: 'Missing node_created for advanced toNodeId (invariant violation).',
-      suggestion: 'Retry; if this persists, treat as invariant violation.',
+      message: 'Missing node_created for advanced toNodeId.',
     });
   }
 
@@ -328,8 +327,7 @@ export function replayFromRecordedAdvance(args: {
       if (!toSnapshot) {
         return neErrorAsync({
           kind: 'invariant_violation' as const,
-          message: 'Missing execution snapshot for advanced node (invariant violation).',
-          suggestion: 'Retry; if this persists, treat as invariant violation.',
+          message: 'Missing execution snapshot for advanced node.',
         });
       }
 

--- a/src/mcp/handlers/v2-execution/start.ts
+++ b/src/mcp/handlers/v2-execution/start.ts
@@ -92,7 +92,6 @@ export function loadAndPinWorkflow(args: {
             return neErrorAsync({
               kind: 'invariant_violation' as const,
               message: 'Failed to pin executable workflow snapshot (missing or invalid pinned workflow).',
-              suggestion: 'Retry start_workflow; if this persists, treat as invariant violation.',
             });
           }
           const pinnedWorkflow = createWorkflow(pinned.definition as WorkflowDefinition, createBundledSource());
@@ -224,6 +223,8 @@ export function buildInitialEvents(args: {
   }
 
   // Emit observation_recorded events for workspace anchors (WU2: observability)
+  // Note: observation_recorded has no scope (session-level, not run/node-level).
+  // Omit the scope field entirely rather than setting to undefined -- JCS rejects undefined.
   for (const obs of observations) {
     const obsEventId = idFactory.mintEventId();
     mutableEvents.push({
@@ -233,7 +234,6 @@ export function buildInitialEvents(args: {
       sessionId,
       kind: EVENT_KIND.OBSERVATION_RECORDED,
       dedupeKey: `observation_recorded:${sessionId}:${obs.key}`,
-      scope: undefined,
       data: {
         key: obs.key,
         value: obs.value,

--- a/src/v2/durable-core/canonical/jcs.ts
+++ b/src/v2/durable-core/canonical/jcs.ts
@@ -64,6 +64,11 @@ function renderNumber(value: number): Result<string, CanonicalJsonError> {
 function renderArray(values: readonly JsonValue[]): Result<string, CanonicalJsonError> {
   const parts: string[] = [];
   for (const v of values) {
+    // undefined in arrays becomes null (matching JSON.stringify behavior)
+    if (v === undefined) {
+      parts.push('null');
+      continue;
+    }
     const r = render(v);
     if (r.isErr()) return err(r.error);
     parts.push(r.value);
@@ -76,8 +81,11 @@ function renderObject(obj: JsonObject): Result<string, CanonicalJsonError> {
   const parts: string[] = [];
 
   for (const key of keys) {
+    const value = obj[key];
+    // Skip undefined values (matching JSON.stringify behavior -- undefined is not valid JSON)
+    if (value === undefined) continue;
     const keyJson = JSON.stringify(key);
-    const valueJson = render(obj[key]!);
+    const valueJson = render(value);
     if (valueJson.isErr()) return err(valueJson.error);
     parts.push(`${keyJson}:${valueJson.value}`);
   }

--- a/tests/unit/mcp-v2-replay-fact-returning.test.ts
+++ b/tests/unit/mcp-v2-replay-fact-returning.test.ts
@@ -237,7 +237,9 @@ describe('v2 replay is fact-returning and fail-closed (Phase 3)', () => {
       expect(res.type).toBe('error');
       if (res.type !== 'error') return;
       expect(res.code).toBe('INTERNAL_ERROR');
-      expect(res.message).toContain('Missing node_created for advanced toNodeId');
+      // Verify the error is agent-friendly (not leaking internal details)
+      expect(res.message).toBeTruthy();
+      expect(res.message).not.toContain('node_created'); // internal event name should not leak
     } finally {
       process.env.WORKRAIL_DATA_DIR = prev;
     }
@@ -399,9 +401,9 @@ describe('v2 replay is fact-returning and fail-closed (Phase 3)', () => {
       expect(res.type).toBe('error');
       if (res.type !== 'error') return;
       expect(['INTERNAL_ERROR', 'SESSION_NOT_HEALTHY']).toContain(res.code);
-      if (res.code === 'INTERNAL_ERROR') {
-        expect(res.message).toContain('Missing execution snapshot');
-      }
+      // Verify the error is agent-friendly (not leaking internal details)
+      expect(res.message).toBeTruthy();
+      expect(res.message).not.toContain('snapshot'); // internal store name should not leak
     } finally {
       process.env.WORKRAIL_DATA_DIR = prev;
     }

--- a/tests/unit/mcp-v2-replay-missing-snapshot.test.ts
+++ b/tests/unit/mcp-v2-replay-missing-snapshot.test.ts
@@ -260,9 +260,9 @@ describe('v2 replay fail-closed: missing snapshot', () => {
       expect(res.type).toBe('error');
       if (res.type !== 'error') return;
       expect(['INTERNAL_ERROR', 'SESSION_NOT_HEALTHY']).toContain(res.code);
-      if (res.code === 'INTERNAL_ERROR') {
-        expect(res.message).toContain('Missing execution snapshot');
-      }
+      // Verify the error is agent-friendly (not leaking internal details)
+      expect(res.message).toBeTruthy();
+      expect(res.message).not.toContain('snapshot'); // internal store name should not leak
     } finally {
       process.env.WORKRAIL_DATA_DIR = prev;
     }

--- a/tests/unit/mcp-v2-session-not-healthy.test.ts
+++ b/tests/unit/mcp-v2-session-not-healthy.test.ts
@@ -131,7 +131,8 @@ describe('v2 execution: SESSION_NOT_HEALTHY error response', () => {
       expect(result.details).toBeDefined();
       const envelope = result.details as any;
       expect(envelope.suggestion).toBeTruthy();
-      expect(envelope.suggestion).toContain('healthy session');
+      // Verify the suggestion is agent-actionable (tells agent what to do)
+      expect(envelope.suggestion).toContain('start_workflow');
       expect(envelope.details).toBeDefined();
       
       const details = envelope.details as SessionHealthDetails;


### PR DESCRIPTION
## Summary
- Rewrites all internal error messages to be agent-actionable with standard escalation guidance
- Fixes JCS canonicalizer crash on undefined values (root cause of start_workflow failure in real repos)
- Adds boundary try/catch in handler factory so unhandled exceptions never leak as raw errors
- Converts the last throw in v2 handlers to a typed error return

## Test plan
- [ ] All 2624 tests pass
- [ ] Run manual test plan scenarios A1-A5 against real repo to verify start_workflow no longer crashes
- [ ] Verify error envelope structure in blocked/retry scenarios