### PR TITLE
fix(v2): resume_session token minting fails on empty workflowHashRef

### DIFF
--- a/tests/unit/v2/session-summary-aggregate-recap.test.ts
+++ b/tests/unit/v2/session-summary-aggregate-recap.test.ts
@@ -29,6 +29,9 @@ import { asSessionId } from '../../../src/v2/durable-core/ids/index.js';
  * First entry is the root (parentNodeId must be null).
  * Last entry is the tip (the pending step).
  */
+/** Valid SHA256 digest for test events. */
+const TEST_WORKFLOW_HASH = 'sha256:' + 'a'.repeat(64);
+
 function buildLinearChain(
   sessionId: string,
   runId: string,
@@ -50,13 +53,13 @@ function buildLinearChain(
   });
 
   events.push(mk('session_created', {}, {}, `session_created:${sessionId}`));
-  events.push(mk('run_started', { runId }, { workflowId, workflowHash: 'hash_abc' }, `run_started:${sessionId}:${runId}`));
+  events.push(mk('run_started', { runId }, { workflowId, workflowHash: TEST_WORKFLOW_HASH }, `run_started:${sessionId}:${runId}`));
 
   for (const entry of chain) {
     events.push(mk(
       'node_created',
       { runId, nodeId: entry.nodeId },
-      { nodeKind: 'step', parentNodeId: entry.parentNodeId, workflowHash: 'hash_abc', snapshotRef: 'snap_1' },
+      { nodeKind: 'step', parentNodeId: entry.parentNodeId, workflowHash: TEST_WORKFLOW_HASH, snapshotRef: 'snap_1' },
       `node_created:${sessionId}:${entry.nodeId}`,
     ));
 


### PR DESCRIPTION
## Summary
- `resume_session` returned `{candidates: [], totalEligible: 5}` because the handler passed `asWorkflowHashRef('')` to the binary token packer, which requires `wf_<base32>` format
- Replaced `WorkflowIdentity` with a discriminated union (`unknown` | `identified`) using branded `WorkflowId` and `WorkflowHash` types
- Validation moved to boundary (`session-summary-provider`), eliminating defensive null checks in handler core
- Added structured `console.error` warning when candidates are skipped during token minting

## Test plan
- [x] All 2,680 tests pass (0 failures)
- [x] Build clean (tsc, no errors)
- [x] Root cause confirmed with runtime proof: empty string fails `BINARY_INVALID_ID_FORMAT`, valid `wf_...` succeeds
- [ ] Manual verification: call `resume_session` with existing sessions and confirm candidates are returned

🤖 Generated with [Firebender](https://firebender.com)