### PR TITLE
docs: add remote references backlog idea

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -26,6 +26,25 @@ Workflow and feature ideas that are worth capturing but not yet planned or desig
 
 ## Feature ideas
 
+### Remote references (URLs, GDocs, Confluence, etc.)
+
+- **Status**: idea
+- **Summary**: Extend the workflow `references` system to support remote sources (HTTP URLs, Google Docs, Confluence pages, etc.) in addition to local file paths. WorkRail remains a pointer system — it resolves and delivers reference metadata, and the agent does the actual fetching using whatever tools it has available. Auth is entirely delegated to the agent.
+- **Core design principle**: same model as today, extended to remote sources. WorkRail validates that a reference declaration is well-formed, delivers the pointer to the agent at workflow start, and the agent fetches the content with its own HTTP or integration tools. If the agent lacks access, it surfaces that to the user — which is the right failure mode. WorkRail does not need to store credentials or act as a fetch proxy.
+- **Why this matters**: teams keep their authoritative docs (architecture decisions, coding standards, runbooks, API contracts) in external systems. Remote refs let workflows point at those docs directly without requiring anyone to maintain a local copy.
+- **Incremental path**:
+  - Phase 1: public HTTP URLs. `resolveFrom: "url"`. WorkRail delivers the URL as a reference pointer. Agent fetches using HTTP tools. No auth surface in WorkRail.
+  - Phase 2: workspace-configured bearer tokens in `.workrail/config.json` keyed by domain. Covers most internal tools (Confluence API tokens, private wikis, etc.) without native integrations.
+  - Phase 3: named integrations (GDocs, Confluence, Notion) as first-class configured sources — the full platform play, only if Phase 1/2 prove insufficient.
+- **Reachability validation**: soft check or skippable at start time. A URL being reachable during validation doesn't guarantee the agent can authenticate at runtime, and a failed ping shouldn't block the workflow from starting.
+- **Design questions**:
+  - Should WorkRail attempt a reachability check at start time, or skip entirely for remote refs?
+  - How should remote refs appear in `workflowHash`? The declaration is stable but content is not — may need content-hashing at fetch time or explicit versioned URLs for determinism.
+  - Should the `references` schema add a `kind` field (`local` vs `remote`) or infer from the `source` value?
+- **Risks / tradeoffs**:
+  - Agent-side fetching means the workflow only works if the agent has appropriate tools — acceptable tradeoff, explicitly the user's responsibility
+  - Remote content can change between runs, weakening the determinism guarantee that local refs provide
+
 ### Declarative workflow composition engine
 
 - **Status**: idea


### PR DESCRIPTION
## Summary

Captures the design for extending workflow `references` to support remote sources (HTTP URLs, GDocs, Confluence, etc.).

Core principle: WorkRail stays a pointer system — it delivers the reference metadata, the agent fetches the content with its own tools. Auth is entirely delegated to the agent; WorkRail stores no credentials.

Incremental path documented: public URLs → workspace bearer tokens → native integrations.

## Test plan

- [x] Backlog entry only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)