### PR TITLE
feat(v2): add ref registry and resolution compiler pass (PR2 of authoring layer)

### DIFF
--- a/src/application/services/compiler/ref-registry.ts
+++ b/src/application/services/compiler/ref-registry.ts
@@ -1,0 +1,90 @@
+/**
+ * Ref Registry — Closed-Set Canonical Snippet Resolution
+ *
+ * Maps `wr.refs.*` IDs to canonical text content. All refs are
+ * WorkRail-owned and resolved at compile time. Unknown IDs fail fast.
+ *
+ * Why closed-set: refs are part of the compiled workflow hash.
+ * User-defined refs would break determinism across environments.
+ */
+
+import type { Result } from 'neverthrow';
+import { ok, err } from 'neverthrow';
+
+// ---------------------------------------------------------------------------
+// Ref registry types
+// ---------------------------------------------------------------------------
+
+export type RefResolveError = {
+  readonly code: 'UNKNOWN_REF';
+  readonly refId: string;
+  readonly message: string;
+};
+
+/** Read-only lookup interface for ref resolution. */
+export interface RefRegistry {
+  readonly resolve: (refId: string) => Result<string, RefResolveError>;
+  readonly has: (refId: string) => boolean;
+  readonly knownIds: () => readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Canonical ref content (closed set, WorkRail-owned)
+// ---------------------------------------------------------------------------
+
+const REF_CONTENT = {
+  'wr.refs.memory_usage': [
+    'If Memory MCP tools are available (memory_briefing, memory_store, memory_query):',
+    '- Query Memory for relevant prior knowledge about this workspace before beginning work',
+    '- After completing significant work, store key discoveries and decisions',
+    '- Use descriptive topics and titles so future sessions can find them',
+    '- Do not block on Memory failures — it is advisory, not load-bearing',
+  ].join('\n'),
+
+  'wr.refs.memory_store': [
+    'If Memory MCP tools are available (memory_store):',
+    '- Store the key findings from this phase with a descriptive topic and title',
+    '- Include file paths, decisions made, and rationale',
+    '- Do not block on Memory failures — continue regardless',
+  ].join('\n'),
+
+  'wr.refs.memory_query': [
+    'If Memory MCP tools are available (memory_briefing, memory_query):',
+    '- Check Memory for prior context relevant to this task',
+    '- Use workspace-scoped queries to find related past work',
+    '- Do not block on Memory failures — proceed without prior context if unavailable',
+  ].join('\n'),
+} as const satisfies Record<string, string>;
+
+type KnownRefId = keyof typeof REF_CONTENT;
+
+// ---------------------------------------------------------------------------
+// Registry constructor
+// ---------------------------------------------------------------------------
+
+/** Create the canonical ref registry (frozen, closed-set). */
+export function createRefRegistry(): RefRegistry {
+  const knownIds = Object.keys(REF_CONTENT) as readonly KnownRefId[];
+
+  return {
+    resolve(refId: string): Result<string, RefResolveError> {
+      const content = REF_CONTENT[refId as KnownRefId];
+      if (content === undefined) {
+        return err({
+          code: 'UNKNOWN_REF',
+          refId,
+          message: `Unknown ref '${refId}'. Known refs: ${knownIds.join(', ')}`,
+        });
+      }
+      return ok(content);
+    },
+
+    has(refId: string): boolean {
+      return refId in REF_CONTENT;
+    },
+
+    knownIds(): readonly string[] {
+      return knownIds;
+    },
+  };
+}

--- a/src/application/services/compiler/resolve-refs.ts
+++ b/src/application/services/compiler/resolve-refs.ts
@@ -1,0 +1,180 @@
+/**
+ * Ref Resolution Compiler Pass
+ *
+ * Walks all promptBlocks in all steps, replacing { kind: 'ref' } parts
+ * with { kind: 'text' } parts using the RefRegistry. Runs before the
+ * promptBlocks rendering pass so refs are fully resolved before rendering.
+ *
+ * Pure function — no I/O, no mutation.
+ */
+
+import type { Result } from 'neverthrow';
+import { ok, err } from 'neverthrow';
+import type { RefRegistry, RefResolveError } from './ref-registry.js';
+import type { PromptPart, PromptValue, PromptBlocks } from './prompt-blocks.js';
+import type { WorkflowStepDefinition, LoopStepDefinition } from '../../../types/workflow-definition.js';
+import { isLoopStepDefinition } from '../../../types/workflow-definition.js';
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export type ResolveRefsPassError = {
+  readonly code: 'REF_RESOLVE_ERROR';
+  readonly stepId: string;
+  readonly cause: RefResolveError;
+};
+
+// ---------------------------------------------------------------------------
+// PromptValue ref resolution
+// ---------------------------------------------------------------------------
+
+/** Resolve all ref parts in a PromptValue to text parts. */
+function resolvePromptValueRefs(
+  value: PromptValue,
+  registry: RefRegistry,
+): Result<PromptValue, RefResolveError> {
+  if (typeof value === 'string') return ok(value);
+
+  const resolved: PromptPart[] = [];
+  for (const part of value) {
+    switch (part.kind) {
+      case 'text':
+        resolved.push(part);
+        break;
+      case 'ref': {
+        const res = registry.resolve(part.refId);
+        if (res.isErr()) return err(res.error);
+        resolved.push({ kind: 'text', text: res.value });
+        break;
+      }
+    }
+  }
+  return ok(resolved);
+}
+
+/** Resolve all ref parts in an array of PromptValues. */
+function resolvePromptValuesRefs(
+  values: readonly PromptValue[],
+  registry: RefRegistry,
+): Result<readonly PromptValue[], RefResolveError> {
+  const resolved: PromptValue[] = [];
+  for (const value of values) {
+    const res = resolvePromptValueRefs(value, registry);
+    if (res.isErr()) return err(res.error);
+    resolved.push(res.value);
+  }
+  return ok(resolved);
+}
+
+// ---------------------------------------------------------------------------
+// PromptBlocks ref resolution
+// ---------------------------------------------------------------------------
+
+/** Resolve all refs in a PromptBlocks object. */
+function resolveBlockRefs(
+  blocks: PromptBlocks,
+  registry: RefRegistry,
+): Result<PromptBlocks, RefResolveError> {
+  let result: PromptBlocks = { ...blocks };
+
+  if (blocks.goal !== undefined) {
+    const res = resolvePromptValueRefs(blocks.goal, registry);
+    if (res.isErr()) return err(res.error);
+    result = { ...result, goal: res.value };
+  }
+
+  if (blocks.constraints !== undefined) {
+    const res = resolvePromptValuesRefs(blocks.constraints, registry);
+    if (res.isErr()) return err(res.error);
+    result = { ...result, constraints: res.value };
+  }
+
+  if (blocks.procedure !== undefined) {
+    const res = resolvePromptValuesRefs(blocks.procedure, registry);
+    if (res.isErr()) return err(res.error);
+    result = { ...result, procedure: res.value };
+  }
+
+  if (blocks.verify !== undefined) {
+    const res = resolvePromptValuesRefs(blocks.verify, registry);
+    if (res.isErr()) return err(res.error);
+    result = { ...result, verify: res.value };
+  }
+
+  // outputRequired is Record<string, string> — no refs possible
+  return ok(result);
+}
+
+// ---------------------------------------------------------------------------
+// Step-level ref resolution
+// ---------------------------------------------------------------------------
+
+function resolveStepRefs(
+  step: WorkflowStepDefinition,
+  registry: RefRegistry,
+): Result<WorkflowStepDefinition, ResolveRefsPassError> {
+  if (!step.promptBlocks) return ok(step);
+
+  const res = resolveBlockRefs(step.promptBlocks, registry);
+  if (res.isErr()) {
+    return err({
+      code: 'REF_RESOLVE_ERROR',
+      stepId: step.id,
+      cause: res.error,
+    });
+  }
+
+  return ok({ ...step, promptBlocks: res.value });
+}
+
+// ---------------------------------------------------------------------------
+// Compiler pass
+// ---------------------------------------------------------------------------
+
+/**
+ * Compiler pass: resolve all wr.refs.* in promptBlocks.
+ *
+ * Must run BEFORE resolvePromptBlocksPass (which rejects unresolved refs).
+ * Pure function — no I/O, no mutation.
+ */
+export function resolveRefsPass(
+  steps: readonly (WorkflowStepDefinition | LoopStepDefinition)[],
+  registry: RefRegistry,
+): Result<readonly (WorkflowStepDefinition | LoopStepDefinition)[], ResolveRefsPassError> {
+  const resolved: (WorkflowStepDefinition | LoopStepDefinition)[] = [];
+
+  for (const step of steps) {
+    if (isLoopStepDefinition(step)) {
+      // Resolve the loop step itself
+      const loopRes = resolveStepRefs(step, registry);
+      if (loopRes.isErr()) return err(loopRes.error);
+
+      // Resolve inline body steps
+      if (Array.isArray(step.body)) {
+        const bodyResolved: WorkflowStepDefinition[] = [];
+        for (const bodyStep of step.body) {
+          const bodyRes = resolveStepRefs(bodyStep, registry);
+          if (bodyRes.isErr()) return err(bodyRes.error);
+          bodyResolved.push(bodyRes.value);
+        }
+        resolved.push({
+          ...step,
+          ...(loopRes.value.promptBlocks ? { promptBlocks: loopRes.value.promptBlocks } : {}),
+          body: bodyResolved,
+        } as LoopStepDefinition);
+      } else {
+        resolved.push({
+          ...step,
+          ...(loopRes.value.promptBlocks ? { promptBlocks: loopRes.value.promptBlocks } : {}),
+        } as LoopStepDefinition);
+      }
+    } else {
+      const res = resolveStepRefs(step, registry);
+      if (res.isErr()) return err(res.error);
+      resolved.push(res.value);
+    }
+  }
+
+  return ok(resolved);
+}

--- a/tests/unit/compiler/ref-registry.test.ts
+++ b/tests/unit/compiler/ref-registry.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Ref Registry — Tests
+ *
+ * Tests the closed-set ref registry: resolution, unknown ref rejection,
+ * and content correctness.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRefRegistry } from '../../../src/application/services/compiler/ref-registry.js';
+
+describe('RefRegistry', () => {
+  const registry = createRefRegistry();
+
+  it('resolves wr.refs.memory_usage to non-empty text', () => {
+    const result = registry.resolve('wr.refs.memory_usage');
+    expect(result.isOk()).toBe(true);
+    const text = result._unsafeUnwrap();
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain('Memory MCP');
+  });
+
+  it('resolves wr.refs.memory_store to non-empty text', () => {
+    const result = registry.resolve('wr.refs.memory_store');
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toContain('memory_store');
+  });
+
+  it('resolves wr.refs.memory_query to non-empty text', () => {
+    const result = registry.resolve('wr.refs.memory_query');
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toContain('memory_briefing');
+  });
+
+  it('returns UNKNOWN_REF for unregistered ref ID', () => {
+    const result = registry.resolve('wr.refs.nonexistent');
+    expect(result.isErr()).toBe(true);
+    const error = result._unsafeUnwrapErr();
+    expect(error.code).toBe('UNKNOWN_REF');
+    expect(error.refId).toBe('wr.refs.nonexistent');
+    expect(error.message).toContain('wr.refs.nonexistent');
+  });
+
+  it('returns UNKNOWN_REF for empty string', () => {
+    const result = registry.resolve('');
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr().code).toBe('UNKNOWN_REF');
+  });
+
+  it('has() returns true for known refs', () => {
+    expect(registry.has('wr.refs.memory_usage')).toBe(true);
+    expect(registry.has('wr.refs.memory_store')).toBe(true);
+    expect(registry.has('wr.refs.memory_query')).toBe(true);
+  });
+
+  it('has() returns false for unknown refs', () => {
+    expect(registry.has('wr.refs.nonexistent')).toBe(false);
+    expect(registry.has('')).toBe(false);
+  });
+
+  it('knownIds() returns all registered ref IDs', () => {
+    const ids = registry.knownIds();
+    expect(ids).toContain('wr.refs.memory_usage');
+    expect(ids).toContain('wr.refs.memory_store');
+    expect(ids).toContain('wr.refs.memory_query');
+    expect(ids.length).toBe(3);
+  });
+
+  it('resolution is deterministic: same ID always returns same content', () => {
+    const a = registry.resolve('wr.refs.memory_usage')._unsafeUnwrap();
+    const b = registry.resolve('wr.refs.memory_usage')._unsafeUnwrap();
+    expect(a).toBe(b);
+  });
+});

--- a/tests/unit/compiler/resolve-refs.test.ts
+++ b/tests/unit/compiler/resolve-refs.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Resolve Refs Compiler Pass — Tests
+ *
+ * Tests ref resolution in promptBlocks at the step and pass level.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveRefsPass } from '../../../src/application/services/compiler/resolve-refs.js';
+import { createRefRegistry } from '../../../src/application/services/compiler/ref-registry.js';
+import type { PromptPart } from '../../../src/application/services/compiler/prompt-blocks.js';
+import type { WorkflowStepDefinition, LoopStepDefinition } from '../../../src/types/workflow-definition.js';
+
+const registry = createRefRegistry();
+
+describe('resolveRefsPass', () => {
+  it('passes through steps without promptBlocks unchanged', () => {
+    const steps: WorkflowStepDefinition[] = [
+      { id: 'step-1', title: 'Step 1', prompt: 'Raw prompt.' },
+    ];
+    const result = resolveRefsPass(steps, registry);
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()[0]!.prompt).toBe('Raw prompt.');
+  });
+
+  it('passes through promptBlocks with no refs unchanged', () => {
+    const steps: WorkflowStepDefinition[] = [
+      {
+        id: 'step-1',
+        title: 'Step 1',
+        promptBlocks: { goal: 'No refs here.' },
+      },
+    ];
+    const result = resolveRefsPass(steps, registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as WorkflowStepDefinition;
+    expect(resolved.promptBlocks!.goal).toBe('No refs here.');
+  });
+
+  it('resolves ref parts in goal to text', () => {
+    const parts: PromptPart[] = [
+      { kind: 'text', text: 'Before. ' },
+      { kind: 'ref', refId: 'wr.refs.memory_usage' },
+      { kind: 'text', text: ' After.' },
+    ];
+    const steps: WorkflowStepDefinition[] = [
+      { id: 'step-1', title: 'Step 1', promptBlocks: { goal: parts } },
+    ];
+    const result = resolveRefsPass(steps, registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as WorkflowStepDefinition;
+    const goalParts = resolved.promptBlocks!.goal as readonly PromptPart[];
+    // All parts should be text now
+    for (const part of goalParts) {
+      expect(part.kind).toBe('text');
+    }
+    // The ref should have been replaced with memory usage content
+    expect((goalParts[1] as { kind: 'text'; text: string }).text).toContain('Memory MCP');
+  });
+
+  it('resolves refs in constraints array', () => {
+    const steps: WorkflowStepDefinition[] = [
+      {
+        id: 'step-1',
+        title: 'Step 1',
+        promptBlocks: {
+          constraints: [
+            'Plain constraint.',
+            [{ kind: 'ref', refId: 'wr.refs.memory_store' }],
+          ],
+        },
+      },
+    ];
+    const result = resolveRefsPass(steps, registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as WorkflowStepDefinition;
+    // First constraint: plain string, unchanged
+    expect(resolved.promptBlocks!.constraints![0]).toBe('Plain constraint.');
+    // Second constraint: ref resolved to text part
+    const secondParts = resolved.promptBlocks!.constraints![1] as readonly PromptPart[];
+    expect(secondParts[0]!.kind).toBe('text');
+  });
+
+  it('resolves refs in procedure array', () => {
+    const steps: WorkflowStepDefinition[] = [
+      {
+        id: 'step-1',
+        title: 'Step 1',
+        promptBlocks: {
+          procedure: [[{ kind: 'ref', refId: 'wr.refs.memory_query' }]],
+        },
+      },
+    ];
+    const result = resolveRefsPass(steps, registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as WorkflowStepDefinition;
+    const parts = resolved.promptBlocks!.procedure![0] as readonly PromptPart[];
+    expect(parts[0]!.kind).toBe('text');
+    expect((parts[0] as { kind: 'text'; text: string }).text).toContain('memory_briefing');
+  });
+
+  it('resolves refs in verify array', () => {
+    const steps: WorkflowStepDefinition[] = [
+      {
+        id: 'step-1',
+        title: 'Step 1',
+        promptBlocks: {
+          verify: [[{ kind: 'ref', refId: 'wr.refs.memory_usage' }]],
+        },
+      },
+    ];
+    const result = resolveRefsPass(steps, registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as WorkflowStepDefinition;
+    const parts = resolved.promptBlocks!.verify![0] as readonly PromptPart[];
+    expect(parts[0]!.kind).toBe('text');
+  });
+
+  it('returns error for unknown ref', () => {
+    const steps: WorkflowStepDefinition[] = [
+      {
+        id: 'step-1',
+        title: 'Step 1',
+        promptBlocks: {
+          goal: [{ kind: 'ref', refId: 'wr.refs.nonexistent' }],
+        },
+      },
+    ];
+    const result = resolveRefsPass(steps, registry);
+    expect(result.isErr()).toBe(true);
+    const error = result._unsafeUnwrapErr();
+    expect(error.code).toBe('REF_RESOLVE_ERROR');
+    expect(error.stepId).toBe('step-1');
+    expect(error.cause.code).toBe('UNKNOWN_REF');
+    expect(error.cause.refId).toBe('wr.refs.nonexistent');
+  });
+
+  it('resolves refs in loop body steps', () => {
+    const loopStep: LoopStepDefinition = {
+      id: 'loop-1',
+      title: 'Loop',
+      prompt: 'Loop prompt.',
+      type: 'loop',
+      loop: { type: 'while', maxIterations: 3 },
+      body: [
+        {
+          id: 'body-1',
+          title: 'Body Step',
+          promptBlocks: {
+            goal: [{ kind: 'ref', refId: 'wr.refs.memory_usage' }],
+          },
+        },
+      ],
+    };
+    const result = resolveRefsPass([loopStep], registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as LoopStepDefinition;
+    const bodyStep = (resolved.body as WorkflowStepDefinition[])[0]!;
+    const parts = bodyStep.promptBlocks!.goal as readonly PromptPart[];
+    expect(parts[0]!.kind).toBe('text');
+  });
+
+  it('preserves loop step structure after resolution', () => {
+    const loopStep: LoopStepDefinition = {
+      id: 'loop-1',
+      title: 'Loop',
+      prompt: 'Loop prompt.',
+      type: 'loop',
+      loop: { type: 'while', maxIterations: 5 },
+      body: [
+        { id: 'body-1', title: 'Body', prompt: 'Body prompt.' },
+      ],
+    };
+    const result = resolveRefsPass([loopStep], registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as LoopStepDefinition;
+    expect(resolved.type).toBe('loop');
+    expect(resolved.loop.type).toBe('while');
+    expect(resolved.loop.maxIterations).toBe(5);
+  });
+
+  it('handles mixed steps correctly', () => {
+    const steps: (WorkflowStepDefinition | LoopStepDefinition)[] = [
+      { id: 'step-1', title: 'Raw', prompt: 'Raw prompt.' },
+      {
+        id: 'step-2',
+        title: 'With Ref',
+        promptBlocks: {
+          goal: [
+            { kind: 'text', text: 'Check: ' },
+            { kind: 'ref', refId: 'wr.refs.memory_usage' },
+          ],
+        },
+      },
+      { id: 'step-3', title: 'Plain Blocks', promptBlocks: { goal: 'No refs.' } },
+    ];
+    const result = resolveRefsPass(steps, registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap();
+    // step-1: unchanged
+    expect(resolved[0]!.prompt).toBe('Raw prompt.');
+    // step-2: ref resolved
+    const goalParts = (resolved[1] as WorkflowStepDefinition).promptBlocks!.goal as readonly PromptPart[];
+    expect(goalParts.every(p => p.kind === 'text')).toBe(true);
+    // step-3: unchanged
+    expect((resolved[2] as WorkflowStepDefinition).promptBlocks!.goal).toBe('No refs.');
+  });
+
+  it('is deterministic: same input always produces same output', () => {
+    const steps: WorkflowStepDefinition[] = [
+      {
+        id: 'step-1',
+        title: 'Step',
+        promptBlocks: {
+          goal: [{ kind: 'ref', refId: 'wr.refs.memory_usage' }],
+        },
+      },
+    ];
+    const a = resolveRefsPass(steps, registry)._unsafeUnwrap();
+    const b = resolveRefsPass(steps, registry)._unsafeUnwrap();
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});


### PR DESCRIPTION
## Summary
- Introduces closed-set `wr.refs.*` registry mapping ref IDs to canonical text content
- `resolveRefsPass()` compiler pass walks promptBlocks, replacing `{ kind: 'ref' }` parts with resolved `{ kind: 'text' }` parts
- Unknown refs fail fast at compile time with descriptive error messages
- Initial refs: `wr.refs.memory_usage`, `wr.refs.memory_store`, `wr.refs.memory_query`
- Pipeline order: resolveRefs -> resolvePromptBlocks -> existing validation

### PR2 of the V2 Workflow Authoring Layer

Builds on PR1 (#85). Refs in promptBlocks are now resolvable:

```jsonc
{
  "promptBlocks": {
    "goal": [
      { "kind": "text", "text": "Investigate the bug. " },
      { "kind": "ref", "refId": "wr.refs.memory_usage" }
    ]
  }
}
```

### Files changed
| File | Change |
|------|--------|
| `src/application/services/compiler/ref-registry.ts` | New -- RefRegistry interface + createRefRegistry() |
| `src/application/services/compiler/resolve-refs.ts` | New -- resolveRefsPass() compiler pass |
| `src/application/services/workflow-compiler.ts` | Wires ref resolution before promptBlocks rendering |
| `tests/unit/compiler/ref-registry.test.ts` | New -- 9 tests |
| `tests/unit/compiler/resolve-refs.test.ts` | New -- 11 tests |

## Test plan
- [x] 20 new tests pass (registry resolution, unknown ref rejection, pass-through, loop bodies, determinism)
- [x] Full test suite passes (2,707 tests, 0 failures)
- [x] Build clean
- [x] Backward compat: existing workflows without refs unaffected