### PR TITLE
feat!: enable v2 tools by default — WorkRail 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ to conclusions.
 WorkRail replaces the human effort of guiding an agent step-by-step.
 
 Instead of one system prompt that fades over time, WorkRail drip-feeds instructions through
-the [Model Context Protocol](https://modelcontextprotocol.org). The agent calls `workflow_next`,
-gets ONE step, completes it, calls again. Future steps stay hidden until previous ones are done.
+the [Model Context Protocol](https://modelcontextprotocol.org). The agent calls `start_workflow`,
+gets the first step, completes it, calls `continue_workflow`. Future steps stay hidden until previous ones are done.
 
 **The agent can't skip to implementation because it doesn't know those steps exist yet.**
 
@@ -44,7 +44,7 @@ You                      Agent                     WorkRail
  │  "Fix the auth bug"     │                          │
  │────────────────────────>│                          │
  │                         │                          │
- │                         │  workflow_next()         │
+ │                         │  start_workflow()        │
  │                         │─────────────────────────>│
  │                         │                          │
  │                         │   Step 1: Understand     │
@@ -55,7 +55,7 @@ You                      Agent                     WorkRail
  │    see exactly?"        │                          │
  │<────────────────────────│                          │
  │                         │                          │
- │         ...             │  workflow_next()         │
+ │         ...             │  continue_workflow()     │
  │                         │─────────────────────────>│
  │                         │                          │
  │                         │   Step 2: Plan your      │
@@ -81,21 +81,21 @@ Agent: "I see the issue! In auth.js line 42, there's a null check that
 You:   "There's a bug in the auth flow"
 
 Agent: "I'll use the bug-investigation workflow."
-        → workflow_next()
+        → start_workflow()
        
        Step 1: Investigation Setup
        "Before I investigate, I need to understand the problem.
         What exactly happens when it fails? Can you share the error?"
        
        [Documents bug, reproduction steps, environment]
-        → workflow_next()
+        → continue_workflow()
        
        Step 2: Plan Investigation
        "I'll trace execution from login through the auth middleware.
         Key areas: token validation, session lookup, error handling."
        
        [Creates investigation plan before touching code]
-        → workflow_next()
+        → continue_workflow()
        
        Step 3: Form Hypotheses
        "Based on my analysis, three possible causes:
@@ -164,13 +164,13 @@ The agent will find the workflow, start at step 1, and proceed systematically.
 
 ## Included Workflows
 
-20+ workflows included for development, debugging, review, documentation, and more:
+30+ workflows included for development, debugging, review, documentation, and more:
 
 | Workflow | When to Use |
 |----------|-------------|
-| `coding-task-workflow-with-loops` | Feature development with analysis, planning, and review |
-| `bug-investigation` | Systematic debugging with hypothesis testing |
-| `mr-review-workflow` | Code review with architecture and security checks |
+| `coding-task-workflow-agentic` | Feature development with notes-first durability and audit loops |
+| `bug-investigation-agentic` | Systematic debugging with evidence-based analysis |
+| `mr-review-workflow-agentic` | Code review with parallel reviewer families |
 | `exploration-workflow` | Understanding an unfamiliar codebase |
 | `document-creation-workflow` | Technical documentation with structure |
 

--- a/docs/integrations/firebender.md
+++ b/docs/integrations/firebender.md
@@ -47,10 +47,10 @@ If you MUST whitelist tools, you must explicitly add the WorkRail suite:
       "tools": [
         "read_file", 
         "grep",
-        "workflow_list",
-        "workflow_get",
-        "workflow_next",
-        "workflow_validate"
+        "list_workflows",
+        "start_workflow",
+        "continue_workflow",
+        "checkpoint_workflow"
       ]
     }
   }
@@ -223,7 +223,7 @@ Each executor works independently, exploring different solution spaces.
 
 **Fix:** Either:
 - Remove the `tools` field entirely from the YAML frontmatter (use inheritance)
-- Or add WorkRail tools to the whitelist: `workflow_list`, `workflow_get`, `workflow_next`
+- Or add WorkRail tools to the whitelist: `list_workflows`, `start_workflow`, `continue_workflow`, `checkpoint_workflow`
 
 The provided `workrail-executor.md` uses inheritance (no `tools` field), so this shouldn't happen unless you modified it.
 

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -81,10 +81,10 @@ export const FEATURE_FLAG_DEFINITIONS: ReadonlyArray<FeatureFlagDefinition> = [
   {
     key: 'v2Tools',
     envVar: 'WORKRAIL_ENABLE_V2_TOOLS',
-    defaultValue: false,
-    description: 'Enable WorkRail v2 MCP tools and .v2.json workflow overrides behind an explicit opt-in flag',
+    defaultValue: true,
+    description: 'WorkRail v2 MCP tools (list_workflows, start_workflow, continue_workflow, checkpoint_workflow, resume_session) and .v2.json workflow overrides',
     since: '0.9.0',
-    stable: false,
+    stable: true,
   },
 ] as const;
 

--- a/src/mcp/handlers/v2-execution/start.ts
+++ b/src/mcp/handlers/v2-execution/start.ts
@@ -19,7 +19,7 @@ import { deriveWorkflowHashRef } from '../../../v2/durable-core/ids/workflow-has
 import type { Sha256PortV2 } from '../../../v2/ports/sha256.port.js';
 import type { TokenCodecPorts } from '../../../v2/durable-core/tokens/token-codec-ports.js';
 import { ResultAsync as RA, okAsync, errAsync as neErrorAsync } from 'neverthrow';
-import { normalizeV1WorkflowToPinnedSnapshot } from '../../../v2/read-only/v1-to-v2-shim.js';
+import { validateWorkflowPhase1a, type ValidationPipelineDepsPhase1a } from '../../../application/services/workflow-validation-pipeline.js';
 import { workflowHashForCompiledSnapshot } from '../../../v2/durable-core/canonical/hashing.js';
 import type { JsonValue } from '../../../v2/durable-core/canonical/json-types.js';
 import { anchorsToObservations, type ObservationEventData } from '../../../v2/durable-core/domain/observation-builder.js';
@@ -47,13 +47,14 @@ export function loadAndPinWorkflow(args: {
   readonly workflowService: import('../../../application/services/workflow-service.js').WorkflowService;
   readonly crypto: Sha256PortV2;
   readonly pinnedStore: import('../../../v2/ports/pinned-workflow-store.port.js').PinnedWorkflowStorePortV2;
+  readonly validationPipelineDeps: ValidationPipelineDepsPhase1a;
 }): RA<{
   readonly workflow: import('../../../types/workflow.js').Workflow;
   readonly workflowHash: WorkflowHash;
   readonly pinnedWorkflow: ReturnType<typeof createWorkflow>;
   readonly firstStep: { readonly id: string };
 }, StartWorkflowError> {
-  const { workflowId, workflowService, crypto, pinnedStore } = args;
+  const { workflowId, workflowService, crypto, pinnedStore, validationPipelineDeps } = args;
 
   return RA.fromPromise(workflowService.getWorkflowById(workflowId), (e) => ({
     kind: 'precondition_failed' as const,
@@ -70,17 +71,29 @@ export function loadAndPinWorkflow(args: {
       return okAsync({ workflow });
     })
     .andThen(({ workflow }) => {
-      // Pin the full v1 workflow definition for determinism.
-      // Strict: if normalization fails (e.g. prompt+promptBlocks XOR, bad templateCall),
-      // reject before session creation — never pin an invalid executable snapshot.
-      const normalizeResult = normalizeV1WorkflowToPinnedSnapshot(workflow);
-      if (normalizeResult.isErr()) {
+      // Run the Phase 1a validation pipeline before creating any durable state.
+      // Phases: schema → structural → v1 compilation → normalization.
+      // This replaces the previous normalize-only call with full validation.
+      const pipelineOutcome = validateWorkflowPhase1a(workflow, validationPipelineDeps);
+      if (pipelineOutcome.kind !== 'phase1a_valid') {
+        // Map pipeline failure variants to StartWorkflowError
+        const message = pipelineOutcome.kind === 'schema_failed'
+          ? `Schema validation failed: ${pipelineOutcome.errors.map(e => e.message ?? e.instancePath).join('; ')}`
+          : pipelineOutcome.kind === 'structural_failed'
+            ? `Structural validation failed: ${pipelineOutcome.issues.join('; ')}`
+            : pipelineOutcome.kind === 'v1_compilation_failed'
+              ? `Compilation failed: ${pipelineOutcome.cause.message}`
+              : pipelineOutcome.kind === 'normalization_failed'
+                ? `Normalization failed: ${pipelineOutcome.cause.message}`
+                : pipelineOutcome.kind === 'executable_compilation_failed'
+                  ? `Executable compilation failed: ${pipelineOutcome.cause.message}`
+                  : 'Unknown validation failure';
         return neErrorAsync({
           kind: 'workflow_compile_failed' as const,
-          message: normalizeResult.error.message,
+          message,
         });
       }
-      const compiled = normalizeResult.value;
+      const compiled = pipelineOutcome.snapshot;
       const workflowHashRes = workflowHashForCompiledSnapshot(compiled as unknown as JsonValue, crypto);
       if (workflowHashRes.isErr()) {
         return neErrorAsync({ kind: 'hash_computation_failed' as const, message: workflowHashRes.error.message });
@@ -316,14 +329,15 @@ export function executeStartWorkflow(
   input: import('../../v2/tools.js').V2StartWorkflowInput,
   ctx: V2ToolContext
 ): RA<z.infer<typeof V2StartWorkflowOutputSchema>, StartWorkflowError> {
-  const { gate, sessionStore, snapshotStore, pinnedStore, crypto, tokenCodecPorts, idFactory } = ctx.v2;
+  const { gate, sessionStore, snapshotStore, pinnedStore, crypto, tokenCodecPorts, idFactory, validationPipelineDeps } = ctx.v2;
 
-  // 1. Load and pin workflow
+  // 1. Load, validate (Phase 1a pipeline), and pin workflow
   return loadAndPinWorkflow({
     workflowId: input.workflowId,
     workflowService: ctx.workflowService,
     crypto,
     pinnedStore,
+    validationPipelineDeps,
   })
     .andThen(({ workflow, firstStep, workflowHash, pinnedWorkflow }) => {
       // 2. Resolve workspace anchors for observation events (graceful: empty on failure).

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -26,6 +26,10 @@ import type { ProcessTerminator } from '../runtime/ports/process-terminator.js';
 import type { ToolContext, V2Dependencies } from './types.js';
 import { assertNever } from '../runtime/assert-never.js';
 import { unsafeTokenCodecPorts } from '../v2/durable-core/tokens/token-codec-ports.js';
+import { validateWorkflowSchema } from '../application/validation.js';
+import { normalizeV1WorkflowToPinnedSnapshot } from '../v2/read-only/v1-to-v2-shim.js';
+import type { WorkflowCompiler } from '../application/services/workflow-compiler.js';
+import type { ValidationEngine } from '../application/services/validation-engine.js';
 import { LocalWorkspaceAnchorV2 } from '../v2/infra/local/workspace-anchor/index.js';
 import { WorkspaceRootsManager } from './workspace-roots-manager.js';
 import { LocalDirectoryListingV2 } from '../v2/infra/local/directory-listing/index.js';
@@ -123,6 +127,16 @@ export async function createToolContext(): Promise<ToolContext> {
       const fsPort = container.resolve<any>(DI.V2.FileSystem);
       const directoryListing = new LocalDirectoryListingV2(fsPort);
 
+      // Construct Phase 1a validation pipeline deps (same pattern as CLI and validate-workflow-json)
+      const validationEngine = container.resolve<ValidationEngine>(DI.Infra.ValidationEngine);
+      const compiler = container.resolve<WorkflowCompiler>(DI.Services.WorkflowCompiler);
+      const validationPipelineDeps = {
+        schemaValidate: validateWorkflowSchema,
+        structuralValidate: validationEngine.validateWorkflowStructureOnly.bind(validationEngine),
+        compiler,
+        normalizeToExecutable: normalizeV1WorkflowToPinnedSnapshot,
+      };
+
       v2 = {
         gate,
         sessionStore,
@@ -132,6 +146,7 @@ export async function createToolContext(): Promise<ToolContext> {
         crypto,
         idFactory,
         tokenCodecPorts,
+        validationPipelineDeps,
         // resolvedRootUris starts empty; overridden per-request at the CallTool boundary
         // with a snapshot of the current MCP client roots (see startServer).
         resolvedRootUris: [],

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -28,6 +28,7 @@ import type { WorkspaceContextResolverPortV2 } from '../v2/ports/workspace-ancho
 import type { DataDirPortV2 } from '../v2/ports/data-dir.port.js';
 import type { DirectoryListingPortV2 } from '../v2/ports/directory-listing.port.js';
 import type { SessionSummaryProviderPortV2 } from '../v2/ports/session-summary-provider.port.js';
+import type { ValidationPipelineDepsPhase1a } from '../application/services/workflow-validation-pipeline.js';
 
 // Note: JsonValue type is imported from output-schemas.js above
 
@@ -209,6 +210,10 @@ export interface V2Dependencies {
 
   // Grouped token dependencies (always complete)
   readonly tokenCodecPorts: TokenCodecPorts;
+
+  // Validation pipeline deps for Phase 1a gate at start_workflow boundary.
+  // Runs schema + structural + v1 compilation + normalization before session creation.
+  readonly validationPipelineDeps: ValidationPipelineDepsPhase1a;
 
   // Per-request workspace root URIs snapshotted from MCP client roots at the CallTool boundary.
   // Absent or empty when the client does not support the MCP roots protocol.

--- a/tests/contract/mcp-v2-execution.contract.test.ts
+++ b/tests/contract/mcp-v2-execution.contract.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -72,6 +73,7 @@ async function createV2Context(): Promise<ToolContext> {
       sha256,
       crypto,
       tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
       idFactory,
     },
   };

--- a/tests/helpers/v2-test-helpers.ts
+++ b/tests/helpers/v2-test-helpers.ts
@@ -22,6 +22,12 @@ import { Bech32mAdapterV2 } from '../../src/v2/infra/local/bech32m/index.js';
 import { signTokenV1Binary, unsafeTokenCodecPorts } from '../../src/v2/durable-core/tokens/index.js';
 import type { V2Dependencies } from '../../src/mcp/types.js';
 import type { KeyringV1 } from '../../src/v2/ports/keyring.port.js';
+import { validateWorkflowSchema } from '../../src/application/validation.js';
+import { normalizeV1WorkflowToPinnedSnapshot } from '../../src/v2/read-only/v1-to-v2-shim.js';
+import { WorkflowCompiler } from '../../src/application/services/workflow-compiler.js';
+import { ValidationEngine } from '../../src/application/services/validation-engine.js';
+import { EnhancedLoopValidator } from '../../src/application/services/enhanced-loop-validator.js';
+import type { ValidationPipelineDepsPhase1a } from '../../src/application/services/workflow-validation-pipeline.js';
 
 /**
  * Create a temporary data directory for v2 tests.
@@ -88,6 +94,22 @@ export function dummyToolContext(): ToolContext {
 }
 
 /**
+ * Create Phase 1a validation pipeline deps for tests.
+ * Same construction pattern as CLI and server.ts composition root.
+ */
+export function createTestValidationPipelineDeps(): ValidationPipelineDepsPhase1a {
+  const loopValidator = new EnhancedLoopValidator();
+  const validationEngine = new ValidationEngine(loopValidator);
+  const compiler = new WorkflowCompiler();
+  return {
+    schemaValidate: validateWorkflowSchema,
+    structuralValidate: validationEngine.validateWorkflowStructureOnly.bind(validationEngine),
+    compiler,
+    normalizeToExecutable: normalizeV1WorkflowToPinnedSnapshot,
+  };
+}
+
+/**
  * Create complete V2Dependencies with all adapters initialized.
  * Useful for integration-style unit tests that need real implementations.
  * 
@@ -138,6 +160,7 @@ export async function createV2Dependencies(dataDir: LocalDataDirV2): Promise<V2D
     crypto,
     idFactory,
     tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
   };
 }
 

--- a/tests/integration/v2/blocked-node-atomicity.test.ts
+++ b/tests/integration/v2/blocked-node-atomicity.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
@@ -91,6 +92,7 @@ async function mkCtxWithWorkflow(workflowId: string, definition: any): Promise<T
       crypto,
       idFactory,
       tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
       sessionEventLogStore: sessionStore,
     },
   };
@@ -114,12 +116,12 @@ describe('Blocked node atomicity (validation + node + edge atomic)', () => {
         version: '1.0.0',
         steps: [
           {
-            id: 'step_validated',
+            id: 'step-validated',
             title: 'Validated step',
             prompt: 'Return "result".',
             validationCriteria: [{ type: 'contains', value: 'result', message: 'Must contain result' }],
           },
-          { id: 'step_next', title: 'Next', prompt: 'Next' },
+          { id: 'step-next', title: 'Next', prompt: 'Next' },
         ],
       });
 
@@ -187,12 +189,12 @@ describe('Blocked node atomicity (validation + node + edge atomic)', () => {
         version: '1.0.0',
         steps: [
           {
-            id: 'step_val',
+            id: 'step-val',
             title: 'Val',
             prompt: 'Return "done".',
             validationCriteria: [{ type: 'contains', value: 'done', message: 'Must contain done' }],
           },
-          { id: 'step_next', title: 'Next', prompt: 'Next' },
+          { id: 'step-next', title: 'Next', prompt: 'Next' },
         ],
       });
 

--- a/tests/integration/v2/blocked-node-concurrent-retries.test.ts
+++ b/tests/integration/v2/blocked-node-concurrent-retries.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
@@ -91,6 +92,7 @@ async function mkCtxWithWorkflow(workflowId: string, definition: any): Promise<T
       crypto,
       idFactory,
       tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
       sessionEventLogStore: sessionStore,
     },
   };
@@ -114,14 +116,14 @@ describe('Blocked node concurrent retries (idempotency + race safety)', () => {
         version: '1.0.0',
         steps: [
           {
-            id: 'step_validated',
+            id: 'step-validated',
             title: 'Validated step',
             prompt: 'Return output with "status" keyword.',
             validationCriteria: [
               { type: 'contains', value: 'status', message: 'Must contain status' },
             ],
           },
-          { id: 'step_next', title: 'Next', prompt: 'Next' },
+          { id: 'step-next', title: 'Next', prompt: 'Next' },
         ],
       });
 
@@ -208,12 +210,12 @@ describe('Blocked node concurrent retries (idempotency + race safety)', () => {
         version: '1.0.0',
         steps: [
           {
-            id: 'step_val',
+            id: 'step-val',
             title: 'Validated',
             prompt: 'Return "ok".',
             validationCriteria: [{ type: 'contains', value: 'ok', message: 'Must contain ok' }],
           },
-          { id: 'step_next', title: 'Next', prompt: 'Next' },
+          { id: 'step-next', title: 'Next', prompt: 'Next' },
         ],
       });
 
@@ -274,14 +276,14 @@ describe('Blocked node concurrent retries (idempotency + race safety)', () => {
         version: '1.0.0',
         steps: [
           {
-            id: 'step_validated',
+            id: 'step-validated',
             title: 'Validated step',
             prompt: 'Return output with "status" keyword.',
             validationCriteria: [
               { type: 'contains', value: 'status', message: 'Must contain status' },
             ],
           },
-          { id: 'step_next', title: 'Next', prompt: 'Next' },
+          { id: 'step-next', title: 'Next', prompt: 'Next' },
         ],
       });
 

--- a/tests/integration/v2/blocked-node-edge-cases.test.ts
+++ b/tests/integration/v2/blocked-node-edge-cases.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
@@ -70,7 +71,7 @@ async function mkCtxWithWorkflow(workflowId: string, definition: any): Promise<T
     featureFlags: null as any,
     sessionManager: null,
     httpServer: null,
-    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, idFactory, tokenCodecPorts, sessionEventLogStore: sessionStore },
+    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, idFactory, tokenCodecPorts, sessionEventLogStore: sessionStore, validationPipelineDeps: createTestValidationPipelineDeps() },
   };
 }
 

--- a/tests/integration/v2/blocked-node-idempotency.test.ts
+++ b/tests/integration/v2/blocked-node-idempotency.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
@@ -69,7 +70,7 @@ async function mkCtxWithWorkflow(workflowId: string, definition: any): Promise<T
     featureFlags: null as any,
     sessionManager: null,
     httpServer: null,
-    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, idFactory, tokenCodecPorts, sessionEventLogStore: sessionStore },
+    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, idFactory, tokenCodecPorts, sessionEventLogStore: sessionStore, validationPipelineDeps: createTestValidationPipelineDeps() },
   };
 }
 

--- a/tests/integration/v2/blocked-node-projection-transitions.test.ts
+++ b/tests/integration/v2/blocked-node-projection-transitions.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
@@ -93,6 +94,7 @@ async function mkCtxWithWorkflow(workflowId: string, definition: any): Promise<T
       crypto,
       idFactory,
       tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
       sessionEventLogStore: sessionStore,
     },
   };
@@ -189,12 +191,12 @@ describe('Blocked node projection consistency (status transitions)', () => {
         version: '1.0.0',
         steps: [
           {
-            id: 'step_a',
+            id: 'step-a',
             title: 'Step A',
             prompt: 'Return "ok".',
             validationCriteria: [{ type: 'contains', value: 'ok', message: 'Must contain ok' }],
           },
-          { id: 'step_b', title: 'Step B', prompt: 'Step B' },
+          { id: 'step-b', title: 'Step B', prompt: 'Step B' },
         ],
       });
 

--- a/tests/integration/v2/blocked-node-retry-flow.test.ts
+++ b/tests/integration/v2/blocked-node-retry-flow.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from '../../helpers/v2-test-helpers.js';
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
@@ -91,6 +92,7 @@ async function mkCtxWithWorkflow(workflowId: string, definition: any): Promise<T
       crypto,
       idFactory,
       tokenCodecPorts,
+      validationPipelineDeps: createTestValidationPipelineDeps(),
       sessionEventLogStore: sessionStore,
     },
   };
@@ -114,14 +116,14 @@ describe('Blocked node retry flow (end-to-end)', () => {
         version: '1.0.0',
         steps: [
           {
-            id: 'step_with_validation',
+            id: 'step-with-validation',
             title: 'Step with validation',
             prompt: 'Return JSON with status field.',
             validationCriteria: [
               { type: 'contains', value: 'status', message: 'Output must contain "status"' },
             ],
           },
-          { id: 'step_next', title: 'Next step', prompt: 'Next step prompt' },
+          { id: 'step-next', title: 'Next step', prompt: 'Next step prompt' },
         ],
       });
 
@@ -221,7 +223,7 @@ describe('Blocked node retry flow (end-to-end)', () => {
         version: '1.0.0',
         steps: [
           {
-            id: 'step_bad_schema',
+            id: 'step-bad-schema',
             title: 'Bad schema step',
             prompt: 'Return JSON.',
             validationCriteria: [
@@ -232,7 +234,7 @@ describe('Blocked node retry flow (end-to-end)', () => {
               },
             ],
           },
-          { id: 'step_next', title: 'Next', prompt: 'Next' },
+          { id: 'step-next', title: 'Next', prompt: 'Next' },
         ],
       });
 
@@ -298,7 +300,7 @@ describe('Blocked node retry flow (end-to-end)', () => {
         version: '1.0.0',
         steps: [
           {
-            id: 'step_strict',
+            id: 'step-strict',
             title: 'Strict validation',
             prompt: 'Return JSON with both status and code.',
             validationCriteria: [
@@ -306,7 +308,7 @@ describe('Blocked node retry flow (end-to-end)', () => {
               { type: 'contains', value: 'code', message: 'Must contain code' },
             ],
           },
-          { id: 'step_next', title: 'Next', prompt: 'Next' },
+          { id: 'step-next', title: 'Next', prompt: 'Next' },
         ],
       });
 

--- a/tests/unit/mcp-v2-advance-recorded.test.ts
+++ b/tests/unit/mcp-v2-advance-recorded.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -66,6 +67,7 @@ async function mkV2Deps(dataDir: LocalDataDirV2): Promise<V2Dependencies> {
     sha256,
     crypto,
     tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
     idFactory,
     // Test convenience (aliases):
     sessionGate,

--- a/tests/unit/mcp-v2-blocked-outcome.test.ts
+++ b/tests/unit/mcp-v2-blocked-outcome.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -64,6 +65,7 @@ async function mkV2Deps(dataDir: LocalDataDirV2): Promise<V2Dependencies> {
     sha256,
     crypto,
     tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
     idFactory,
     // Test convenience (aliases):
     sessionGate,

--- a/tests/unit/mcp-v2-context-persistence.test.ts
+++ b/tests/unit/mcp-v2-context-persistence.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -92,6 +93,7 @@ async function mkCtxWithWorkflow(workflowId: string): Promise<ToolContext> {
       crypto,
       idFactory,
       tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
     },
   };
 }

--- a/tests/unit/mcp-v2-continue-behavior-lock.test.ts
+++ b/tests/unit/mcp-v2-continue-behavior-lock.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 /**
  * Behavioral lock tests for orchestrateContinueWorkflow.
  * 
@@ -68,7 +69,7 @@ async function mkV2Deps() {
   const keyring = await keyringPort.loadOrCreate().match(v => v, e => { throw new Error(`keyring: ${e.code}`); });
 
   const tokenCodecPorts = unsafeTokenCodecPorts({ keyring, hmac, base64url, base32, bech32m });
-  return { gate, sessionStore, snapshotStore, pinnedStore, keyring, sha256, crypto, idFactory, tokenCodecPorts, hmac, base64url, base32, bech32m };
+  return { gate, sessionStore, snapshotStore, pinnedStore, keyring, sha256, crypto, idFactory, tokenCodecPorts, hmac, base64url, base32, bech32m, validationPipelineDeps: createTestValidationPipelineDeps() };
 }
 
 describe('v2 continue_workflow behavioral locks (pre-refactor baseline)', () => {

--- a/tests/unit/mcp-v2-execution.test.ts
+++ b/tests/unit/mcp-v2-execution.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -75,6 +76,7 @@ async function mkV2Deps(): Promise<V2Dependencies> {
     crypto,
     idFactory,
     tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
   };
 }
 

--- a/tests/unit/mcp-v2-fork-detection.test.ts
+++ b/tests/unit/mcp-v2-fork-detection.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, it, expect } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -87,6 +88,7 @@ async function mkCtxWithWorkflow(workflowId: string, dataDir: string): Promise<T
       sha256: sha256V2,
       crypto: cryptoV2,
       tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
       idFactory: idFactoryV2,
     },
   };

--- a/tests/unit/mcp-v2-mode-driven-blocking.test.ts
+++ b/tests/unit/mcp-v2-mode-driven-blocking.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -65,6 +66,7 @@ async function mkV2Deps(dataDir: LocalDataDirV2): Promise<V2Dependencies> {
     sha256,
     crypto,
     tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
     idFactory,
     sessionGate,
     sessionEventLogStore,

--- a/tests/unit/mcp-v2-next-call.test.ts
+++ b/tests/unit/mcp-v2-next-call.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 /**
  * Tests for buildNextCall pure function and nextCall response field.
  *
@@ -205,7 +206,7 @@ async function mkCtx(): Promise<ToolContext> {
     featureFlags,
     sessionManager: null,
     httpServer: null,
-    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, tokenCodecPorts, idFactory },
+    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, tokenCodecPorts, idFactory, validationPipelineDeps: createTestValidationPipelineDeps() },
   };
 }
 

--- a/tests/unit/mcp-v2-next-intent.test.ts
+++ b/tests/unit/mcp-v2-next-intent.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -65,6 +66,7 @@ async function mkV2Deps(dataDir: LocalDataDirV2): Promise<V2Dependencies> {
     sha256,
     crypto,
     tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
     idFactory,
     sessionGate,
     sessionEventLogStore,

--- a/tests/unit/mcp-v2-rehydrate-purity.test.ts
+++ b/tests/unit/mcp-v2-rehydrate-purity.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -85,7 +86,7 @@ async function mkCtxWithWorkflow(workflowId: string): Promise<ToolContext> {
     featureFlags: null as any,
     sessionManager: null,
     httpServer: null,
-    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, idFactory, tokenCodecPorts },
+    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, idFactory, tokenCodecPorts, validationPipelineDeps: createTestValidationPipelineDeps() },
   };
 }
 

--- a/tests/unit/mcp-v2-replay-fact-returning.test.ts
+++ b/tests/unit/mcp-v2-replay-fact-returning.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -73,6 +74,7 @@ async function createV2Context() {
     crypto,
     idFactory,
     tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
     hmac,
     base64url,
     base32,

--- a/tests/unit/mcp-v2-replay-missing-snapshot.test.ts
+++ b/tests/unit/mcp-v2-replay-missing-snapshot.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -250,6 +251,7 @@ describe('v2 replay fail-closed: missing snapshot', () => {
         sha256,
         crypto,
         tokenCodecPorts,
+    validationPipelineDeps: createTestValidationPipelineDeps(),
         hmac,
         base64url: localBase64url,
         base32,

--- a/tests/unit/mcp-v2-session-not-healthy.test.ts
+++ b/tests/unit/mcp-v2-session-not-healthy.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -54,7 +55,7 @@ async function mkV2Deps() {
   const keyring = await keyringPort.loadOrCreate().match(v => v, e => { throw new Error(`keyring: ${e.code}`); });
 
   const tokenCodecPorts = unsafeTokenCodecPorts({ keyring, hmac, base64url, base32, bech32m });
-  return { gate, sessionStore, snapshotStore, pinnedStore, keyring, sha256, crypto, idFactory, tokenCodecPorts, hmac, base64url, base32, bech32m };
+  return { gate, sessionStore, snapshotStore, pinnedStore, keyring, sha256, crypto, idFactory, tokenCodecPorts, hmac, base64url, base32, bech32m, validationPipelineDeps: createTestValidationPipelineDeps() };
 }
 
 async function mkCtxWithWorkflow(workflowId: string): Promise<ToolContext> {

--- a/tests/unit/mcp-v2-start-workflow-preferences.test.ts
+++ b/tests/unit/mcp-v2-start-workflow-preferences.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -85,7 +86,7 @@ async function mkCtxWithWorkflow(workflowId: string): Promise<ToolContext> {
     featureFlags: null as any,
     sessionManager: null,
     httpServer: null,
-    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, idFactory, tokenCodecPorts },
+    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, idFactory, tokenCodecPorts, validationPipelineDeps: createTestValidationPipelineDeps() },
   };
 }
 

--- a/tests/unit/mcp-v2-start-workflow.test.ts
+++ b/tests/unit/mcp-v2-start-workflow.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from '../helpers/v2-test-helpers.js';
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -94,7 +95,8 @@ async function mkCtxWithWorkflow(workflowId: string): Promise<ToolContext> {
       sha256,
       crypto,
       idFactory,
-      tokenCodecPorts
+      tokenCodecPorts,
+      validationPipelineDeps: createTestValidationPipelineDeps(),
     },
   };
 }
@@ -153,7 +155,7 @@ async function mkCtxWithInvalidWorkflow(workflowId: string): Promise<ToolContext
     featureFlags: null as any,
     sessionManager: null,
     httpServer: null,
-    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, idFactory, tokenCodecPorts },
+    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, idFactory, tokenCodecPorts, validationPipelineDeps: createTestValidationPipelineDeps() },
   };
 }
 

--- a/tests/unit/v2/checkpoint-handler-integration.test.ts
+++ b/tests/unit/v2/checkpoint-handler-integration.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 /**
  * Checkpoint Handler Integration Tests
  *
@@ -62,7 +63,7 @@ async function mkV2Deps() {
   const keyringPort = new LocalKeyringV2(dataDir, fsPort, base64url, entropy);
   const keyring = await keyringPort.loadOrCreate().match(v => v, e => { throw new Error(`keyring: ${e.code}`); });
   const tokenCodecPorts = unsafeTokenCodecPorts({ keyring, hmac, base64url, base32, bech32m });
-  return { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, idFactory, tokenCodecPorts };
+  return { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, idFactory, tokenCodecPorts, validationPipelineDeps: createTestValidationPipelineDeps() };
 }
 
 describe('handleV2CheckpointWorkflow (integration)', () => {

--- a/tests/unit/v2/fork-harness.test.ts
+++ b/tests/unit/v2/fork-harness.test.ts
@@ -1,3 +1,4 @@
+import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
@@ -83,7 +84,7 @@ async function createV2Context(): Promise<ToolContext> {
     featureFlags,
     sessionManager: null,
     httpServer: null,
-    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, tokenCodecPorts, idFactory },
+    v2: { gate, sessionStore, snapshotStore, pinnedStore, sha256, crypto, tokenCodecPorts, idFactory, validationPipelineDeps: createTestValidationPipelineDeps() },
   };
 }
 


### PR DESCRIPTION
## Summary

- Enable v2 MCP tools by default (`v2Tools` flag flipped to `defaultValue: true`, `stable: true`)
- Enforce Phase 1a validation pipeline at the `start_workflow` boundary (schema + structural + v1 compilation + normalization) before any durable session state is created
- Update README and Firebender integration docs to reflect v2 tool names

## Details

**Validation gate**: `start_workflow` now runs `validateWorkflowPhase1a()` in `loadAndPinWorkflow()` instead of the previous bare `normalizeV1WorkflowToPinnedSnapshot()` call. Invalid workflows get typed error responses with descriptive messages. The pipeline's output snapshot is reused for pinning (no double normalization).

**v2 flag flip**: `v2Tools.defaultValue` changed from `false` to `true` in `feature-flags.ts`. Users can opt out with `WORKRAIL_ENABLE_V2_TOOLS=false`.

**Breaking change**: The v2 tool surface (`list_workflows`, `start_workflow`, `continue_workflow`, `checkpoint_workflow`, `resume_session`) replaces v1 (`discover_workflows`, `advance_workflow`) as the default. Agents discover tools dynamically via MCP, so no user migration is needed.

## Test plan

- [ ] 2971 tests pass (215 files + 2 new files from recent merge)
- [ ] 62 contract tests pass
- [ ] `tsc --noEmit` clean
- [ ] CI passes on all 3 OS + 2 Node versions

🤖 Generated with [Firebender](https://firebender.com)