### PR TITLE
fix(v2): remove context from start_workflow (unused at start time)

### DIFF
--- a/src/mcp/v2/tools.ts
+++ b/src/mcp/v2/tools.ts
@@ -12,7 +12,6 @@ export type V2InspectWorkflowInput = z.infer<typeof V2InspectWorkflowInput>;
 
 export const V2StartWorkflowInput = z.object({
   workflowId: z.string().min(1).regex(/^[A-Za-z0-9_-]+$/, 'Workflow ID must contain only letters, numbers, hyphens, and underscores').describe('The workflow ID to start'),
-  context: z.record(z.unknown()).optional().describe('Structured context for this workflow — must be a JSON OBJECT with string keys, NOT a string. For design/analysis workflows: {"problem":"describe the problem","constraints":"...","goals":"..."}. For coding workflows: {"ticketId":"ACEI-1234","branch":"main"}. WorkRail injects these into step prompts. Pass once at start; re-pass only values that have CHANGED.'),
   workspacePath: z.string()
     .refine((p) => p.startsWith('/'), 'workspacePath must be an absolute path (starting with /)')
     .optional()

--- a/tests/architecture/v2-tool-schema-snapshot.test.ts
+++ b/tests/architecture/v2-tool-schema-snapshot.test.ts
@@ -67,7 +67,6 @@ describe('v2 tool schema field snapshots (anti-drift)', () => {
 
   it('start_workflow: exact field set', () => {
     expect(extractFieldNames(V2StartWorkflowInput)).toEqual([
-      'context',
       'workflowId',
       'workspacePath',
     ]);

--- a/tests/contract/mcp-v2-execution.contract.test.ts
+++ b/tests/contract/mcp-v2-execution.contract.test.ts
@@ -108,7 +108,7 @@ describe('MCP contract: v2 start_workflow / continue_workflow (Slice 3)', () => 
   it('start -> rehydrate -> ack replay is deterministic and idempotent', async () => {
     const ctx = await createV2Context();
 
-    const start = await handleV2StartWorkflow({ workflowId: 'v2-exec-contract', context: {} } as any, ctx);
+    const start = await handleV2StartWorkflow({ workflowId: 'v2-exec-contract' } as any, ctx);
     expect(start.type).toBe('success');
     if (start.type !== 'success') return;
 


### PR DESCRIPTION
## Summary
- Remove `context` parameter from `start_workflow` -- it was never evaluated at start time (no runConditions checked, no interpreter.next() called)
- Agents that need context can pass it on the first `continue_workflow` call where it is actually consumed for condition routing, loop control, and validation
- Eliminates a common agent mistake: passing unstructured text as context string, hitting validation error, then retrying with empty context and losing the data

## Test plan
- [x] All 36 tests in affected files pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Schema snapshot test updated to reflect removed field
- [x] Context persistence test updated (no context_set on start)
- [x] Contract test updated (no context on start call)
- [x] Existing continue_workflow context tests unaffected

🤖 Generated with [Firebender](https://firebender.com)