### PR TITLE
fix(v2): Auto-infer intent from ackToken and add nextCall to checkpoint response

### DIFF
--- a/src/mcp/handlers/v2-checkpoint.ts
+++ b/src/mcp/handlers/v2-checkpoint.ts
@@ -197,6 +197,7 @@ function replayCheckpoint(
   return okAsync(V2CheckpointWorkflowOutputSchema.parse({
     checkpointNodeId,
     stateToken: tokenResult.value,
+    nextCall: { tool: 'continue_workflow', params: { intent: 'rehydrate', stateToken: tokenResult.value } },
   }));
 }
 
@@ -283,6 +284,7 @@ function writeCheckpoint(
       return okAsync(V2CheckpointWorkflowOutputSchema.parse({
         checkpointNodeId: String(checkpointNodeId),
         stateToken: tokenResult.value,
+        nextCall: { tool: 'continue_workflow', params: { intent: 'rehydrate', stateToken: tokenResult.value } },
       }));
     });
 }

--- a/src/mcp/handlers/v2-execution/index.ts
+++ b/src/mcp/handlers/v2-execution/index.ts
@@ -39,14 +39,15 @@ import { handleAdvanceIntent } from './continue-advance.js';
 // Pure function: derives the pre-built continuation template from response values.
 // Tells the agent exactly what to call when done — no memory of tool descriptions needed.
 
-type NextCallTemplate = {
+type NextCallAdvance = {
   readonly tool: 'continue_workflow';
-  readonly params: {
-    readonly intent: 'advance';
-    readonly stateToken: string;
-    readonly ackToken: string;
-  };
+  readonly params: { readonly intent: 'advance'; readonly stateToken: string; readonly ackToken: string };
 };
+type NextCallRehydrate = {
+  readonly tool: 'continue_workflow';
+  readonly params: { readonly intent: 'rehydrate'; readonly stateToken: string };
+};
+type NextCallTemplate = NextCallAdvance | NextCallRehydrate;
 
 export function buildNextCall(args: {
   readonly stateToken: string;

--- a/tests/architecture/schema-consistency.test.ts
+++ b/tests/architecture/schema-consistency.test.ts
@@ -87,10 +87,14 @@ const ALL_SCHEMAS = [...WORKFLOW_SCHEMAS, ...SESSION_SCHEMAS];
 
 /** Extract parameter names from a Zod object schema */
 function getParameterNames(schema: z.ZodType): string[] {
-  // Unwrap ZodEffects layers (from .strict(), .superRefine(), .refine(), etc.)
+  // Unwrap ZodEffects (.strict(), .superRefine(), .transform()) and ZodPipeline (.pipe())
   let current: z.ZodType = schema;
   while (current instanceof z.ZodEffects) {
     current = current._def.schema;
+  }
+  // ZodPipeline wraps the input schema as `in`
+  if ((current as any)._def?.typeName === 'ZodPipeline') {
+    return getParameterNames((current as any)._def.in);
   }
   if (current instanceof z.ZodObject) {
     return Object.keys(current._def.shape());

--- a/tests/contract/v2-mcp-tools.contract.test.ts
+++ b/tests/contract/v2-mcp-tools.contract.test.ts
@@ -364,6 +364,7 @@ describe('checkpoint_workflow response contract', () => {
     const response = {
       checkpointNodeId: 'node_abc123',
       stateToken: VALID_STATE_TOKEN,
+      nextCall: { tool: 'continue_workflow', params: { intent: 'rehydrate', stateToken: VALID_STATE_TOKEN } },
     };
     expect(V2CheckpointWorkflowOutputSchema.safeParse(response).success).toBe(true);
   });

--- a/tests/unit/mcp-v2-continue-intent-validation.test.ts
+++ b/tests/unit/mcp-v2-continue-intent-validation.test.ts
@@ -89,17 +89,26 @@ describe('V2ContinueWorkflowInput boundary validation', () => {
     expect(result.success).toBe(false);
   });
 
-  // ── Missing intent ───────────────────────────────────────────────
+  // ── Intent auto-inference ───────────────────────────────────────
 
-  it('rejects input without intent field', () => {
+  it('auto-infers advance when intent omitted and ackToken present', () => {
     const result = V2ContinueWorkflowInput.safeParse({
       stateToken: 'st1abc',
       ackToken: 'ack1abc',
     });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const intentError = result.error.errors.find((e) => e.path.includes('intent'));
-      expect(intentError).toBeDefined();
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.intent).toBe('advance');
+    }
+  });
+
+  it('auto-infers rehydrate when intent omitted and ackToken absent', () => {
+    const result = V2ContinueWorkflowInput.safeParse({
+      stateToken: 'st1abc',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.intent).toBe('rehydrate');
     }
   });
 

--- a/tests/unit/v2/checkpoint-schema.test.ts
+++ b/tests/unit/v2/checkpoint-schema.test.ts
@@ -24,6 +24,7 @@ describe('V2CheckpointWorkflowOutputSchema', () => {
     const result = V2CheckpointWorkflowOutputSchema.safeParse({
       checkpointNodeId: 'chk-node-001',
       stateToken: VALID_STATE,
+      nextCall: { tool: 'continue_workflow', params: { intent: 'rehydrate', stateToken: VALID_STATE } },
     });
     expect(result.success).toBe(true);
   });


### PR DESCRIPTION
## Summary
- `intent` on `continue_workflow` is now optional -- auto-inferred from ackToken presence (ackToken present = advance, absent = rehydrate)
- `checkpoint_workflow` response now includes `nextCall` with a rehydrate template, completing the guidance chain
- `V2NextCallSchema` is a discriminated union: advance always has ackToken, rehydrate never does (illegal states unrepresentable)
- Tool descriptions updated in both standard and authoritative modes

## Test plan
- [ ] All 2627 tests pass locally
- [ ] Architecture snapshot tests updated for new schema structure
- [ ] Intent auto-inference tested with explicit and omitted values
- [ ] NextCall discriminated union tested: advance requires ackToken, rehydrate strips it

Co-Authored-By: Firebender <help@firebender.com>