### PR TITLE
docs: backlog ideas for delegation+fallback and session linking

### DIFF
--- a/ideas/delegation-with-injection-fallback.md
+++ b/ideas/delegation-with-injection-fallback.md
@@ -1,0 +1,70 @@
+# Idea: Engine-Driven Delegation with Inline Injection Fallback
+
+## Status
+Backlog
+
+## Problem
+
+Routine delegation in WorkRail is currently NL-driven: the main agent reads a prose instruction ("spawn ONE WorkRail Executor running `routine-X`") and decides whether and how to spawn a subagent. This is fragile — the agent may ignore the instruction, misinterpret it, or fail to spawn correctly depending on the model and client environment.
+
+Additionally, some environments cannot spawn subagents at all:
+- MCP clients that don't support nested/recursive tool calls
+- Environments where `agenticRoutines` is disabled
+- Cost-constrained or embedded contexts
+- Models that don't reliably follow delegation instructions
+
+When delegation fails silently, the routine is simply skipped — no error, no fallback, no structured execution. The phase is lost.
+
+`templateCall` exists as a compile-time injection mechanism (main agent executes routine steps inline) but it serves a different purpose: it is for main-agent-owned cognitive work, not independent subagent perspective. Using templateCall for routines that require independence (hypothesis-challenge, plan-analysis, design-review) degrades quality, but it is strictly better than skipping the phase entirely.
+
+## Desired Behavior
+
+A step should be able to declare:
+1. A **delegation intent** — spawn a subagent to run this routine (primary, when available)
+2. An **injection fallback** — inline the routine steps for the main agent (when subagent unavailable)
+
+The engine resolves at runtime:
+- Subagent spawning available → engine-driven delegation (fresh subagent gets routine steps)
+- Subagent spawning unavailable → templateCall-style injection (main agent executes inline)
+
+## Proposed Step Shape
+
+```json
+{
+  "id": "phase-5-diagnosis-validation",
+  "title": "Diagnosis Validation",
+  "delegation": {
+    "routine": "routine-hypothesis-challenge",
+    "args": { "deliverableName": "hypothesis-challenge-findings.md" }
+  },
+  "injectionFallback": {
+    "templateId": "wr.templates.routine.hypothesis-challenge",
+    "args": { "deliverableName": "hypothesis-challenge-findings.md" }
+  }
+}
+```
+
+## Degradation Spectrum
+
+| Mode | Who executes | Independent? | Reliable? |
+|---|---|---|---|
+| Engine-driven delegation | Fresh subagent | Yes | Yes |
+| NL delegation (current) | Fresh subagent (if agent follows) | Yes | Fragile |
+| Injection fallback | Main agent | No | Yes |
+| Nothing (current failure mode) | Nobody | No | - |
+
+Independence degrades gracefully — you lose fresh-context isolation but keep structured execution and artifact production.
+
+## What Needs to Be Built
+
+1. **`delegation` step field** in schema and `WorkflowStepDefinition` type
+2. **`injectionFallback` step field** in schema — same shape as `templateCall`
+3. **Subagent availability detection** in the engine — determine at session start or step execution time whether spawning is supported
+4. **Engine-driven delegation execution** — engine spawns subagent, hands it the routine's steps, waits for artifacts, validates output contract
+5. **Fallback resolution** — when delegation unavailable, compile/expand injection fallback inline
+
+## Relation to Other Ideas
+
+- **Subagent session linking** (`subagent-session-linking.md`): engine-driven delegation is a prerequisite for session linking — the engine must know a subagent was spawned to link the sessions
+- **Extension points** (`docs/design/workflow-extension-points.md`): bindings resolve which routine fills a slot; delegation + fallback determines how that routine executes
+- **templateCall**: remains the right primitive for main-agent-owned inline work; injection fallback reuses the same mechanism but as a secondary path, not the primary

--- a/ideas/subagent-session-linking.md
+++ b/ideas/subagent-session-linking.md
@@ -1,0 +1,47 @@
+# Idea: Subagent Session Linking
+
+## Status
+Backlog
+
+## Problem
+
+When the main agent spawns a WorkRail Executor to run a routine or sub-workflow, that sub-session is completely disconnected from the parent session. There is no link between them in any durable or observable sense.
+
+This means:
+- The parent session has no record that a sub-session was spawned
+- The sub-session has no record of who spawned it or why
+- No traceability from parent to child executions
+- No way to surface sub-session findings back into the parent session's durable record
+- Debugging requires manually correlating session IDs across separate session files
+- The WorkRail dashboard (if active) cannot show a unified execution tree
+
+This is observable today: if you look at a parent session's event log, you see the agent completed a step that delegated to a routine. But you cannot see what happened inside that routine run, which steps it took, what it found, or whether it succeeded.
+
+## Why It Matters Now
+
+Extension points (`.workrail/bindings.json`) and templateCall both increase the role of routines and sub-workflows as first-class cognitive units. As workrail moves toward engine-driven delegation rather than NL prose delegation, the parent-child execution relationship will become more common and more critical to observe and debug.
+
+The lack of session linking is currently masked because delegation is NL-driven and opaque anyway. Once engine-driven delegation exists, the absence of a parent-child link will become a first-class gap.
+
+## Desired Behavior
+
+When a sub-session is started by a WorkRail Executor that itself is running inside a parent session:
+
+1. The sub-session should record its parent session ID and the parent step that triggered it
+2. The parent session should record the sub-session ID and the routine/workflow that was delegated to
+3. The link should be inspectable via the dashboard or `workrail inspect`
+4. On session resume, the parent session should be able to surface a summary of what sub-sessions ran during its execution
+
+## Design Questions
+
+- Should linking be automatic (engine detects parent context from environment) or explicit (agent passes parent session ID when starting sub-session)?
+- Should the sub-session's output artifacts be referenced in the parent session's event log?
+- Should a failed sub-session propagate to the parent as a typed event?
+- How does this interact with checkpoint/resume - if the parent is resumed, are sub-sessions re-run or their results re-used?
+- What is the right data model - is this a tree (one parent per child) or a DAG (a sub-session could be invoked by multiple parents)?
+
+## Relation to Other Ideas
+
+- Extension points (`docs/design/workflow-extension-points.md`): once bindings resolve which routine fills a slot, session linking would make that delegation visible and traceable
+- templateCall: templateCall inlines steps so no linking needed; session linking applies to delegation (black-box child runs), not injection
+- Dashboard: the web dashboard would be the natural surface for visualizing the parent-child session tree


### PR DESCRIPTION
## Summary

Two new backlog ideas captured from design session:

- **`ideas/delegation-with-injection-fallback.md`**: Engine-driven subagent delegation with templateCall as graceful degradation fallback when subagent spawning is unavailable. Addresses the gap between fragile NL delegation and full engine-driven sub-session management.

- **`ideas/subagent-session-linking.md`**: Link sub-sessions spawned by WorkRail Executor back to the parent session for traceability, debugging, and dashboard visibility. Identified as a prerequisite for engine-driven delegation.

## No code changes — docs/backlog only

🤖 Generated with [Claude Code](https://claude.com/claude-code)