### PR TITLE
chore: include console build in main build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "web"
   ],
   "scripts": {
-    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true});\" && tsc -p tsconfig.build.json",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true});\" && tsc -p tsconfig.build.json && npm run console:build",
     "console:build": "cd console && npm install && npm run build",
     "console:dev": "cd console && npm run dev",
-    "build:all": "npm run build && npm run console:build",
+    "build:all": "npm run build",
     "docs:workflows": "node scripts/generate-workflow-docs.js",
     "generate:locks": "npx ts-node scripts/generate-lock-coverage.ts && npx ts-node scripts/generate-lock-coverage.ts --json",
     "verify:generated": "npm run generate:locks && git diff --exit-code -- docs/generated/v2-lock-coverage.json docs/generated/v2-lock-coverage.md docs/generated/v2-lock-closure-plan.md",


### PR DESCRIPTION
## Summary
- The `build` script now chains `console:build` so `npm run build` and `npm run dev` always produce a complete, servable artifact
- Eliminates the partial-build state where the server starts but can't serve the console UI
- `build:all` retained as alias

## Test plan
- [x] `npm run build` produces both `dist/` and `console/dist/`
- [x] `npm run dev` starts server with console available at `/console`

🤖 Generated with [Firebender](https://firebender.com)