### PR TITLE
fix(v2): use named wildcard for Express 5 path-to-regexp compatibility

### DIFF
--- a/src/v2/usecases/console-routes.ts
+++ b/src/v2/usecases/console-routes.ts
@@ -61,7 +61,7 @@ export function mountConsoleRoutes(app: Application, consoleService: ConsoleServ
 
     // SPA catch-all: any /console/* route serves index.html
     // (lets React handle client-side routing)
-    app.get('/console/*', (_req: Request, res: Response) => {
+    app.get('/console/*path', (_req: Request, res: Response) => {
       res.sendFile(path.join(consoleDist, 'index.html'));
     });
 


### PR DESCRIPTION
## Summary
- Express 5 uses path-to-regexp v8 which requires named wildcard parameters
- `/console/*` crashes the server at startup; `/console/*path` is the correct syntax

## Test plan
- [x] Server starts without `PathError` crash
- [x] `/console` serves the SPA
- [x] `/console/session/<id>` falls through to `index.html` for client-side routing

🤖 Generated with [Firebender](https://firebender.com)