### PR TITLE
fix: improve resume session matching and context

### DIFF
--- a/src/mcp/handler-factory.ts
+++ b/src/mcp/handler-factory.ts
@@ -25,7 +25,7 @@ import { toBoundedJsonValue } from './validation/bounded-json.js';
 import type { PreValidateResult } from './validation/workflow-next-prevalidate.js';
 import type { WrappedToolHandler, McpCallToolResult } from './types/workflow-tool-edition.js';
 import { internalSuggestion } from './handlers/v2-execution-helpers.js';
-import { formatV2ExecutionResponse, type FormattedResponse } from './v2-response-formatter.js';
+import { formatV2ExecutionResponse, formatV2ResumeResponse, type FormattedResponse } from './v2-response-formatter.js';
 import { getV2ExecutionRenderEnvelope } from './render-envelope.js';
 
 // -----------------------------------------------------------------------------
@@ -44,7 +44,8 @@ export function toMcpResult<T>(result: ToolResult<T>): McpCallToolResult {
   switch (result.type) {
     case 'success': {
       if (!jsonResponsesOverride) {
-        const formatted: FormattedResponse | null = formatV2ExecutionResponse(result.data);
+        const formatted: FormattedResponse | null =
+          formatV2ExecutionResponse(result.data) ?? formatV2ResumeResponse(result.data);
         if (formatted !== null) {
           const content: { type: 'text'; text: string }[] = [{ type: 'text', text: formatted.primary }];
           if (formatted.references != null) {

--- a/src/mcp/handlers/v2-resume.ts
+++ b/src/mcp/handlers/v2-resume.ts
@@ -74,6 +74,8 @@ export async function handleV2ResumeSession(
     gitHeadSha: input.gitHeadSha ?? anchorValue(anchors, 'git_head_sha'),
     gitBranch: input.gitBranch ?? anchorValue(anchors, 'git_branch'),
     freeTextQuery: input.query,
+    runId: input.runId,
+    sessionId: input.sessionId,
   };
 
   // Run resume
@@ -115,6 +117,9 @@ interface MintedCandidate {
   readonly resumeToken: string;
   readonly snippet: string;
   readonly whyMatched: string[];
+  readonly pendingStepId: string | null;
+  readonly isComplete: boolean;
+  readonly lastModifiedMs: number | null;
   /** Pre-built template — the agent picks the best candidate and calls continue_workflow with this. */
   readonly nextCall: {
     readonly tool: 'continue_workflow';
@@ -169,6 +174,9 @@ function mintCandidateTokens(
       resumeToken: resumeTokenRes.value,
       snippet: candidate.snippet,
       whyMatched: [...candidate.whyMatched],
+      pendingStepId: candidate.pendingStepId,
+      isComplete: candidate.isComplete,
+      lastModifiedMs: candidate.lastModifiedMs,
       nextCall: {
         tool: 'continue_workflow',
         params: { continueToken: resumeTokenRes.value, intent: 'rehydrate' },

--- a/src/mcp/output-schemas.ts
+++ b/src/mcp/output-schemas.ts
@@ -346,15 +346,28 @@ export const V2ResumeSessionOutputSchema = z.object({
      */
     resumeToken: z.string().regex(STATE_TOKEN_PATTERN, 'Invalid resumeToken format'),
     snippet: z.string().max(1024),
+    pendingStepId: z.string().nullable().describe(
+      'The current pending step ID (e.g. "phase-3-implement") if the workflow is in progress. ' +
+      'Null if the workflow is complete or the step could not be determined.'
+    ),
+    isComplete: z.boolean().describe(
+      'Whether the workflow run has completed. Completed sessions are deprioritized in ranking.'
+    ),
+    lastModifiedMs: z.number().nullable().describe(
+      'Filesystem modification time (epoch ms) of the session. Null if unavailable.'
+    ),
     whyMatched: z.array(z.enum([
-      'matched_head_sha',    // Tier 1 — exact git commit match (strongest signal)
+      'matched_exact_id',    // Tier 0 — exact runId or sessionId match (strongest signal)
+      'matched_head_sha',    // Tier 1 — exact git commit match
       'matched_branch',      // Tier 2 — same git branch
-      'matched_notes',       // Tier 3 — query matched recap notes (semantic)
-      'matched_workflow_id', // Tier 4 — same workflow ID
-      'recency_fallback',    // Tier 5 — no signal; most recent sessions only. Verify snippet before resuming.
+      'matched_notes',       // Tier 3 — query matched ALL recap note tokens
+      'matched_notes_partial', // Tier 4 — query matched SOME recap note tokens
+      'matched_workflow_id', // Tier 5 — same workflow ID
+      'recency_fallback',    // Tier 6 — no signal; most recent sessions only. Verify snippet before resuming.
     ])).describe(
       'Match signals explaining why this candidate was ranked. ' +
-      'matched_head_sha/branch/notes/workflow_id = strong signal. ' +
+      'matched_exact_id/head_sha/branch/notes = strong signal. ' +
+      'matched_notes_partial = moderate signal (some query words matched). ' +
       'recency_fallback = no strong signal; inspect the snippet before resuming.'
     ),
     /**

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -166,6 +166,7 @@ export async function createToolContext(): Promise<ToolContext> {
           directoryListing,
           dataDir,
           sessionStore,
+          snapshotStore,
         }),
       };
       console.error('[FeatureFlags] v2 tools enabled');

--- a/src/mcp/v2-response-formatter.ts
+++ b/src/mcp/v2-response-formatter.ts
@@ -659,3 +659,209 @@ function formatV2Clean(data: V2ExecutionResponse): Pick<FormattedResponse, 'prim
     primary: formatCleanSuccess(data),
   };
 }
+
+// ---------------------------------------------------------------------------
+// Resume session response formatter
+// ---------------------------------------------------------------------------
+
+interface ResumeCandidate {
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly workflowId: string;
+  readonly resumeToken: string;
+  readonly snippet: string;
+  readonly whyMatched: readonly string[];
+  readonly pendingStepId?: string | null;
+  readonly isComplete?: boolean;
+  readonly lastModifiedMs?: number | null;
+  readonly nextCall: {
+    readonly tool: 'continue_workflow';
+    readonly params: { readonly continueToken: string; readonly intent: 'rehydrate' };
+  };
+}
+
+interface ResumeSessionResponse {
+  readonly candidates: readonly ResumeCandidate[];
+  readonly totalEligible: number;
+}
+
+function isResumeSessionResponse(data: unknown): data is ResumeSessionResponse {
+  if (typeof data !== 'object' || data === null) return false;
+  const d = data as Record<string, unknown>;
+  // Distinguish from execution responses (which have pending/nextIntent/preferences)
+  // and other tool outputs. Resume responses uniquely have candidates + totalEligible
+  // WITHOUT the execution response fields.
+  return (
+    Array.isArray(d.candidates) &&
+    typeof d.totalEligible === 'number' &&
+    !('pending' in d) &&
+    !('nextIntent' in d)
+  );
+}
+
+const WHY_MATCHED_LABELS: Readonly<Record<string, string>> = {
+  matched_exact_id: 'Exact ID match',
+  matched_head_sha: 'Same git commit (HEAD SHA)',
+  matched_branch: 'Same git branch',
+  matched_notes: 'Query matched session notes',
+  matched_notes_partial: 'Query partially matched session notes',
+  matched_workflow_id: 'Query matched workflow type',
+  recency_fallback: 'No strong match signal (recent session)',
+};
+
+/** Format a relative time string from epoch ms (e.g. "2 hours ago", "3 days ago"). */
+function formatRelativeTime(epochMs: number): string {
+  const diffMs = Date.now() - epochMs;
+  if (diffMs < 0) return 'just now';
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days} day${days === 1 ? '' : 's'} ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks} week${weeks === 1 ? '' : 's'} ago`;
+  const months = Math.floor(days / 30);
+  return `${months} month${months === 1 ? '' : 's'} ago`;
+}
+
+function formatResumeCandidate(c: ResumeCandidate, index: number): string {
+  const lines: string[] = [];
+  const matchLabel = c.whyMatched.map(w => WHY_MATCHED_LABELS[w] ?? w).join(', ');
+  const isWeak = c.whyMatched.every(w => w === 'recency_fallback');
+  const statusTag = c.isComplete ? ' (completed)' : '';
+
+  lines.push(`### Candidate ${index + 1}: \`${c.workflowId}\`${statusTag}${isWeak ? ' (weak match)' : ''}`);
+  lines.push(`- **Session**: \`${c.sessionId}\``);
+  lines.push(`- **Run**: \`${c.runId}\``);
+  lines.push(`- **Match reason**: ${matchLabel}`);
+
+  if (c.pendingStepId) {
+    lines.push(`- **Current step**: \`${c.pendingStepId}\``);
+  } else if (c.isComplete) {
+    lines.push('- **Status**: Workflow completed');
+  }
+
+  if (c.lastModifiedMs != null) {
+    lines.push(`- **Last active**: ${formatRelativeTime(c.lastModifiedMs)}`);
+  }
+
+  if (c.snippet) {
+    // Show first ~200 chars of snippet
+    const preview = c.snippet.length > 200 ? c.snippet.slice(0, 200) + '...' : c.snippet;
+    lines.push(`- **Preview**: ${preview.replace(/\n/g, ' ')}`);
+  } else {
+    lines.push('- **Preview**: (no recap notes available)');
+  }
+
+  if (c.isComplete) {
+    lines.push('');
+    lines.push('> This workflow has already completed. Resuming it will show the final state.');
+  }
+
+  lines.push('');
+  lines.push('To resume, call `continue_workflow` with:');
+  lines.push('```json');
+  lines.push(JSON.stringify(c.nextCall.params, null, 2));
+  lines.push('```');
+
+  return lines.join('\n');
+}
+
+/** Help text showing the agent what parameters are available for narrowing results. */
+const SEARCH_PARAMS_HELP = [
+  '**To narrow results, call `resume_session` again with any of these parameters:**',
+  '- `query`: Free text keywords from the session (e.g. "mr ownership", "ACEI-1234", "login feature")',
+  '- `runId`: Exact run ID if the user has one (e.g. "run_abc123def456")',
+  '- `sessionId`: Exact session ID if the user has one (e.g. "sess_abc123")',
+  '- `workspacePath`: Absolute path to the workspace (helps match by git branch/commit)',
+].join('\n');
+
+/**
+ * Format a resume_session response as natural language.
+ *
+ * The key design goal: an agent with ZERO context about WorkRail should be able
+ * to read this response and know exactly what to do. The formatter explains:
+ * 1. What these candidates are
+ * 2. Which one to pick and why
+ * 3. Exactly how to resume (copy-paste JSON)
+ * 4. What to do if none match
+ * 5. What parameters are available for better searching
+ */
+export function formatV2ResumeResponse(data: unknown): FormattedResponse | null {
+  if (!isResumeSessionResponse(data)) return null;
+
+  const { candidates, totalEligible } = data;
+  const lines: string[] = [];
+
+  if (candidates.length === 0) {
+    lines.push('## No Resumable Sessions Found');
+    lines.push('');
+    lines.push(`Searched ${totalEligible} session(s) but none matched your query or workspace context.`);
+    lines.push('');
+    lines.push('**What to do**: Ask the user for more details about which session they want to resume. They might know:');
+    lines.push('- A description of what they were working on (pass as `query`)');
+    lines.push('- A run ID or session ID (pass as `runId` or `sessionId`)');
+    lines.push('- Or start a fresh workflow with `start_workflow`.');
+    lines.push('');
+    lines.push(SEARCH_PARAMS_HELP);
+    return { primary: lines.join('\n') };
+  }
+
+  const hasStrongMatch = candidates.some(c => !c.whyMatched.every(w => w === 'recency_fallback'));
+  const allRecencyFallback = !hasStrongMatch;
+
+  if (allRecencyFallback) {
+    // No search signal was provided or nothing matched - show recent sessions as context
+    // but tell the agent to ask the user
+    lines.push('## Recent Workflow Sessions');
+    lines.push('');
+    lines.push(`No specific search criteria matched, so here are the **${candidates.length} most recent** sessions (out of ${totalEligible} total).`);
+    lines.push('');
+    lines.push('**Action required**: Present these to the user and ask which one they want to resume. If none of these are right, ask the user to describe what they were working on so you can search more specifically.');
+    lines.push('');
+
+    for (let i = 0; i < candidates.length; i++) {
+      lines.push(formatResumeCandidate(candidates[i]!, i));
+      lines.push('');
+    }
+
+    if (totalEligible > candidates.length) {
+      lines.push('---');
+      lines.push(`${totalEligible - candidates.length} more session(s) not shown.`);
+      lines.push('');
+    }
+
+    lines.push(SEARCH_PARAMS_HELP);
+  } else {
+    // We have signal - show ranked results
+    lines.push('## Resumable Workflow Sessions');
+    lines.push('');
+    lines.push(`Found **${totalEligible}** session(s) total. Showing the top ${candidates.length} ranked by match strength.`);
+    lines.push('');
+
+    const best = candidates[0]!;
+    const bestIsExact = best.whyMatched.includes('matched_exact_id');
+    if (bestIsExact) {
+      lines.push(`**Recommendation**: Candidate 1 is an exact ID match. Resume it directly.`);
+    } else {
+      lines.push(`**Recommendation**: Candidate 1 has the strongest match signal. Present the top candidates to the user and let them confirm which one to resume.`);
+    }
+    lines.push('');
+
+    for (let i = 0; i < candidates.length; i++) {
+      lines.push(formatResumeCandidate(candidates[i]!, i));
+      lines.push('');
+    }
+
+    if (totalEligible > candidates.length) {
+      lines.push('---');
+      lines.push(`${totalEligible - candidates.length} more session(s) not shown.`);
+      lines.push('');
+      lines.push(SEARCH_PARAMS_HELP);
+    }
+  }
+
+  return { primary: lines.join('\n') };
+}

--- a/src/mcp/v2/tools.ts
+++ b/src/mcp/v2/tools.ts
@@ -129,7 +129,16 @@ export type V2ContinueWorkflowInput = z.infer<typeof V2ContinueWorkflowInput>;
 export const V2ResumeSessionInput = z.object({
   query: z.string().min(1).max(256).optional().describe(
     'Free text search to find a relevant session. Matches against recap notes and workflow IDs. ' +
+    'Tip: use the user\'s exact words (e.g. "mr ownership", "ACEI-1234"). ' +
     'Without query, only git-context matching runs — the semantic (notes) tier is skipped.'
+  ),
+  runId: z.string().regex(/^run_[a-z0-9]+$/).optional().describe(
+    'Exact run ID to find (e.g. "run_tbi2ag7njfjgc2aitt4qg5eaiq"). ' +
+    'When provided, the matching session is returned as the sole top-priority candidate.'
+  ),
+  sessionId: z.string().regex(/^sess_[a-zA-Z0-9_]+$/).optional().describe(
+    'Exact session ID to find (e.g. "sess_s5o2ieem4mwypoqnn6ztzyyag4"). ' +
+    'When provided, the matching session is returned as the sole top-priority candidate.'
   ),
   gitBranch: z.string().max(256).optional().describe(
     'Git branch name to match against session observations. Overrides auto-detected branch.'

--- a/src/mcp/workflow-protocol-contracts.ts
+++ b/src/mcp/workflow-protocol-contracts.ts
@@ -213,44 +213,44 @@ export const CHECKPOINT_WORKFLOW_PROTOCOL: WorkflowProtocolContract = {
 export const RESUME_SESSION_PROTOCOL: WorkflowProtocolContract = {
   canonicalParams: {
     required: [],
-    optional: ['query', 'gitBranch', 'gitHeadSha', 'workspacePath'],
+    optional: ['query', 'runId', 'sessionId', 'gitBranch', 'gitHeadSha', 'workspacePath'],
   },
   descriptions: {
     standard: {
-      purpose: 'Find and reconnect to an existing WorkRail v2 workflow session.',
+      purpose: 'Find and reconnect to an existing WorkRail workflow session. WorkRail is a workflow engine that persists session state across chat conversations. When a user says "resume my workflow", this is the tool to call.',
       whenToUse:
-        'Use this when you need to resume a previously started workflow but no longer have the latest continueToken in chat context.',
+        'Use this when the user wants to resume, continue, or reconnect to a previously started workflow. The user may provide a session ID, run ID, a description of what they were working on, or nothing at all. This tool searches stored sessions and returns the best matches.',
       rules: [
-        'Always pass query with the user\'s stated topic or intent (e.g. "resume the ACEI-1234 workflow"). Without query, only git-context matching runs and the right session may not surface.',
-        'Pass workspacePath when available so WorkRail can match sessions to the correct workspace and git context.',
-        'Pick the best candidate, then call continue_workflow using its nextCall template — no manual parameter construction needed.',
-        'Do not call read_session to resume; use the nextCall from the chosen candidate.',
-        'If candidates is empty, no eligible session exists — call start_workflow to begin a new session instead.',
-        'If all candidates have whyMatched: ["recency_fallback"], the match had no strong signal (git or notes). Verify the snippet before resuming.',
+        'If the user provides a run ID (run_...) or session ID (sess_...), pass it as runId or sessionId for an exact match. This is the most reliable way to find a specific session.',
+        'If the user describes what they were working on (e.g. "the mr ownership task"), pass their words as query. This searches session recap notes and workflow IDs for matching keywords.',
+        'Always pass workspacePath (from your system parameters) so WorkRail can also match by git context (branch, commit).',
+        'The response includes ranked candidates with match explanations and ready-to-use continuation templates. Present the top candidates to the user if there is ambiguity.',
+        'To resume a candidate: call continue_workflow with the candidate\'s nextCall.params (continueToken and intent: "rehydrate"). The response will give you the full session context.',
+        'If no candidates match, ask the user for more details or suggest starting a fresh workflow with start_workflow.',
       ],
       examplePayload: {
         workspacePath: '/Users/you/git/my-project',
         query: 'resume the coding task workflow for protocol drift',
       },
-      returns: 'Up to 5 ranked candidates, each with whyMatched explaining the match signal and a nextCall template for continue_workflow. If candidates is empty, call start_workflow.',
+      returns: 'Up to 5 ranked candidates with match signals, session previews, and ready-to-use continuation templates. The response explains which candidate to pick and exactly how to resume it.',
     },
     authoritative: {
-      purpose: 'Find an existing WorkRail v2 session and reconnect to it deterministically.',
+      purpose: 'Find an existing WorkRail workflow session and reconnect to it. WorkRail persists workflow state across chat conversations. When a user says "resume my workflow", call this tool.',
       whenToUse:
-        'Call this when resuming a workflow without the latest in-chat token block.',
+        'Call this when resuming a workflow. The user may provide a run ID, session ID, a description, or nothing.',
       rules: [
-        'Always pass query with the user\'s stated topic or intent. Semantic (notes) matching only runs when query is provided.',
-        'Pass workspacePath set to the current workspace whenever possible.',
-        'Pick the best candidate and call continue_workflow with its nextCall — the resumeToken is already embedded in nextCall.params.continueToken.',
-        'Do not invent token values or call read_session to resume execution.',
-        'If candidates is empty, no eligible session exists — call start_workflow instead.',
-        'whyMatched values: matched_head_sha / matched_branch / matched_notes = strong signal; recency_fallback = no signal, verify snippet before resuming.',
+        'If the user provides a run ID (run_...) or session ID (sess_...), pass it as runId or sessionId for exact lookup.',
+        'If the user describes their task, pass their words as query to search session notes.',
+        'Always pass workspacePath from your system parameters for git-context matching.',
+        'Present candidates to the user when there is ambiguity. The response explains match strength.',
+        'To resume: call continue_workflow with the chosen candidate\'s nextCall.params (continueToken + intent: "rehydrate").',
+        'If no candidates match, ask for more details or start a fresh workflow.',
       ],
       examplePayload: {
         workspacePath: '/Users/you/git/my-project',
         query: 'resume the coding task workflow for protocol drift',
       },
-      returns: 'Up to 5 ranked candidates, each with whyMatched confidence signals and a pre-built nextCall. Empty candidates means no session found — call start_workflow.',
+      returns: 'Up to 5 ranked candidates with match signals, previews, and ready-to-use continuation templates.',
     },
   },
 };

--- a/src/v2/infra/local/session-summary-provider/index.ts
+++ b/src/v2/infra/local/session-summary-provider/index.ts
@@ -3,17 +3,19 @@ import { okAsync } from 'neverthrow';
 import type { DirectoryListingPortV2 } from '../../../ports/directory-listing.port.js';
 import type { DataDirPortV2 } from '../../../ports/data-dir.port.js';
 import type { SessionEventLogReadonlyStorePortV2, LoadedSessionTruthV2 } from '../../../ports/session-event-log-store.port.js';
+import type { SnapshotStorePortV2 } from '../../../ports/snapshot-store.port.js';
 import type { SessionSummaryProviderPortV2, SessionSummaryError } from '../../../ports/session-summary-provider.port.js';
 import type { HealthySessionSummary, SessionObservations, IdentifiedWorkflow, RecapSnippet } from '../../../projections/resume-ranking.js';
 import { asRecapSnippet } from '../../../projections/resume-ranking.js';
 import type { RunDagRunV2, RunDagNodeV2 } from '../../../projections/run-dag.js';
-import { enumerateSessionsByRecency } from '../../../usecases/enumerate-sessions.js';
+import { enumerateSessionsByRecency, type SessionWithMtime } from '../../../usecases/enumerate-sessions.js';
 import { projectSessionHealthV2 } from '../../../projections/session-health.js';
 import { projectRunDagV2 } from '../../../projections/run-dag.js';
 import { projectNodeOutputsV2, type NodeOutputsProjectionV2 } from '../../../projections/node-outputs.js';
+import { derivePendingStep, deriveIsComplete } from '../../../durable-core/projections/snapshot-state.js';
 import type { DomainEventV1 } from '../../../durable-core/schemas/session/index.js';
-import type { SessionId } from '../../../durable-core/ids/index.js';
-import { asWorkflowId, asWorkflowHash, asSha256Digest } from '../../../durable-core/ids/index.js';
+import type { SessionId, SnapshotRef } from '../../../durable-core/ids/index.js';
+import { asWorkflowId, asWorkflowHash, asSha256Digest, asSnapshotRef } from '../../../durable-core/ids/index.js';
 import { EVENT_KIND, OUTPUT_CHANNEL, PAYLOAD_KIND, SHA256_DIGEST_PATTERN } from '../../../durable-core/constants.js';
 
 // ---------------------------------------------------------------------------
@@ -44,6 +46,7 @@ type RunStartedEventV1 = Extract<DomainEventV1, { kind: 'run_started' }>;
 interface RunWithTip {
   readonly run: RunDagRunV2;
   readonly tipNodeId: string;
+  readonly tipSnapshotRef: string;
   readonly lastActivityEventIndex: number;
 }
 
@@ -55,7 +58,7 @@ interface RunWithTip {
  * Max sessions to scan (explicit bound to prevent unbounded enumeration).
  * Locked: prevents runaway scanning on large workspaces.
  */
-const MAX_SESSIONS_TO_SCAN = 50;
+const MAX_SESSIONS_TO_SCAN = 200;
 
 /**
  * Max ancestor depth for recap aggregation.
@@ -69,6 +72,12 @@ const MAX_RECAP_ANCESTOR_DEPTH = 100;
 // ---------------------------------------------------------------------------
 // Empty sentinels (named, not inlined)
 // ---------------------------------------------------------------------------
+
+/** Internal result from projectSessionSummary — carries snapshotRef for enrichment. */
+interface ProjectedSummary {
+  readonly summary: HealthySessionSummary;
+  readonly tipSnapshotRef: string;
+}
 
 const EMPTY_OBSERVATIONS: SessionObservations = {
   gitHeadSha: null,
@@ -89,6 +98,8 @@ export interface LocalSessionSummaryProviderPorts {
   readonly directoryListing: DirectoryListingPortV2;
   readonly dataDir: DataDirPortV2;
   readonly sessionStore: SessionEventLogReadonlyStorePortV2;
+  /** Optional: enables pendingStepId and isComplete extraction from tip snapshots. */
+  readonly snapshotStore?: SnapshotStorePortV2;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,10 +127,11 @@ export class LocalSessionSummaryProviderV2 implements SessionSummaryProviderPort
         code: 'SESSION_SUMMARY_ENUMERATION_FAILED',
         message: `Failed to enumerate sessions: ${fsErr.message}`,
       }))
-      .andThen((sessionIds) =>
+      .andThen((entries) =>
         collectHealthySummaries(
-          sessionIds.slice(0, MAX_SESSIONS_TO_SCAN),
+          entries.slice(0, MAX_SESSIONS_TO_SCAN),
           this.ports.sessionStore,
+          this.ports.snapshotStore ?? null,
         )
       );
   }
@@ -138,13 +150,14 @@ export class LocalSessionSummaryProviderV2 implements SessionSummaryProviderPort
  * Uses a functional reduce so the accumulator is immutable at each step.
  */
 function collectHealthySummaries(
-  sessionIds: readonly SessionId[],
+  entries: readonly SessionWithMtime[],
   sessionStore: SessionEventLogReadonlyStorePortV2,
+  snapshotStore: SnapshotStorePortV2 | null,
 ): ResultAsync<readonly HealthySessionSummary[], SessionSummaryError> {
-  return sessionIds.reduce(
-    (acc, sessionId) =>
+  return entries.reduce(
+    (acc, entry) =>
       acc.andThen((summaries) =>
-        loadSessionSummary(sessionId, sessionStore).map((summary) =>
+        loadSessionSummary(entry, sessionStore, snapshotStore).map((summary) =>
           summary !== null ? [...summaries, summary] : summaries,
         )
       ),
@@ -157,13 +170,43 @@ function collectHealthySummaries(
  * Returns null on any failure — graceful degradation for individual sessions.
  */
 function loadSessionSummary(
-  sessionId: SessionId,
+  entry: SessionWithMtime,
   sessionStore: SessionEventLogReadonlyStorePortV2,
+  snapshotStore: SnapshotStorePortV2 | null,
 ): ResultAsync<HealthySessionSummary | null, never> {
   return sessionStore
-    .load(sessionId)
-    .map((truth) => projectSessionSummary(sessionId, truth))
+    .load(entry.sessionId)
+    .andThen((truth) => {
+      const projected = projectSessionSummary(entry.sessionId, truth, entry.mtimeMs);
+      if (!projected) return okAsync(null);
+
+      // If snapshot store is available, enrich with pendingStepId and isComplete
+      if (!snapshotStore) return okAsync(projected.summary);
+
+      const ref = safeSnapshotRef(projected.tipSnapshotRef);
+      if (!ref) return okAsync(projected.summary);
+
+      return snapshotStore.getExecutionSnapshotV1(ref)
+        .map((snapshot) => {
+          if (!snapshot) return projected.summary;
+          const engineState = snapshot.enginePayload.engineState;
+          const pending = derivePendingStep(engineState);
+          const isComplete = deriveIsComplete(engineState);
+          return {
+            ...projected.summary,
+            pendingStepId: pending?.stepId ?? null,
+            isComplete,
+          };
+        })
+        .orElse(() => okAsync(projected.summary)); // Graceful: snapshot failures don't break summary
+    })
     .orElse(() => okAsync(null)); // Graceful skip: individual store failures don't abort enumeration
+}
+
+/** Convert a raw snapshot ref string to a branded SnapshotRef, returning null if malformed. */
+function safeSnapshotRef(raw: string): SnapshotRef | null {
+  if (!raw || !SHA256_DIGEST_PATTERN.test(raw)) return null;
+  return asSnapshotRef(asSha256Digest(raw));
 }
 
 // ---------------------------------------------------------------------------
@@ -180,7 +223,8 @@ function loadSessionSummary(
 function projectSessionSummary(
   sessionId: SessionId,
   truth: LoadedSessionTruthV2,
-): HealthySessionSummary | null {
+  mtimeMs: number,
+): ProjectedSummary | null {
   // Gate: unhealthy sessions cannot be summarized
   const health = projectSessionHealthV2(truth);
   if (health.isErr() || health.value.kind !== 'healthy') return null;
@@ -204,16 +248,23 @@ function projectSessionSummary(
     : null;
 
   return {
-    sessionId,
-    runId: bestRun.run.runId,
-    preferredTip: {
-      nodeId: bestRun.tipNodeId,
-      lastActivityEventIndex: bestRun.lastActivityEventIndex,
-    },
-    recapSnippet,
-    observations: extractObservations(truth.events),
-    workflow,
-  } satisfies HealthySessionSummary;
+    summary: {
+      sessionId,
+      runId: bestRun.run.runId,
+      preferredTip: {
+        nodeId: bestRun.tipNodeId,
+        lastActivityEventIndex: bestRun.lastActivityEventIndex,
+      },
+      recapSnippet,
+      observations: extractObservations(truth.events),
+      workflow,
+      lastModifiedMs: mtimeMs,
+      // Defaults; enriched by snapshot store if available
+      pendingStepId: null,
+      isComplete: false,
+    } satisfies HealthySessionSummary,
+    tipSnapshotRef: bestRun.tipSnapshotRef,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -231,7 +282,8 @@ function selectBestRun(runs: readonly RunDagRunV2[]): RunWithTip | null {
     const tipNodeId = r.preferredTipNodeId;
     if (!tipNodeId) return [];
     const tipNode = r.nodesById[tipNodeId];
-    return [{ run: r, tipNodeId, lastActivityEventIndex: tipNode?.createdAtEventIndex ?? 0 }];
+    if (!tipNode) return [];
+    return [{ run: r, tipNodeId, tipSnapshotRef: tipNode.snapshotRef, lastActivityEventIndex: tipNode.createdAtEventIndex }];
   });
 
   if (runsWithTip.length === 0) return null;

--- a/src/v2/projections/resume-ranking.ts
+++ b/src/v2/projections/resume-ranking.ts
@@ -75,6 +75,12 @@ export interface HealthySessionSummary {
   readonly recapSnippet: RecapSnippet | null;
   readonly observations: SessionObservations;
   readonly workflow: IdentifiedWorkflow;
+  /** Filesystem modification time (epoch ms). Used for relative-time display. */
+  readonly lastModifiedMs: number | null;
+  /** Current pending step ID from execution snapshot, if the workflow is in progress. */
+  readonly pendingStepId: string | null;
+  /** Whether the workflow run has completed (engine state = 'complete'). */
+  readonly isComplete: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -83,19 +89,23 @@ export interface HealthySessionSummary {
 
 /** Closed set: why a session matched (locked §2.3). */
 export type WhyMatched =
+  | 'matched_exact_id'
   | 'matched_head_sha'
   | 'matched_branch'
   | 'matched_notes'
+  | 'matched_notes_partial'
   | 'matched_workflow_id'
   | 'recency_fallback';
 
 /** Tier assignment — discriminated union. Exhaustive, testable independently. */
 export type TierAssignment =
+  | { readonly tier: 0; readonly kind: 'matched_exact_id'; readonly matchField: 'runId' | 'sessionId' }
   | { readonly tier: 1; readonly kind: 'matched_head_sha' }
   | { readonly tier: 2; readonly kind: 'matched_branch'; readonly matchType: 'exact' | 'prefix' }
   | { readonly tier: 3; readonly kind: 'matched_notes' }
-  | { readonly tier: 4; readonly kind: 'matched_workflow_id' }
-  | { readonly tier: 5; readonly kind: 'recency_fallback' };
+  | { readonly tier: 4; readonly kind: 'matched_notes_partial'; readonly matchRatio: number }
+  | { readonly tier: 5; readonly kind: 'matched_workflow_id' }
+  | { readonly tier: 6; readonly kind: 'recency_fallback' };
 
 // ---------------------------------------------------------------------------
 // Text normalization (locked §2.3)
@@ -133,6 +143,59 @@ export function allQueryTokensMatch(
   return true;
 }
 
+/**
+ * Compute the ratio of query tokens that appear in the candidate token set.
+ * Returns 0 if either set is empty.
+ */
+export function queryTokenMatchRatio(
+  queryTokens: ReadonlySet<string>,
+  candidateTokens: ReadonlySet<string>,
+): number {
+  if (queryTokens.size === 0 || candidateTokens.size === 0) return 0;
+  let matched = 0;
+  for (const token of queryTokens) {
+    if (candidateTokens.has(token)) matched++;
+  }
+  return matched / queryTokens.size;
+}
+
+/**
+ * Fuzzy token match: checks if a query token matches any candidate token via
+ * substring containment (either direction).
+ *
+ * Examples: "owner" matches "ownership", "auth" matches "authentication",
+ *           "authentication" matches "auth".
+ *
+ * Exact matches are handled by Set.has in callers — not duplicated here.
+ * Tokens shorter than 3 chars are skipped to avoid false positives.
+ */
+export function fuzzyTokenMatch(queryToken: string, candidateTokens: ReadonlySet<string>): boolean {
+  // Skip very short tokens (1-2 chars) to avoid false positives
+  if (queryToken.length < 3) return false;
+  for (const ct of candidateTokens) {
+    if (ct.length < 3) continue;
+    if (ct.includes(queryToken) || queryToken.includes(ct)) return true;
+  }
+  return false;
+}
+
+/**
+ * Compute the ratio of query tokens that match candidate tokens using fuzzy matching.
+ * Combines exact match + substring containment.
+ * Returns 0 if either set is empty.
+ */
+export function fuzzyQueryTokenMatchRatio(
+  queryTokens: ReadonlySet<string>,
+  candidateTokens: ReadonlySet<string>,
+): number {
+  if (queryTokens.size === 0 || candidateTokens.size === 0) return 0;
+  let matched = 0;
+  for (const qt of queryTokens) {
+    if (candidateTokens.has(qt) || fuzzyTokenMatch(qt, candidateTokens)) matched++;
+  }
+  return matched / queryTokens.size;
+}
+
 // ---------------------------------------------------------------------------
 // Query type
 // ---------------------------------------------------------------------------
@@ -141,17 +204,32 @@ export interface ResumeQuery {
   readonly gitHeadSha?: string;
   readonly gitBranch?: string;
   readonly freeTextQuery?: string;
+  /** Exact run ID to find — bypasses all other ranking when matched. */
+  readonly runId?: string;
+  /** Exact session ID to find — bypasses all other ranking when matched. */
+  readonly sessionId?: string;
 }
 
 // ---------------------------------------------------------------------------
 // Tier assignment logic
 // ---------------------------------------------------------------------------
 
+/** Minimum partial match ratio to qualify as a partial notes match. */
+const MIN_PARTIAL_MATCH_RATIO = 0.4;
+
 /**
  * Assign a tier to a session summary based on the query.
- * Highest matching tier wins (tier 1 = best).
+ * Highest matching tier wins (tier 0 = best, exact ID match).
  */
 export function assignTier(summary: HealthySessionSummary, query: ResumeQuery): TierAssignment {
+  // Tier 0: exact match on runId or sessionId
+  if (query.runId && summary.runId === query.runId) {
+    return { tier: 0, kind: 'matched_exact_id', matchField: 'runId' };
+  }
+  if (query.sessionId && String(summary.sessionId) === query.sessionId) {
+    return { tier: 0, kind: 'matched_exact_id', matchField: 'sessionId' };
+  }
+
   // Tier 1: exact match on git_head_sha
   if (query.gitHeadSha && summary.observations.gitHeadSha === query.gitHeadSha) {
     return { tier: 1, kind: 'matched_head_sha' };
@@ -168,26 +246,38 @@ export function assignTier(summary: HealthySessionSummary, query: ResumeQuery): 
     }
   }
 
-  // Tier 3: token match on recap notes
-  if (query.freeTextQuery && summary.recapSnippet) {
-    const queryTokens = normalizeToTokens(query.freeTextQuery);
+  // Normalize query tokens once for text-based tiers (3, 4, 5)
+  const queryTokens = query.freeTextQuery ? normalizeToTokens(query.freeTextQuery) : null;
+
+  // Tier 3: ALL token match on recap notes (exact)
+  if (queryTokens && queryTokens.size > 0 && summary.recapSnippet) {
     const noteTokens = normalizeToTokens(summary.recapSnippet);
     if (allQueryTokensMatch(queryTokens, noteTokens)) {
       return { tier: 3, kind: 'matched_notes' };
     }
-  }
-
-  // Tier 4: token match on workflow id
-  if (query.freeTextQuery && summary.workflow.kind === 'identified') {
-    const queryTokens = normalizeToTokens(query.freeTextQuery);
-    const workflowTokens = normalizeToTokens(String(summary.workflow.workflowId));
-    if (allQueryTokensMatch(queryTokens, workflowTokens)) {
-      return { tier: 4, kind: 'matched_workflow_id' };
+    // Tier 4: partial/fuzzy token match on recap notes (at least MIN_PARTIAL_MATCH_RATIO)
+    // Uses fuzzy matching so "owner" matches "ownership", "auth" matches "authentication"
+    const ratio = fuzzyQueryTokenMatchRatio(queryTokens, noteTokens);
+    if (ratio >= MIN_PARTIAL_MATCH_RATIO) {
+      return { tier: 4, kind: 'matched_notes_partial', matchRatio: ratio };
     }
   }
 
-  // Tier 5: recency fallback
-  return { tier: 5, kind: 'recency_fallback' };
+  // Tier 5: exact token match on workflow id
+  if (queryTokens && queryTokens.size > 0 && summary.workflow.kind === 'identified') {
+    const workflowTokens = normalizeToTokens(String(summary.workflow.workflowId));
+    if (allQueryTokensMatch(queryTokens, workflowTokens)) {
+      return { tier: 5, kind: 'matched_workflow_id' };
+    }
+    // Tier 5 also: fuzzy/partial match on workflow id
+    const ratio = fuzzyQueryTokenMatchRatio(queryTokens, workflowTokens);
+    if (ratio >= MIN_PARTIAL_MATCH_RATIO) {
+      return { tier: 5, kind: 'matched_workflow_id' };
+    }
+  }
+
+  // Tier 6: recency fallback
+  return { tier: 6, kind: 'recency_fallback' };
 }
 
 /**
@@ -195,9 +285,11 @@ export function assignTier(summary: HealthySessionSummary, query: ResumeQuery): 
  */
 function tierToWhyMatched(tier: TierAssignment): WhyMatched {
   switch (tier.kind) {
+    case 'matched_exact_id': return 'matched_exact_id';
     case 'matched_head_sha': return 'matched_head_sha';
     case 'matched_branch': return 'matched_branch';
     case 'matched_notes': return 'matched_notes';
+    case 'matched_notes_partial': return 'matched_notes_partial';
     case 'matched_workflow_id': return 'matched_workflow_id';
     case 'recency_fallback': return 'recency_fallback';
   }
@@ -219,6 +311,12 @@ export interface RankedResumeCandidate {
   readonly workflowHash: WorkflowHash;
   /** Non-nullable: required to identify the workflow for session resumption. */
   readonly workflowId: WorkflowId;
+  /** Current pending step ID (e.g. "phase-3-implement"), null if unknown or complete. */
+  readonly pendingStepId: string | null;
+  /** Whether the workflow run has completed. */
+  readonly isComplete: boolean;
+  /** Filesystem modification time (epoch ms), null if unavailable. */
+  readonly lastModifiedMs: number | null;
 }
 
 /** Max candidates returned (locked §2.3). */
@@ -229,7 +327,7 @@ export const MAX_RESUME_CANDIDATES = 5;
 // ---------------------------------------------------------------------------
 
 /**
- * Rank session summaries against a query using the locked 5-tier algorithm.
+ * Rank session summaries against a query using the 7-tier algorithm.
  *
  * Lock §2.3: Strict tiered matching, deterministic ordering.
  *
@@ -249,9 +347,20 @@ export function rankResumeCandidates(
     tier: assignTier(summary, query),
   }));
 
-  // Sort: tier asc, lastActivityEventIndex desc, sessionId lex
+  // Sort: tier asc, then completed after in-progress within same tier,
+  // matchRatio desc (for partial matches), lastActivityEventIndex desc, sessionId lex.
+  // Note: tier takes priority over completion status so that a completed session
+  // with an exact ID match (tier 0) still ranks above an in-progress recency fallback (tier 6).
   const sorted = [...withTier].sort((a, b) => {
     if (a.tier.tier !== b.tier.tier) return a.tier.tier - b.tier.tier;
+    // Within the same tier, completed sessions sort after in-progress ones
+    if (a.summary.isComplete !== b.summary.isComplete) {
+      return a.summary.isComplete ? 1 : -1;
+    }
+    // Within partial notes tier, higher match ratio wins
+    if (a.tier.kind === 'matched_notes_partial' && b.tier.kind === 'matched_notes_partial') {
+      if (a.tier.matchRatio !== b.tier.matchRatio) return b.tier.matchRatio - a.tier.matchRatio;
+    }
     const actA = a.summary.preferredTip.lastActivityEventIndex;
     const actB = b.summary.preferredTip.lastActivityEventIndex;
     if (actA !== actB) return actB - actA; // desc
@@ -269,5 +378,8 @@ export function rankResumeCandidates(
     lastActivityEventIndex: summary.preferredTip.lastActivityEventIndex,
     workflowHash: summary.workflow.workflowHash,
     workflowId: summary.workflow.workflowId,
+    pendingStepId: summary.pendingStepId,
+    isComplete: summary.isComplete,
+    lastModifiedMs: summary.lastModifiedMs,
   }));
 }

--- a/src/v2/usecases/enumerate-sessions.ts
+++ b/src/v2/usecases/enumerate-sessions.ts
@@ -34,6 +34,12 @@ export function enumerateSessions(ports: {
     );
 }
 
+/** Session ID with its filesystem modification time. */
+export interface SessionWithMtime {
+  readonly sessionId: SessionId;
+  readonly mtimeMs: number;
+}
+
 /**
  * Enumerate session IDs by most recent modification time (descending).
  *
@@ -41,6 +47,8 @@ export function enumerateSessions(ports: {
  * With >50 sessions, alphabetical ordering causes random exclusion since session IDs
  * are uncorrelated with recency. Sorting by mtime ensures the most relevant sessions
  * are prioritized.
+ *
+ * Returns sessionId + mtimeMs pairs so callers can surface recency to users.
  *
  * Filters directory entries to valid session ID format only.
  * Sorts by mtime descending, with alphabetical tie-breaking for determinism.
@@ -50,7 +58,7 @@ export function enumerateSessions(ports: {
 export function enumerateSessionsByRecency(ports: {
   readonly directoryListing: DirectoryListingPortV2;
   readonly dataDir: DataDirPortV2;
-}): ResultAsync<readonly SessionId[], FsError> {
+}): ResultAsync<readonly SessionWithMtime[], FsError> {
   return ports.directoryListing
     .readdirWithMtime(ports.dataDir.sessionsDir())
     .map((entries) =>
@@ -62,6 +70,6 @@ export function enumerateSessionsByRecency(ports: {
           // Tie-break alphabetically by name (deterministic)
           return a.name.localeCompare(b.name);
         })
-        .map((entry) => asSessionId(entry.name))
+        .map((entry) => ({ sessionId: asSessionId(entry.name), mtimeMs: entry.mtimeMs }))
     );
 }

--- a/tests/architecture/v2-tool-schema-snapshot.test.ts
+++ b/tests/architecture/v2-tool-schema-snapshot.test.ts
@@ -108,6 +108,8 @@ describe('v2 tool schema field snapshots (anti-drift)', () => {
       'gitBranch',
       'gitHeadSha',
       'query',
+      'runId',
+      'sessionId',
       'workspacePath',
     ]);
   });

--- a/tests/contract/v2-mcp-tools.contract.test.ts
+++ b/tests/contract/v2-mcp-tools.contract.test.ts
@@ -464,6 +464,9 @@ function validResumeCandidate(overrides?: Partial<{
     workflowId: 'coding-task-workflow-agentic',
     resumeToken: VALID_STATE_TOKEN,
     snippet: 'Working on feature X...',
+    pendingStepId: 'phase-2-define-problem',
+    isComplete: false,
+    lastModifiedMs: 1700000000000,
     whyMatched: ['matched_branch'],
     nextCall: {
       tool: 'continue_workflow',
@@ -507,9 +510,11 @@ describe('V2ResumeSessionOutputSchema', () => {
 
   it('accepts all valid whyMatched values', () => {
     const LOCKED_WHY_MATCHED = [
+      'matched_exact_id',
       'matched_head_sha',
       'matched_branch',
       'matched_notes',
+      'matched_notes_partial',
       'matched_workflow_id',
       'recency_fallback',
     ];

--- a/tests/unit/v2/enumerate-sessions-cap-diagnostic.test.ts
+++ b/tests/unit/v2/enumerate-sessions-cap-diagnostic.test.ts
@@ -154,12 +154,12 @@ describe('Session enumeration cap regression', () => {
 
     expect(result.value).toHaveLength(60);
     // sess_0060 should be first (newest mtime)
-    expect(String(result.value[0])).toBe('sess_0060');
+    expect(String(result.value[0]!.sessionId)).toBe('sess_0060');
 
     // After provider cap at 50:
     const capped = result.value.slice(0, 50);
     // sess_0060 IS in the capped list (it's first)
-    expect(capped.map(String)).toContain('sess_0060');
+    expect(capped.map(e => String(e.sessionId))).toContain('sess_0060');
 
     console.log('[FIX VERIFIED] Most recent session (sess_0060) is first despite alphabetically last');
   });
@@ -183,7 +183,7 @@ describe('Session enumeration cap regression', () => {
     expect(result.isOk()).toBe(true);
     if (!result.isOk()) return;
 
-    const sorted = result.value.map(String);
+    const sorted = result.value.map(e => String(e.sessionId));
     // E1 should be first (newest mtime)
     expect(sorted[0]).toBe('sess_dlzozumq6yypgv6lfspxxr7oq4');
 

--- a/tests/unit/v2/enumerate-sessions.test.ts
+++ b/tests/unit/v2/enumerate-sessions.test.ts
@@ -104,9 +104,12 @@ describe('enumerateSessionsByRecency', () => {
     expect(result.isOk()).toBe(true);
     if (!result.isOk()) return;
 
-    const ids = result.value.map(String);
+    const ids = result.value.map(e => String(e.sessionId));
     // Most recent first
     expect(ids).toEqual(['sess_zzz', 'sess_mmm', 'sess_aaa']);
+    // Mtime is preserved
+    expect(result.value[0]!.mtimeMs).toBe(3000);
+    expect(result.value[2]!.mtimeMs).toBe(1000);
   });
 
   it('tie-breaks by session ID alphabetically when mtime is equal', async () => {
@@ -121,7 +124,7 @@ describe('enumerateSessionsByRecency', () => {
     expect(result.isOk()).toBe(true);
     if (!result.isOk()) return;
 
-    const ids = result.value.map(String);
+    const ids = result.value.map(e => String(e.sessionId));
     // All same mtime → alphabetical
     expect(ids).toEqual(['sess_aaa', 'sess_mmm', 'sess_zzz']);
   });
@@ -138,7 +141,7 @@ describe('enumerateSessionsByRecency', () => {
     expect(result.isOk()).toBe(true);
     if (!result.isOk()) return;
 
-    expect(result.value.map(String)).toEqual(['sess_valid']);
+    expect(result.value.map(e => String(e.sessionId))).toEqual(['sess_valid']);
   });
 
   it('returns empty array when no sessions exist', async () => {
@@ -170,6 +173,6 @@ describe('enumerateSessionsByRecency', () => {
 
     expect(result.value).toHaveLength(60);
     // Most recent first (mtimeMs=99999), even though it's alphabetically last
-    expect(String(result.value[0])).toBe('sess_0060');
+    expect(String(result.value[0]!.sessionId)).toBe('sess_0060');
   });
 });

--- a/tests/unit/v2/resume-ranking.test.ts
+++ b/tests/unit/v2/resume-ranking.test.ts
@@ -10,6 +10,9 @@ import {
   assignTier,
   normalizeToTokens,
   allQueryTokensMatch,
+  queryTokenMatchRatio,
+  fuzzyTokenMatch,
+  fuzzyQueryTokenMatchRatio,
   asRecapSnippet,
   MAX_RESUME_CANDIDATES,
   type HealthySessionSummary,
@@ -37,6 +40,9 @@ function mkSummary(overrides: Partial<HealthySessionSummary> & { sessionId: stri
     recapSnippet: overrides.recapSnippet ?? null,
     observations: overrides.observations ?? { gitHeadSha: null, gitBranch: null, repoRootHash: null },
     workflow: overrides.workflow ?? DEFAULT_WORKFLOW,
+    lastModifiedMs: overrides.lastModifiedMs ?? null,
+    pendingStepId: overrides.pendingStepId ?? null,
+    isComplete: overrides.isComplete ?? false,
   };
 }
 
@@ -154,7 +160,7 @@ describe('assignTier', () => {
     expect(tier).toEqual({ tier: 3, kind: 'matched_notes' });
   });
 
-  it('returns tier 4 for text match on workflow id', () => {
+  it('returns tier 5 for text match on workflow id', () => {
     const summary = mkSummary({
       sessionId: 'sess_1',
       runId: 'run_1',
@@ -165,16 +171,16 @@ describe('assignTier', () => {
       },
     });
     const tier = assignTier(summary, { freeTextQuery: 'coding-task-agentic' });
-    expect(tier).toEqual({ tier: 4, kind: 'matched_workflow_id' });
+    expect(tier).toEqual({ tier: 5, kind: 'matched_workflow_id' });
   });
 
-  it('returns tier 5 for recency fallback', () => {
+  it('returns tier 6 for recency fallback', () => {
     const summary = mkSummary({
       sessionId: 'sess_1',
       runId: 'run_1',
     });
     const tier = assignTier(summary, {});
-    expect(tier).toEqual({ tier: 5, kind: 'recency_fallback' });
+    expect(tier).toEqual({ tier: 6, kind: 'recency_fallback' });
   });
 
   it('prefers tier 1 over tier 2 when both match', () => {
@@ -215,9 +221,9 @@ describe('rankResumeCandidates', () => {
 
     const ranked = rankResumeCandidates(summaries, { gitHeadSha: 'sha1' });
 
-    // sess_b is tier 1 (sha match), others are tier 5
+    // sess_b is tier 1 (sha match), others are tier 6 (recency fallback)
     expect(ranked[0]!.sessionId).toBe(asSessionId('sess_b'));
-    // Among tier 5: sess_c (15) before sess_a (5)
+    // Among tier 6: sess_c (15) before sess_a (5)
     expect(ranked[1]!.sessionId).toBe(asSessionId('sess_c'));
     expect(ranked[2]!.sessionId).toBe(asSessionId('sess_a'));
   });
@@ -237,7 +243,7 @@ describe('rankResumeCandidates', () => {
     ];
 
     const ranked = rankResumeCandidates(summaries, {});
-    // Both tier 5 with same activity, sess_a < sess_z lex
+    // Both tier 6 with same activity, sess_a < sess_z lex
     expect(ranked[0]!.sessionId).toBe(asSessionId('sess_a'));
     expect(ranked[1]!.sessionId).toBe(asSessionId('sess_z'));
   });
@@ -280,5 +286,339 @@ describe('rankResumeCandidates', () => {
     const summaries = [mkSummary({ sessionId: 'sess_1', runId: 'run_1' })];
     const ranked = rankResumeCandidates(summaries, {});
     expect(ranked[0]!.snippet).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// queryTokenMatchRatio
+// ---------------------------------------------------------------------------
+
+describe('queryTokenMatchRatio', () => {
+  it('returns 1.0 when all query tokens match', () => {
+    expect(queryTokenMatchRatio(new Set(['a', 'b']), new Set(['a', 'b', 'c']))).toBe(1.0);
+  });
+
+  it('returns 0.5 when half of query tokens match', () => {
+    expect(queryTokenMatchRatio(new Set(['a', 'x']), new Set(['a', 'b', 'c']))).toBe(0.5);
+  });
+
+  it('returns 0 for empty query', () => {
+    expect(queryTokenMatchRatio(new Set(), new Set(['a']))).toBe(0);
+  });
+
+  it('returns 0 for empty candidate', () => {
+    expect(queryTokenMatchRatio(new Set(['a']), new Set())).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exact ID matching (Tier 0)
+// ---------------------------------------------------------------------------
+
+describe('assignTier - exact ID matching', () => {
+  it('returns tier 0 for exact runId match', () => {
+    const summary = mkSummary({
+      sessionId: 'sess_1',
+      runId: 'run_abc123',
+    });
+    const tier = assignTier(summary, { runId: 'run_abc123' });
+    expect(tier).toEqual({ tier: 0, kind: 'matched_exact_id', matchField: 'runId' });
+  });
+
+  it('returns tier 0 for exact sessionId match', () => {
+    const summary = mkSummary({
+      sessionId: 'sess_abc123',
+      runId: 'run_1',
+    });
+    const tier = assignTier(summary, { sessionId: 'sess_abc123' });
+    expect(tier).toEqual({ tier: 0, kind: 'matched_exact_id', matchField: 'sessionId' });
+  });
+
+  it('prefers tier 0 over tier 1', () => {
+    const summary = mkSummary({
+      sessionId: 'sess_1',
+      runId: 'run_target',
+      observations: { gitHeadSha: 'abc123', gitBranch: null, repoRootHash: null },
+    });
+    const tier = assignTier(summary, { runId: 'run_target', gitHeadSha: 'abc123' });
+    expect(tier.tier).toBe(0);
+  });
+
+  it('ranks exact ID match first in rankResumeCandidates', () => {
+    const summaries = [
+      mkSummary({
+        sessionId: 'sess_other',
+        runId: 'run_other',
+        observations: { gitHeadSha: 'sha1', gitBranch: null, repoRootHash: null },
+      }),
+      mkSummary({
+        sessionId: 'sess_target',
+        runId: 'run_target',
+      }),
+    ];
+
+    const ranked = rankResumeCandidates(summaries, { runId: 'run_target', gitHeadSha: 'sha1' });
+    expect(ranked[0]!.sessionId).toBe(asSessionId('sess_target'));
+    expect(ranked[0]!.whyMatched).toEqual(['matched_exact_id']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partial notes matching (Tier 3.5)
+// ---------------------------------------------------------------------------
+
+describe('assignTier - partial notes matching', () => {
+  it('returns tier 4 (partial notes) when some but not all query tokens match notes', () => {
+    const summary = mkSummary({
+      sessionId: 'sess_1',
+      runId: 'run_1',
+      recapSnippet: asRecapSnippet('Working on MR ownership feature for the team'),
+    });
+    // "mr ownership task dev" - "mr" and "ownership" match, "task" and "dev" don't
+    const tier = assignTier(summary, { freeTextQuery: 'mr ownership task dev' });
+    expect(tier.kind).toBe('matched_notes_partial');
+    expect(tier.tier).toBe(4);
+  });
+
+  it('does not return partial match when ratio is below threshold', () => {
+    const summary = mkSummary({
+      sessionId: 'sess_1',
+      runId: 'run_1',
+      recapSnippet: asRecapSnippet('Completely unrelated content about databases'),
+    });
+    // Only 1 of 5 tokens might match by coincidence
+    const tier = assignTier(summary, { freeTextQuery: 'mr ownership task dev feature' });
+    expect(tier.kind).not.toBe('matched_notes_partial');
+  });
+
+  it('returns partial match at exactly 40% boundary (2 of 5 tokens)', () => {
+    const summary = mkSummary({
+      sessionId: 'sess_1',
+      runId: 'run_1',
+      recapSnippet: asRecapSnippet('Working on alpha and beta releases'),
+    });
+    // 2 of 5 = 0.4 = exactly at threshold
+    const tier = assignTier(summary, { freeTextQuery: 'alpha beta gamma delta epsilon' });
+    expect(tier.kind).toBe('matched_notes_partial');
+    expect(tier.tier).toBe(4);
+  });
+
+  it('falls through to recency when runId does not match', () => {
+    const summary = mkSummary({
+      sessionId: 'sess_1',
+      runId: 'run_1',
+    });
+    const tier = assignTier(summary, { runId: 'run_nonexistent' });
+    expect(tier.kind).toBe('recency_fallback');
+    expect(tier.tier).toBe(6);
+  });
+
+  it('falls through to recency when sessionId does not match', () => {
+    const summary = mkSummary({
+      sessionId: 'sess_1',
+      runId: 'run_1',
+    });
+    const tier = assignTier(summary, { sessionId: 'sess_nonexistent' });
+    expect(tier.kind).toBe('recency_fallback');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partial match ratio sorting within tier 4
+// ---------------------------------------------------------------------------
+
+describe('rankResumeCandidates - partial match ratio sorting', () => {
+  it('sorts higher match ratio before lower within tier 4', () => {
+    const summaries = [
+      mkSummary({
+        sessionId: 'sess_low_ratio',
+        runId: 'run_low',
+        recapSnippet: asRecapSnippet('Working on alpha feature'),
+        // "alpha beta gamma delta epsilon" -> only "alpha" matches (1/5 = 0.2 → below threshold)
+        // But let's use a scenario where both are above threshold
+      }),
+      mkSummary({
+        sessionId: 'sess_high_ratio',
+        runId: 'run_high',
+        recapSnippet: asRecapSnippet('Working on alpha beta gamma feature for the team'),
+        // "alpha beta gamma" match (3/5 = 0.6)
+      }),
+      mkSummary({
+        sessionId: 'sess_med_ratio',
+        runId: 'run_med',
+        recapSnippet: asRecapSnippet('Working on alpha beta feature deployment'),
+        // "alpha beta" match (2/5 = 0.4)
+      }),
+    ];
+
+    const ranked = rankResumeCandidates(summaries, { freeTextQuery: 'alpha beta gamma delta epsilon' });
+
+    // Filter to only tier 4 (partial) matches
+    const partialMatches = ranked.filter(r => r.tierAssignment.kind === 'matched_notes_partial');
+    // high (0.6) before med (0.4); low should not appear (0.2 below threshold)
+    expect(partialMatches.length).toBeGreaterThanOrEqual(2);
+    expect(partialMatches[0]!.sessionId).toBe(asSessionId('sess_high_ratio'));
+    expect(partialMatches[1]!.sessionId).toBe(asSessionId('sess_med_ratio'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fuzzy token matching
+// ---------------------------------------------------------------------------
+
+describe('fuzzyTokenMatch', () => {
+  it('matches when query token is a substring of candidate token', () => {
+    expect(fuzzyTokenMatch('owner', new Set(['ownership', 'feature']))).toBe(true);
+  });
+
+  it('matches when candidate token is a substring of query token', () => {
+    expect(fuzzyTokenMatch('authentication', new Set(['auth', 'feature']))).toBe(true);
+  });
+
+  it('does not match unrelated tokens', () => {
+    expect(fuzzyTokenMatch('owner', new Set(['feature', 'login']))).toBe(false);
+  });
+
+  it('skips very short tokens to avoid false positives', () => {
+    expect(fuzzyTokenMatch('mr', new Set(['mr-ownership']))).toBe(false);
+    expect(fuzzyTokenMatch('abc', new Set(['ab']))).toBe(false);
+  });
+
+  it('matches 3+ char tokens', () => {
+    expect(fuzzyTokenMatch('auth', new Set(['authentication']))).toBe(true);
+  });
+});
+
+describe('fuzzyQueryTokenMatchRatio', () => {
+  it('counts both exact and fuzzy matches', () => {
+    // "owner" fuzzy-matches "ownership", "feature" exact-matches "feature"
+    const ratio = fuzzyQueryTokenMatchRatio(
+      new Set(['owner', 'feature', 'xyz']),
+      new Set(['ownership', 'feature', 'other']),
+    );
+    expect(ratio).toBeCloseTo(2 / 3);
+  });
+
+  it('returns 0 for no matches', () => {
+    expect(fuzzyQueryTokenMatchRatio(new Set(['abc']), new Set(['xyz']))).toBe(0);
+  });
+});
+
+describe('assignTier - fuzzy matching integration', () => {
+  it('matches notes via fuzzy substring (owner -> ownership)', () => {
+    const summary = mkSummary({
+      sessionId: 'sess_1',
+      runId: 'run_1',
+      recapSnippet: asRecapSnippet('Working on MR ownership feature for the team'),
+    });
+    // "owner" should fuzzy-match "ownership", giving at least partial match
+    const tier = assignTier(summary, { freeTextQuery: 'owner feature' });
+    expect(tier.kind === 'matched_notes' || tier.kind === 'matched_notes_partial').toBe(true);
+  });
+
+  it('matches workflow ID via fuzzy partial (coding task -> coding-task-workflow-agentic)', () => {
+    const summary = mkSummary({
+      sessionId: 'sess_1',
+      runId: 'run_1',
+      workflow: {
+        kind: 'identified',
+        workflowId: asWorkflowId('coding-task-workflow-agentic'),
+        workflowHash: asWorkflowHash(asSha256Digest('sha256:' + 'b'.repeat(64))),
+      },
+    });
+    const tier = assignTier(summary, { freeTextQuery: 'coding task' });
+    expect(tier.kind).toBe('matched_workflow_id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Completed session deprioritization
+// ---------------------------------------------------------------------------
+
+describe('rankResumeCandidates - completed session deprioritization', () => {
+  it('sorts completed sessions after in-progress ones at the same tier', () => {
+    const summaries = [
+      mkSummary({
+        sessionId: 'sess_complete',
+        runId: 'run_complete',
+        isComplete: true,
+        preferredTip: { nodeId: 'n1', lastActivityEventIndex: 20 },
+      }),
+      mkSummary({
+        sessionId: 'sess_active',
+        runId: 'run_active',
+        isComplete: false,
+        preferredTip: { nodeId: 'n2', lastActivityEventIndex: 5 },
+      }),
+    ];
+
+    const ranked = rankResumeCandidates(summaries, {});
+    // Both are tier 6 (recency fallback), but completed should sort after in-progress
+    expect(ranked[0]!.sessionId).toBe(asSessionId('sess_active'));
+    expect(ranked[1]!.sessionId).toBe(asSessionId('sess_complete'));
+    expect(ranked[1]!.isComplete).toBe(true);
+  });
+
+  it('preserves tier priority over completion status (completed tier 1 beats in-progress tier 6)', () => {
+    const summaries = [
+      mkSummary({
+        sessionId: 'sess_active',
+        runId: 'run_active',
+        isComplete: false,
+        // No match signals -> tier 6
+      }),
+      mkSummary({
+        sessionId: 'sess_complete_but_matched',
+        runId: 'run_complete_matched',
+        isComplete: true,
+        observations: { gitHeadSha: 'abc123', gitBranch: null, repoRootHash: null },
+        // SHA match -> tier 1
+      }),
+    ];
+
+    const ranked = rankResumeCandidates(summaries, { gitHeadSha: 'abc123' });
+    // Completed with tier 1 should still beat in-progress with tier 6
+    expect(ranked[0]!.sessionId).toBe(asSessionId('sess_complete_but_matched'));
+    expect(ranked[0]!.isComplete).toBe(true);
+    expect(ranked[1]!.sessionId).toBe(asSessionId('sess_active'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// New output fields
+// ---------------------------------------------------------------------------
+
+describe('rankResumeCandidates - new output fields', () => {
+  it('includes pendingStepId, isComplete, and lastModifiedMs in output', () => {
+    const summaries = [
+      mkSummary({
+        sessionId: 'sess_1',
+        runId: 'run_1',
+        pendingStepId: 'phase-3-implement',
+        isComplete: false,
+        lastModifiedMs: 1700000000000,
+      }),
+    ];
+
+    const ranked = rankResumeCandidates(summaries, {});
+    expect(ranked[0]!.pendingStepId).toBe('phase-3-implement');
+    expect(ranked[0]!.isComplete).toBe(false);
+    expect(ranked[0]!.lastModifiedMs).toBe(1700000000000);
+  });
+
+  it('includes null pendingStepId for completed sessions', () => {
+    const summaries = [
+      mkSummary({
+        sessionId: 'sess_1',
+        runId: 'run_1',
+        isComplete: true,
+        pendingStepId: null,
+        lastModifiedMs: 1700000000000,
+      }),
+    ];
+
+    const ranked = rankResumeCandidates(summaries, {});
+    expect(ranked[0]!.pendingStepId).toBeNull();
+    expect(ranked[0]!.isComplete).toBe(true);
   });
 });

--- a/tests/unit/v2/v2-response-formatter-resume.test.ts
+++ b/tests/unit/v2/v2-response-formatter-resume.test.ts
@@ -1,0 +1,317 @@
+/**
+ * V2 Resume Response Formatter Tests
+ *
+ * Tests the natural language formatting of resume_session responses.
+ * Verifies the formatter produces helpful output for agents with zero
+ * WorkRail context.
+ *
+ * @module tests/unit/v2/v2-response-formatter-resume
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatV2ResumeResponse } from '../../../src/mcp/v2-response-formatter.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function mkCandidate(overrides: Partial<{
+  sessionId: string;
+  runId: string;
+  workflowId: string;
+  resumeToken: string;
+  snippet: string;
+  whyMatched: string[];
+  pendingStepId: string | null;
+  isComplete: boolean;
+  lastModifiedMs: number | null;
+}> = {}) {
+  const token = overrides.resumeToken ?? 'st1_test_token';
+  return {
+    sessionId: overrides.sessionId ?? 'sess_test1',
+    runId: overrides.runId ?? 'run_test1',
+    workflowId: overrides.workflowId ?? 'coding-task-workflow-agentic',
+    resumeToken: token,
+    snippet: overrides.snippet ?? 'Working on MR ownership feature',
+    whyMatched: overrides.whyMatched ?? ['recency_fallback'],
+    pendingStepId: overrides.pendingStepId ?? null,
+    isComplete: overrides.isComplete ?? false,
+    lastModifiedMs: overrides.lastModifiedMs ?? null,
+    nextCall: {
+      tool: 'continue_workflow' as const,
+      params: { continueToken: token, intent: 'rehydrate' as const },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shape detection
+// ---------------------------------------------------------------------------
+
+describe('formatV2ResumeResponse - shape detection', () => {
+  it('returns null for non-resume data', () => {
+    expect(formatV2ResumeResponse({ foo: 'bar' })).toBeNull();
+    expect(formatV2ResumeResponse(null)).toBeNull();
+    expect(formatV2ResumeResponse('string')).toBeNull();
+  });
+
+  it('returns null for execution responses (has pending/nextIntent)', () => {
+    // Execution responses have candidates-like fields but also pending/nextIntent
+    const executionLike = {
+      candidates: [],
+      totalEligible: 0,
+      pending: { stepId: 'step1', title: 'Do something', prompt: 'Do it' },
+      nextIntent: 'advance',
+    };
+    expect(formatV2ResumeResponse(executionLike)).toBeNull();
+  });
+
+  it('recognizes valid resume response', () => {
+    const data = { candidates: [mkCandidate()], totalEligible: 1 };
+    expect(formatV2ResumeResponse(data)).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty candidates
+// ---------------------------------------------------------------------------
+
+describe('formatV2ResumeResponse - empty candidates', () => {
+  it('explains no sessions found and suggests what to do', () => {
+    const data = { candidates: [], totalEligible: 0 };
+    const result = formatV2ResumeResponse(data);
+    expect(result).not.toBeNull();
+    const text = result!.primary;
+
+    expect(text).toContain('No Resumable Sessions Found');
+    expect(text).toContain('Ask the user');
+    // Should include search params help
+    expect(text).toContain('query');
+    expect(text).toContain('runId');
+    expect(text).toContain('sessionId');
+    expect(text).toContain('workspacePath');
+  });
+
+  it('mentions total searched when some existed but none matched', () => {
+    const data = { candidates: [], totalEligible: 30 };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('30 session(s)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// All recency fallback (no search signal)
+// ---------------------------------------------------------------------------
+
+describe('formatV2ResumeResponse - all recency fallback', () => {
+  it('labels as recent sessions and tells agent to ask user', () => {
+    const data = {
+      candidates: [
+        mkCandidate({ whyMatched: ['recency_fallback'] }),
+        mkCandidate({ sessionId: 'sess_2', runId: 'run_2', whyMatched: ['recency_fallback'] }),
+      ],
+      totalEligible: 50,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    const text = result.primary;
+
+    expect(text).toContain('Recent Workflow Sessions');
+    expect(text).toContain('Action required');
+    expect(text).toContain('ask which one');
+    expect(text).toContain('2 most recent');
+    expect(text).toContain('50 total');
+  });
+
+  it('shows search params help', () => {
+    const data = {
+      candidates: [mkCandidate({ whyMatched: ['recency_fallback'] })],
+      totalEligible: 1,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('To narrow results');
+    expect(result.primary).toContain('runId');
+  });
+
+  it('shows overflow count when more sessions exist', () => {
+    const data = {
+      candidates: [mkCandidate({ whyMatched: ['recency_fallback'] })],
+      totalEligible: 50,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('49 more session(s) not shown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Strong match signal
+// ---------------------------------------------------------------------------
+
+describe('formatV2ResumeResponse - strong match', () => {
+  it('recommends direct resume for exact ID match', () => {
+    const data = {
+      candidates: [mkCandidate({ whyMatched: ['matched_exact_id'] })],
+      totalEligible: 50,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    const text = result.primary;
+
+    expect(text).toContain('Resumable Workflow Sessions');
+    expect(text).toContain('exact ID match');
+    expect(text).toContain('Resume it directly');
+  });
+
+  it('recommends user confirmation for non-exact strong match', () => {
+    const data = {
+      candidates: [mkCandidate({ whyMatched: ['matched_notes'] })],
+      totalEligible: 10,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('strongest match signal');
+    expect(result.primary).toContain('confirm which one');
+  });
+
+  it('treats mixed strong+weak results as strong match', () => {
+    const data = {
+      candidates: [
+        mkCandidate({ whyMatched: ['matched_branch'] }),
+        mkCandidate({ sessionId: 'sess_2', runId: 'run_2', whyMatched: ['recency_fallback'] }),
+      ],
+      totalEligible: 10,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('Resumable Workflow Sessions');
+    expect(result.primary).not.toContain('Recent Workflow Sessions');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Candidate formatting
+// ---------------------------------------------------------------------------
+
+describe('formatV2ResumeResponse - candidate details', () => {
+  it('includes session ID, run ID, workflow ID, and match reason', () => {
+    const data = {
+      candidates: [mkCandidate({
+        sessionId: 'sess_abc',
+        runId: 'run_xyz',
+        workflowId: 'my-workflow',
+        whyMatched: ['matched_head_sha'],
+      })],
+      totalEligible: 1,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    const text = result.primary;
+
+    expect(text).toContain('sess_abc');
+    expect(text).toContain('run_xyz');
+    expect(text).toContain('my-workflow');
+    expect(text).toContain('Same git commit');
+  });
+
+  it('includes snippet preview', () => {
+    const data = {
+      candidates: [mkCandidate({ snippet: 'Implementing OAuth flow', whyMatched: ['matched_notes'] })],
+      totalEligible: 1,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('Implementing OAuth flow');
+  });
+
+  it('truncates long snippets', () => {
+    const longSnippet = 'A'.repeat(300);
+    const data = {
+      candidates: [mkCandidate({ snippet: longSnippet, whyMatched: ['matched_notes'] })],
+      totalEligible: 1,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('...');
+    expect(result.primary).not.toContain('A'.repeat(300));
+  });
+
+  it('shows placeholder when no snippet exists', () => {
+    const data = {
+      candidates: [mkCandidate({ snippet: '', whyMatched: ['matched_branch'] })],
+      totalEligible: 1,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('no recap notes available');
+  });
+
+  it('includes continue_workflow JSON template with only params (no tool field)', () => {
+    const data = {
+      candidates: [mkCandidate({ resumeToken: 'st1_mytoken', whyMatched: ['matched_notes'] })],
+      totalEligible: 1,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    const text = result.primary;
+
+    // Should contain the params
+    expect(text).toContain('"continueToken"');
+    expect(text).toContain('"rehydrate"');
+    expect(text).toContain('st1_mytoken');
+    // Should NOT contain "tool" as a JSON key (it's mentioned in prose but not in the JSON block)
+    expect(text).not.toContain('"tool"');
+  });
+
+  it('marks weak matches with (weak match) label', () => {
+    const data = {
+      candidates: [mkCandidate({ whyMatched: ['recency_fallback'] })],
+      totalEligible: 1,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('(weak match)');
+  });
+
+  it('shows pending step ID when available', () => {
+    const data = {
+      candidates: [mkCandidate({
+        pendingStepId: 'phase-3-implement',
+        whyMatched: ['matched_notes'],
+      })],
+      totalEligible: 1,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('phase-3-implement');
+    expect(result.primary).toContain('Current step');
+  });
+
+  it('shows completed status tag and warning', () => {
+    const data = {
+      candidates: [mkCandidate({
+        isComplete: true,
+        whyMatched: ['matched_notes'],
+      })],
+      totalEligible: 1,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('(completed)');
+    expect(result.primary).toContain('already completed');
+  });
+
+  it('shows relative time when lastModifiedMs is present', () => {
+    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+    const data = {
+      candidates: [mkCandidate({
+        lastModifiedMs: twoHoursAgo,
+        whyMatched: ['matched_notes'],
+      })],
+      totalEligible: 1,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('Last active');
+    expect(result.primary).toContain('2 hours ago');
+  });
+
+  it('shows status for completed sessions without pendingStepId', () => {
+    const data = {
+      candidates: [mkCandidate({
+        isComplete: true,
+        pendingStepId: null,
+        whyMatched: ['matched_branch'],
+      })],
+      totalEligible: 1,
+    };
+    const result = formatV2ResumeResponse(data)!;
+    expect(result.primary).toContain('Workflow completed');
+  });
+});


### PR DESCRIPTION
## Summary
- improve `resume_session` matching with exact ID lookup, fuzzy text matching, and richer ranking signals
- enrich resume candidates with pending step, completion status, recency, and more helpful natural-language formatting
- add coverage for formatter, ranking, enumeration, and contract behavior

## Test plan
- [x] Run `npx tsc --noEmit`
- [x] Run `npx vitest run --exclude 'tests/integration/ui-dashboard/**'`