### PR TITLE
docs: mark workflow authoring modernization as shipped

### DIFF
--- a/docs/roadmap/now-next-later.md
+++ b/docs/roadmap/now-next-later.md
@@ -7,7 +7,7 @@ This is the lightweight cross-cutting roadmap view for WorkRail.
 - ~~Complete v2 sign-off and cleanup~~ (done -- v2 is default-on; stale docs cleaned up)
 - ~~Expand lifecycle validation coverage to a realistic target~~ (done -- auto-walk smoke test covers all bundled workflows)
 - ~~Finish prompt vs supplement boundary alignment across runtime, docs, and planning~~ (done -- boundary is documented consistently across authoring locks, execution contract, and planning docs)
-- Modernize `workflow-for-workflows.v2.json` so one canonical authoring workflow supports both creating and modernizing workflows (active -- issue `#151`)
+- ~~Modernize `workflow-for-workflows.v2.json` so one canonical authoring workflow supports both creating and modernizing workflows~~ (done -- shipped in `#152`, tracked from issue `#151`)
 
 ## Next
 

--- a/docs/roadmap/open-work-inventory.md
+++ b/docs/roadmap/open-work-inventory.md
@@ -145,10 +145,11 @@ For explicit status on the major older planning docs themselves, see `docs/roadm
 
 ### Legacy workflow modernization
 
-- **Status**: active
+- **Status**: partial / in progress
+- **Recently shipped**:
+  - `workflows/workflow-for-workflows.v2.json` now supports both creating a new workflow and modernizing an existing one (`#152`, from issue `#151`)
 - **Active focus now**:
-  - modernize `workflows/workflow-for-workflows.v2.json` so it can handle both creating a new workflow and modernizing an existing one
-  - track execution in issue `#151`
+  - next highest-value modernization candidate remains `workflows/exploration-workflow.json`
 - **Why it is here**:
   - several bundled workflows are still authored in older styles
   - many are not `.v2` or `.lean.v2` variants


### PR DESCRIPTION
## Summary
- mark the `workflow-for-workflows.v2.json` modernization work as shipped in the roadmap
- update the legacy workflow modernization inventory to point to the next target after the shipped authoring workflow work
- close the execution loop after PR #152 and issue #151

## Test plan
- [x] `npm run validate:registry`

🤖 Generated with [Firebender](https://firebender.com)