### PR TITLE
ci: align release dry-run invocation with real release job

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -38,4 +38,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKRAIL_ALLOW_MAJOR_RELEASE: ${{ vars.WORKRAIL_ALLOW_MAJOR_RELEASE }}
-        run: npx semantic-release --dry-run --no-ci
+        run: |
+          set -euo pipefail
+
+          # Mirror the real release job: use the upgraded global npm and avoid
+          # PATH shadowing from ./node_modules/.bin when invoking semantic-release.
+          export PATH="$(echo "$PATH" | tr ':' '\n' | awk '!/\/node_modules\/\.bin/' | paste -sd ':' -)"
+          hash -r
+
+          node ./node_modules/semantic-release/bin/semantic-release.js --dry-run --no-ci


### PR DESCRIPTION
## Summary

- aligns `release-dry-run.yml` with the real release job by invoking `semantic-release` directly instead of through `npx`
- mirrors the PATH handling used in the production release workflow to reduce dry-run vs real-run drift

## Test plan

- [ ] confirm GitHub Actions workflow syntax is valid
- [ ] confirm release dry-run job passes in CI
- [ ] confirm no release is triggered by this PR merge

🤖 Generated with [Firebender](https://firebender.com)