### PR TITLE
feat(v2): add template registry and expansion compiler pass (PR4 of authoring layer)

### DIFF
--- a/src/application/services/compiler/resolve-templates.ts
+++ b/src/application/services/compiler/resolve-templates.ts
@@ -1,0 +1,104 @@
+/**
+ * Template Resolution Compiler Pass
+ *
+ * Replaces steps with `templateCall` with the expanded steps from the
+ * template registry. Runs FIRST in the compiler pipeline — before
+ * features, refs, and promptBlocks rendering.
+ *
+ * Why first: templates produce real steps that may use promptBlocks,
+ * refs, and features. All subsequent passes operate on the expanded steps.
+ *
+ * Pure function — no I/O, no mutation.
+ */
+
+import type { Result } from 'neverthrow';
+import { ok, err } from 'neverthrow';
+import type { TemplateRegistry, TemplateResolveError, TemplateExpandError } from './template-registry.js';
+import type { WorkflowStepDefinition, LoopStepDefinition } from '../../../types/workflow-definition.js';
+import { isLoopStepDefinition } from '../../../types/workflow-definition.js';
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export type ResolveTemplatesPassError =
+  | { readonly code: 'TEMPLATE_RESOLVE_ERROR'; readonly stepId: string; readonly cause: TemplateResolveError }
+  | { readonly code: 'TEMPLATE_EXPAND_ERROR'; readonly stepId: string; readonly cause: TemplateExpandError };
+
+// ---------------------------------------------------------------------------
+// Step-level template resolution
+// ---------------------------------------------------------------------------
+
+function resolveStepTemplate(
+  step: WorkflowStepDefinition,
+  registry: TemplateRegistry,
+): Result<readonly WorkflowStepDefinition[], ResolveTemplatesPassError> {
+  if (!step.templateCall) return ok([step]);
+
+  const { templateId, args } = step.templateCall;
+
+  // Resolve the template expander
+  const expanderResult = registry.resolve(templateId);
+  if (expanderResult.isErr()) {
+    return err({
+      code: 'TEMPLATE_RESOLVE_ERROR',
+      stepId: step.id,
+      cause: expanderResult.error,
+    });
+  }
+
+  // Expand the template
+  const expandResult = expanderResult.value(step.id, args ?? {});
+  if (expandResult.isErr()) {
+    return err({
+      code: 'TEMPLATE_EXPAND_ERROR',
+      stepId: step.id,
+      cause: expandResult.error,
+    });
+  }
+
+  return ok(expandResult.value);
+}
+
+// ---------------------------------------------------------------------------
+// Compiler pass
+// ---------------------------------------------------------------------------
+
+/**
+ * Compiler pass: expand all template_call steps into real steps.
+ *
+ * Must run FIRST in the pipeline (before features, refs, blocks).
+ * Template calls in loop body steps are also expanded.
+ * Pure function — no I/O, no mutation.
+ */
+export function resolveTemplatesPass(
+  steps: readonly (WorkflowStepDefinition | LoopStepDefinition)[],
+  registry: TemplateRegistry,
+): Result<readonly (WorkflowStepDefinition | LoopStepDefinition)[], ResolveTemplatesPassError> {
+  const resolved: (WorkflowStepDefinition | LoopStepDefinition)[] = [];
+
+  for (const step of steps) {
+    if (isLoopStepDefinition(step)) {
+      // Loop steps themselves cannot be template calls (loops have their own structure).
+      // But inline body steps can be template calls.
+      if (Array.isArray(step.body)) {
+        const bodyResolved: WorkflowStepDefinition[] = [];
+        for (const bodyStep of step.body) {
+          const res = resolveStepTemplate(bodyStep, registry);
+          if (res.isErr()) return err(res.error);
+          bodyResolved.push(...res.value);
+        }
+        resolved.push({ ...step, body: bodyResolved } as LoopStepDefinition);
+      } else {
+        resolved.push(step);
+      }
+    } else {
+      const res = resolveStepTemplate(step, registry);
+      if (res.isErr()) return err(res.error);
+      // Template expansion may produce multiple steps — splice them in
+      resolved.push(...res.value);
+    }
+  }
+
+  return ok(resolved);
+}

--- a/src/application/services/compiler/template-registry.ts
+++ b/src/application/services/compiler/template-registry.ts
@@ -1,0 +1,91 @@
+/**
+ * Template Registry — Closed-Set Step Expansion
+ *
+ * Maps `wr.templates.*` IDs to template expansion functions.
+ * Templates expand a single step into one or more real steps at compile time.
+ *
+ * Why closed-set: templates produce steps that become part of the compiled
+ * workflow hash. User-defined templates would break determinism.
+ *
+ * The registry starts empty — template definitions are added in future PRs.
+ * This PR ships the expansion machinery and compiler wiring.
+ */
+
+import type { Result } from 'neverthrow';
+import { ok, err } from 'neverthrow';
+import type { WorkflowStepDefinition } from '../../../types/workflow-definition.js';
+
+// ---------------------------------------------------------------------------
+// Template definition types
+// ---------------------------------------------------------------------------
+
+/**
+ * A template expansion function.
+ *
+ * Takes the calling step's ID (used as prefix for expanded step IDs)
+ * and optional args, returns one or more real steps.
+ *
+ * Pure function — no I/O, deterministic.
+ */
+export type TemplateExpander = (
+  callerId: string,
+  args: Readonly<Record<string, unknown>>,
+) => Result<readonly WorkflowStepDefinition[], TemplateExpandError>;
+
+export type TemplateExpandError = {
+  readonly code: 'TEMPLATE_EXPAND_FAILED';
+  readonly templateId: string;
+  readonly message: string;
+};
+
+export type TemplateResolveError = {
+  readonly code: 'UNKNOWN_TEMPLATE';
+  readonly templateId: string;
+  readonly message: string;
+};
+
+/** Read-only lookup interface for template resolution. */
+export interface TemplateRegistry {
+  readonly resolve: (templateId: string) => Result<TemplateExpander, TemplateResolveError>;
+  readonly has: (templateId: string) => boolean;
+  readonly knownIds: () => readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Canonical template definitions (closed set, WorkRail-owned)
+// ---------------------------------------------------------------------------
+
+// Empty for now — template definitions will be added in future PRs.
+// The registry machinery and compiler pass are the deliverable for PR4.
+const TEMPLATE_DEFINITIONS = new Map<string, TemplateExpander>();
+
+// ---------------------------------------------------------------------------
+// Registry constructor
+// ---------------------------------------------------------------------------
+
+/** Create the canonical template registry (frozen, closed-set). */
+export function createTemplateRegistry(): TemplateRegistry {
+  const knownIds = [...TEMPLATE_DEFINITIONS.keys()];
+
+  return {
+    resolve(templateId: string): Result<TemplateExpander, TemplateResolveError> {
+      const expander = TEMPLATE_DEFINITIONS.get(templateId);
+      if (!expander) {
+        return err({
+          code: 'UNKNOWN_TEMPLATE',
+          templateId,
+          message: `Unknown template '${templateId}'. Known templates: ${knownIds.length > 0 ? knownIds.join(', ') : '(none)'}`,
+        });
+      }
+      return ok(expander);
+    },
+
+    has(templateId: string): boolean {
+      return TEMPLATE_DEFINITIONS.has(templateId);
+    },
+
+    knownIds(): readonly string[] {
+      return knownIds;
+    },
+  };
+}

--- a/src/types/workflow-definition.ts
+++ b/src/types/workflow-definition.ts
@@ -74,9 +74,24 @@ export interface WorkflowStepDefinition {
    * the session history.
    */
   readonly notesOptional?: boolean;
+  /**
+   * Template call: expands this step into one or more steps at compile time.
+   * When present, prompt/promptBlocks are ignored — the template provides them.
+   * The step's id becomes a prefix for expanded step IDs (e.g. "phase-0" ->
+   * "phase-0.investigate", "phase-0.plan").
+   */
+  readonly templateCall?: TemplateCall;
   readonly functionDefinitions?: readonly FunctionDefinition[];
   readonly functionCalls?: readonly FunctionCall[];
   readonly functionReferences?: readonly string[];
+}
+
+/** A compile-time template invocation. */
+export interface TemplateCall {
+  /** Template ID from the closed-set registry (wr.templates.*). */
+  readonly templateId: string;
+  /** Optional arguments passed to the template expansion function. */
+  readonly args?: Readonly<Record<string, unknown>>;
 }
 
 export interface LoopStepDefinition extends WorkflowStepDefinition {

--- a/tests/unit/compiler/resolve-templates.test.ts
+++ b/tests/unit/compiler/resolve-templates.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Resolve Templates Compiler Pass — Tests
+ *
+ * Tests template expansion with a fake registry (since the real
+ * registry is empty). Validates the expansion machinery works.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveTemplatesPass } from '../../../src/application/services/compiler/resolve-templates.js';
+import { createTemplateRegistry } from '../../../src/application/services/compiler/template-registry.js';
+import type { TemplateRegistry } from '../../../src/application/services/compiler/template-registry.js';
+import type { WorkflowStepDefinition, LoopStepDefinition } from '../../../src/types/workflow-definition.js';
+import { ok, err } from 'neverthrow';
+
+// ---------------------------------------------------------------------------
+// Fake registry for testing expansion machinery
+// ---------------------------------------------------------------------------
+
+function createTestRegistry(): TemplateRegistry {
+  return {
+    resolve(templateId: string) {
+      if (templateId === 'wr.templates.test_probe') {
+        return ok((callerId: string, _args: Readonly<Record<string, unknown>>) => {
+          return ok([
+            { id: `${callerId}.check`, title: 'Check capability', prompt: 'Check if capability exists.' },
+            { id: `${callerId}.use`, title: 'Use capability', prompt: 'Use the capability.' },
+          ] as const satisfies readonly WorkflowStepDefinition[]);
+        });
+      }
+      if (templateId === 'wr.templates.failing') {
+        return ok((_callerId: string, _args: Readonly<Record<string, unknown>>) => {
+          return err({
+            code: 'TEMPLATE_EXPAND_FAILED' as const,
+            templateId: 'wr.templates.failing',
+            message: 'Intentional expansion failure.',
+          });
+        });
+      }
+      return err({
+        code: 'UNKNOWN_TEMPLATE' as const,
+        templateId,
+        message: `Unknown template '${templateId}'.`,
+      });
+    },
+    has(id: string) {
+      return id === 'wr.templates.test_probe' || id === 'wr.templates.failing';
+    },
+    knownIds() {
+      return ['wr.templates.test_probe', 'wr.templates.failing'];
+    },
+  };
+}
+
+const testRegistry = createTestRegistry();
+
+describe('resolveTemplatesPass', () => {
+  describe('with real (empty) registry', () => {
+    const emptyRegistry = createTemplateRegistry();
+
+    it('passes through steps without templateCall unchanged', () => {
+      const steps: WorkflowStepDefinition[] = [
+        { id: 'step-1', title: 'Step 1', prompt: 'Do something.' },
+      ];
+      const result = resolveTemplatesPass(steps, emptyRegistry);
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap()).toEqual(steps);
+    });
+
+    it('returns error for step with templateCall (registry is empty)', () => {
+      const steps: WorkflowStepDefinition[] = [
+        {
+          id: 'step-1',
+          title: 'Probe',
+          templateCall: { templateId: 'wr.templates.test_probe' },
+        },
+      ];
+      const result = resolveTemplatesPass(steps, emptyRegistry);
+      expect(result.isErr()).toBe(true);
+      const error = result._unsafeUnwrapErr();
+      expect(error.code).toBe('TEMPLATE_RESOLVE_ERROR');
+      expect(error.stepId).toBe('step-1');
+    });
+  });
+
+  describe('with test registry', () => {
+    it('expands a template_call step into multiple steps', () => {
+      const steps: WorkflowStepDefinition[] = [
+        {
+          id: 'phase-0',
+          title: 'Probe',
+          templateCall: { templateId: 'wr.templates.test_probe' },
+        },
+      ];
+      const result = resolveTemplatesPass(steps, testRegistry);
+      expect(result.isOk()).toBe(true);
+      const resolved = result._unsafeUnwrap();
+      expect(resolved.length).toBe(2);
+      expect(resolved[0]!.id).toBe('phase-0.check');
+      expect(resolved[1]!.id).toBe('phase-0.use');
+    });
+
+    it('preserves non-template steps around expanded steps', () => {
+      const steps: WorkflowStepDefinition[] = [
+        { id: 'before', title: 'Before', prompt: 'Before.' },
+        {
+          id: 'probe',
+          title: 'Probe',
+          templateCall: { templateId: 'wr.templates.test_probe' },
+        },
+        { id: 'after', title: 'After', prompt: 'After.' },
+      ];
+      const result = resolveTemplatesPass(steps, testRegistry);
+      expect(result.isOk()).toBe(true);
+      const resolved = result._unsafeUnwrap();
+      expect(resolved.length).toBe(4);
+      expect(resolved[0]!.id).toBe('before');
+      expect(resolved[1]!.id).toBe('probe.check');
+      expect(resolved[2]!.id).toBe('probe.use');
+      expect(resolved[3]!.id).toBe('after');
+    });
+
+    it('returns error for unknown template', () => {
+      const steps: WorkflowStepDefinition[] = [
+        {
+          id: 'step-1',
+          title: 'Unknown',
+          templateCall: { templateId: 'wr.templates.nonexistent' },
+        },
+      ];
+      const result = resolveTemplatesPass(steps, testRegistry);
+      expect(result.isErr()).toBe(true);
+      const error = result._unsafeUnwrapErr();
+      expect(error.code).toBe('TEMPLATE_RESOLVE_ERROR');
+      expect(error.stepId).toBe('step-1');
+      expect(error.cause.code).toBe('UNKNOWN_TEMPLATE');
+    });
+
+    it('returns error when template expansion fails', () => {
+      const steps: WorkflowStepDefinition[] = [
+        {
+          id: 'step-1',
+          title: 'Failing',
+          templateCall: { templateId: 'wr.templates.failing' },
+        },
+      ];
+      const result = resolveTemplatesPass(steps, testRegistry);
+      expect(result.isErr()).toBe(true);
+      const error = result._unsafeUnwrapErr();
+      expect(error.code).toBe('TEMPLATE_EXPAND_ERROR');
+      expect(error.stepId).toBe('step-1');
+    });
+
+    it('expands template_call in loop body steps', () => {
+      const loopStep: LoopStepDefinition = {
+        id: 'loop-1',
+        title: 'Loop',
+        prompt: 'Loop prompt.',
+        type: 'loop',
+        loop: { type: 'while', maxIterations: 3 },
+        body: [
+          {
+            id: 'body-probe',
+            title: 'Body Probe',
+            templateCall: { templateId: 'wr.templates.test_probe' },
+          },
+        ],
+      };
+      const result = resolveTemplatesPass([loopStep], testRegistry);
+      expect(result.isOk()).toBe(true);
+      const resolved = result._unsafeUnwrap()[0] as LoopStepDefinition;
+      const body = resolved.body as WorkflowStepDefinition[];
+      expect(body.length).toBe(2);
+      expect(body[0]!.id).toBe('body-probe.check');
+      expect(body[1]!.id).toBe('body-probe.use');
+    });
+
+    it('preserves loop structure after expansion', () => {
+      const loopStep: LoopStepDefinition = {
+        id: 'loop-1',
+        title: 'Loop',
+        prompt: 'Loop prompt.',
+        type: 'loop',
+        loop: { type: 'while', maxIterations: 5 },
+        body: [{ id: 'body-1', title: 'Body', prompt: 'Body prompt.' }],
+      };
+      const result = resolveTemplatesPass([loopStep], testRegistry);
+      expect(result.isOk()).toBe(true);
+      const resolved = result._unsafeUnwrap()[0] as LoopStepDefinition;
+      expect(resolved.type).toBe('loop');
+      expect(resolved.loop.type).toBe('while');
+      expect(resolved.loop.maxIterations).toBe(5);
+    });
+
+    it('is deterministic: same input always produces same output', () => {
+      const steps: WorkflowStepDefinition[] = [
+        {
+          id: 'probe',
+          title: 'Probe',
+          templateCall: { templateId: 'wr.templates.test_probe' },
+        },
+      ];
+      const a = resolveTemplatesPass(steps, testRegistry)._unsafeUnwrap();
+      const b = resolveTemplatesPass(steps, testRegistry)._unsafeUnwrap();
+      expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    });
+  });
+});

--- a/tests/unit/compiler/template-registry.test.ts
+++ b/tests/unit/compiler/template-registry.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Template Registry — Tests
+ */
+import { describe, it, expect } from 'vitest';
+import { createTemplateRegistry } from '../../../src/application/services/compiler/template-registry.js';
+
+describe('TemplateRegistry', () => {
+  const registry = createTemplateRegistry();
+
+  it('returns UNKNOWN_TEMPLATE for any template ID (registry is empty)', () => {
+    const result = registry.resolve('wr.templates.something');
+    expect(result.isErr()).toBe(true);
+    const error = result._unsafeUnwrapErr();
+    expect(error.code).toBe('UNKNOWN_TEMPLATE');
+    expect(error.templateId).toBe('wr.templates.something');
+    expect(error.message).toContain('(none)');
+  });
+
+  it('returns UNKNOWN_TEMPLATE for empty string', () => {
+    const result = registry.resolve('');
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr().code).toBe('UNKNOWN_TEMPLATE');
+  });
+
+  it('has() returns false for all IDs (registry is empty)', () => {
+    expect(registry.has('wr.templates.something')).toBe(false);
+    expect(registry.has('')).toBe(false);
+  });
+
+  it('knownIds() returns empty array', () => {
+    expect(registry.knownIds()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Introduces closed-set `wr.templates.*` registry for compile-time step expansion
- `resolveTemplatesPass()` replaces `templateCall` steps with expanded real steps
- Runs first in the compiler pipeline so expanded steps go through features/refs/blocks
- `TemplateCall` type added to `WorkflowStepDefinition` with `templateId` + optional `args`
- Registry starts empty -- template definitions will be added in future PRs
- This PR ships the expansion machinery and compiler wiring

### PR4 of the V2 Workflow Authoring Layer

Builds on PR1-PR3 (#85, #86, #87). Full compiler pipeline:

```
resolveTemplates -> resolveFeatures -> resolveRefs -> resolvePromptBlocks -> existing validation
```

Usage in workflow JSON:
```jsonc
{
  "steps": [
    {
      "id": "phase-0",
      "title": "Capability Probe",
      "templateCall": {
        "templateId": "wr.templates.capability_probe",
        "args": { "capability": "memory" }
      }
    }
  ]
}
```

### Files changed
| File | Change |
|------|--------|
| `src/application/services/compiler/template-registry.ts` | New -- TemplateRegistry + createTemplateRegistry() |
| `src/application/services/compiler/resolve-templates.ts` | New -- resolveTemplatesPass() compiler pass |
| `src/application/services/workflow-compiler.ts` | Wires template expansion as first pass |
| `src/types/workflow-definition.ts` | Adds `templateCall?` + `TemplateCall` type |
| `tests/unit/compiler/template-registry.test.ts` | New -- 4 tests |
| `tests/unit/compiler/resolve-templates.test.ts` | New -- 9 tests (using fake registry) |

## Test plan
- [x] 13 new tests pass (registry empty-state, expansion with fake registry, loop bodies, errors, determinism)
- [x] Full test suite passes (2,738 tests, 0 failures)
- [x] Build clean
- [x] Backward compat: no existing workflows use templateCall