### PR TITLE
fix: avoid blocking stdio startup on initial roots probe

### DIFF
--- a/src/mcp/transports/stdio-entry.ts
+++ b/src/mcp/transports/stdio-entry.ts
@@ -8,6 +8,19 @@
 import { composeServer } from '../server.js';
 import { wireShutdownHooks, wireStdinShutdown } from './shutdown-hooks.js';
 
+const INITIAL_ROOTS_TIMEOUT_MS = 1000;
+
+async function fetchInitialRootsWithTimeout(server: {
+  listRoots: () => Promise<{ roots: Array<{ uri: string }> }>;
+}): Promise<{ roots: Array<{ uri: string }> } | null> {
+  return Promise.race([
+    server.listRoots(),
+    new Promise<null>((resolve) => {
+      setTimeout(() => resolve(null), INITIAL_ROOTS_TIMEOUT_MS);
+    }),
+  ]);
+}
+
 export async function startStdioServer(): Promise<void> {
   const { server, ctx, rootsManager } = await composeServer();
 
@@ -35,18 +48,24 @@ export async function startStdioServer(): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
+  console.error('[Transport] WorkRail MCP Server running on stdio');
+
   // -------------------------------------------------------------------------
   // stdio-specific: Fetch initial workspace roots from the IDE client
   // -------------------------------------------------------------------------
-  try {
-    const result = await server.listRoots();
-    rootsManager.updateRootUris(result.roots.map((r: { uri: string }) => r.uri));
-    console.error(`[Roots] Initial workspace roots: ${result.roots.map((r: { uri: string }) => r.uri).join(', ') || '(none)'}`);
-  } catch {
-    console.error('[Roots] Client does not support roots/list; workspace context will use server CWD fallback');
-  }
+  void fetchInitialRootsWithTimeout(server)
+    .then((result) => {
+      if (result == null) {
+        console.error('[Roots] Initial roots probe timed out; workspace context will use server CWD fallback');
+        return;
+      }
 
-  console.error('[Transport] WorkRail MCP Server running on stdio');
+      rootsManager.updateRootUris(result.roots.map((r: { uri: string }) => r.uri));
+      console.error(`[Roots] Initial workspace roots: ${result.roots.map((r: { uri: string }) => r.uri).join(', ') || '(none)'}`);
+    })
+    .catch(() => {
+      console.error('[Roots] Client does not support roots/list; workspace context will use server CWD fallback');
+    });
 
   // -------------------------------------------------------------------------
   // Shutdown hooks (shared + stdio-specific stdin watcher)


### PR DESCRIPTION
## Summary
- avoid blocking stdio server readiness on the initial `roots/list` probe
- time out the initial roots fetch and fall back to server CWD when the client is slow or does not support roots
- preserve the existing roots update path after startup and keep shutdown behavior unchanged

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `node dist/mcp-server.js </dev/null`