### PR TITLE
feat(v2): add feature registry and middleware compiler pass (PR3 of authoring layer)

### DIFF
--- a/src/application/services/compiler/feature-registry.ts
+++ b/src/application/services/compiler/feature-registry.ts
@@ -1,0 +1,97 @@
+/**
+ * Feature Registry — Closed-Set Compiler Middleware
+ *
+ * Maps `wr.features.*` IDs to feature definitions. Each feature
+ * specifies content to inject into promptBlocks sections.
+ *
+ * Features are cross-cutting concerns applied at the workflow level.
+ * The compiler applies declared features to every step that uses
+ * promptBlocks, injecting constraints, procedure steps, etc.
+ *
+ * Why closed-set: features modify compiled content that becomes part
+ * of the workflow hash. User-defined features would break determinism.
+ */
+
+import type { Result } from 'neverthrow';
+import { ok, err } from 'neverthrow';
+import type { PromptValue } from './prompt-blocks.js';
+
+// ---------------------------------------------------------------------------
+// Feature definition types
+// ---------------------------------------------------------------------------
+
+/**
+ * A feature definition describes content to inject into promptBlocks.
+ *
+ * Each field maps to a promptBlocks section. Injected content is
+ * appended to existing content (never replaces).
+ */
+export interface FeatureDefinition {
+  readonly id: string;
+  /** Constraints to append to every step's constraints block. */
+  readonly constraints?: readonly PromptValue[];
+  /** Procedure steps to append to every step's procedure block. */
+  readonly procedure?: readonly PromptValue[];
+  /** Verify items to append to every step's verify block. */
+  readonly verify?: readonly PromptValue[];
+}
+
+export type FeatureResolveError = {
+  readonly code: 'UNKNOWN_FEATURE';
+  readonly featureId: string;
+  readonly message: string;
+};
+
+/** Read-only lookup interface for feature resolution. */
+export interface FeatureRegistry {
+  readonly resolve: (featureId: string) => Result<FeatureDefinition, FeatureResolveError>;
+  readonly has: (featureId: string) => boolean;
+  readonly knownIds: () => readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Canonical feature definitions (closed set, WorkRail-owned)
+// ---------------------------------------------------------------------------
+
+const FEATURE_DEFINITIONS: readonly FeatureDefinition[] = [
+  {
+    id: 'wr.features.memory_context',
+    constraints: [
+      [
+        { kind: 'ref', refId: 'wr.refs.memory_usage' },
+      ],
+    ],
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Registry constructor
+// ---------------------------------------------------------------------------
+
+/** Create the canonical feature registry (frozen, closed-set). */
+export function createFeatureRegistry(): FeatureRegistry {
+  const byId = new Map(FEATURE_DEFINITIONS.map(f => [f.id, f]));
+  const knownIds = FEATURE_DEFINITIONS.map(f => f.id);
+
+  return {
+    resolve(featureId: string): Result<FeatureDefinition, FeatureResolveError> {
+      const def = byId.get(featureId);
+      if (!def) {
+        return err({
+          code: 'UNKNOWN_FEATURE',
+          featureId,
+          message: `Unknown feature '${featureId}'. Known features: ${knownIds.join(', ')}`,
+        });
+      }
+      return ok(def);
+    },
+
+    has(featureId: string): boolean {
+      return byId.has(featureId);
+    },
+
+    knownIds(): readonly string[] {
+      return knownIds;
+    },
+  };
+}

--- a/src/application/services/compiler/resolve-features.ts
+++ b/src/application/services/compiler/resolve-features.ts
@@ -1,0 +1,132 @@
+/**
+ * Feature Resolution Compiler Pass
+ *
+ * Applies declared features to all steps that use promptBlocks.
+ * Features inject content into promptBlocks sections (constraints,
+ * procedure, verify). Runs BEFORE ref resolution, since features
+ * may inject refs that need resolving.
+ *
+ * Steps using raw `prompt` strings are not modified — features only
+ * apply to promptBlocks-based steps. This is intentional: raw prompt
+ * steps are fully authored by the workflow author.
+ *
+ * Pure function — no I/O, no mutation.
+ */
+
+import type { Result } from 'neverthrow';
+import { ok, err } from 'neverthrow';
+import type { FeatureRegistry, FeatureDefinition, FeatureResolveError } from './feature-registry.js';
+import type { PromptBlocks, PromptValue } from './prompt-blocks.js';
+import type { WorkflowStepDefinition, LoopStepDefinition } from '../../../types/workflow-definition.js';
+import { isLoopStepDefinition } from '../../../types/workflow-definition.js';
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export type ResolveFeaturesPassError =
+  | { readonly code: 'FEATURE_RESOLVE_ERROR'; readonly cause: FeatureResolveError }
+  | { readonly code: 'FEATURE_ON_RAW_PROMPT_STEP'; readonly stepId: string; readonly message: string };
+
+// ---------------------------------------------------------------------------
+// Block merging — append feature content to existing blocks
+// ---------------------------------------------------------------------------
+
+function appendValues(
+  existing: readonly PromptValue[] | undefined,
+  injected: readonly PromptValue[] | undefined,
+): readonly PromptValue[] | undefined {
+  if (!injected || injected.length === 0) return existing;
+  if (!existing || existing.length === 0) return injected;
+  return [...existing, ...injected];
+}
+
+/** Merge feature injections into a step's promptBlocks. */
+function applyFeatureToBlocks(
+  blocks: PromptBlocks,
+  feature: FeatureDefinition,
+): PromptBlocks {
+  return {
+    ...blocks,
+    constraints: appendValues(blocks.constraints, feature.constraints),
+    procedure: appendValues(blocks.procedure, feature.procedure),
+    verify: appendValues(blocks.verify, feature.verify),
+  };
+}
+
+/** Apply all features to a step's promptBlocks. */
+function applyFeaturesToStep(
+  step: WorkflowStepDefinition,
+  features: readonly FeatureDefinition[],
+): WorkflowStepDefinition {
+  if (!step.promptBlocks || features.length === 0) return step;
+
+  let blocks = step.promptBlocks;
+  for (const feature of features) {
+    blocks = applyFeatureToBlocks(blocks, feature);
+  }
+  return { ...step, promptBlocks: blocks };
+}
+
+// ---------------------------------------------------------------------------
+// Compiler pass
+// ---------------------------------------------------------------------------
+
+/**
+ * Compiler pass: apply declared features to all promptBlocks-based steps.
+ *
+ * Must run BEFORE resolveRefsPass (features may inject refs).
+ * Pure function — no I/O, no mutation.
+ *
+ * @param steps - workflow steps
+ * @param featureIds - declared feature IDs from WorkflowDefinition.features
+ * @param registry - feature registry for looking up definitions
+ */
+export function resolveFeaturesPass(
+  steps: readonly (WorkflowStepDefinition | LoopStepDefinition)[],
+  featureIds: readonly string[],
+  registry: FeatureRegistry,
+): Result<readonly (WorkflowStepDefinition | LoopStepDefinition)[], ResolveFeaturesPassError> {
+  if (featureIds.length === 0) return ok(steps);
+
+  // Resolve all feature IDs upfront (fail fast on unknown)
+  const features: FeatureDefinition[] = [];
+  for (const id of featureIds) {
+    const res = registry.resolve(id);
+    if (res.isErr()) {
+      return err({ code: 'FEATURE_RESOLVE_ERROR', cause: res.error });
+    }
+    features.push(res.value);
+  }
+
+  // Apply features to each step
+  const resolved: (WorkflowStepDefinition | LoopStepDefinition)[] = [];
+
+  for (const step of steps) {
+    if (isLoopStepDefinition(step)) {
+      // Apply to the loop step itself
+      const resolvedLoop = applyFeaturesToStep(step, features);
+
+      // Apply to inline body steps
+      if (Array.isArray(step.body)) {
+        const bodyResolved = step.body.map(bodyStep =>
+          applyFeaturesToStep(bodyStep, features)
+        );
+        resolved.push({
+          ...step,
+          ...(resolvedLoop.promptBlocks ? { promptBlocks: resolvedLoop.promptBlocks } : {}),
+          body: bodyResolved,
+        } as LoopStepDefinition);
+      } else {
+        resolved.push({
+          ...step,
+          ...(resolvedLoop.promptBlocks ? { promptBlocks: resolvedLoop.promptBlocks } : {}),
+        } as LoopStepDefinition);
+      }
+    } else {
+      resolved.push(applyFeaturesToStep(step, features));
+    }
+  }
+
+  return ok(resolved);
+}

--- a/src/types/workflow-definition.ts
+++ b/src/types/workflow-definition.ts
@@ -189,6 +189,12 @@ export interface WorkflowDefinition {
    * warnings are emitted as gap_recorded events (severity: warning).
    */
   readonly recommendedPreferences?: WorkflowRecommendedPreferences;
+  /**
+   * Workflow-level feature declarations (closed-set, wr.features.*).
+   * Features are compiler middleware that inject content into promptBlocks.
+   * Resolved at compile time — unknown feature IDs fail fast.
+   */
+  readonly features?: readonly string[];
 }
 
 // =============================================================================

--- a/tests/unit/compiler/feature-registry.test.ts
+++ b/tests/unit/compiler/feature-registry.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Feature Registry — Tests
+ */
+import { describe, it, expect } from 'vitest';
+import { createFeatureRegistry } from '../../../src/application/services/compiler/feature-registry.js';
+
+describe('FeatureRegistry', () => {
+  const registry = createFeatureRegistry();
+
+  it('resolves wr.features.memory_context', () => {
+    const result = registry.resolve('wr.features.memory_context');
+    expect(result.isOk()).toBe(true);
+    const def = result._unsafeUnwrap();
+    expect(def.id).toBe('wr.features.memory_context');
+    expect(def.constraints).toBeDefined();
+    expect(def.constraints!.length).toBeGreaterThan(0);
+  });
+
+  it('returns UNKNOWN_FEATURE for unregistered feature ID', () => {
+    const result = registry.resolve('wr.features.nonexistent');
+    expect(result.isErr()).toBe(true);
+    const error = result._unsafeUnwrapErr();
+    expect(error.code).toBe('UNKNOWN_FEATURE');
+    expect(error.featureId).toBe('wr.features.nonexistent');
+  });
+
+  it('returns UNKNOWN_FEATURE for empty string', () => {
+    const result = registry.resolve('');
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr().code).toBe('UNKNOWN_FEATURE');
+  });
+
+  it('has() returns true for known features', () => {
+    expect(registry.has('wr.features.memory_context')).toBe(true);
+  });
+
+  it('has() returns false for unknown features', () => {
+    expect(registry.has('wr.features.nonexistent')).toBe(false);
+  });
+
+  it('knownIds() returns all registered feature IDs', () => {
+    const ids = registry.knownIds();
+    expect(ids).toContain('wr.features.memory_context');
+    expect(ids.length).toBe(1);
+  });
+
+  it('memory_context feature injects a ref to wr.refs.memory_usage', () => {
+    const def = registry.resolve('wr.features.memory_context')._unsafeUnwrap();
+    const firstConstraint = def.constraints![0];
+    // Should be an array of PromptParts containing a ref
+    expect(Array.isArray(firstConstraint)).toBe(true);
+    const parts = firstConstraint as readonly { kind: string; refId?: string }[];
+    expect(parts.some(p => p.kind === 'ref' && p.refId === 'wr.refs.memory_usage')).toBe(true);
+  });
+});

--- a/tests/unit/compiler/resolve-features.test.ts
+++ b/tests/unit/compiler/resolve-features.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Resolve Features Compiler Pass — Tests
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveFeaturesPass } from '../../../src/application/services/compiler/resolve-features.js';
+import { createFeatureRegistry } from '../../../src/application/services/compiler/feature-registry.js';
+import type { WorkflowStepDefinition, LoopStepDefinition } from '../../../src/types/workflow-definition.js';
+
+const registry = createFeatureRegistry();
+
+describe('resolveFeaturesPass', () => {
+  it('returns steps unchanged when no features declared', () => {
+    const steps: WorkflowStepDefinition[] = [
+      { id: 'step-1', title: 'Step 1', prompt: 'Raw prompt.' },
+    ];
+    const result = resolveFeaturesPass(steps, [], registry);
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBe(steps); // same reference
+  });
+
+  it('does not modify steps with raw prompt (no promptBlocks)', () => {
+    const steps: WorkflowStepDefinition[] = [
+      { id: 'step-1', title: 'Step 1', prompt: 'Raw prompt.' },
+    ];
+    const result = resolveFeaturesPass(steps, ['wr.features.memory_context'], registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as WorkflowStepDefinition;
+    // Raw prompt step is unchanged — no promptBlocks to inject into
+    expect(resolved.prompt).toBe('Raw prompt.');
+    expect(resolved.promptBlocks).toBeUndefined();
+  });
+
+  it('injects feature constraints into promptBlocks step', () => {
+    const steps: WorkflowStepDefinition[] = [
+      {
+        id: 'step-1',
+        title: 'Step 1',
+        promptBlocks: {
+          goal: 'Find the bug.',
+          constraints: ['Follow the mode.'],
+        },
+      },
+    ];
+    const result = resolveFeaturesPass(steps, ['wr.features.memory_context'], registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as WorkflowStepDefinition;
+    // Original constraint preserved + feature constraint appended
+    expect(resolved.promptBlocks!.constraints!.length).toBeGreaterThan(1);
+    expect(resolved.promptBlocks!.constraints![0]).toBe('Follow the mode.');
+  });
+
+  it('creates constraints array when step had none', () => {
+    const steps: WorkflowStepDefinition[] = [
+      {
+        id: 'step-1',
+        title: 'Step 1',
+        promptBlocks: { goal: 'Do the thing.' },
+      },
+    ];
+    const result = resolveFeaturesPass(steps, ['wr.features.memory_context'], registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as WorkflowStepDefinition;
+    expect(resolved.promptBlocks!.constraints).toBeDefined();
+    expect(resolved.promptBlocks!.constraints!.length).toBeGreaterThan(0);
+  });
+
+  it('preserves goal and other blocks unchanged', () => {
+    const steps: WorkflowStepDefinition[] = [
+      {
+        id: 'step-1',
+        title: 'Step 1',
+        promptBlocks: {
+          goal: 'Find the bug.',
+          verify: ['Evidence is grounded.'],
+        },
+      },
+    ];
+    const result = resolveFeaturesPass(steps, ['wr.features.memory_context'], registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as WorkflowStepDefinition;
+    expect(resolved.promptBlocks!.goal).toBe('Find the bug.');
+    // verify unchanged (memory_context doesn't inject verify items)
+    expect(resolved.promptBlocks!.verify).toEqual(['Evidence is grounded.']);
+  });
+
+  it('returns error for unknown feature', () => {
+    const steps: WorkflowStepDefinition[] = [
+      { id: 'step-1', title: 'Step 1', promptBlocks: { goal: 'Goal.' } },
+    ];
+    const result = resolveFeaturesPass(steps, ['wr.features.nonexistent'], registry);
+    expect(result.isErr()).toBe(true);
+    const error = result._unsafeUnwrapErr();
+    expect(error.code).toBe('FEATURE_RESOLVE_ERROR');
+    if (error.code === 'FEATURE_RESOLVE_ERROR') {
+      expect(error.cause.featureId).toBe('wr.features.nonexistent');
+    }
+  });
+
+  it('fails fast on first unknown feature even if others are valid', () => {
+    const steps: WorkflowStepDefinition[] = [
+      { id: 'step-1', title: 'Step 1', promptBlocks: { goal: 'Goal.' } },
+    ];
+    const result = resolveFeaturesPass(
+      steps,
+      ['wr.features.memory_context', 'wr.features.nonexistent'],
+      registry,
+    );
+    expect(result.isErr()).toBe(true);
+  });
+
+  it('applies features to loop body steps', () => {
+    const loopStep: LoopStepDefinition = {
+      id: 'loop-1',
+      title: 'Loop',
+      prompt: 'Loop prompt.',
+      type: 'loop',
+      loop: { type: 'while', maxIterations: 3 },
+      body: [
+        {
+          id: 'body-1',
+          title: 'Body Step',
+          promptBlocks: { goal: 'Body goal.' },
+        },
+      ],
+    };
+    const result = resolveFeaturesPass([loopStep], ['wr.features.memory_context'], registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as LoopStepDefinition;
+    const bodyStep = (resolved.body as WorkflowStepDefinition[])[0]!;
+    expect(bodyStep.promptBlocks!.constraints).toBeDefined();
+    expect(bodyStep.promptBlocks!.constraints!.length).toBeGreaterThan(0);
+  });
+
+  it('preserves loop structure after feature application', () => {
+    const loopStep: LoopStepDefinition = {
+      id: 'loop-1',
+      title: 'Loop',
+      prompt: 'Loop prompt.',
+      type: 'loop',
+      loop: { type: 'while', maxIterations: 5 },
+      body: [{ id: 'body-1', title: 'Body', prompt: 'Body prompt.' }],
+    };
+    const result = resolveFeaturesPass([loopStep], ['wr.features.memory_context'], registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap()[0] as LoopStepDefinition;
+    expect(resolved.type).toBe('loop');
+    expect(resolved.loop.type).toBe('while');
+    expect(resolved.loop.maxIterations).toBe(5);
+  });
+
+  it('handles mixed steps correctly', () => {
+    const steps: (WorkflowStepDefinition | LoopStepDefinition)[] = [
+      { id: 'step-1', title: 'Raw', prompt: 'Raw prompt.' },
+      { id: 'step-2', title: 'Blocks', promptBlocks: { goal: 'Structured.' } },
+    ];
+    const result = resolveFeaturesPass(steps, ['wr.features.memory_context'], registry);
+    expect(result.isOk()).toBe(true);
+    const resolved = result._unsafeUnwrap();
+    // step-1: raw prompt, unmodified
+    expect((resolved[0] as WorkflowStepDefinition).promptBlocks).toBeUndefined();
+    // step-2: feature applied
+    expect((resolved[1] as WorkflowStepDefinition).promptBlocks!.constraints).toBeDefined();
+  });
+
+  it('is deterministic: same inputs always produce same output', () => {
+    const steps: WorkflowStepDefinition[] = [
+      { id: 'step-1', title: 'Step', promptBlocks: { goal: 'Goal.' } },
+    ];
+    const a = resolveFeaturesPass(steps, ['wr.features.memory_context'], registry)._unsafeUnwrap();
+    const b = resolveFeaturesPass(steps, ['wr.features.memory_context'], registry)._unsafeUnwrap();
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});


### PR DESCRIPTION
## Summary
- Introduces closed-set `wr.features.*` registry for compile-time middleware
- Features inject content into promptBlocks sections across all steps (cross-cutting)
- `resolveFeaturesPass()` runs before ref resolution so features can inject refs
- Initial feature: `wr.features.memory_context` -- injects `wr.refs.memory_usage` as a constraint
- `WorkflowDefinition.features` field added for declaring features per workflow

### PR3 of the V2 Workflow Authoring Layer

Builds on PR1 (#85) and PR2 (#86). Full compiler pipeline:

```
resolveFeatures -> resolveRefs -> resolvePromptBlocks -> existing validation
```

Usage in workflow JSON:
```jsonc
{
  "features": ["wr.features.memory_context"],
  "steps": [
    {
      "id": "phase-0",
      "title": "Investigate",
      "promptBlocks": { "goal": "Find the root cause." }
    }
  ]
}
```

The compiler injects memory usage instructions as a constraint into every promptBlocks-based step. Raw prompt steps are unmodified.

### Files changed
| File | Change |
|------|--------|
| `src/application/services/compiler/feature-registry.ts` | New -- FeatureRegistry + createFeatureRegistry() |
| `src/application/services/compiler/resolve-features.ts` | New -- resolveFeaturesPass() compiler pass |
| `src/application/services/workflow-compiler.ts` | Wires feature resolution before ref resolution |
| `src/types/workflow-definition.ts` | Adds `features?: readonly string[]` to WorkflowDefinition |
| `tests/unit/compiler/feature-registry.test.ts` | New -- 7 tests |
| `tests/unit/compiler/resolve-features.test.ts` | New -- 11 tests |

## Test plan
- [x] 18 new tests pass (registry, resolution, loop bodies, error cases, determinism)
- [x] Full test suite passes (2,725 tests, 0 failures)
- [x] Build clean
- [x] Backward compat: workflows without `features` field unaffected