### PR TITLE
fix(validation): Restore optional fields to correctTemplate on wrong-type error

### DIFF
--- a/src/mcp/v2/tools.ts
+++ b/src/mcp/v2/tools.ts
@@ -12,7 +12,7 @@ export type V2InspectWorkflowInput = z.infer<typeof V2InspectWorkflowInput>;
 
 export const V2StartWorkflowInput = z.object({
   workflowId: z.string().min(1).regex(/^[A-Za-z0-9_-]+$/, 'Workflow ID must contain only letters, numbers, hyphens, and underscores').describe('The workflow ID to start'),
-  context: z.record(z.unknown()).optional().describe('External facts influencing execution (ticketId, branch, constraints). Pass once at start to establish baseline. WorkRail auto-loads context on subsequent continue_workflow calls. Only pass context again if facts have CHANGED (e.g., user provided new information). Do NOT re-pass unchanged values.'),
+  context: z.record(z.unknown()).optional().describe('Structured context for this workflow — must be a JSON OBJECT with string keys, NOT a string. For design/analysis workflows: {"problem":"describe the problem","constraints":"...","goals":"..."}. For coding workflows: {"ticketId":"ACEI-1234","branch":"main"}. WorkRail injects these into step prompts. Pass once at start; re-pass only values that have CHANGED.'),
   workspacePath: z.string()
     .refine((p) => p.startsWith('/'), 'workspacePath must be an absolute path (starting with /)')
     .optional()

--- a/src/mcp/validation/index.ts
+++ b/src/mcp/validation/index.ts
@@ -54,4 +54,6 @@ export {
   generateSuggestions,
   formatSuggestionDetails,
   hasSuggestions,
+  patchTemplateForFailedOptionals,
 } from './suggestion-generator.js';
+export type { ZodIssue } from './suggestion-generator.js';


### PR DESCRIPTION
## Summary

- When an agent passes `context: "long string"` instead of `context: {}`, the validation error returned a `correctTemplate` containing only required fields — `context` was absent, so agents inferred they should drop it on retry
- Add `patchTemplateForFailedOptionals()` — pure function that adds example values for optional fields that were provided with the wrong type, so the template shows the correct format rather than implying "remove this field"
- Update `context` field description to explicitly say it must be a JSON object (not a string) and give concrete examples for both design/analysis and coding workflows

## Test plan

- 5 new unit tests in `parameter-suggestions.test.ts` covering: restores wrong-type optional, doesn't add unprovided fields, doesn't overwrite already-present fields, handles null template, returns same ref when no patching needed
- 2659 tests passing