### PR TITLE
fix(v2): artifact_contract while loops enter on first iteration and use latest artifact

### DIFF
--- a/src/application/services/workflow-interpreter.ts
+++ b/src/application/services/workflow-interpreter.ts
@@ -415,14 +415,11 @@ export class WorkflowInterpreter {
         if (result.kind === 'found') {
           return ok(result.decision === 'continue');
         }
-        // Missing or invalid artifact = error (not silent exit)
-        return err({
-          code: 'LOOP_MISSING_CONTEXT',
-          loopId: loopCompiled.loop.id,
-          message: result.kind === 'not_found'
-            ? `Loop '${source.loopId}' requires a wr.loop_control artifact but none was provided`
-            : `Loop '${source.loopId}' has an invalid loop control artifact: ${result.reason}`,
-        });
+        // not_found: no artifact yet — default to continue (enter the loop).
+        // The loop_control artifact is produced inside the body (exit-decision step);
+        // it cannot exist before the first iteration runs. Only an explicit 'stop'
+        // decision exits the loop; absence of the artifact is not a stop signal.
+        return ok(true);
       }
       case 'context_variable': {
         // ONLY context. No artifact awareness.

--- a/src/v2/durable-core/schemas/artifacts/loop-control.ts
+++ b/src/v2/durable-core/schemas/artifacts/loop-control.ts
@@ -129,17 +129,23 @@ export function parseLoopControlArtifact(artifact: unknown): LoopControlArtifact
 }
 
 /**
- * Find a loop control artifact for a specific loopId in an artifacts array.
- * 
- * @param artifacts - Array of unknown artifacts
+ * Find the most recent loop control artifact for a specific loopId.
+ *
+ * Iterates in reverse so the last (newest) matching artifact wins.
+ * Artifacts are collected in chronological order by the engine, so the last
+ * one is the most recent exit-decision — the only one that matters for
+ * deciding whether to continue or stop.
+ *
+ * @param artifacts - Array of unknown artifacts (chronological order)
  * @param loopId - The loop ID to find
- * @returns The matching loop control artifact or null
+ * @returns The most recent matching loop control artifact or null
  */
 export function findLoopControlArtifact(
   artifacts: readonly unknown[],
   loopId: string
 ): LoopControlArtifactV1 | null {
-  for (const artifact of artifacts) {
+  for (let i = artifacts.length - 1; i >= 0; i--) {
+    const artifact = artifacts[i];
     if (!isLoopControlArtifact(artifact)) continue;
     const parsed = parseLoopControlArtifact(artifact);
     if (parsed && parsed.loopId === loopId) {


### PR DESCRIPTION
## Summary

- `while` loops with `artifact_contract` conditionSource threw `INTERNAL_ERROR` when the preceding step was completed — the loop could never be entered
- `findLoopControlArtifact` returned the oldest artifact, causing multi-iteration loops to always use iteration 0's exit decision and never stop

## Root Causes

**Bug 1 — INTERNAL_ERROR on loop entry** (`workflow-interpreter.ts`)

`evaluateWhileUntilCondition` returned `LOOP_MISSING_CONTEXT` when no `wr.loop_control` artifact was found. At iteration 0 the exit-decision body step hasn't run yet, so no artifact can ever exist at that point. Absence of an artifact is not a stop signal. Fixed: `not_found` now returns `ok(true)` — the loop enters unconditionally on the first iteration and only exits on an explicit `stop` artifact.

**Bug 2 — Oldest artifact wins** (`loop-control.ts`)

`findLoopControlArtifact` iterated forward and returned the first (oldest) match. After multiple iterations, iteration 0's `continue` artifact would override a later `stop` decision, keeping the loop running until `maxIterations`. Fixed: iterate in reverse so the most recent (last) artifact wins.

## Files Changed

- `src/application/services/workflow-interpreter.ts` — `not_found` → `ok(true)` in `artifact_contract` branch
- `src/v2/durable-core/schemas/artifacts/loop-control.ts` — `findLoopControlArtifact` now returns last match
- `tests/unit/workflow-interpreter-loop-artifacts.test.ts` — 4 tests updated (wrong assertions removed), 2 tests added for latest-artifact-wins semantics