### PR TITLE
fix(v1): validation engine accepts promptBlocks and templateCall

### DIFF
--- a/src/application/services/validation-engine.ts
+++ b/src/application/services/validation-engine.ts
@@ -8,7 +8,7 @@ import type {
   FunctionDefinition,
   FunctionParameter,
 } from '../../types/workflow-definition';
-import { isLoopStepDefinition } from '../../types/workflow-definition';
+import { isLoopStepDefinition, stepHasPromptSource } from '../../types/workflow-definition';
 import type { Workflow } from '../../types/workflow';
 import { 
   ValidationRule, 
@@ -587,9 +587,9 @@ export class ValidationEngine {
             suggestions.push('Add a title to all inline steps');
           }
           
-          if (!inlineStep.prompt) {
-            issues.push(`Inline step '${inlineStep.id || 'unknown'}' must have a prompt`);
-            suggestions.push('Add a prompt to all inline steps');
+          if (!stepHasPromptSource(inlineStep as WorkflowStepDefinition)) {
+            issues.push(`Inline step '${inlineStep.id || 'unknown'}' must have prompt, promptBlocks, or templateCall`);
+            suggestions.push('Add a prompt string, structured promptBlocks, or a templateCall to all inline steps');
           }
           
           // Check for nested loops
@@ -686,8 +686,9 @@ export class ValidationEngine {
         if (!step.title) {
           issues.push(`Step '${step.id}' missing required title`);
         }
-        if (!step.prompt) {
-          issues.push(`Step '${step.id}' missing required prompt`);
+        if (!stepHasPromptSource(step as WorkflowStepDefinition)) {
+          issues.push(`Step '${step.id}' must have prompt, promptBlocks, or templateCall`);
+          suggestions.push('Add a prompt string, structured promptBlocks, or a templateCall to each step');
         }
 
         this.collectQuotedJsonValidationMessageWarnings(step as any, `Step '${step.id}'`, warnings);

--- a/src/types/workflow-definition.ts
+++ b/src/types/workflow-definition.ts
@@ -228,6 +228,22 @@ export function isWorkflowStepDefinition(
   return !isLoopStepDefinition(step);
 }
 
+/**
+ * Whether a step declares at least one prompt source.
+ *
+ * Valid prompt sources (exactly one required):
+ * - prompt: raw string (backward compat)
+ * - promptBlocks: structured blocks (compiled to prompt)
+ * - templateCall: expands to steps that have their own prompt source
+ *
+ * This is the single source of truth for "does this step have content?"
+ * Used by both the validation engine (pre-compilation) and can be reused
+ * anywhere that needs this check.
+ */
+export function stepHasPromptSource(step: WorkflowStepDefinition): boolean {
+  return Boolean(step.prompt || step.promptBlocks || step.templateCall);
+}
+
 // =============================================================================
 // VALIDATION HELPERS
 // =============================================================================

--- a/tests/unit/compiler/validator-prompt-source.test.ts
+++ b/tests/unit/compiler/validator-prompt-source.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Validator Prompt Source — Tests
+ *
+ * Proves the validation engine accepts all three prompt sources
+ * (prompt, promptBlocks, templateCall) and rejects steps with none.
+ */
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { container } from 'tsyringe';
+import { ValidationEngine } from '../../../src/application/services/validation-engine';
+import { EnhancedLoopValidator } from '../../../src/application/services/enhanced-loop-validator';
+import { createWorkflow, createBundledSource } from '../../../src/types/workflow';
+import { stepHasPromptSource } from '../../../src/types/workflow-definition';
+import type { WorkflowStepDefinition, LoopStepDefinition } from '../../../src/types/workflow-definition';
+
+describe('stepHasPromptSource', () => {
+  it('returns true for step with prompt', () => {
+    const step = { id: 's', title: 'S', prompt: 'Do it.' } as WorkflowStepDefinition;
+    expect(stepHasPromptSource(step)).toBe(true);
+  });
+
+  it('returns true for step with promptBlocks', () => {
+    const step = {
+      id: 's',
+      title: 'S',
+      promptBlocks: { goal: 'Do it.' },
+    } as WorkflowStepDefinition;
+    expect(stepHasPromptSource(step)).toBe(true);
+  });
+
+  it('returns true for step with templateCall', () => {
+    const step = {
+      id: 's',
+      title: 'S',
+      templateCall: { templateId: 'wr.templates.probe' },
+    } as WorkflowStepDefinition;
+    expect(stepHasPromptSource(step)).toBe(true);
+  });
+
+  it('returns false for step with none', () => {
+    const step = { id: 's', title: 'S' } as WorkflowStepDefinition;
+    expect(stepHasPromptSource(step)).toBe(false);
+  });
+});
+
+describe('ValidationEngine accepts promptBlocks and templateCall', () => {
+  let validationEngine: ValidationEngine;
+
+  beforeEach(() => {
+    container.clearInstances();
+    const enhancedLoopValidator = container.resolve(EnhancedLoopValidator);
+    validationEngine = new ValidationEngine(enhancedLoopValidator);
+  });
+
+  afterEach(() => {
+    container.clearInstances();
+  });
+
+  function mkWorkflow(steps: readonly (WorkflowStepDefinition | LoopStepDefinition)[]) {
+    return createWorkflow(
+      {
+        id: 'test-wf',
+        name: 'Test',
+        description: 'Test',
+        version: '1.0.0',
+        steps,
+      },
+      createBundledSource(),
+    );
+  }
+
+  it('accepts step with prompt (backward compat)', () => {
+    const wf = mkWorkflow([{ id: 'step-1', title: 'Step 1', prompt: 'Do it.' }]);
+    const result = validationEngine.validateWorkflow(wf);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('accepts step with promptBlocks', () => {
+    const wf = mkWorkflow([
+      { id: 'step-1', title: 'Step 1', promptBlocks: { goal: 'Do it.' } } as WorkflowStepDefinition,
+    ]);
+    const result = validationEngine.validateWorkflow(wf);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('accepts step with templateCall', () => {
+    const wf = mkWorkflow([
+      {
+        id: 'step-1',
+        title: 'Step 1',
+        templateCall: { templateId: 'wr.templates.probe' },
+      } as WorkflowStepDefinition,
+    ]);
+    const result = validationEngine.validateWorkflow(wf);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('rejects step with no prompt source', () => {
+    const wf = mkWorkflow([{ id: 'step-1', title: 'Step 1' } as WorkflowStepDefinition]);
+    const result = validationEngine.validateWorkflow(wf);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.includes('must have prompt, promptBlocks, or templateCall'))).toBe(true);
+  });
+
+  it('accepts inline loop body step with promptBlocks', () => {
+    const wf = mkWorkflow([
+      {
+        id: 'loop-1',
+        title: 'Loop',
+        type: 'loop',
+        loop: { type: 'for', count: 3, maxIterations: 3 },
+        body: [
+          { id: 'body-1', title: 'Body Step', promptBlocks: { goal: 'Iterate.' } } as WorkflowStepDefinition,
+        ],
+      } as LoopStepDefinition,
+    ]);
+    const result = validationEngine.validateWorkflow(wf);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('rejects inline loop body step with no prompt source', () => {
+    const wf = mkWorkflow([
+      {
+        id: 'loop-1',
+        title: 'Loop',
+        type: 'loop',
+        loop: { type: 'for', count: 3, maxIterations: 3 },
+        body: [{ id: 'body-1', title: 'Body Step' } as WorkflowStepDefinition],
+      } as LoopStepDefinition,
+    ]);
+    const result = validationEngine.validateWorkflow(wf);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.includes('must have prompt, promptBlocks, or templateCall'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `stepHasPromptSource()` type guard to `workflow-definition.ts` as single source of truth
- Update `validation-engine.ts` to accept promptBlocks and templateCall as valid prompt sources (2 sites: standard steps + inline loop body steps)
- 10 new tests covering all prompt source combinations

## Why
The v1 validation engine (`validateWorkflow`) runs before compilation in `workflow-service.ts:141`. It rejected steps without raw `prompt`, which means promptBlocks-only workflows were dead on arrival -- the compiler never got a chance to resolve promptBlocks into prompt strings.

## Test plan
- [x] 2,768 tests pass (10 new)
- [x] Steps with prompt: accepted (backward compat)
- [x] Steps with promptBlocks: accepted
- [x] Steps with templateCall: accepted
- [x] Steps with no prompt source: rejected with clear error
- [x] Inline loop body steps: same behavior

Generated with [Firebender](https://firebender.com)