### PR TITLE
fix(v2): Single source of truth for blocking reasons (architectural)

### DIFF
--- a/src/mcp/handlers/v2-advance-core/outcome-success.ts
+++ b/src/mcp/handlers/v2-advance-core/outcome-success.ts
@@ -52,7 +52,7 @@ export function buildSuccessOutcome(args: {
 }): RA<void, InternalError | SessionEventLogStoreError | SnapshotStoreError> {
   const { mode, v, lock, ports } = args;
   const { truth, sessionId, runId, currentNodeId, attemptId, workflowHash, inputOutput, pinnedWorkflow, engineState, pendingStep } = args.ctx;
-  const { effectiveReasons, outputRequirement, validation } = args.computed;
+  const { reasons, outputRequirement, validation } = args.computed;
   const { snapshotStore, sessionStore, sha256, idFactory } = ports;
 
   // Compile + interpret
@@ -92,10 +92,10 @@ export function buildSuccessOutcome(args: {
   const extraEventsToAppend: PartialEvent[] = [];
 
   // Gap events (never-stop mode)
-  if (v.autonomy === 'full_auto_never_stop' && effectiveReasons.length > 0) {
+  if (v.autonomy === 'full_auto_never_stop' && reasons.length > 0) {
     extraEventsToAppend.push(
       ...buildGapEvents({
-        gaps: effectiveReasons,
+        gaps: reasons,
         sessionId: String(sessionId),
         runId,
         nodeId: currentNodeId,


### PR DESCRIPTION
## Problem

Agent hit INTERNAL_ERROR when advancing without notes.

## Root Cause (Architectural)

`ComputedAdvanceResults` contained both pre-guardrail and post-guardrail reasons arrays. This redundancy violated single source of truth and created illegal states where functions could select the wrong array.

`buildBlockedOutcome` used `effectiveReasons` for blockers but `reasons` for primaryReason — inconsistent data sources.

## Architectural Fix

**Removed pre-guardrail reasons entirely.** Keep only post-guardrail reasons (the single source of truth).

- Renamed `effectiveReasons` → `reasons` (it's THE reasons, post-guardrails)
- Updated all consumers to use single array
- Type system now prevents array-selection bugs

## Philosophy Alignment

✅ Single source of truth  
✅ Make illegal states unrepresentable  
✅ Architectural fix not patch  
✅ Type safety prevents recurrence

## Test Results

2680 tests pass

🤖 Generated with [Firebender](https://firebender.com)