### PR TITLE
fix(v2): Replace schema duck-typing with canonical shape schemas

### DIFF
--- a/src/mcp/v2/tool-registry.ts
+++ b/src/mcp/v2/tool-registry.ts
@@ -16,6 +16,7 @@ import { createHandler } from '../handler-factory.js';
 import {
   V2CheckpointWorkflowInput,
   V2ContinueWorkflowInput,
+  V2ContinueWorkflowInputShape,
   V2InspectWorkflowInput,
   V2ListWorkflowsInput,
   V2ResumeSessionInput,
@@ -93,7 +94,8 @@ export function buildV2ToolRegistry(buildTool: ToolBuilder): V2ToolRegistration 
     list_workflows: createHandler(V2ListWorkflowsInput, handleV2ListWorkflows),
     inspect_workflow: createHandler(V2InspectWorkflowInput, handleV2InspectWorkflow),
     start_workflow: createHandler(V2StartWorkflowInput, handleV2StartWorkflow),
-    continue_workflow: createHandler(V2ContinueWorkflowInput, handleV2ContinueWorkflow),
+    // continue_workflow uses separate shape schema for introspection (canonical source)
+    continue_workflow: createHandler(V2ContinueWorkflowInput, handleV2ContinueWorkflow, V2ContinueWorkflowInputShape),
     checkpoint_workflow: createHandler(V2CheckpointWorkflowInput, handleV2CheckpointWorkflow),
     resume_session: createHandler(V2ResumeSessionInput, handleV2ResumeSession),
   };

--- a/src/mcp/validation/suggestion-config.ts
+++ b/src/mcp/validation/suggestion-config.ts
@@ -38,6 +38,16 @@ export interface SuggestionConfig {
    * Prevents unbounded recursion in deeply nested schemas.
    */
   readonly maxTemplateDepth: number;
+
+  /**
+   * Whether to include optional fields in the correctTemplate.
+   *
+   * Set true for error-guidance contexts: agents need to see the FULL valid
+   * structure when they've used wrong field names, not just the required-field
+   * skeleton. For example, continue_workflow's correctTemplate should show
+   * output.notesMarkdown even though output is optional.
+   */
+  readonly includeOptionalInTemplate: boolean;
 }
 
 /**
@@ -53,6 +63,9 @@ export const DEFAULT_SUGGESTION_CONFIG: SuggestionConfig = {
   maxSuggestions: 3,
   includeTemplate: true,
   maxTemplateDepth: 3,
+  // Show optional fields in error templates — agents need the full structure
+  // to self-correct, not just the required-field skeleton.
+  includeOptionalInTemplate: true,
 } as const;
 
 /**
@@ -64,4 +77,5 @@ export const MINIMAL_SUGGESTION_CONFIG: SuggestionConfig = {
   maxSuggestions: 1,
   includeTemplate: false,
   maxTemplateDepth: 1,
+  includeOptionalInTemplate: false,
 } as const;

--- a/src/mcp/validation/suggestion-generator.ts
+++ b/src/mcp/validation/suggestion-generator.ts
@@ -148,7 +148,7 @@ export function generateSuggestions(
 
   // Generate template if configured
   const correctTemplate = config.includeTemplate
-    ? generateTemplate(schema, config.maxTemplateDepth)
+    ? generateTemplate(schema, config.maxTemplateDepth, config.includeOptionalInTemplate)
     : null;
 
   return {


### PR DESCRIPTION
## Problem

Agents got `correctTemplate: null` when passing unknown keys to `continue_workflow`, causing them to drop valid fields on retry.

Root cause: `V2ContinueWorkflowInput` uses `.strict().transform().pipe()` which wraps the ZodObject. Introspection functions only handled bare ZodObject instances.

## Architectural Fix (Not a Patch)

**Separate shape schema from validation schema** (interface segregation):
- `V2ContinueWorkflowInputShape` — canonical source for field names/types/descriptions (bare ZodObject)
- `V2ContinueWorkflowInput` — derives from shape, adds transforms for intent auto-inference

Introspection reads the shape schema; handlers use the validation schema.

## Changes

- Added `V2ContinueWorkflowInputShape` (marked `@canonical`)
- Derived `V2ContinueWorkflowInput` from shape via `.transform().pipe()`
- Updated `createHandler` to accept optional `shapeSchema` for introspection
- Reverted `unwrapToObject()` duck-typing from `schema-introspection.ts`
- Added `includeOptionalInTemplate` to `SuggestionConfig` (agents see full structure)
- Updated tests

## Philosophy Alignment

✅ Type safety (zero duck-typing)  
✅ Interface segregation (introspection ≠ validation)  
✅ Single source of truth (shape is canonical)  
✅ Explicit over implicit (`@canonical` marker)  
✅ Future-ready (shape schemas → codegen inputs)

## Test Results

2680 tests pass

🤖 Generated with [Firebender](https://firebender.com)