### PR TITLE
fix: worktrees view blank page and slow load

### DIFF
--- a/console/src/api/hooks.ts
+++ b/console/src/api/hooks.ts
@@ -36,6 +36,7 @@ export function useWorktreeList() {
   return useQuery({
     queryKey: ['worktrees'],
     queryFn: () => fetchApi<ConsoleWorktreeListResponse>('/api/v2/worktrees'),
-    refetchInterval: 10_000, // refresh every 10s so status stays current
+    refetchInterval: 30_000, // refresh every 30s — each request loads all sessions + runs git
+    staleTime: 20_000,       // keep showing previous data while refetching, no flash to loading
   });
 }

--- a/src/v2/usecases/console-routes.ts
+++ b/src/v2/usecases/console-routes.ts
@@ -48,9 +48,15 @@ export function mountConsoleRoutes(app: Application, consoleService: ConsoleServ
   // Repo roots are derived from session observations (repo_root anchor) so the view
   // covers all repos agents have worked in, not just the current CWD's repo.
 
-  // Cache the CWD's git root — process.cwd() is stable and resolveRepoRoot runs a
-  // git subprocess, so there is no reason to re-resolve it on every request.
+  // CWD root: stable for the lifetime of the process — resolve once, cache forever.
   let cwdRepoRootPromise: Promise<string | null> | null = null;
+
+  // Repo roots from sessions: changes only when new sessions appear from new repos.
+  // Cache with a TTL so we re-scan sessions infrequently rather than on every request.
+  // Active session counts (for worktree badges) still come from each full session scan.
+  const REPO_ROOTS_TTL_MS = 60_000;
+  let cachedRepoRoots: readonly string[] = [];
+  let repoRootsExpiresAt = 0;
 
   app.get('/api/v2/worktrees', async (_req: Request, res: Response) => {
     try {
@@ -58,19 +64,19 @@ export function mountConsoleRoutes(app: Application, consoleService: ConsoleServ
       const sessions = sessionResult.isOk() ? sessionResult.value.sessions : [];
       const activeSessions = buildActiveSessionCounts(sessions);
 
-      // Collect unique repo roots from session observations.
-      // Type predicate excludes nulls from sessions predating this feature.
-      const repoRootSet = new Set<string>(
-        sessions.map(s => s.repoRoot).filter((r): r is string => r !== null),
-      );
+      // Refresh the known-repos set at most once per TTL window.
+      if (Date.now() > repoRootsExpiresAt) {
+        cwdRepoRootPromise ??= resolveRepoRoot(process.cwd());
+        const cwdRoot = await cwdRepoRootPromise;
+        const repoRootSet = new Set<string>(
+          sessions.map(s => s.repoRoot).filter((r): r is string => r !== null),
+        );
+        if (cwdRoot !== null) repoRootSet.add(cwdRoot);
+        cachedRepoRoots = [...repoRootSet];
+        repoRootsExpiresAt = Date.now() + REPO_ROOTS_TTL_MS;
+      }
 
-      // Always include the CWD's repo root so the current project appears
-      // even if it has no sessions yet (graceful: silently skipped if not a git repo).
-      cwdRepoRootPromise ??= resolveRepoRoot(process.cwd());
-      const cwdRoot = await cwdRepoRootPromise;
-      if (cwdRoot !== null) repoRootSet.add(cwdRoot);
-
-      const data = await getWorktreeList([...repoRootSet], activeSessions);
+      const data = await getWorktreeList(cachedRepoRoots, activeSessions);
       res.json({ success: true, data });
     } catch (e) {
       res.status(500).json({ success: false, error: e instanceof Error ? e.message : String(e) });


### PR DESCRIPTION
## What broke and why

After #185 merged, the page went completely blank (including nav bar) and loads were slow.

**Blank page:** The running workrail process had a stale `dist/` — the old backend returning `{ worktrees: [...] }` while the new frontend JS expected `{ repos: [...] }`. `data.repos.length` threw a `TypeError` that crashed the React root. Rebuild fixes the shape mismatch.

**Slow load:**
1. `getSessionList()` reads every session file on every `/api/v2/worktrees` request to derive the known-repos set. On a large session store this is expensive and was firing every 10s.
2. No `staleTime` meant the UI flashed to a loading spinner on every background refetch.

## Fixes

- **Route:** Cache the repo roots set for 60s. Re-derive from sessions only when the TTL expires. Active session counts (for worktree badges) still come from each fresh session scan so the badges stay current.
- **Hook:** `refetchInterval` 10s → 30s, added `staleTime: 20s` so previous data stays visible during background refresh.

## After merging

Restart MCP (`/mcp`) then open http://localhost:3456/console → Worktrees tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)