### PR TITLE
fix: allow expanded step ids in durable workflow state

### DIFF
--- a/src/mcp/handlers/v2-execution/start.ts
+++ b/src/mcp/handlers/v2-execution/start.ts
@@ -2,7 +2,7 @@ import type { V2ToolContext } from '../../types.js';
 import { V2StartWorkflowOutputSchema, toPendingStep } from '../../output-schemas.js';
 import { deriveIsComplete, derivePendingStep } from '../../../v2/durable-core/projections/snapshot-state.js';
 import type { ExecutionSnapshotFileV1 } from '../../../v2/durable-core/schemas/execution-snapshot/index.js';
-import { asDelimiterSafeIdV1 } from '../../../v2/durable-core/schemas/execution-snapshot/step-instance-key.js';
+import { asExpandedStepIdV1 } from '../../../v2/durable-core/schemas/execution-snapshot/step-instance-key.js';
 import { createWorkflow } from '../../../types/workflow.js';
 import type { DomainEventV1 } from '../../../v2/durable-core/schemas/session/index.js';
 import {
@@ -341,7 +341,7 @@ export function executeStartWorkflow(
               kind: 'running' as const,
               completed: { kind: 'set' as const, values: [] },
               loopStack: [],
-              pending: { kind: 'some' as const, step: { stepId: asDelimiterSafeIdV1(firstStep.id), loopPath: [] } },
+              pending: { kind: 'some' as const, step: { stepId: asExpandedStepIdV1(firstStep.id), loopPath: [] } },
             },
           },
         };

--- a/src/mcp/handlers/v2-state-conversion.ts
+++ b/src/mcp/handlers/v2-state-conversion.ts
@@ -8,7 +8,11 @@
  */
 
 import type { EngineStateV1, LoopPathFrameV1 } from '../../v2/durable-core/schemas/execution-snapshot/index.js';
-import { asDelimiterSafeIdV1, stepInstanceKeyFromParts } from '../../v2/durable-core/schemas/execution-snapshot/step-instance-key.js';
+import {
+  asDelimiterSafeIdV1,
+  asExpandedStepIdV1,
+  stepInstanceKeyFromParts,
+} from '../../v2/durable-core/schemas/execution-snapshot/step-instance-key.js';
 import type { ExecutionState, LoopFrame } from '../../domain/execution/state.js';
 import type { RunId, NodeId } from '../../v2/durable-core/ids/index.js';
 import type { LoadedSessionTruthV2 } from '../../v2/ports/session-event-log-store.port.js';
@@ -52,7 +56,7 @@ export function convertRunningExecutionStateToEngineState(
   const completedArray: readonly string[] = [...state.completed].sort((a: string, b: string) =>
     a.localeCompare(b)
   );
-  const completed = completedArray.map(s => stepInstanceKeyFromParts(asDelimiterSafeIdV1(s), []));
+  const completed = completedArray.map(s => stepInstanceKeyFromParts(asExpandedStepIdV1(s), []));
 
   const loopStack = state.loopStack.map((f: LoopFrame) => ({
     loopId: asDelimiterSafeIdV1(f.loopId),
@@ -64,7 +68,7 @@ export function convertRunningExecutionStateToEngineState(
     ? {
         kind: 'some' as const,
         step: {
-          stepId: asDelimiterSafeIdV1(state.pendingStep.stepId),
+          stepId: asExpandedStepIdV1(state.pendingStep.stepId),
           loopPath: state.pendingStep.loopPath.map((p) => ({
             loopId: asDelimiterSafeIdV1(p.loopId),
             iteration: p.iteration,

--- a/src/v2/durable-core/schemas/execution-snapshot/execution-snapshot.v1.ts
+++ b/src/v2/durable-core/schemas/execution-snapshot/execution-snapshot.v1.ts
@@ -5,6 +5,7 @@ import type { Brand } from '../../../../runtime/brand.js';
 import { BlockedSnapshotV1Schema } from './blocked-snapshot.js';
 import {
   DelimiterSafeIdV1Schema,
+  ExpandedStepIdV1Schema,
   StepInstanceKeyV1Schema,
   stepInstanceKeyFromParts,
   type DelimiterSafeIdV1,
@@ -66,7 +67,7 @@ export const LoopPathFrameV1Schema = z.object({
 export type PendingStepV1 = z.infer<typeof PendingStepV1Schema>;
 
 export const PendingStepV1Schema = z.object({
-  stepId: DelimiterSafeIdV1Schema,
+  stepId: ExpandedStepIdV1Schema,
   loopPath: z.array(LoopPathFrameV1Schema),
 }).strict();
 

--- a/src/v2/durable-core/schemas/execution-snapshot/step-instance-key.ts
+++ b/src/v2/durable-core/schemas/execution-snapshot/step-instance-key.ts
@@ -20,6 +20,28 @@ export const DelimiterSafeIdV1Schema = z
   .transform(asDelimiterSafeIdV1);
 
 /**
+ * Expanded step identifiers for executable state.
+ *
+ * Supports routine-expanded step IDs like `template-call.step-id` while still
+ * forbidding loop/path delimiters such as `@`, `/`, and `:`.
+ */
+export type ExpandedStepIdV1 = Brand<string, 'v2.ExpandedStepIdV1'>;
+
+export function asExpandedStepIdV1(value: string): ExpandedStepIdV1 {
+  return value as ExpandedStepIdV1;
+}
+
+const EXPANDED_STEP_ID_PATTERN = /^[a-z0-9_-]+(?:\.[a-z0-9_-]+)*$/;
+
+export const ExpandedStepIdV1Schema = z
+  .string()
+  .regex(
+    EXPANDED_STEP_ID_PATTERN,
+    'Expected expanded step id: [a-z0-9_-]+(?:\\.[a-z0-9_-]+)*'
+  )
+  .transform(asExpandedStepIdV1);
+
+/**
  * StepInstanceKey canonical format (locked).
  *
  * - If `loopPath` is empty: `stepId`
@@ -42,7 +64,7 @@ function asStepInstanceKeyV1(value: string): StepInstanceKeyV1 {
   return value as StepInstanceKeyV1;
 }
 
-export function stepInstanceKeyFromParts(stepId: DelimiterSafeIdV1, loopPath: readonly LoopPathFrameV1[]): StepInstanceKeyV1 {
+export function stepInstanceKeyFromParts(stepId: ExpandedStepIdV1, loopPath: readonly LoopPathFrameV1[]): StepInstanceKeyV1 {
   if (loopPath.length === 0) return asStepInstanceKeyV1(stepId);
   const prefix = loopPath.map((f) => `${f.loopId}@${f.iteration}`).join('/');
   return asStepInstanceKeyV1(`${prefix}::${stepId}`);
@@ -55,7 +77,7 @@ export function parseStepInstanceKeyV1(raw: string): Result<StepInstanceKeyV1, S
   const parts = raw.split('::');
   if (parts.length === 1) {
     const stepId = parts[0]!;
-    if (!/^[a-z0-9_-]+$/.test(stepId)) {
+    if (!EXPANDED_STEP_ID_PATTERN.test(stepId)) {
       return err({ code: 'STEP_INSTANCE_KEY_BAD_FORMAT', message: 'Invalid stepId segment' });
     }
     return ok(asStepInstanceKeyV1(stepId));
@@ -65,7 +87,7 @@ export function parseStepInstanceKeyV1(raw: string): Result<StepInstanceKeyV1, S
   }
 
   const [loopPathRaw, stepId] = parts as [string, string];
-  if (!/^[a-z0-9_-]+$/.test(stepId)) {
+  if (!EXPANDED_STEP_ID_PATTERN.test(stepId)) {
     return err({ code: 'STEP_INSTANCE_KEY_BAD_FORMAT', message: 'Invalid stepId segment' });
   }
 

--- a/src/v2/durable-core/schemas/lib/decision-trace-ref.ts
+++ b/src/v2/durable-core/schemas/lib/decision-trace-ref.ts
@@ -24,13 +24,22 @@ export const DecisionTraceRefKindSchema = z.enum([
 
 export type DecisionTraceRefKind = z.infer<typeof DecisionTraceRefKindSchema>;
 
+const EXPANDED_STEP_ID_PATTERN = /^[a-z0-9_-]+(?:\.[a-z0-9_-]+)*$/;
+
 /**
  * Decision trace ref: step_id
- * References a workflow step by its delimiter-safe ID.
+ * References a workflow step by ID.
+ *
+ * Supports both:
+ * - author-authored step IDs: `step-id`
+ * - routine-expanded step IDs: `template-call.step-id`
  */
 const StepIdRefSchema = z.object({
   kind: z.literal('step_id'),
-  stepId: z.string().regex(DELIMITER_SAFE_ID_PATTERN, 'stepId must be delimiter-safe: [a-z0-9_-]+'),
+  stepId: z.string().regex(
+    EXPANDED_STEP_ID_PATTERN,
+    'stepId must be delimiter-safe segments joined by dots: [a-z0-9_-]+(?:\\.[a-z0-9_-]+)*'
+  ),
 }).strict();
 
 /**

--- a/tests/unit/v2/ack-advance-append-plan.test.ts
+++ b/tests/unit/v2/ack-advance-append-plan.test.ts
@@ -115,4 +115,57 @@ describe('ack-advance-append-plan', () => {
     expect(plan.events[1]!.sessionId).toBe('sess_01jh_test');
     for (const e of plan.events) expect(() => DomainEventV1Schema.parse(e)).not.toThrow();
   });
+
+  it('accepts decision trace extra events that reference dotted expanded step IDs', () => {
+    const res = buildAckAdvanceAppendPlanV1({
+      sessionId: 'sess_01jh_test',
+      runId: 'run_01jh_test',
+      fromNodeId: 'node_01jh_from',
+      workflowHash: 'sha256:0000000000000000000000000000000000000000000000000000000000000000' as any,
+      attemptId: 'att_01jh_test',
+      nextEventIndex: 10,
+      outcome: { kind: 'advanced', toNodeId: 'node_01jh_to' },
+      toNodeId: 'node_01jh_to',
+      toNodeKind: 'step',
+      snapshotRef: 'sha256:4444444444444444444444444444444444444444444444444444444444444444' as any,
+      causeKind: 'intentional_fork',
+      extraEventsToAppend: [
+        {
+          v: 1,
+          eventId: 'evt_01jh_trace',
+          kind: 'decision_trace_appended',
+          dedupeKey: 'decision_trace_appended:sess_01jh_test:trace_01jh_test',
+          scope: { runId: 'run_01jh_test', nodeId: 'node_01jh_from' },
+          data: {
+            traceId: 'trace_01jh_test',
+            entries: [
+              {
+                kind: 'selected_next_step',
+                summary: 'Selected next step phase-1b-design-deep.step-discover-philosophy.',
+                refs: [{ kind: 'step_id', stepId: 'phase-1b-design-deep.step-discover-philosophy' }],
+              },
+            ],
+          },
+        },
+      ],
+      minted: {
+        advanceRecordedEventId: 'evt_01jh_adv',
+        nodeCreatedEventId: 'evt_01jh_node',
+        edgeCreatedEventId: 'evt_01jh_edge',
+        outputEventIds: [],
+      },
+      outputsToAppend: [],
+    });
+
+    expect(res.isOk()).toBe(true);
+
+    const plan = res._unsafeUnwrap();
+    expect(plan.events.map((e) => e.kind)).toEqual([
+      'advance_recorded',
+      'decision_trace_appended',
+      'node_created',
+      'edge_created',
+    ]);
+    for (const e of plan.events) expect(() => DomainEventV1Schema.parse(e)).not.toThrow();
+  });
 });

--- a/tests/unit/v2/decision-trace-builder.test.ts
+++ b/tests/unit/v2/decision-trace-builder.test.ts
@@ -25,6 +25,7 @@ import {
   MAX_DECISION_TRACE_TOTAL_BYTES,
   TRUNCATION_MARKER,
 } from '../../../src/v2/durable-core/constants.js';
+import { DomainEventV1Schema } from '../../../src/v2/durable-core/schemas/session/index.js';
 
 const utf8Bytes = (s: string) => new TextEncoder().encode(s).length;
 
@@ -178,6 +179,28 @@ describe('buildDecisionTraceEventData', () => {
       expect(result.value.entries).toHaveLength(3);
       expect(result.value.entries[0]!.kind).toBe('entered_loop');
       expect(result.value.entries[2]!.kind).toBe('selected_next_step');
+    }
+  });
+
+  it('preserves dotted expanded step IDs that still validate as domain events', () => {
+    const entries: DecisionTraceEntry[] = [
+      traceSelectedNextStep('phase-1b-design-deep.step-discover-philosophy'),
+    ];
+
+    const result = buildDecisionTraceEventData('trace_005', entries);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const event = {
+        v: 1 as const,
+        eventId: 'evt_trace_005',
+        eventIndex: 0,
+        sessionId: 'sess_1',
+        kind: 'decision_trace_appended' as const,
+        dedupeKey: 'decision_trace_appended:sess_1:trace_005',
+        scope: { runId: 'run_1', nodeId: 'node_1' },
+        data: result.value,
+      };
+      expect(() => DomainEventV1Schema.parse(event)).not.toThrow();
     }
   });
 

--- a/tests/unit/v2/execution-snapshot-expanded-step-id.test.ts
+++ b/tests/unit/v2/execution-snapshot-expanded-step-id.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ExecutionSnapshotFileV1Schema,
+} from '../../../src/v2/durable-core/schemas/execution-snapshot/index.js';
+import {
+  StepInstanceKeyV1Schema,
+  parseStepInstanceKeyV1,
+} from '../../../src/v2/durable-core/schemas/execution-snapshot/step-instance-key.js';
+
+describe('execution snapshot expanded step IDs', () => {
+  it('accepts dotted expanded step IDs in step instance keys', () => {
+    expect(() =>
+      StepInstanceKeyV1Schema.parse('phase-1b-design-deep.step-discover-philosophy')
+    ).not.toThrow();
+    expect(
+      parseStepInstanceKeyV1('phase-1b-design-deep.step-discover-philosophy').isOk()
+    ).toBe(true);
+  });
+
+  it('accepts dotted expanded step IDs in pending snapshots', () => {
+    expect(() =>
+      ExecutionSnapshotFileV1Schema.parse({
+        v: 1,
+        kind: 'execution_snapshot',
+        enginePayload: {
+          v: 1,
+          engineState: {
+            kind: 'running',
+            completed: {
+              kind: 'set',
+              values: [
+                'phase-0-understand-and-classify',
+                'phase-1a-hypothesis',
+              ],
+            },
+            loopStack: [],
+            pending: {
+              kind: 'some',
+              step: {
+                stepId: 'phase-1b-design-deep.step-discover-philosophy',
+                loopPath: [],
+              },
+            },
+          },
+        },
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- allow dotted routine-expanded step ids in v2 decision trace refs and execution snapshot schemas
- update state conversion and start flow to persist expanded step ids instead of delimiter-safe-only ids
- add regression coverage for decision traces, append plans, and execution snapshots

## Test plan
- [x] `npm run build`
- [x] `npx vitest run tests/unit/v2/decision-trace-builder.test.ts tests/unit/v2/ack-advance-append-plan.test.ts tests/unit/v2/execution-snapshot-expanded-step-id.test.ts`
- [x] `npx vitest run tests/unit/v2/`
- [x] manually verified `continue_workflow` rehydrate and fresh-session advance via MCP

Generated with [Firebender](https://firebender.com)