### PR TITLE
fix(v2): surface missing forEach context as PRECONDITION_FAILED instead of INTERNAL_ERROR

### DIFF
--- a/src/mcp/handlers/v2-advance-core/outcome-success.ts
+++ b/src/mcp/handlers/v2-advance-core/outcome-success.ts
@@ -82,6 +82,11 @@ export function buildSuccessOutcome(args: {
   });
   const nextRes = interpreter.next(compiledWf.value, advanced.value, v.mergedContext, artifactsForEval);
   if (nextRes.isErr()) {
+    // Distinguish missing context (recoverable, agent can fix) from other errors (system failures).
+    // MissingContext means a loop requires a context variable the agent hasn't set yet.
+    if (nextRes.error._tag === 'MissingContext') {
+      return errAsync({ kind: 'advance_next_missing_context', message: nextRes.error.message } as const);
+    }
     return errAsync({ kind: 'advance_next_failed', message: nextRes.error.message } as const);
   }
 

--- a/src/mcp/handlers/v2-error-mapping.ts
+++ b/src/mcp/handlers/v2-error-mapping.ts
@@ -24,6 +24,7 @@ export type InternalError =
   | { readonly kind: 'invariant_violation'; readonly message: string }
   | { readonly kind: 'advance_apply_failed'; readonly message: string }
   | { readonly kind: 'advance_next_failed'; readonly message: string }
+  | { readonly kind: 'advance_next_missing_context'; readonly message: string }
   | { readonly kind: 'missing_node_or_run' }
   | { readonly kind: 'workflow_hash_mismatch' }
   | { readonly kind: 'missing_snapshot' }
@@ -209,6 +210,12 @@ export function mapInternalErrorToToolError(e: InternalError): ToolFailure {
         'WorkRail could not compute the next workflow step. This is not caused by your input.',
         internalSuggestion('Retry the call.', 'WorkRail could not compute the next step.'),
       );
+    case 'advance_next_missing_context':
+      return errNotRetryable(
+        'PRECONDITION_FAILED',
+        e.message,
+        { suggestion: 'Set the required context variable in the `context` field of your continue_workflow output. The variable must be a JSON array.' },
+      ) as ToolFailure;
     default:
       const _exhaustive: never = e;
       return internalError(

--- a/src/mcp/handlers/v2-execution/continue-advance.ts
+++ b/src/mcp/handlers/v2-execution/continue-advance.ts
@@ -181,6 +181,15 @@ export function handleAdvanceIntent(args: {
         )
         .mapErr((cause) => {
           if (isInternalError(cause)) {
+            // Missing context is a recoverable agent-facing error, not an internal failure.
+            // Surface it as precondition_failed so the agent gets an actionable message.
+            if (cause.kind === 'advance_next_missing_context') {
+              return {
+                kind: 'precondition_failed' as const,
+                message: cause.message,
+                suggestion: 'Set the required context variable in the `context` field of your continue_workflow output. The variable must be a JSON array.',
+              };
+            }
             return {
               kind: 'invariant_violation' as const,
               message: `Advance failed due to internal error: ${cause.kind}`,

--- a/tests/unit/workflow-interpreter-foreach-missing-context.test.ts
+++ b/tests/unit/workflow-interpreter-foreach-missing-context.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Reproduction test for INTERNAL_ERROR at phase-planning-complete-gate.
+ *
+ * Root cause: When a step before a forEach loop completes, interpreter.next()
+ * tries to enter the forEach loop. If the required context variable (items array)
+ * is missing, it returns LOOP_MISSING_CONTEXT → DomainError.MissingContext.
+ * This gets mapped through 3 layers to an opaque INTERNAL_ERROR.
+ *
+ * This test reproduces the exact scenario from the coding-task-workflow-agentic
+ * workflow where `phase-planning-complete-gate` completes but `slices` (the
+ * forEach items variable) was never set as a context variable.
+ */
+import { describe, it, expect } from 'vitest';
+import { WorkflowInterpreter } from '../../src/application/services/workflow-interpreter';
+import { WorkflowCompiler } from '../../src/application/services/workflow-compiler';
+import { createWorkflow } from '../../src/types/workflow';
+import { createBundledSource } from '../../src/types/workflow-source';
+import type { WorkflowDefinition } from '../../src/types/workflow-definition';
+import type { ExecutionState } from '../../src/domain/execution/state';
+import { mapContinueWorkflowErrorToToolError, type ContinueWorkflowError } from '../../src/mcp/handlers/v2-execution-helpers';
+import { mapInternalErrorToToolError, type InternalError } from '../../src/mcp/handlers/v2-error-mapping';
+
+const baseState: ExecutionState = { kind: 'init' };
+
+function compileWorkflow(def: WorkflowDefinition) {
+  const compiler = new WorkflowCompiler();
+  const workflow = createWorkflow(def, createBundledSource());
+  const compiled = compiler.compile(workflow);
+  if (compiled.isErr()) throw new Error(`Compile failed: ${compiled.error.message}`);
+  return compiled.value;
+}
+
+/**
+ * Minimal workflow that reproduces the bug:
+ * - A gate step (simulating phase-planning-complete-gate)
+ * - Followed immediately by a forEach loop on `slices`
+ */
+function buildGateThenForEachWorkflow(): WorkflowDefinition {
+  return {
+    id: 'gate-foreach-test',
+    name: 'Gate Then ForEach Test',
+    description: 'Reproduces INTERNAL_ERROR when forEach items missing',
+    version: '1.0.0',
+    steps: [
+      {
+        id: 'gate-step',
+        title: 'Planning Gate',
+        prompt: 'Confirm planning is complete. Set: planningComplete = true',
+        requireConfirmation: true,
+      },
+      {
+        id: 'impl-loop',
+        type: 'loop',
+        title: 'Implementation Loop',
+        loop: {
+          type: 'forEach',
+          items: 'slices',
+          itemVar: 'currentSlice',
+          indexVar: 'sliceIndex',
+          maxIterations: 20,
+        },
+        body: [
+          {
+            id: 'impl-step',
+            title: 'Implement Slice',
+            prompt: 'Implement {{currentSlice.name}}',
+            requireConfirmation: false,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('forEach loop with missing context variable (bug reproduction)', () => {
+  const interpreter = new WorkflowInterpreter();
+  const compiled = compileWorkflow(buildGateThenForEachWorkflow());
+
+  it('returns MissingContext error when forEach items variable is not set', () => {
+    // Step 1: Advance to gate step
+    const first = interpreter.next(compiled, baseState, {}, []);
+    expect(first.isOk()).toBe(true);
+    expect(first._unsafeUnwrap().next?.stepInstanceId.stepId).toBe('gate-step');
+
+    // Step 2: Complete the gate step
+    const afterGate = interpreter.applyEvent(first._unsafeUnwrap().state, {
+      kind: 'step_completed',
+      stepInstanceId: { stepId: 'gate-step', loopPath: [] },
+    });
+    expect(afterGate.isOk()).toBe(true);
+
+    // Step 3: Try to get next step — this should try to enter the forEach loop
+    // but `slices` is NOT in the context → LOOP_MISSING_CONTEXT
+    const next = interpreter.next(compiled, afterGate._unsafeUnwrap(), {}, []);
+
+    // BUG: This returns an error instead of gracefully handling missing items.
+    // The error is DomainError.MissingContext which gets mapped to INTERNAL_ERROR.
+    expect(next.isErr()).toBe(true);
+    if (next.isErr()) {
+      expect(next.error._tag).toBe('MissingContext');
+      expect(next.error.message).toContain("forEach loop 'impl-loop' requires array context['slices']");
+    }
+  });
+
+  it('succeeds when forEach items variable is set as array', () => {
+    // Step 1: Advance to gate step
+    const first = interpreter.next(compiled, baseState, {}, []);
+    expect(first.isOk()).toBe(true);
+
+    // Step 2: Complete the gate step
+    const afterGate = interpreter.applyEvent(first._unsafeUnwrap().state, {
+      kind: 'step_completed',
+      stepInstanceId: { stepId: 'gate-step', loopPath: [] },
+    });
+    expect(afterGate.isOk()).toBe(true);
+
+    // Step 3: With slices set, should enter the loop successfully
+    const context = {
+      slices: [{ name: 'Slice 1' }, { name: 'Slice 2' }],
+    };
+    const next = interpreter.next(compiled, afterGate._unsafeUnwrap(), context, []);
+    expect(next.isOk()).toBe(true);
+    if (next.isOk()) {
+      expect(next.value.next?.stepInstanceId.stepId).toBe('impl-step');
+    }
+  });
+
+  it('treats empty array as valid (skips loop)', () => {
+    // Step 1: Advance to gate step
+    const first = interpreter.next(compiled, baseState, {}, []);
+    expect(first.isOk()).toBe(true);
+
+    // Step 2: Complete the gate step
+    const afterGate = interpreter.applyEvent(first._unsafeUnwrap().state, {
+      kind: 'step_completed',
+      stepInstanceId: { stepId: 'gate-step', loopPath: [] },
+    });
+    expect(afterGate.isOk()).toBe(true);
+
+    // Step 3: Empty array means 0 items → loop exits immediately → workflow complete
+    const context = { slices: [] };
+    const next = interpreter.next(compiled, afterGate._unsafeUnwrap(), context, []);
+    expect(next.isOk()).toBe(true);
+    if (next.isOk()) {
+      expect(next.value.isComplete).toBe(true);
+    }
+  });
+});
+
+describe('[H2] Error mapping chain: MissingContext → INTERNAL_ERROR (before fix)', () => {
+  it('advance_next_failed (non-context errors) still maps to opaque INTERNAL_ERROR', () => {
+    // Non-context errors (e.g. invalid state) should remain internal errors
+    const internalError: InternalError = {
+      kind: 'advance_next_failed',
+      message: "Unsupported state kind 'invalid'",
+    };
+    const toolError = mapInternalErrorToToolError(internalError);
+    expect(toolError.code).toBe('INTERNAL_ERROR');
+    expect(toolError.message).toContain('could not compute the next workflow step');
+  });
+});
+
+describe('[FIX] Missing context now surfaces as actionable MISSING_CONTEXT error', () => {
+  it('advance_next_missing_context maps to MISSING_CONTEXT with original message preserved', () => {
+    const originalMessage = "forEach loop 'phase-7-implement-slices' requires array context['slices']";
+    const internalError: InternalError = {
+      kind: 'advance_next_missing_context',
+      message: originalMessage,
+    };
+    const toolError = mapInternalErrorToToolError(internalError);
+
+    // FIX: The original message IS preserved
+    expect(toolError.code).toBe('PRECONDITION_FAILED');
+    expect(toolError.message).toContain('slices');
+    expect(toolError.message).toContain('forEach');
+    // FIX: Actionable suggestion included
+    expect((toolError as any).details?.suggestion).toContain('context');
+  });
+
+  it('precondition_failed (from continue-advance routing) surfaces clear message to agent', () => {
+    const continueError: ContinueWorkflowError = {
+      kind: 'precondition_failed',
+      message: "forEach loop 'phase-7-implement-slices' requires array context['slices']",
+      suggestion: 'Set the required context variable in the `context` field of your continue_workflow output.',
+    };
+    const toolError = mapContinueWorkflowErrorToToolError(continueError);
+
+    // FIX: Clear, actionable error
+    expect(toolError.code).toBe('PRECONDITION_FAILED');
+    expect(toolError.message).toContain('slices');
+    expect(toolError.message).toContain('forEach');
+  });
+});


### PR DESCRIPTION
## Summary
- When a forEach loop's items variable is not set as a context variable, the engine previously returned an opaque `INTERNAL_ERROR` saying "not caused by your input"
- The error was actually caused by missing input -- the agent never set the required context variable (e.g. `slices`) as a JSON array
- Now surfaces as `PRECONDITION_FAILED` with the original message preserved and an actionable suggestion

## Root Cause
The error mapping chain wrapped `MissingContext` through 3 layers:
1. `DomainError.MissingContext` -> `InternalError.advance_next_failed` (outcome-success.ts)
2. `InternalError` -> `ContinueWorkflowError.invariant_violation` (continue-advance.ts)
3. `invariant_violation` -> `INTERNAL_ERROR` (v2-execution-helpers.ts)

Each layer lost the original error message. The agent saw "not caused by your input" when the fix was entirely in its control.

## Changes
- Added `advance_next_missing_context` variant to `InternalError` (v2-error-mapping.ts)
- Distinguish `MissingContext` from other domain errors in success path (outcome-success.ts)
- Route missing context to `precondition_failed` instead of `invariant_violation` (continue-advance.ts)
- 6 tests covering bug reproduction and fix verification

## Test plan
- [x] 6 new tests pass (3 reproduction, 3 fix verification)
- [x] 1759 existing unit tests pass (0 regressions)
- [x] TypeScript compiles cleanly (exhaustive switches verified)
- [ ] Manual: run coding-task-workflow-agentic through planning-complete-gate without setting slices context variable, verify PRECONDITION_FAILED with clear message

Generated with [Firebender](https://firebender.com)