### PR TITLE
fix: strengthen retrieval budgets and recovery surfaces

### DIFF
--- a/docs/design/v2-core-design-locks.md
+++ b/docs/design/v2-core-design-locks.md
@@ -657,7 +657,7 @@ Within a tier, order by:
 
 ### Response budget (locked)
 - max candidates: 5
-- max snippet bytes per candidate: 1024 (UTF-8, with canonical truncation marker)
+- max snippet bytes per candidate: 2048 (UTF-8, with canonical truncation marker)
 
 ### Match explanations (locked intent)
 Each candidate includes a closed-set `whyMatched[]`, e.g.:

--- a/docs/roadmap/now-next-later.md
+++ b/docs/roadmap/now-next-later.md
@@ -8,11 +8,13 @@ This is the lightweight cross-cutting roadmap view for WorkRail.
 - ~~Expand lifecycle validation coverage to a realistic target~~ (done -- auto-walk smoke test covers all bundled workflows)
 - ~~Finish prompt vs supplement boundary alignment across runtime, docs, and planning~~ (done -- boundary is documented consistently across authoring locks, execution contract, and planning docs)
 - ~~Modernize `workflow-for-workflows.v2.json` so one canonical authoring workflow supports both creating and modernizing workflows~~ (done -- shipped in `#152`, tracked from issue `#151`)
+- Strengthen rehydrate and resume retrieval budgets with deterministic retrieval contracts and broader verification
 
 ## Next
 
 - ~~Content coherence: introduce StepContentEnvelope and linked references~~ (done -- see `docs/plans/content-coherence-and-references.md`)
 - ~~Workflow-source setup phase 1: rooted team sharing, remembered roots, grouped source visibility, and migration-aware precedence explanation~~ (done -- phase-1 workflow-source setup landed across `#160`–`#164`; see `docs/plans/workflow-source-setup-phase-1.md`)
+- Decide whether the current retrieval tier model needs another refinement pass after broader usage, or whether the next move should be doc/spec consolidation only
 - Design console execution-trace UX so runs explain fast paths, conditions, and skipped authoring phases instead of only showing created DAG nodes
 - Build a concrete plan for composition and middleware
 - Resolve progress notification design issues and decide whether it is worth doing now

--- a/docs/roadmap/open-work-inventory.md
+++ b/docs/roadmap/open-work-inventory.md
@@ -14,7 +14,24 @@ For explicit status on the major older planning docs themselves, see `docs/roadm
 
 ## Active partials
 
-### ~~1. Clean response formatting and supplement hardening~~ (done)
+### 1. Retrieval budget and recovery-surface strengthening
+
+- **Status**: active
+- **Why it is here**: the old budget system was too conservative for agent usefulness, especially on `rehydrate` and `resume_session`
+- **What was delivered so far**:
+  - explicit retrieval contracts for rehydrate and resume preview surfaces
+  - deterministic tiering with `core` vs `tail` retention behavior
+  - larger bounded budgets for recovery packs and resume previews
+  - stronger behavior tests covering tier dropping, bounded rendering, and usefulness-oriented scenarios
+- **Still open**:
+  - decide whether the current tier model needs refinement after more real usage
+  - finish broader doc/spec cleanup wherever the old budget story still leaks through
+  - decide whether checkpoint-related retrieval should stay as-is or follow the same contract pattern later
+- **Source docs**:
+  - `docs/design/v2-core-design-locks.md`
+  - `docs/reference/workflow-execution-contract.md`
+
+### ~~2. Clean response formatting and supplement hardening~~ (done)
 
 - **Status**: complete
 - **What was done**: the boundary between workflow-authored prompts and runtime-owned response supplements is documented consistently across authoring locks (`authoring.md`), the execution contract (`workflow-execution-contract.md`), and the authoring guide (`authoring-v2.md`). Supplements are runtime-owned today; authorable supplements are tracked as a future typed feature in the Next bucket.
@@ -24,7 +41,7 @@ For explicit status on the major older planning docs themselves, see `docs/roadm
   - `docs/reference/workflow-execution-contract.md` (response content structure)
   - `docs/plans/agentic-orchestration-roadmap.md` (authorable supplements as future backlog)
 
-### ~~2. V2 production readiness and sign-off~~ (done)
+### ~~3. V2 production readiness and sign-off~~ (done)
 
 - **Status**: complete
 - **What was done**: v2 is default-on (`v2Tools` flag defaults to `true` since 0.9.0). Stale docs referencing `WORKRAIL_ENABLE_V2_TOOLS` as a prerequisite have been updated with historical notes. Planning/roadmap docs no longer assume v2 needs unflagging.
@@ -33,7 +50,7 @@ For explicit status on the major older planning docs themselves, see `docs/roadm
   - `docs/plans/workflow-v2-design.md`
   - `docs/plans/v2-followup-enhancements.md`
 
-### 3. God-tier validation lifecycle coverage
+### 4. God-tier validation lifecycle coverage
 
 - **Status**: partial
 - **Why it is here**: the validation pipeline and registry validation are largely shipped, but the lifecycle-harness ambition is not fully closed
@@ -45,7 +62,7 @@ For explicit status on the major older planning docs themselves, see `docs/roadm
   - `docs/plans/workflow-validation-roadmap.md`
   - `docs/plans/workflow-validation-design.md`
 
-### 4. Planning system adoption
+### 5. Planning system adoption
 
 - **Status**: partial
 - **Why it is here**: the planning taxonomy now exists, but old initiative docs still dominate the repo and the new system has not been fully adopted yet

--- a/docs/tickets/next-up.md
+++ b/docs/tickets/next-up.md
@@ -2,7 +2,44 @@
 
 These are the **groomed near-term tickets**. They are the clearest current candidates for actual execution.
 
-## Ticket 1: Complete v2 sign-off and cleanup
+## Ticket 1: Strengthen retrieval budgets and recovery surfaces
+
+### Problem
+
+The old budget system was too conservative on the agent-facing recovery path. `rehydrate` and `resume_session` were bounded, but the bounded surfaces were too small and too weakly structured to preserve enough useful context.
+
+### Goal
+
+Strengthen retrieval by using deterministic typed recovery contracts, larger but still bounded budgets, and verification that proves useful context survives before low-value tail material.
+
+### Acceptance criteria
+
+- `rehydrate` uses an explicit deterministic retrieval contract with ordered tiers and bounded rendering
+- `resume_session` preview rendering uses an explicit bounded preview contract rather than ad hoc snippet logic
+- recovery and preview budgets are increased to more useful values while remaining deterministic and schema-bounded
+- worst-case tests cover tier dropping, bounded rendering, and usefulness-oriented scenarios
+- runtime constants, MCP schemas, and design-lock docs agree on the new budget values
+
+### Verification
+
+- `npx vitest run`
+- `npm run typecheck`
+
+### Non-goals
+
+- Making retrieval literally unbounded
+- Introducing a new durable memory substrate in the first move
+- Redesigning checkpoint semantics as part of this slice
+
+### Related files/docs
+
+- `src/v2/durable-core/domain/retrieval-contract.ts`
+- `src/v2/durable-core/domain/prompt-renderer.ts`
+- `src/v2/projections/resume-ranking.ts`
+- `src/mcp/output-schemas.ts`
+- `docs/design/v2-core-design-locks.md`
+
+## Ticket 2: Complete v2 sign-off and cleanup
 
 ### Problem
 
@@ -27,7 +64,7 @@ Finish the remaining doc cleanup and confirm all validation scenarios are record
 - `docs/plans/v2-followup-enhancements.md`
 - `docs/roadmap/open-work-inventory.md`
 
-## ~~Ticket 2: Workflow-source setup phase 1~~ (done)
+## ~~Ticket 3: Workflow-source setup phase 1~~ (done)
 
 ### Problem
 
@@ -55,7 +92,7 @@ Verification:
 - current local `npm run build` passes
 - planning docs now reflect the delivered phase-1 state
 
-## Ticket 3: Expand lifecycle validation coverage
+## Ticket 4: Expand lifecycle validation coverage
 
 ### Problem
 
@@ -82,7 +119,7 @@ Define a realistic lifecycle coverage target and expand tests toward it.
 - `docs/plans/workflow-validation-design.md`
 - `docs/roadmap/open-work-inventory.md`
 
-## Ticket 4: Design console execution-trace explainability
+## Ticket 5: Design console execution-trace explainability
 
 ### Problem
 
@@ -114,7 +151,7 @@ Design the DTO and UX changes needed so the console explains why the engine took
 - `src/v2/usecases/console-service.ts`
 - `console/src/api/types.ts`
 
-## ~~Ticket 5: Finish prompt vs supplement boundary alignment~~ (done)
+## ~~Ticket 6: Finish prompt vs supplement boundary alignment~~ (done)
 
 All acceptance criteria met -- the boundary is documented consistently:
 

--- a/src/mcp/output-schemas.ts
+++ b/src/mcp/output-schemas.ts
@@ -5,6 +5,7 @@ import {
   CHECKPOINT_TOKEN_PATTERN,
   CONTINUE_TOKEN_PATTERN,
 } from '../v2/durable-core/tokens/token-patterns.js';
+import { MAX_RESUME_PREVIEW_BYTES } from '../v2/durable-core/constants.js';
 
 // -----------------------------------------------------------------------------
 // JSON-safe value schema (prevents undefined / functions leaking across boundary)
@@ -370,7 +371,7 @@ export const V2ResumeSessionOutputSchema = z.object({
      * nextCall is the action interface. Use nextCall, not resumeToken, to resume.
      */
     resumeToken: z.string().regex(STATE_TOKEN_PATTERN, 'Invalid resumeToken format'),
-    snippet: z.string().max(1024),
+    snippet: z.string().max(MAX_RESUME_PREVIEW_BYTES),
     confidence: z.enum(['strong', 'medium', 'weak']).describe(
       'Coarse confidence band for how likely this candidate is the intended session.'
     ),

--- a/src/v2/durable-core/constants.ts
+++ b/src/v2/durable-core/constants.ts
@@ -195,11 +195,20 @@ export const TRUNCATION_MARKER = '\n\n[TRUNCATED]';
 /**
  * Recovery budget for rehydrate-only responses (recap + function definitions combined).
  * 
- * Lock: Midpoint of contract §340 guidance "8-16 KB" for deterministic budgeting.
+ * Lock: Generous but still bounded rehydrate budget for deterministic recovery packs.
  * 
- * Why 12 KB: Balances context recovery needs with token budget constraints.
+ * Why 24 KB: Preserves substantially more durable recap context and structural guidance
+ * before trimming, while remaining comfortably bounded for tool transport.
  */
-export const RECOVERY_BUDGET_BYTES = 12288; // 12 KB
+export const RECOVERY_BUDGET_BYTES = 24 * 1024; // 24 KB
+
+/**
+ * Resume preview budget for ranked resume_session candidates.
+ *
+ * Why 2 KB: Allows identity context plus a materially more informative recap
+ * preview than the old 1 KB ceiling, while keeping candidate lists compact.
+ */
+export const MAX_RESUME_PREVIEW_BYTES = 2 * 1024; // 2 KB
 
 // =============================================================================
 // Regex Patterns

--- a/src/v2/durable-core/domain/prompt-renderer.ts
+++ b/src/v2/durable-core/domain/prompt-renderer.ts
@@ -13,13 +13,21 @@ import { projectNodeOutputsV2 } from '../../projections/node-outputs.js';
 import type { NodeOutputsProjectionV2 } from '../../projections/node-outputs.js';
 import { collectAncestryRecap, collectDownstreamRecap, buildChildSummary } from './recap-recovery.js';
 import { expandFunctionDefinitions, formatFunctionDef } from './function-definition-expander.js';
-import { EVENT_KIND, OUTPUT_CHANNEL, PAYLOAD_KIND, RECOVERY_BUDGET_BYTES, TRUNCATION_MARKER } from '../constants.js';
+import { EVENT_KIND, OUTPUT_CHANNEL, PAYLOAD_KIND } from '../constants.js';
 import { extractValidationRequirements } from './validation-requirements-extractor.js';
 import { LOOP_CONTROL_CONTRACT_REF } from '../schemas/artifacts/index.js';
 import { projectRunContextV2 } from '../../projections/run-context.js';
 import { evaluateCondition } from '../../../utils/condition-evaluator.js';
 import { resolveContextTemplates } from './context-template-resolver.js';
 import type { LoopStepDefinition } from '../../../types/workflow-definition.js';
+import {
+  createAncestryRecapSegment,
+  createBranchSummarySegment,
+  createDownstreamRecapSegment,
+  createFunctionDefinitionsSegment,
+  renderBudgetedRehydrateRecovery,
+  type RetrievalPackSegment,
+} from './retrieval-contract.js';
 
 export type PromptRenderError = {
   readonly code: 'RENDER_FAILED';
@@ -27,18 +35,19 @@ export type PromptRenderError = {
 };
 
 /**
- * Build non-tip recovery sections (child summaries + downstream recap).
+ * Build non-tip recovery segments (child summaries + downstream recap).
  */
-function buildNonTipSections(args: {
+function buildNonTipSegments(args: {
   readonly nodeId: NodeId;
   readonly run: RunDagRunV2;
   readonly outputs: NodeOutputsProjectionV2;
-}): readonly string[] {
-  const sections: string[] = [];
+}): readonly RetrievalPackSegment[] {
+  const segments: RetrievalPackSegment[] = [];
 
   const childSummary = buildChildSummary({ nodeId: args.nodeId, dag: args.run });
-  if (childSummary) {
-    sections.push(`### Branch Summary\n${childSummary}`);
+  const childSummarySegment = createBranchSummarySegment(childSummary);
+  if (childSummarySegment) {
+    segments.push(childSummarySegment);
   }
 
   if (args.run.preferredTipNodeId && args.run.preferredTipNodeId !== String(args.nodeId)) {
@@ -49,21 +58,24 @@ function buildNonTipSections(args: {
       outputs: args.outputs,
     });
     if (downstreamRes.isOk() && downstreamRes.value.length > 0) {
-      sections.push(`### Downstream Recap (Preferred Branch)\n${downstreamRes.value.join('\n\n')}`);
+      const downstreamSegment = createDownstreamRecapSegment(downstreamRes.value.join('\n\n'));
+      if (downstreamSegment) {
+        segments.push(downstreamSegment);
+      }
     }
   }
 
-  return sections;
+  return segments;
 }
 
 /**
- * Build ancestry recap section.
+ * Build ancestry recap segment.
  */
-function buildAncestrySections(args: {
+function buildAncestrySegments(args: {
   readonly nodeId: NodeId;
   readonly run: RunDagRunV2;
   readonly outputs: NodeOutputsProjectionV2;
-}): readonly string[] {
+}): readonly RetrievalPackSegment[] {
   const ancestryRes = collectAncestryRecap({
     nodeId: args.nodeId,
     dag: args.run,
@@ -72,21 +84,22 @@ function buildAncestrySections(args: {
   });
 
   if (ancestryRes.isOk() && ancestryRes.value.length > 0) {
-    return [`### Ancestry Recap\n${ancestryRes.value.join('\n\n')}`];
+    const ancestrySegment = createAncestryRecapSegment(ancestryRes.value.join('\n\n'));
+    return ancestrySegment ? [ancestrySegment] : [];
   }
 
   return [];
 }
 
 /**
- * Build function definitions section.
+ * Build function definitions segment.
  */
-function buildFunctionDefsSections(args: {
+function buildFunctionDefsSegments(args: {
   readonly workflow: Workflow;
   readonly stepId: string;
   readonly loopPath: readonly LoopPathFrameV1[];
   readonly functionReferences: readonly string[];
-}): readonly string[] {
+}): readonly RetrievalPackSegment[] {
   const funcsRes = expandFunctionDefinitions({
     workflow: args.workflow,
     stepId: args.stepId,
@@ -96,7 +109,8 @@ function buildFunctionDefsSections(args: {
 
   if (funcsRes.isOk() && funcsRes.value.length > 0) {
     const formatted = funcsRes.value.map(formatFunctionDef).join('\n\n');
-    return [`### Function Definitions\n\`\`\`\n${formatted}\n\`\`\``];
+    const functionDefinitionsSegment = createFunctionDefinitionsSegment(`\`\`\`\n${formatted}\n\`\`\``);
+    return functionDefinitionsSegment ? [functionDefinitionsSegment] : [];
   }
 
   return [];
@@ -115,108 +129,30 @@ function hasPriorNotesInRun(args: {
 }
 
 /**
- * Build recovery sections (tip/non-tip aware).
+ * Build recovery segments (tip/non-tip aware).
  * Pure function extracting recovery logic.
  */
-function buildRecoverySections(args: {
+function buildRecoverySegments(args: {
   readonly nodeId: NodeId;
-  readonly dag: RunDagRunV2;
   readonly run: RunDagRunV2;
   readonly outputs: NodeOutputsProjectionV2;
   readonly workflow: Workflow;
   readonly stepId: string;
   readonly loopPath: readonly LoopPathFrameV1[];
   readonly functionReferences: readonly string[];
-}): readonly string[] {
+}): readonly RetrievalPackSegment[] {
   const isTip = args.run.tipNodeIds.includes(String(args.nodeId));
 
   return [
-    ...(isTip ? [] : buildNonTipSections({ nodeId: args.nodeId, run: args.run, outputs: args.outputs })),
-    ...buildAncestrySections({ nodeId: args.nodeId, run: args.run, outputs: args.outputs }),
-    ...buildFunctionDefsSections({
+    ...(isTip ? [] : buildNonTipSegments({ nodeId: args.nodeId, run: args.run, outputs: args.outputs })),
+    ...buildAncestrySegments({ nodeId: args.nodeId, run: args.run, outputs: args.outputs }),
+    ...buildFunctionDefsSegments({
       workflow: args.workflow,
       stepId: args.stepId,
       loopPath: args.loopPath,
       functionReferences: args.functionReferences,
     }),
   ];
-}
-
-/**
- * Trim bytes to UTF-8 boundary (O(1) algorithm, always returns valid UTF-8).
- * 
- * Analyzes UTF-8 byte patterns directly to find incomplete trailing characters.
- * - Scans last 4 bytes max (UTF-8 chars are 1-4 bytes)
- * - Identifies lead byte and expected character length
- * - Drops incomplete character if found
- * 
- * Algorithm from notes-markdown.ts (battle-tested).
- * Lock: UTF-8 safe truncation for deterministic budgeting.
- */
-function trimToUtf8Boundary(bytes: Uint8Array): Uint8Array {
-  const n = bytes.length;
-  if (n === 0) return bytes;
-
-  // Count continuation bytes at end (10xxxxxx pattern)
-  let cont = 0;
-  for (let i = n - 1; i >= 0 && i >= n - 4; i--) {
-    const b = bytes[i]!;
-    if ((b & 0b1100_0000) === 0b1000_0000) {
-      cont++;
-    } else {
-      break;
-    }
-  }
-
-  if (cont === 0) return bytes; // No continuation bytes at end
-
-  const leadByteIndex = n - cont - 1;
-  if (leadByteIndex < 0) {
-    // All bytes at end are continuation bytes (invalid)
-    return new Uint8Array(0);
-  }
-
-  const leadByte = bytes[leadByteIndex]!;
-
-  // Determine expected character length from lead byte
-  const expectedLen =
-    (leadByte & 0b1000_0000) === 0 ? 1 : // 0xxxxxxx = 1-byte (ASCII)
-    (leadByte & 0b1110_0000) === 0b1100_0000 ? 2 : // 110xxxxx = 2-byte
-    (leadByte & 0b1111_0000) === 0b1110_0000 ? 3 : // 1110xxxx = 3-byte
-    (leadByte & 0b1111_1000) === 0b1111_0000 ? 4 : // 11110xxx = 4-byte
-    0; // Invalid lead byte
-
-  // If the last character is incomplete or invalid, drop it
-  const actualLen = cont + 1;
-  if (expectedLen === 0 || expectedLen !== actualLen) {
-    return bytes.subarray(0, leadByteIndex);
-  }
-
-  return bytes;
-}
-
-/**
- * Apply recovery budget and truncate if needed.
- * Pure function handling deterministic truncation.
- */
-function applyPromptBudget(combinedPrompt: string): string {
-  const encoder = new TextEncoder();
-  const promptBytes = encoder.encode(combinedPrompt);
-
-  if (promptBytes.length <= RECOVERY_BUDGET_BYTES) {
-    return combinedPrompt;
-  }
-
-  // Over budget: truncate deterministically
-  const markerText = TRUNCATION_MARKER;
-  const omissionNote = `\nOmitted recovery content due to budget constraints.`;
-  const suffixBytes = encoder.encode(markerText + omissionNote);
-  const maxContentBytes = RECOVERY_BUDGET_BYTES - suffixBytes.length;
-
-  // Trim to UTF-8 boundary
-  const truncatedBytes = trimToUtf8Boundary(promptBytes.subarray(0, maxContentBytes));
-  const decoder = new TextDecoder('utf-8');
-  return decoder.decode(truncatedBytes) + markerText + omissionNote;
 }
 
 /**
@@ -618,10 +554,9 @@ export function renderPendingPrompt(args: {
 
   const { run, outputs } = projectionsRes.value;
 
-  // Build recovery sections (extracted helper)
-  const sections = buildRecoverySections({
+  // Build recovery segments (extracted helper)
+  const segments = buildRecoverySegments({
     nodeId: args.nodeId,
-    dag: run,
     run,
     outputs,
     workflow: args.workflow,
@@ -631,15 +566,17 @@ export function renderPendingPrompt(args: {
   });
 
   // No recovery content
-  if (sections.length === 0) {
+  if (segments.length === 0) {
     return ok({ stepId: args.stepId, title: baseTitle, prompt: enhancedPrompt, agentRole, requireConfirmation });
   }
 
-  // Combine and apply budget (extracted helpers)
+  // Combine and apply budget with tier-aware recovery rendering.
   const recoveryHeader = cleanResponseFormat ? 'Your previous work:' : '## Recovery Context';
-  const recoveryText = `${recoveryHeader}\n\n${sections.join('\n\n')}`;
-  const combinedPrompt = `${enhancedPrompt}\n\n${recoveryText}`;
-  const finalPrompt = applyPromptBudget(combinedPrompt);
+  const recoveryText = renderBudgetedRehydrateRecovery({
+    header: recoveryHeader,
+    segments,
+  }).text;
+  const finalPrompt = `${enhancedPrompt}\n\n${recoveryText}`;
 
   return ok({ stepId: args.stepId, title: baseTitle, prompt: finalPrompt, agentRole, requireConfirmation });
 }

--- a/src/v2/durable-core/domain/retrieval-contract.ts
+++ b/src/v2/durable-core/domain/retrieval-contract.ts
@@ -1,0 +1,454 @@
+import { MAX_RESUME_PREVIEW_BYTES, RECOVERY_BUDGET_BYTES, TRUNCATION_MARKER } from '../constants.js';
+
+export type RetrievalPackSurface = 'rehydrate';
+export type ResumePreviewSurface = 'resume_preview';
+
+export type RetrievalPackTier = 'structural_context' | 'durable_recap' | 'reference_material';
+export type ResumePreviewTier = 'identity_context' | 'durable_recap';
+
+export interface RetrievalPackTierDefinition {
+  readonly tier: RetrievalPackTier;
+  readonly purpose: string;
+  readonly priority: number;
+  readonly retention: 'core' | 'tail';
+}
+
+export interface ResumePreviewTierDefinition {
+  readonly tier: ResumePreviewTier;
+  readonly purpose: string;
+  readonly priority: number;
+  readonly maxBytes: number;
+}
+
+export interface RetrievalPackTruncationPolicy {
+  readonly mode: 'drop_lower_tiers_then_global_utf8_trim';
+  readonly budgetScope: 'shared_recovery_prompt';
+  readonly antiReconstructionRule: 'select_order_and_compress_explicit_facts_only';
+}
+
+export interface RetrievalPackContract {
+  readonly surface: RetrievalPackSurface;
+  readonly tiers: readonly RetrievalPackTierDefinition[];
+  readonly truncation: RetrievalPackTruncationPolicy;
+}
+
+export interface ResumePreviewContract {
+  readonly surface: ResumePreviewSurface;
+  readonly tiers: readonly ResumePreviewTierDefinition[];
+  readonly budgetBytes: number;
+}
+
+export interface BranchSummarySegment {
+  readonly kind: 'branch_summary';
+  readonly tier: 'structural_context';
+  readonly source: 'deterministic_structure';
+  readonly title: 'Branch Summary';
+  readonly body: string;
+}
+
+export interface DownstreamRecapSegment {
+  readonly kind: 'downstream_recap';
+  readonly tier: 'structural_context';
+  readonly source: 'explicit_durable_fact';
+  readonly title: 'Downstream Recap (Preferred Branch)';
+  readonly body: string;
+}
+
+export interface AncestryRecapSegment {
+  readonly kind: 'ancestry_recap';
+  readonly tier: 'durable_recap';
+  readonly source: 'explicit_durable_fact';
+  readonly title: 'Ancestry Recap';
+  readonly body: string;
+}
+
+export interface FunctionDefinitionsSegment {
+  readonly kind: 'function_definitions';
+  readonly tier: 'reference_material';
+  readonly source: 'workflow_definition';
+  readonly title: 'Function Definitions';
+  readonly body: string;
+}
+
+export type RetrievalPackSegment =
+  | BranchSummarySegment
+  | DownstreamRecapSegment
+  | AncestryRecapSegment
+  | FunctionDefinitionsSegment;
+
+export interface RetrievalPackRenderResult {
+  readonly text: string;
+  readonly includedTiers: readonly RetrievalPackTier[];
+  readonly omittedTierCount: number;
+  readonly truncatedWithinTier: boolean;
+}
+
+export interface SessionTitlePreviewSegment {
+  readonly kind: 'session_title_preview';
+  readonly tier: 'identity_context';
+  readonly source: 'persisted_context';
+  readonly body: string;
+}
+
+export interface RecapPreviewSegment {
+  readonly kind: 'recap_preview';
+  readonly tier: 'durable_recap';
+  readonly source: 'explicit_durable_fact';
+  readonly body: string;
+}
+
+export type ResumePreviewSegment = SessionTitlePreviewSegment | RecapPreviewSegment;
+
+export type ResumePreviewText = string & { readonly __brand: 'ResumePreviewText' };
+
+export interface ResumePreviewRenderResult {
+  readonly text: ResumePreviewText;
+  readonly includedTiers: readonly ResumePreviewTier[];
+}
+
+const REHYDRATE_TIER_DEFINITIONS = [
+  {
+    tier: 'structural_context',
+    purpose: 'Orient the agent to branch shape and preferred continuation path.',
+    priority: 0,
+    retention: 'core',
+  },
+  {
+    tier: 'durable_recap',
+    purpose: 'Surface durable notes captured from explicit recap outputs.',
+    priority: 1,
+    retention: 'core',
+  },
+  {
+    tier: 'reference_material',
+    purpose: 'Surface authored workflow definitions referenced by the current step.',
+    priority: 2,
+    retention: 'tail',
+  },
+] as const satisfies readonly RetrievalPackTierDefinition[];
+
+export const REHYDRATE_RETRIEVAL_CONTRACT: RetrievalPackContract = {
+  surface: 'rehydrate',
+  tiers: REHYDRATE_TIER_DEFINITIONS,
+  truncation: {
+    mode: 'drop_lower_tiers_then_global_utf8_trim',
+    budgetScope: 'shared_recovery_prompt',
+    antiReconstructionRule: 'select_order_and_compress_explicit_facts_only',
+  },
+};
+
+const RESUME_PREVIEW_TIER_DEFINITIONS = [
+  {
+    tier: 'identity_context',
+    purpose: 'Surface the best concise identity hint for the session.',
+    priority: 0,
+    maxBytes: 320,
+  },
+  {
+    tier: 'durable_recap',
+    purpose: 'Surface durable recap text, focused around the user query when possible.',
+    priority: 1,
+    maxBytes: 1600,
+  },
+] as const satisfies readonly ResumePreviewTierDefinition[];
+
+export const RESUME_PREVIEW_CONTRACT: ResumePreviewContract = {
+  surface: 'resume_preview',
+  tiers: RESUME_PREVIEW_TIER_DEFINITIONS,
+  budgetBytes: MAX_RESUME_PREVIEW_BYTES,
+};
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder('utf-8');
+
+function getTierPriority(tier: RetrievalPackTier): number {
+  return REHYDRATE_RETRIEVAL_CONTRACT.tiers.find((candidate) => candidate.tier === tier)?.priority ?? Number.MAX_SAFE_INTEGER;
+}
+
+function getTierRetention(tier: RetrievalPackTier): 'core' | 'tail' {
+  return REHYDRATE_RETRIEVAL_CONTRACT.tiers.find((candidate) => candidate.tier === tier)?.retention ?? 'tail';
+}
+
+function getResumePreviewTierPriority(tier: ResumePreviewTier): number {
+  return RESUME_PREVIEW_CONTRACT.tiers.find((candidate) => candidate.tier === tier)?.priority ?? Number.MAX_SAFE_INTEGER;
+}
+
+function getResumePreviewTierMaxBytes(tier: ResumePreviewTier): number {
+  return RESUME_PREVIEW_CONTRACT.tiers.find((candidate) => candidate.tier === tier)?.maxBytes ?? RESUME_PREVIEW_CONTRACT.budgetBytes;
+}
+
+function compareAscii(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function trimToUtf8Boundary(bytes: Uint8Array): Uint8Array {
+  const n = bytes.length;
+  if (n === 0) return bytes;
+
+  let cont = 0;
+  for (let i = n - 1; i >= 0 && i >= n - 4; i--) {
+    const b = bytes[i]!;
+    if ((b & 0b1100_0000) === 0b1000_0000) {
+      cont++;
+    } else {
+      break;
+    }
+  }
+
+  if (cont === 0) return bytes;
+
+  const leadByteIndex = n - cont - 1;
+  if (leadByteIndex < 0) {
+    return new Uint8Array(0);
+  }
+
+  const leadByte = bytes[leadByteIndex]!;
+  const expectedLen =
+    (leadByte & 0b1000_0000) === 0 ? 1 :
+    (leadByte & 0b1110_0000) === 0b1100_0000 ? 2 :
+    (leadByte & 0b1111_0000) === 0b1110_0000 ? 3 :
+    (leadByte & 0b1111_1000) === 0b1111_0000 ? 4 :
+    0;
+
+  const actualLen = cont + 1;
+  if (expectedLen === 0 || expectedLen !== actualLen) {
+    return bytes.subarray(0, leadByteIndex);
+  }
+
+  return bytes;
+}
+
+function truncateUtf8(text: string, maxBytes: number): string {
+  const bytes = encoder.encode(text);
+  if (bytes.length <= maxBytes) {
+    return text;
+  }
+  return decoder.decode(trimToUtf8Boundary(bytes.subarray(0, Math.max(0, maxBytes))));
+}
+
+function buildOmissionSuffix(omittedTierCount: number): string {
+  const omissionLine = omittedTierCount > 0
+    ? `\nOmitted ${omittedTierCount} lower-priority tier${omittedTierCount === 1 ? '' : 's'} due to budget constraints.`
+    : '\nOmitted recovery content due to budget constraints.';
+  return `${TRUNCATION_MARKER}${omissionLine}`;
+}
+
+function trimFinalRecoveryText(text: string, omittedTierCount: number): string {
+  const suffix = buildOmissionSuffix(omittedTierCount);
+  const maxContentBytes = RECOVERY_BUDGET_BYTES - encoder.encode(suffix).length;
+  const truncated = truncateUtf8(text, maxContentBytes);
+  return truncated + suffix;
+}
+
+function normalizePreviewFocusTerms(focusTerms: readonly string[]): readonly string[] {
+  return [...new Set(focusTerms.map((term) => term.trim().toLowerCase()).filter((term) => term.length >= 3))];
+}
+
+function findFocusIndex(text: string, focusTerms: readonly string[]): number {
+  if (focusTerms.length === 0) return -1;
+  const lower = text.toLowerCase();
+  return focusTerms.reduce((bestIndex, term) => {
+    const idx = lower.indexOf(term);
+    if (idx === -1) return bestIndex;
+    if (bestIndex === -1) return idx;
+    return Math.min(bestIndex, idx);
+  }, -1);
+}
+
+function excerptAroundFocus(text: string, maxBytes: number, focusTerms: readonly string[]): string {
+  const focusIndex = findFocusIndex(text, focusTerms);
+  if (focusIndex === -1) {
+    const truncated = truncateUtf8(text, maxBytes);
+    return truncated.length < text.length ? `${truncated}...` : truncated;
+  }
+
+  const contextChars = Math.max(80, Math.floor(maxBytes / 4));
+  const start = Math.max(0, focusIndex - contextChars);
+  const end = Math.min(text.length, focusIndex + contextChars * 2);
+  const slice = text.slice(start, end).trim();
+  const prefix = start > 0 ? '...' : '';
+  const suffix = end < text.length ? '...' : '';
+  const excerpt = `${prefix}${slice}${suffix}`;
+  return truncateUtf8(excerpt, maxBytes);
+}
+
+export function createBranchSummarySegment(body: string): BranchSummarySegment | null {
+  const trimmed = body.trim();
+  return trimmed.length === 0
+    ? null
+    : {
+        kind: 'branch_summary',
+        tier: 'structural_context',
+        source: 'deterministic_structure',
+        title: 'Branch Summary',
+        body: trimmed,
+      };
+}
+
+export function createDownstreamRecapSegment(body: string): DownstreamRecapSegment | null {
+  const trimmed = body.trim();
+  return trimmed.length === 0
+    ? null
+    : {
+        kind: 'downstream_recap',
+        tier: 'structural_context',
+        source: 'explicit_durable_fact',
+        title: 'Downstream Recap (Preferred Branch)',
+        body: trimmed,
+      };
+}
+
+export function createAncestryRecapSegment(body: string): AncestryRecapSegment | null {
+  const trimmed = body.trim();
+  return trimmed.length === 0
+    ? null
+    : {
+        kind: 'ancestry_recap',
+        tier: 'durable_recap',
+        source: 'explicit_durable_fact',
+        title: 'Ancestry Recap',
+        body: trimmed,
+      };
+}
+
+export function createFunctionDefinitionsSegment(body: string): FunctionDefinitionsSegment | null {
+  const trimmed = body.trim();
+  return trimmed.length === 0
+    ? null
+    : {
+        kind: 'function_definitions',
+        tier: 'reference_material',
+        source: 'workflow_definition',
+        title: 'Function Definitions',
+        body: trimmed,
+      };
+}
+
+export function createSessionTitlePreviewSegment(body: string): SessionTitlePreviewSegment | null {
+  const trimmed = body.trim();
+  return trimmed.length === 0
+    ? null
+    : {
+        kind: 'session_title_preview',
+        tier: 'identity_context',
+        source: 'persisted_context',
+        body: trimmed,
+      };
+}
+
+export function createRecapPreviewSegment(body: string): RecapPreviewSegment | null {
+  const trimmed = body.trim();
+  return trimmed.length === 0
+    ? null
+    : {
+        kind: 'recap_preview',
+        tier: 'durable_recap',
+        source: 'explicit_durable_fact',
+        body: trimmed,
+      };
+}
+
+export function compareRetrievalPackSegments(a: RetrievalPackSegment, b: RetrievalPackSegment): number {
+  const tierDiff = getTierPriority(a.tier) - getTierPriority(b.tier);
+  if (tierDiff !== 0) return tierDiff;
+
+  const titleDiff = compareAscii(a.title, b.title);
+  if (titleDiff !== 0) return titleDiff;
+
+  return compareAscii(a.body, b.body);
+}
+
+export function orderRetrievalPackSegments(
+  segments: readonly RetrievalPackSegment[],
+): readonly RetrievalPackSegment[] {
+  return [...segments].sort(compareRetrievalPackSegments);
+}
+
+export function renderRetrievalPackSections(
+  segments: readonly RetrievalPackSegment[],
+): readonly string[] {
+  return orderRetrievalPackSegments(segments).map((segment) => `### ${segment.title}\n${segment.body}`);
+}
+
+function compareResumePreviewSegments(a: ResumePreviewSegment, b: ResumePreviewSegment): number {
+  const tierDiff = getResumePreviewTierPriority(a.tier) - getResumePreviewTierPriority(b.tier);
+  if (tierDiff !== 0) return tierDiff;
+  return compareAscii(a.body, b.body);
+}
+
+export function renderBudgetedResumePreview(args: {
+  readonly segments: readonly ResumePreviewSegment[];
+  readonly focusTerms?: readonly string[];
+}): ResumePreviewRenderResult {
+  const ordered = [...args.segments].sort(compareResumePreviewSegments);
+  if (ordered.length === 0) {
+    return { text: '' as ResumePreviewText, includedTiers: [] };
+  }
+
+  const focusTerms = normalizePreviewFocusTerms(args.focusTerms ?? []);
+  const tierTexts = ordered.map((segment) => {
+    const maxBytes = getResumePreviewTierMaxBytes(segment.tier);
+    return {
+      tier: segment.tier,
+      text: excerptAroundFocus(segment.body, maxBytes, focusTerms),
+    };
+  });
+
+  const joined = tierTexts.map((entry) => entry.text).filter((text) => text.length > 0).join('\n\n');
+  const finalText = truncateUtf8(joined, RESUME_PREVIEW_CONTRACT.budgetBytes) as ResumePreviewText;
+  const includedTiers = [...new Set(tierTexts.filter((entry) => entry.text.length > 0).map((entry) => entry.tier))];
+  return { text: finalText, includedTiers };
+}
+
+export function renderBudgetedRehydrateRecovery(args: {
+  readonly header: string;
+  readonly segments: readonly RetrievalPackSegment[];
+}): RetrievalPackRenderResult {
+  const ordered = orderRetrievalPackSegments(args.segments);
+  if (ordered.length === 0) {
+    return { text: '', includedTiers: [], omittedTierCount: 0, truncatedWithinTier: false };
+  }
+
+  const tiersInOrder = REHYDRATE_RETRIEVAL_CONTRACT.tiers.map((tier) => tier.tier);
+  const sectionsByTier = new Map<RetrievalPackTier, readonly string[]>(
+    tiersInOrder.map((tier) => [tier, ordered.filter((segment) => segment.tier === tier).map((segment) => `### ${segment.title}\n${segment.body}`)]),
+  );
+
+  const renderFromTiers = (tiers: readonly RetrievalPackTier[]): string => {
+    const sections = tiers.flatMap((tier) => sectionsByTier.get(tier) ?? []);
+    return sections.length === 0 ? '' : `${args.header}\n\n${sections.join('\n\n')}`;
+  };
+
+  const initiallyIncludedTiers = tiersInOrder.filter((tier) => (sectionsByTier.get(tier) ?? []).length > 0);
+  let includedTiers = initiallyIncludedTiers;
+  let recoveryText = renderFromTiers(includedTiers);
+
+  while (encoder.encode(recoveryText).length > RECOVERY_BUDGET_BYTES) {
+    const droppableTierIndex = [...includedTiers]
+      .reverse()
+      .findIndex((tier) => getTierRetention(tier) === 'tail');
+
+    if (droppableTierIndex === -1) {
+      break;
+    }
+
+    const actualIndex = includedTiers.length - 1 - droppableTierIndex;
+    includedTiers = includedTiers.filter((_, index) => index !== actualIndex);
+    recoveryText = renderFromTiers(includedTiers);
+  }
+
+  const omittedTierCount = initiallyIncludedTiers.length - includedTiers.length;
+  const needsSuffix = omittedTierCount > 0 || encoder.encode(recoveryText).length > RECOVERY_BUDGET_BYTES || includedTiers.length === 0;
+  const finalText = recoveryText.length === 0
+    ? trimFinalRecoveryText(args.header, initiallyIncludedTiers.length)
+    : !needsSuffix
+      ? recoveryText
+      : trimFinalRecoveryText(recoveryText, omittedTierCount);
+
+  return {
+    text: finalText,
+    includedTiers,
+    omittedTierCount,
+    truncatedWithinTier: encoder.encode(recoveryText).length > RECOVERY_BUDGET_BYTES || includedTiers.length === 0,
+  };
+}

--- a/src/v2/projections/resume-ranking.ts
+++ b/src/v2/projections/resume-ranking.ts
@@ -1,5 +1,11 @@
 import type { SessionId, WorkflowHash, WorkflowId } from '../durable-core/ids/index.js';
-import { TRUNCATION_MARKER } from '../durable-core/constants.js';
+import { MAX_RESUME_PREVIEW_BYTES, TRUNCATION_MARKER } from '../durable-core/constants.js';
+import {
+  createRecapPreviewSegment,
+  createSessionTitlePreviewSegment,
+  renderBudgetedResumePreview,
+} from '../durable-core/domain/retrieval-contract.js';
+export { MAX_RESUME_PREVIEW_BYTES } from '../durable-core/constants.js';
 
 // ---------------------------------------------------------------------------
 // Domain types — make illegal states unrepresentable
@@ -12,7 +18,7 @@ import { TRUNCATION_MARKER } from '../durable-core/constants.js';
 export type RecapSnippet = string & { readonly __brand: 'RecapSnippet' };
 
 /** Max bytes per snippet (locked §2.3). */
-const MAX_SNIPPET_BYTES = 1024;
+const MAX_SNIPPET_BYTES = MAX_RESUME_PREVIEW_BYTES;
 
 /**
  * Construct a RecapSnippet from raw text.
@@ -320,28 +326,15 @@ function collectMatchReasons(summary: HealthySessionSummary, query: ResumeQuery,
 }
 
 function buildPreviewSnippet(summary: HealthySessionSummary, query: ResumeQuery): string {
-  const previewSource = buildSearchableSessionText(summary);
-  if (!previewSource) return '';
+  const segments = [
+    summary.sessionTitle ? createSessionTitlePreviewSegment(summary.sessionTitle) : null,
+    summary.recapSnippet ? createRecapPreviewSegment(summary.recapSnippet) : null,
+  ].filter((segment): segment is NonNullable<typeof segment> => segment !== null);
 
-  const queryTokens = query.freeTextQuery ? [...normalizeToTokens(query.freeTextQuery)] : [];
-  if (queryTokens.length === 0) return summary.recapSnippet ?? previewSource;
+  if (segments.length === 0) return '';
 
-  const lower = previewSource.toLowerCase();
-  let bestIndex = -1;
-  for (const token of queryTokens) {
-    if (token.length < 3) continue;
-    const idx = lower.indexOf(token);
-    if (idx !== -1 && (bestIndex === -1 || idx < bestIndex)) bestIndex = idx;
-  }
-
-  if (bestIndex === -1) return summary.recapSnippet ?? previewSource;
-
-  const start = Math.max(0, bestIndex - 100);
-  const end = Math.min(previewSource.length, bestIndex + 180);
-  const slice = previewSource.slice(start, end).trim();
-  const prefix = start > 0 ? '...' : '';
-  const suffix = end < previewSource.length ? '...' : '';
-  return `${prefix}${slice}${suffix}`;
+  const focusTerms = query.freeTextQuery ? [...normalizeToTokens(query.freeTextQuery)] : [];
+  return renderBudgetedResumePreview({ segments, focusTerms }).text;
 }
 
 function deriveConfidence(tier: TierAssignment, reasons: readonly WhyMatched[]): 'strong' | 'medium' | 'weak' {

--- a/tests/unit/v2/constants.test.ts
+++ b/tests/unit/v2/constants.test.ts
@@ -24,6 +24,8 @@ describe('v2 constants module', () => {
       'MAX_OUTPUT_NOTES_MARKDOWN_BYTES',
       'MAX_CONTEXT_BYTES',
       'MAX_CONTEXT_DEPTH',
+      'RECOVERY_BUDGET_BYTES',
+      'MAX_RESUME_PREVIEW_BYTES',
       'MAX_OBSERVATION_SHORT_STRING_LENGTH',
       'SESSION_LOCK_RETRY_AFTER_MS',
       'DEFAULT_RETRY_AFTER_MS',
@@ -48,6 +50,8 @@ describe('v2 constants module', () => {
     expect(constants.MAX_OUTPUT_NOTES_MARKDOWN_BYTES).toBe(4096);
     expect(constants.MAX_CONTEXT_BYTES).toBe(256 * 1024);
     expect(constants.MAX_CONTEXT_DEPTH).toBe(64);
+    expect(constants.RECOVERY_BUDGET_BYTES).toBe(24 * 1024);
+    expect(constants.MAX_RESUME_PREVIEW_BYTES).toBe(2 * 1024);
     expect(constants.MAX_OBSERVATION_SHORT_STRING_LENGTH).toBe(80);
   });
 

--- a/tests/unit/v2/prompt-renderer.test.ts
+++ b/tests/unit/v2/prompt-renderer.test.ts
@@ -106,12 +106,64 @@ describe('renderPendingPrompt', () => {
   });
 
   describe('budget constraints', () => {
-    it('applies budget to recovery context when over limit', () => {
-      // Note: Budget applies to recovery context, not base prompt
-      // For this test, we'd need a rehydrateOnly=true scenario with large recovery
-      // Skipping for now as it requires complex DAG setup
-      // The budget logic is tested via UTF-8 boundary handling in prompt-renderer.ts:158-168
-      expect(true).toBe(true);
+    it('preserves structural recovery context while dropping tail reference material under pressure', () => {
+      const workflowWithFunctions = createWorkflow(
+        {
+          id: 'test-recovery-budget',
+          name: 'Recovery Budget',
+          description: 'Recovery Budget',
+          version: '1.0.0',
+          functionDefinitions: [
+            {
+              name: 'hugeHelper',
+              scope: 'workflow',
+              definition: 'does a very large amount of helper work\n' + 'B'.repeat(30000),
+            },
+          ],
+          steps: [{
+            id: 'step1',
+            title: 'Step 1',
+            prompt: 'Do step 1',
+            requireConfirmation: false,
+            functionReferences: ['hugeHelper'],
+          }],
+        } as any,
+        createBundledSource()
+      );
+
+      const largeRecap = 'A'.repeat(26000);
+      const truth = {
+        events: [
+          { v: 1, eventId: 'e0', eventIndex: 0, sessionId: 's1', kind: 'session_created', dedupeKey: 'session_created:s1', data: {} },
+          { v: 1, eventId: 'e1', eventIndex: 1, sessionId: 's1', kind: 'run_started', dedupeKey: 'run_started:s1:run_1', scope: { runId: 'run_1' }, data: { workflowId: 'test', workflowHash: 'sha256:abc123' + '0'.repeat(58), workflowSourceKind: 'bundled', workflowSourceRef: '(bundled)' } },
+          { v: 1, eventId: 'e2', eventIndex: 2, sessionId: 's1', kind: 'node_created', dedupeKey: 'node_created:s1:run_1:node_root', scope: { runId: 'run_1', nodeId: 'node_root' }, data: { nodeKind: 'step', parentNodeId: null, workflowHash: 'sha256:abc123' + '0'.repeat(58), snapshotRef: 'sha256:def456' + '0'.repeat(58) } },
+          { v: 1, eventId: 'e3', eventIndex: 3, sessionId: 's1', kind: 'node_output_appended', dedupeKey: 'node_output_appended:s1:run_1:node_root:1', scope: { runId: 'run_1', nodeId: 'node_root' }, data: { outputChannel: 'recap', payload: { payloadKind: 'notes', notesMarkdown: largeRecap } } },
+          { v: 1, eventId: 'e4', eventIndex: 4, sessionId: 's1', kind: 'node_created', dedupeKey: 'node_created:s1:run_1:node_1', scope: { runId: 'run_1', nodeId: 'node_1' }, data: { nodeKind: 'step', parentNodeId: 'node_root', workflowHash: 'sha256:abc123' + '0'.repeat(58), snapshotRef: 'sha256:ghi789' + '0'.repeat(58) } },
+          { v: 1, eventId: 'e5', eventIndex: 5, sessionId: 's1', kind: 'edge_created', dedupeKey: 'edge_created:s1:run_1:node_root:node_1', scope: { runId: 'run_1', edgeId: 'edge_1' }, data: { fromNodeId: 'node_root', toNodeId: 'node_1', edgeKind: 'acked_step', cause: 'intentional_fork' } },
+          { v: 1, eventId: 'e6', eventIndex: 6, sessionId: 's1', kind: 'node_output_appended', dedupeKey: 'node_output_appended:s1:run_1:node_1:1', scope: { runId: 'run_1', nodeId: 'node_1' }, data: { outputChannel: 'recap', payload: { payloadKind: 'notes', notesMarkdown: 'Child branch recap with the most relevant downstream details.' } } },
+        ] as any,
+        manifest: [],
+      };
+
+      const result = renderPendingPrompt({
+        workflow: workflowWithFunctions,
+        stepId: 'step1',
+        loopPath: [],
+        truth,
+        runId: 'run_1',
+        nodeId: 'node_root',
+        rehydrateOnly: true,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.prompt).toContain('## Recovery Context');
+        expect(result.value.prompt).toContain('### Branch Summary');
+        expect(result.value.prompt).toContain('### Downstream Recap (Preferred Branch)');
+        expect(result.value.prompt).not.toContain('### Function Definitions');
+        expect(result.value.prompt).toContain('[TRUNCATED]');
+        expect(result.value.prompt).toContain('Omitted 1 lower-priority tier due to budget constraints.');
+      }
     });
   });
 

--- a/tests/unit/v2/resume-ranking.test.ts
+++ b/tests/unit/v2/resume-ranking.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import {
+  MAX_RESUME_PREVIEW_BYTES,
   rankResumeCandidates,
   assignTier,
   computeQueryRelevanceScore,
@@ -109,11 +110,11 @@ describe('asRecapSnippet', () => {
     expect(String(snippet)).toBe('Some text');
   });
 
-  it('truncates text exceeding 1024 bytes', () => {
+  it('truncates text exceeding the shared resume preview budget', () => {
     const longText = 'a'.repeat(2000);
     const snippet = asRecapSnippet(longText);
     const bytes = new TextEncoder().encode(String(snippet));
-    expect(bytes.length).toBeLessThanOrEqual(1024);
+    expect(bytes.length).toBeLessThanOrEqual(MAX_RESUME_PREVIEW_BYTES);
   });
 });
 
@@ -731,6 +732,56 @@ describe('rankResumeCandidates - new output fields', () => {
 
     const ranked = rankResumeCandidates(summaries, { freeTextQuery: 'ownership' });
     expect(ranked[0]!.snippet.toLowerCase()).toContain('ownership');
+  });
+
+  it('includes identity context in the preview when a session title is present', () => {
+    const summaries = [
+      mkSummary({
+        sessionId: 'sess_identity',
+        runId: 'run_identity',
+        sessionTitle: 'Task dev for MR ownership',
+        recapSnippet: asRecapSnippet('Implemented ownership-aware resume ranking and branch filtering.'),
+      }),
+    ];
+
+    const ranked = rankResumeCandidates(summaries, {});
+    expect(ranked[0]!.snippet).toContain('Task dev for MR ownership');
+    expect(ranked[0]!.snippet).toContain('Implemented ownership-aware resume ranking');
+  });
+
+  it('keeps previews bounded by the shared resume preview budget', () => {
+    const summaries = [
+      mkSummary({
+        sessionId: 'sess_bounded',
+        runId: 'run_bounded',
+        sessionTitle: 'Task dev for MR ownership and broader recovery architecture',
+        recapSnippet: asRecapSnippet('A'.repeat(5000)),
+      }),
+    ];
+
+    const ranked = rankResumeCandidates(summaries, {});
+    const bytes = new TextEncoder().encode(ranked[0]!.snippet);
+    expect(bytes.length).toBeLessThanOrEqual(MAX_RESUME_PREVIEW_BYTES);
+  });
+
+  it('preserves more recap detail under the larger preview budget', () => {
+    const summaries = [
+      mkSummary({
+        sessionId: 'sess_detail',
+        runId: 'run_detail',
+        sessionTitle: 'Task dev for MR ownership and retrieval contracts',
+        recapSnippet: asRecapSnippet(
+          'Initial setup and generic work. ' +
+          'Then we implemented deterministic tiered retrieval for rehydrate and resume previews, ' +
+          'including ownership-aware matching, tail-tier dropping, and bounded rendering.'
+        ),
+      }),
+    ];
+
+    const ranked = rankResumeCandidates(summaries, { freeTextQuery: 'ownership retrieval bounded' });
+    expect(ranked[0]!.snippet.toLowerCase()).toContain('ownership');
+    expect(ranked[0]!.snippet.toLowerCase()).toContain('bounded');
+    expect(ranked[0]!.snippet.length).toBeGreaterThan(120);
   });
 
   it('assigns strong confidence to exact ID matches', () => {

--- a/tests/unit/v2/retrieval-contract.test.ts
+++ b/tests/unit/v2/retrieval-contract.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_RESUME_PREVIEW_BYTES } from '../../../src/v2/durable-core/constants.js';
+import {
+  REHYDRATE_RETRIEVAL_CONTRACT,
+  RESUME_PREVIEW_CONTRACT,
+  compareRetrievalPackSegments,
+  createAncestryRecapSegment,
+  createBranchSummarySegment,
+  createDownstreamRecapSegment,
+  createFunctionDefinitionsSegment,
+  createRecapPreviewSegment,
+  createSessionTitlePreviewSegment,
+  orderRetrievalPackSegments,
+  renderBudgetedRehydrateRecovery,
+  renderBudgetedResumePreview,
+  renderRetrievalPackSections,
+  type RetrievalPackSegment,
+} from '../../../src/v2/durable-core/domain/retrieval-contract.js';
+
+describe('retrieval-contract', () => {
+  it('defines an explicit rehydrate retrieval contract', () => {
+    expect(REHYDRATE_RETRIEVAL_CONTRACT.surface).toBe('rehydrate');
+    expect(REHYDRATE_RETRIEVAL_CONTRACT.tiers.map((tier) => tier.tier)).toEqual([
+      'structural_context',
+      'durable_recap',
+      'reference_material',
+    ]);
+    expect(REHYDRATE_RETRIEVAL_CONTRACT.truncation).toEqual({
+      mode: 'drop_lower_tiers_then_global_utf8_trim',
+      budgetScope: 'shared_recovery_prompt',
+      antiReconstructionRule: 'select_order_and_compress_explicit_facts_only',
+    });
+  });
+
+  it('uses the contract as the runtime tier ordering source', () => {
+    expect(REHYDRATE_RETRIEVAL_CONTRACT.tiers.map((tier) => [tier.tier, tier.priority])).toEqual([
+      ['structural_context', 0],
+      ['durable_recap', 1],
+      ['reference_material', 2],
+    ]);
+    expect(REHYDRATE_RETRIEVAL_CONTRACT.tiers.map((tier) => [tier.tier, tier.retention])).toEqual([
+      ['structural_context', 'core'],
+      ['durable_recap', 'core'],
+      ['reference_material', 'tail'],
+    ]);
+    expect(RESUME_PREVIEW_CONTRACT.budgetBytes).toBe(MAX_RESUME_PREVIEW_BYTES);
+  });
+
+  it('drops empty segments instead of manufacturing placeholder content', () => {
+    expect(createAncestryRecapSegment('   ')).toBeNull();
+  });
+
+  it('creates typed segments with explicit titles and allowed sources', () => {
+    expect(createFunctionDefinitionsSegment('```ts\nconst fn = 1;\n```')).toEqual({
+      kind: 'function_definitions',
+      tier: 'reference_material',
+      source: 'workflow_definition',
+      title: 'Function Definitions',
+      body: '```ts\nconst fn = 1;\n```',
+    });
+  });
+
+  it('orders segments deterministically by tier and segment kind priority', () => {
+    const segments: readonly RetrievalPackSegment[] = [
+      createFunctionDefinitionsSegment('```txt\nfn\n```')!,
+      createAncestryRecapSegment('Prior notes')!,
+      createDownstreamRecapSegment('Preferred branch notes')!,
+      createBranchSummarySegment('This node has 2 children.')!,
+    ];
+
+    expect(orderRetrievalPackSegments(segments).map((segment) => segment.kind)).toEqual([
+      'branch_summary',
+      'downstream_recap',
+      'ancestry_recap',
+      'function_definitions',
+    ]);
+  });
+
+  it('uses lexical fallback for otherwise identical segments', () => {
+    const a = createAncestryRecapSegment('A')!;
+    const b = createAncestryRecapSegment('B')!;
+
+    expect(compareRetrievalPackSegments(a, b)).toBeLessThan(0);
+    expect(compareRetrievalPackSegments(b, a)).toBeGreaterThan(0);
+  });
+
+  it('renders ordered markdown sections without changing the segment bodies', () => {
+    const rendered = renderRetrievalPackSections([
+      createFunctionDefinitionsSegment('```txt\nfn\n```')!,
+      createBranchSummarySegment('This node has 1 child.')!,
+    ]);
+
+    expect(rendered).toEqual([
+      '### Branch Summary\nThis node has 1 child.',
+      '### Function Definitions\n```txt\nfn\n```',
+    ]);
+  });
+
+  it('drops lower-priority tail tiers before trimming within core recovery tiers', () => {
+    const result = renderBudgetedRehydrateRecovery({
+      header: '## Recovery Context',
+      segments: [
+        createBranchSummarySegment('Stable orientation context')!,
+        createAncestryRecapSegment('A'.repeat(26000))!,
+        createFunctionDefinitionsSegment('```txt\n' + 'B'.repeat(16000) + '\n```')!,
+      ],
+    });
+
+    expect(result.includedTiers).toEqual(['structural_context', 'durable_recap']);
+    expect(result.omittedTierCount).toBe(1);
+    expect(result.text).toContain('### Branch Summary');
+    expect(result.text).toContain('### Ancestry Recap');
+    expect(result.text).not.toContain('### Function Definitions');
+    expect(result.text).toContain('[TRUNCATED]');
+    expect(result.truncatedWithinTier).toBe(true);
+  });
+
+  it('keeps all rehydrate tiers when the larger budget can accommodate them', () => {
+    const result = renderBudgetedRehydrateRecovery({
+      header: '## Recovery Context',
+      segments: [
+        createBranchSummarySegment('Stable orientation context')!,
+        createAncestryRecapSegment('A'.repeat(6000))!,
+        createFunctionDefinitionsSegment('```txt\n' + 'B'.repeat(2500) + '\n```')!,
+      ],
+    });
+
+    expect(result.includedTiers).toEqual(['structural_context', 'durable_recap', 'reference_material']);
+    expect(result.omittedTierCount).toBe(0);
+    expect(result.text).toContain('### Function Definitions');
+  });
+
+  it('keeps both identity context and recap in larger resume previews', () => {
+    const result = renderBudgetedResumePreview({
+      segments: [
+        createSessionTitlePreviewSegment('Task dev for MR ownership and budget redesign')!,
+        createRecapPreviewSegment('ownership-aware resume previews ' + 'A'.repeat(1700))!,
+      ],
+    });
+
+    const bytes = new TextEncoder().encode(result.text);
+    expect(result.includedTiers).toEqual(['identity_context', 'durable_recap']);
+    expect(bytes.length).toBeLessThanOrEqual(MAX_RESUME_PREVIEW_BYTES);
+    expect(result.text).toContain('Task dev for MR ownership');
+    expect(result.text.toLowerCase()).toContain('ownership-aware');
+  });
+});


### PR DESCRIPTION
## Summary
- strengthen rehydrate and resume retrieval with explicit deterministic contracts and larger bounded budgets
- align runtime constants, MCP schema limits, tests, planning docs, and design locks with the new retrieval model
- add worst-case verification so core context survives before lower-priority tail material is dropped

## Test plan
- [x] `npx vitest run`
- [x] `npm run typecheck`

Closes #175