### PR TITLE
feat(v2): add promptBlocks structured prompt authoring (PR1 of authoring layer)

### DIFF
--- a/src/application/services/compiler/prompt-blocks.ts
+++ b/src/application/services/compiler/prompt-blocks.ts
@@ -1,0 +1,260 @@
+/**
+ * PromptBlocks — Structured Prompt Authoring
+ *
+ * Provides typed prompt blocks as an alternative to raw prompt strings.
+ * Blocks are rendered into a deterministic text prompt at compile time.
+ *
+ * Why compile-time: the rendered prompt is included in the workflow hash,
+ * ensuring deterministic execution. The runtime prompt renderer reads
+ * step.prompt (already a string) and is unchanged.
+ *
+ * Lock: promptBlocks rendering order is deterministic (goal → constraints →
+ * procedure → outputRequired → verify). Same blocks always produce same text.
+ */
+
+import type { Result } from 'neverthrow';
+import { ok, err } from 'neverthrow';
+
+// ---------------------------------------------------------------------------
+// PromptPart — discriminated union for inline content
+// ---------------------------------------------------------------------------
+
+/**
+ * A single part of a prompt value.
+ *
+ * Why discriminated union: a prompt part is either literal text or a
+ * reference to a canonical WorkRail snippet. The union makes the two
+ * cases exhaustive and prevents stringly-typed ref IDs from being
+ * confused with literal text.
+ *
+ * Refs are resolved in a separate compiler pass (PR2). This module
+ * treats 'ref' parts as opaque — they must be resolved before rendering.
+ */
+export type PromptPart =
+  | { readonly kind: 'text'; readonly text: string }
+  | { readonly kind: 'ref'; readonly refId: string };
+
+/** A prompt value is either a plain string or an array of parts. */
+export type PromptValue = string | readonly PromptPart[];
+
+// ---------------------------------------------------------------------------
+// PromptBlocks — structured prompt sections
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured prompt blocks for a workflow step.
+ *
+ * Canonical block set (locked): goal, constraints, procedure,
+ * outputRequired, verify. Rendered in this deterministic order.
+ *
+ * All fields are optional — authors include only the sections they need.
+ * At least one block must be present (validated at compile time).
+ */
+export interface PromptBlocks {
+  readonly goal?: PromptValue;
+  readonly constraints?: readonly PromptValue[];
+  readonly procedure?: readonly PromptValue[];
+  readonly outputRequired?: Readonly<Record<string, string>>;
+  readonly verify?: readonly PromptValue[];
+}
+
+// ---------------------------------------------------------------------------
+// Rendering — pure, deterministic
+// ---------------------------------------------------------------------------
+
+export type PromptBlocksRenderError =
+  | { readonly code: 'EMPTY_BLOCKS'; readonly message: string }
+  | { readonly code: 'UNRESOLVED_REF'; readonly refId: string; readonly message: string };
+
+/**
+ * Resolve a PromptValue to a plain string.
+ *
+ * Returns an error if any ref parts remain unresolved. Refs must be
+ * resolved by the ref resolution pass before rendering.
+ */
+function resolvePromptValue(value: PromptValue): Result<string, PromptBlocksRenderError> {
+  if (typeof value === 'string') return ok(value);
+
+  const parts: string[] = [];
+  for (const part of value) {
+    switch (part.kind) {
+      case 'text':
+        parts.push(part.text);
+        break;
+      case 'ref':
+        return err({
+          code: 'UNRESOLVED_REF',
+          refId: part.refId,
+          message: `Unresolved ref '${part.refId}' in prompt blocks. Refs must be resolved before rendering.`,
+        });
+    }
+  }
+  return ok(parts.join(''));
+}
+
+/**
+ * Resolve an array of PromptValues to an array of strings.
+ */
+function resolvePromptValues(values: readonly PromptValue[]): Result<readonly string[], PromptBlocksRenderError> {
+  const resolved: string[] = [];
+  for (const value of values) {
+    const res = resolvePromptValue(value);
+    if (res.isErr()) return err(res.error);
+    resolved.push(res.value);
+  }
+  return ok(resolved);
+}
+
+/**
+ * Render PromptBlocks into a deterministic prompt string.
+ *
+ * Section order is locked: goal → constraints → procedure →
+ * outputRequired → verify. Same blocks always produce same text.
+ *
+ * All ref parts must be resolved before calling this function.
+ * Use the ref resolution pass first, then render.
+ */
+export function renderPromptBlocks(blocks: PromptBlocks): Result<string, PromptBlocksRenderError> {
+  const sections: string[] = [];
+
+  // Goal
+  if (blocks.goal !== undefined) {
+    const res = resolvePromptValue(blocks.goal);
+    if (res.isErr()) return err(res.error);
+    sections.push(`## Goal\n${res.value}`);
+  }
+
+  // Constraints
+  if (blocks.constraints !== undefined && blocks.constraints.length > 0) {
+    const res = resolvePromptValues(blocks.constraints);
+    if (res.isErr()) return err(res.error);
+    sections.push(`## Constraints\n${res.value.map(c => `- ${c}`).join('\n')}`);
+  }
+
+  // Procedure
+  if (blocks.procedure !== undefined && blocks.procedure.length > 0) {
+    const res = resolvePromptValues(blocks.procedure);
+    if (res.isErr()) return err(res.error);
+    sections.push(`## Procedure\n${res.value.map((p, i) => `${i + 1}. ${p}`).join('\n')}`);
+  }
+
+  // Output Required
+  if (blocks.outputRequired !== undefined && Object.keys(blocks.outputRequired).length > 0) {
+    const entries = Object.entries(blocks.outputRequired)
+      .map(([key, value]) => `- **${key}**: ${value}`)
+      .join('\n');
+    sections.push(`## Output Required\n${entries}`);
+  }
+
+  // Verify
+  if (blocks.verify !== undefined && blocks.verify.length > 0) {
+    const res = resolvePromptValues(blocks.verify);
+    if (res.isErr()) return err(res.error);
+    sections.push(`## Verify\n${res.value.map(v => `- ${v}`).join('\n')}`);
+  }
+
+  if (sections.length === 0) {
+    return err({
+      code: 'EMPTY_BLOCKS',
+      message: 'promptBlocks must contain at least one non-empty section.',
+    });
+  }
+
+  return ok(sections.join('\n\n'));
+}
+
+// ---------------------------------------------------------------------------
+// Compiler pass — resolve promptBlocks into prompt strings
+// ---------------------------------------------------------------------------
+
+import type { WorkflowStepDefinition, LoopStepDefinition } from '../../../types/workflow-definition.js';
+import { isLoopStepDefinition } from '../../../types/workflow-definition.js';
+
+export type PromptBlocksPassError =
+  | { readonly code: 'PROMPT_BLOCKS_ERROR'; readonly stepId: string; readonly cause: PromptBlocksRenderError }
+  | { readonly code: 'PROMPT_AND_BLOCKS_BOTH_SET'; readonly stepId: string; readonly message: string };
+
+/**
+ * Resolve a single step's promptBlocks into a prompt string.
+ *
+ * Rules:
+ * - If step has prompt (non-empty): use as-is (backward compat)
+ * - If step has promptBlocks: render to prompt string
+ * - If step has both: compile-time error (handled by validation, not here)
+ * - If step has neither: leave prompt undefined (validation catches later)
+ */
+function resolveStepPromptBlocks(
+  step: WorkflowStepDefinition,
+): Result<WorkflowStepDefinition, PromptBlocksPassError> {
+  // Mutual exclusion: prompt XOR promptBlocks
+  if (step.prompt && step.promptBlocks) {
+    return err({
+      code: 'PROMPT_AND_BLOCKS_BOTH_SET',
+      stepId: step.id,
+      message: `Step '${step.id}' declares both prompt and promptBlocks. Use exactly one.`,
+    });
+  }
+
+  if (!step.promptBlocks) return ok(step);
+
+  const renderResult = renderPromptBlocks(step.promptBlocks);
+  if (renderResult.isErr()) {
+    return err({
+      code: 'PROMPT_BLOCKS_ERROR',
+      stepId: step.id,
+      cause: renderResult.error,
+    });
+  }
+
+  // Produce a new step with prompt filled from rendered blocks.
+  // promptBlocks is preserved for introspection (Studio, export).
+  return ok({
+    ...step,
+    prompt: renderResult.value,
+  });
+}
+
+/**
+ * Compiler pass: resolve all promptBlocks into prompt strings.
+ *
+ * Processes top-level steps and inline loop body steps.
+ * Pure function — no I/O, no mutation.
+ */
+export function resolvePromptBlocksPass(
+  steps: readonly (WorkflowStepDefinition | LoopStepDefinition)[],
+): Result<readonly (WorkflowStepDefinition | LoopStepDefinition)[], PromptBlocksPassError> {
+  const resolved: (WorkflowStepDefinition | LoopStepDefinition)[] = [];
+
+  for (const step of steps) {
+    if (isLoopStepDefinition(step)) {
+      // Resolve the loop step itself
+      const loopRes = resolveStepPromptBlocks(step);
+      if (loopRes.isErr()) return err(loopRes.error);
+
+      // Resolve inline body steps
+      if (Array.isArray(step.body)) {
+        const bodyResolved: WorkflowStepDefinition[] = [];
+        for (const bodyStep of step.body) {
+          const bodyRes = resolveStepPromptBlocks(bodyStep);
+          if (bodyRes.isErr()) return err(bodyRes.error);
+          bodyResolved.push(bodyRes.value);
+        }
+        // Preserve the full LoopStepDefinition shape (type, loop, body)
+        const resolvedLoop: LoopStepDefinition = {
+          ...step,
+          ...(loopRes.value.prompt !== undefined ? { prompt: loopRes.value.prompt } : {}),
+          body: bodyResolved,
+        };
+        resolved.push(resolvedLoop);
+      } else {
+        resolved.push({ ...step, ...(loopRes.value.prompt !== undefined ? { prompt: loopRes.value.prompt } : {}) } as LoopStepDefinition);
+      }
+    } else {
+      const res = resolveStepPromptBlocks(step);
+      if (res.isErr()) return err(res.error);
+      resolved.push(res.value);
+    }
+  }
+
+  return ok(resolved);
+}

--- a/src/application/services/workflow-interpreter.ts
+++ b/src/application/services/workflow-interpreter.ts
@@ -498,7 +498,7 @@ export class WorkflowInterpreter {
     if (step.guidance && step.guidance.length > 0) {
       promptParts.push(`## Step Guidance\n${step.guidance.map((g) => `- ${g}`).join('\n')}\n`);
     }
-    promptParts.push(step.prompt);
+    promptParts.push(step.prompt ?? '');
 
     // Minimal loop info for UX (derived from instance.loopPath)
     if (instance.loopPath.length > 0) {

--- a/src/types/workflow-definition.ts
+++ b/src/types/workflow-definition.ts
@@ -11,6 +11,7 @@
 
 import { ValidationCriteria } from './validation';
 import type { ArtifactContractRef } from '../v2/durable-core/schemas/artifacts/index';
+import type { PromptBlocks } from '../application/services/compiler/prompt-blocks.js';
 
 // =============================================================================
 // STEP TYPES
@@ -32,7 +33,18 @@ export interface OutputContract {
 export interface WorkflowStepDefinition {
   readonly id: string;
   readonly title: string;
-  readonly prompt: string;
+  /**
+   * Raw prompt string. Required for text-prompt steps.
+   * Optional when promptBlocks is used — the compiler renders blocks into
+   * this field during compilation, so it is always present after compilation.
+   */
+  readonly prompt?: string;
+  /**
+   * Structured prompt blocks. Alternative to raw prompt string.
+   * Rendered into prompt during compilation (deterministic, locked order).
+   * A step must declare exactly one of prompt or promptBlocks.
+   */
+  readonly promptBlocks?: PromptBlocks;
   readonly agentRole?: string;
   readonly guidance?: readonly string[];
   readonly askForFiles?: boolean;

--- a/tests/unit/compiler/prompt-blocks.test.ts
+++ b/tests/unit/compiler/prompt-blocks.test.ts
@@ -1,0 +1,265 @@
+/**
+ * PromptBlocks — Rendering and Compiler Pass Tests
+ *
+ * Tests the pure rendering function and the compiler pass that
+ * resolves promptBlocks into prompt strings.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  renderPromptBlocks,
+  resolvePromptBlocksPass,
+  type PromptBlocks,
+  type PromptPart,
+} from '../../../src/application/services/compiler/prompt-blocks.js';
+import type { WorkflowStepDefinition, LoopStepDefinition } from '../../../src/types/workflow-definition.js';
+
+// ---------------------------------------------------------------------------
+// renderPromptBlocks
+// ---------------------------------------------------------------------------
+
+describe('renderPromptBlocks', () => {
+  it('renders goal-only blocks', () => {
+    const blocks: PromptBlocks = { goal: 'Investigate the bug.' };
+    const result = renderPromptBlocks(blocks);
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBe('## Goal\nInvestigate the bug.');
+  });
+
+  it('renders all sections in deterministic order', () => {
+    const blocks: PromptBlocks = {
+      goal: 'Find the root cause.',
+      constraints: ['Follow the selected mode.', 'Do not skip steps.'],
+      procedure: ['Gather evidence.', 'Test hypotheses.'],
+      outputRequired: { notesMarkdown: 'Summary of findings.' },
+      verify: ['Root cause is grounded in evidence.'],
+    };
+    const result = renderPromptBlocks(blocks);
+    expect(result.isOk()).toBe(true);
+    const text = result._unsafeUnwrap();
+
+    // Sections appear in locked order
+    const goalIdx = text.indexOf('## Goal');
+    const constraintsIdx = text.indexOf('## Constraints');
+    const procedureIdx = text.indexOf('## Procedure');
+    const outputIdx = text.indexOf('## Output Required');
+    const verifyIdx = text.indexOf('## Verify');
+
+    expect(goalIdx).toBeLessThan(constraintsIdx);
+    expect(constraintsIdx).toBeLessThan(procedureIdx);
+    expect(procedureIdx).toBeLessThan(outputIdx);
+    expect(outputIdx).toBeLessThan(verifyIdx);
+  });
+
+  it('renders constraints as bullet points', () => {
+    const blocks: PromptBlocks = {
+      constraints: ['Rule A.', 'Rule B.'],
+    };
+    const text = renderPromptBlocks(blocks)._unsafeUnwrap();
+    expect(text).toContain('- Rule A.');
+    expect(text).toContain('- Rule B.');
+  });
+
+  it('renders procedure as numbered steps', () => {
+    const blocks: PromptBlocks = {
+      procedure: ['Step one.', 'Step two.', 'Step three.'],
+    };
+    const text = renderPromptBlocks(blocks)._unsafeUnwrap();
+    expect(text).toContain('1. Step one.');
+    expect(text).toContain('2. Step two.');
+    expect(text).toContain('3. Step three.');
+  });
+
+  it('renders outputRequired as key-value pairs', () => {
+    const blocks: PromptBlocks = {
+      outputRequired: { notesMarkdown: 'Recap.', artifacts: 'Loop control.' },
+    };
+    const text = renderPromptBlocks(blocks)._unsafeUnwrap();
+    expect(text).toContain('**notesMarkdown**: Recap.');
+    expect(text).toContain('**artifacts**: Loop control.');
+  });
+
+  it('returns EMPTY_BLOCKS error for empty blocks', () => {
+    const blocks: PromptBlocks = {};
+    const result = renderPromptBlocks(blocks);
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr().code).toBe('EMPTY_BLOCKS');
+  });
+
+  it('returns UNRESOLVED_REF error for unresolved ref parts', () => {
+    const parts: PromptPart[] = [
+      { kind: 'text', text: 'Before. ' },
+      { kind: 'ref', refId: 'wr.refs.some_snippet' },
+    ];
+    const blocks: PromptBlocks = { goal: parts };
+    const result = renderPromptBlocks(blocks);
+    expect(result.isErr()).toBe(true);
+    const error = result._unsafeUnwrapErr();
+    expect(error.code).toBe('UNRESOLVED_REF');
+    if (error.code === 'UNRESOLVED_REF') {
+      expect(error.refId).toBe('wr.refs.some_snippet');
+    }
+  });
+
+  it('renders text PromptPart arrays by concatenation', () => {
+    const parts: PromptPart[] = [
+      { kind: 'text', text: 'Part A. ' },
+      { kind: 'text', text: 'Part B.' },
+    ];
+    const blocks: PromptBlocks = { goal: parts };
+    const text = renderPromptBlocks(blocks)._unsafeUnwrap();
+    expect(text).toBe('## Goal\nPart A. Part B.');
+  });
+
+  it('skips empty optional sections', () => {
+    const blocks: PromptBlocks = {
+      goal: 'Do the thing.',
+      constraints: [], // empty array
+      procedure: [], // empty array
+    };
+    const text = renderPromptBlocks(blocks)._unsafeUnwrap();
+    expect(text).not.toContain('## Constraints');
+    expect(text).not.toContain('## Procedure');
+    expect(text).toContain('## Goal');
+  });
+
+  it('is deterministic: same blocks produce same output', () => {
+    const blocks: PromptBlocks = {
+      goal: 'Goal.',
+      constraints: ['C1.', 'C2.'],
+      procedure: ['P1.'],
+    };
+    const a = renderPromptBlocks(blocks)._unsafeUnwrap();
+    const b = renderPromptBlocks(blocks)._unsafeUnwrap();
+    expect(a).toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolvePromptBlocksPass
+// ---------------------------------------------------------------------------
+
+describe('resolvePromptBlocksPass', () => {
+  it('passes through steps with prompt string unchanged', () => {
+    const steps: WorkflowStepDefinition[] = [
+      { id: 'step-1', title: 'Step 1', prompt: 'Do something.' },
+    ];
+    const result = resolvePromptBlocksPass(steps);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap();
+    expect(resolved[0]!.prompt).toBe('Do something.');
+  });
+
+  it('renders promptBlocks into prompt', () => {
+    const steps: WorkflowStepDefinition[] = [
+      {
+        id: 'step-1',
+        title: 'Step 1',
+        promptBlocks: { goal: 'Find the bug.' },
+      },
+    ];
+    const result = resolvePromptBlocksPass(steps);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap();
+    expect(resolved[0]!.prompt).toBe('## Goal\nFind the bug.');
+  });
+
+  it('resolves promptBlocks in loop body steps', () => {
+    const loopStep: LoopStepDefinition = {
+      id: 'loop-1',
+      title: 'Loop',
+      prompt: 'Loop prompt.',
+      type: 'loop',
+      loop: { type: 'while', maxIterations: 3 },
+      body: [
+        {
+          id: 'body-1',
+          title: 'Body Step',
+          promptBlocks: { goal: 'Body goal.' },
+        },
+      ],
+    };
+    const result = resolvePromptBlocksPass([loopStep]);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as LoopStepDefinition;
+    expect(Array.isArray(resolved.body)).toBe(true);
+    const bodyStep = (resolved.body as WorkflowStepDefinition[])[0]!;
+    expect(bodyStep.prompt).toBe('## Goal\nBody goal.');
+  });
+
+  it('preserves loop step structure after resolution', () => {
+    const loopStep: LoopStepDefinition = {
+      id: 'loop-1',
+      title: 'Loop',
+      prompt: 'Loop prompt.',
+      type: 'loop',
+      loop: { type: 'while', maxIterations: 5 },
+      body: [
+        { id: 'body-1', title: 'Body', prompt: 'Body prompt.' },
+      ],
+    };
+    const result = resolvePromptBlocksPass([loopStep]);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as LoopStepDefinition;
+    expect(resolved.type).toBe('loop');
+    expect(resolved.loop.type).toBe('while');
+    expect(resolved.loop.maxIterations).toBe(5);
+  });
+
+  it('returns error for empty promptBlocks', () => {
+    const steps: WorkflowStepDefinition[] = [
+      { id: 'step-1', title: 'Step 1', promptBlocks: {} },
+    ];
+    const result = resolvePromptBlocksPass(steps);
+    expect(result.isErr()).toBe(true);
+    const error = result._unsafeUnwrapErr();
+    expect(error.stepId).toBe('step-1');
+    expect(error.cause.code).toBe('EMPTY_BLOCKS');
+  });
+
+  it('returns error for unresolved refs in promptBlocks', () => {
+    const steps: WorkflowStepDefinition[] = [
+      {
+        id: 'step-1',
+        title: 'Step 1',
+        promptBlocks: {
+          goal: [{ kind: 'ref', refId: 'wr.refs.unknown' }],
+        },
+      },
+    ];
+    const result = resolvePromptBlocksPass(steps);
+    expect(result.isErr()).toBe(true);
+    const error = result._unsafeUnwrapErr();
+    expect(error.stepId).toBe('step-1');
+    expect(error.cause.code).toBe('UNRESOLVED_REF');
+  });
+
+  it('returns error when step has both prompt and promptBlocks', () => {
+    const steps: WorkflowStepDefinition[] = [
+      {
+        id: 'step-1',
+        title: 'Step 1',
+        prompt: 'Raw prompt.',
+        promptBlocks: { goal: 'Structured goal.' },
+      },
+    ];
+    const result = resolvePromptBlocksPass(steps);
+    expect(result.isErr()).toBe(true);
+    const error = result._unsafeUnwrapErr();
+    expect(error.code).toBe('PROMPT_AND_BLOCKS_BOTH_SET');
+    expect(error.stepId).toBe('step-1');
+  });
+
+  it('handles mixed steps (some with prompt, some with promptBlocks)', () => {
+    const steps: WorkflowStepDefinition[] = [
+      { id: 'step-1', title: 'Step 1', prompt: 'Raw prompt.' },
+      { id: 'step-2', title: 'Step 2', promptBlocks: { goal: 'Structured goal.' } },
+      { id: 'step-3', title: 'Step 3', prompt: 'Another raw prompt.' },
+    ];
+    const result = resolvePromptBlocksPass(steps);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap();
+    expect(resolved[0]!.prompt).toBe('Raw prompt.');
+    expect(resolved[1]!.prompt).toBe('## Goal\nStructured goal.');
+    expect(resolved[2]!.prompt).toBe('Another raw prompt.');
+  });
+});


### PR DESCRIPTION
## Summary
- Introduces `PromptBlocks` as a compile-time alternative to raw `prompt` strings on `WorkflowStepDefinition`
- Steps can now declare structured sections (`goal`, `constraints`, `procedure`, `outputRequired`, `verify`) using a `PromptPart` discriminated union (`text` | `ref`)
- The compiler renders blocks into a deterministic prompt string during compilation — runtime prompt renderer is unchanged
- Mutual exclusion enforced: `prompt` XOR `promptBlocks` (compile-time fail-fast)
- Fully backward compatible: existing workflows with `prompt: string` work unchanged

### PR1 of the V2 Workflow Authoring Layer

This is the foundation PR that introduces the type system and rendering for the authoring layer designed in `docs/design/workflow-authoring-v2.md`. Subsequent PRs will add:
- PR2: `wr.refs.*` registry and ref resolution compiler pass
- PR3: `wr.features.*` registry and feature middleware compiler pass
- PR4: `wr.templates.*` registry and template expansion compiler pass
- PR5: `wr.features.memory_context` feature implementation

### Files changed
| File | Change |
|------|--------|
| `src/application/services/compiler/prompt-blocks.ts` | **New** — `PromptPart`, `PromptBlocks`, `renderPromptBlocks()`, `resolvePromptBlocksPass()` |
| `src/types/workflow-definition.ts` | `prompt` now optional, `promptBlocks?` added to `WorkflowStepDefinition` |
| `src/application/services/workflow-compiler.ts` | Wires `resolvePromptBlocksPass` into compilation pipeline |
| `src/application/services/workflow-interpreter.ts` | Guard for optional `prompt` (v1 compat) |
| `tests/unit/compiler/prompt-blocks.test.ts` | **New** — 18 tests covering rendering, compiler pass, error cases |

## Test plan
- [x] All 18 new unit tests pass (rendering, pass-through, loop body resolution, mutual exclusion, error cases)
- [x] Full test suite passes (2,687 tests, 0 failures)
- [x] Build clean (no TypeScript errors)
- [x] Backward compat: all existing workflows continue working unchanged

🤖 Generated with [Firebender](https://firebender.com)