### PR TITLE
feat(console): Workspace unified view

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
+import { WorkspaceView } from './views/WorkspaceView';
 import { SessionList } from './views/SessionList';
 import { SessionDetail } from './views/SessionDetail';
 import { WorktreeList } from './views/WorktreeList';
 
-type Tab = 'sessions' | 'worktrees';
+type Tab = 'workspace' | 'sessions' | 'worktrees';
 
 export function App() {
-  const [activeTab, setActiveTab] = useState<Tab>('sessions');
+  const [activeTab, setActiveTab] = useState<Tab>('workspace');
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const [sessionSearch, setSessionSearch] = useState('');
   const [sessionRepoRoot, setSessionRepoRoot] = useState<string | null>(null);
@@ -39,11 +40,16 @@ export function App() {
     setSelectedSessionId(null);
   };
 
+  // When in SessionDetail from the Sessions or Worktrees tab the workspace tab
+  // is not active, so we only need the extra "keep mounted" trick for Workspace.
+  const isInSessionDetail = selectedSessionId !== null;
+  const sessionDetailFromNonWorkspace = isInSessionDetail && activeTab !== 'workspace';
+
   return (
     <div className="min-h-screen bg-[var(--bg-primary)]">
       <header className="border-b border-[var(--border)] px-6 py-4">
         <div className="flex items-center gap-4">
-          {selectedSessionId && (
+          {isInSessionDetail && (
             <button
               onClick={handleBack}
               className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
@@ -54,16 +60,16 @@ export function App() {
           <h1 className="text-lg font-semibold text-[var(--text-primary)]">
             WorkRail Console
           </h1>
-          {selectedSessionId && (
+          {isInSessionDetail && (
             <span className="text-sm text-[var(--text-muted)] font-mono">
               {selectedSessionId}
             </span>
           )}
 
-          {/* Tab nav — hidden when viewing session detail */}
-          {!selectedSessionId && (
+          {/* Tab nav -- hidden when viewing session detail */}
+          {!isInSessionDetail && (
             <nav className="ml-4 flex gap-1">
-              {(['sessions', 'worktrees'] as Tab[]).map(tab => (
+              {(['workspace', 'sessions', 'worktrees'] as Tab[]).map(tab => (
                 <button
                   key={tab}
                   onClick={() => handleTabChange(tab)}
@@ -82,19 +88,63 @@ export function App() {
       </header>
 
       <main className="p-6">
-        {selectedSessionId ? (
+        {/* SessionDetail for sessions opened from Sessions or Worktrees tabs */}
+        {sessionDetailFromNonWorkspace && (
           <SessionDetail sessionId={selectedSessionId} />
-        ) : activeTab === 'worktrees' ? (
-          <WorktreeList onSelectBranch={handleSelectBranch} />
-        ) : (
-          <SessionList
-            key={sessionSearchNonce}
-            onSelectSession={handleSelectSession}
-            initialSearch={sessionSearch}
-            initialRepoRoot={sessionRepoRoot}
-          />
+        )}
+
+        {/* Workspace tab -- always mounted when active so scroll position survives
+            back-navigation from SessionDetail. Hidden via CSS when in session detail. */}
+        {activeTab === 'workspace' && !sessionDetailFromNonWorkspace && (
+          <>
+            <WorkspaceView
+              onSelectSession={handleSelectSession}
+              hidden={isInSessionDetail}
+            />
+            {/* SessionDetail overlaid; WorkspaceView hidden (not unmounted) behind it */}
+            {isInSessionDetail && (
+              <SessionDetail sessionId={selectedSessionId} />
+            )}
+          </>
+        )}
+
+        {/* Sessions tab with redirect banner */}
+        {!isInSessionDetail && activeTab === 'sessions' && (
+          <>
+            <RedirectBanner />
+            <SessionList
+              key={sessionSearchNonce}
+              onSelectSession={handleSelectSession}
+              initialSearch={sessionSearch}
+              initialRepoRoot={sessionRepoRoot}
+            />
+          </>
+        )}
+
+        {/* Worktrees tab with redirect banner */}
+        {!isInSessionDetail && activeTab === 'worktrees' && (
+          <>
+            <RedirectBanner />
+            <WorktreeList onSelectBranch={handleSelectBranch} />
+          </>
         )}
       </main>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Redirect banner -- shown on Sessions and Worktrees tabs
+// ---------------------------------------------------------------------------
+
+function RedirectBanner() {
+  return (
+    <div className="flex items-center gap-3 bg-[var(--bg-card)] border border-[var(--border)] rounded-lg px-4 py-2.5 mb-4 text-sm text-[var(--text-muted)]"
+      style={{ borderLeftColor: 'var(--accent)', borderLeftWidth: '3px' }}
+    >
+      This view has moved to{' '}
+      <strong className="text-[var(--text-secondary)]">Workspace</strong>
+      {' '}-- the Sessions and Worktrees tabs will be removed in the next release.
     </div>
   );
 }

--- a/console/src/views/WorkspaceView.tsx
+++ b/console/src/views/WorkspaceView.tsx
@@ -1,0 +1,1139 @@
+import {
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  useCallback,
+} from 'react';
+import { useSessionList } from '../api/hooks';
+import { useWorktreeList } from '../api/hooks';
+import { SessionList } from './SessionList';
+import type { ConsoleSessionSummary, ConsoleSessionStatus } from '../api/types';
+import {
+  type WorkspaceItem,
+  type Scope,
+  type SectionKind,
+  joinSessionsAndWorktrees,
+  sortWorkspaceItems,
+  sectionFor,
+  countNeedsAttention,
+} from './workspace-types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STATUS_ACCENT: Record<ConsoleSessionStatus, string> = {
+  blocked: 'var(--blocked)',
+  dormant: 'var(--text-muted)',
+  complete_with_gaps: 'var(--warning)',
+  in_progress: 'var(--accent)',
+  complete: 'var(--success)',
+};
+
+const STATUS_DOT_LABEL: Record<ConsoleSessionStatus, string> = {
+  in_progress: 'In progress',
+  dormant: 'Dormant',
+  blocked: 'Blocked',
+  complete_with_gaps: 'Complete with gaps',
+  complete: 'Complete',
+};
+
+// ---------------------------------------------------------------------------
+// Rotating content
+// ---------------------------------------------------------------------------
+
+interface ActionPrompt {
+  readonly workflow: string;
+  readonly task: string;
+}
+
+const ACTION_PROMPTS: readonly ActionPrompt[] = [
+  { workflow: 'coding task workflow', task: 'add a dark mode toggle to the settings page' },
+  { workflow: 'coding task workflow', task: 'write tests for the authentication module' },
+  { workflow: 'coding task workflow', task: 'refactor the data layer to use a repository pattern' },
+  { workflow: 'coding task workflow', task: 'add pagination to the search results view' },
+  { workflow: 'bug investigation workflow', task: 'find why the API returns 500 on logout' },
+  { workflow: 'bug investigation workflow', task: 'trace why notifications stop sending after 24 hours' },
+  { workflow: 'bug investigation workflow', task: 'figure out why the build is failing on CI but not locally' },
+  { workflow: 'MR review workflow', task: 'review my latest changes on this branch' },
+  { workflow: 'MR review workflow', task: 'review PR #123 before it merges' },
+];
+
+// 3 stale tips removed (Worktrees tab reference, Group by Status reference, Sessions tab search reference)
+const DISCOVERY_TIPS: readonly string[] = [
+  'The DAG view shows every node the agent created, including blocked attempts and alternative paths.',
+  'Dormant sessions have been idle for 3 days -- return to the original conversation to resume.',
+  'Gaps are open questions the agent flagged but could not resolve. Check them in the node detail panel.',
+  'The preferred tip node (highlighted in yellow in the DAG) is the most recent forward position.',
+  'Complete with gaps means the workflow finished but left critical follow-ups unresolved.',
+  'The tip count badge shows how many execution paths a session explored.',
+  'Use j and k to navigate between branches, Enter to expand, and / to open the full session archive.',
+];
+
+function pickRandom<T>(pool: readonly T[]): T {
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+// ---------------------------------------------------------------------------
+// Text utilities (same as Homepage.tsx)
+// ---------------------------------------------------------------------------
+
+function stripMarkdown(md: string): string {
+  return md
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/\*{1,3}([^*\n]+)\*{1,3}/g, '$1')
+    .replace(/^[-*+]\s+/gm, '')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/\n+/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+function excerptRecap(md: string, maxLen = 220): string {
+  const plain = stripMarkdown(md);
+  if (plain.length <= maxLen) return plain;
+  const cut = plain.lastIndexOf(' ', maxLen);
+  return plain.slice(0, cut > 0 ? cut : maxLen) + '\u2026';
+}
+
+function formatRelativeTime(ms: number): string {
+  const delta = Date.now() - ms;
+  if (delta < 0) return 'just now';
+  const seconds = Math.floor(delta / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}w ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Archive state
+// ---------------------------------------------------------------------------
+
+interface ArchiveState {
+  readonly repoName: string | undefined;
+  readonly repoRoot: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface Props {
+  onSelectSession: (sessionId: string) => void;
+  /** When true, the view is hidden (parent navigated to SessionDetail). Kept
+   * mounted so state is preserved for scroll restoration on back-nav. */
+  hidden?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// WorkspaceView
+// ---------------------------------------------------------------------------
+
+export function WorkspaceView({ onSelectSession, hidden = false }: Props) {
+  const { data: sessionData, isLoading: sessionsLoading, error: sessionsError, refetch } = useSessionList();
+  const { data: worktreeData, isFetching: worktreesFetching } = useWorktreeList();
+
+  const [scope, setScope] = useState<Scope>('active');
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+  const [attentionFilter, setAttentionFilter] = useState(false);
+  const [archive, setArchive] = useState<ArchiveState | null>(null);
+
+  // Scroll restoration: capture before navigating away, restore on re-show
+  const scrollYRef = useRef<number>(0);
+  const expandedKeyBeforeNavRef = useRef<string | null>(null);
+  // Track first render so scroll restoration doesn't fire on mount (would scroll to 0 needlessly)
+  const isFirstRender = useRef(true);
+
+  const wrappedSelectSession = useCallback(
+    (sessionId: string) => {
+      scrollYRef.current = window.scrollY;
+      expandedKeyBeforeNavRef.current = expandedKey;
+      onSelectSession(sessionId);
+    },
+    [onSelectSession, expandedKey],
+  );
+
+  // Restore scroll and expanded state when returning from SessionDetail.
+  // Skip on first mount -- page is already at 0 and there is nothing to restore.
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    if (!hidden) {
+      setExpandedKey(expandedKeyBeforeNavRef.current);
+      // Defer scroll restoration until after paint
+      const id = requestAnimationFrame(() => {
+        window.scrollTo({ top: scrollYRef.current });
+      });
+      return () => cancelAnimationFrame(id);
+    }
+  }, [hidden]);
+
+  const { items, needsAttentionCount, archiveRepos } = useMemo(() => {
+    const nowMs = Date.now();
+    if (!sessionData) return { items: [], needsAttentionCount: 0, archiveRepos: [] as Array<[string, string]> };
+    const repos = worktreeData?.repos ?? [];
+    const joined = joinSessionsAndWorktrees(sessionData.sessions, repos);
+    const sorted = sortWorkspaceItems(joined, scope, nowMs);
+    const filtered = attentionFilter
+      ? sorted.filter((item) => {
+          const s = item.primarySession?.status;
+          return s === 'blocked' || s === 'dormant';
+        })
+      : sorted;
+
+    // Derive archive repos from the full joined list (not filtered) so that ArchiveLinks
+    // shows all repos even when the attention filter hides some of their items.
+    const reposSeen = new Map<string, string>(); // repoRoot -> repoName
+    for (const item of joined) {
+      if (!reposSeen.has(item.repoRoot)) {
+        reposSeen.set(item.repoRoot, item.repoName);
+      }
+    }
+
+    return {
+      items: filtered,
+      needsAttentionCount: countNeedsAttention(joined),
+      archiveRepos: [...reposSeen.entries()] as Array<[string, string]>,
+    };
+  }, [sessionData, worktreeData, scope, attentionFilter]);
+
+  const activeItems = useMemo(() => {
+    const nowMs = Date.now();
+    return items.filter((item) => sectionFor(item, scope, nowMs) === 'active');
+  }, [items, scope]);
+
+  const recentItems = useMemo(() => {
+    const nowMs = Date.now();
+    return items.filter((item) => sectionFor(item, scope, nowMs) === 'recent');
+  }, [items, scope]);
+
+  // Flat ordered list for keyboard navigation
+  const orderedItems = useMemo(() => [...activeItems, ...recentItems], [activeItems, recentItems]);
+
+  // Reset keyboard focus when the item list changes length (e.g. after scope toggle).
+  // Prevents focusedIndex pointing to a different item than the user expects.
+  useEffect(() => {
+    setFocusedIndex(-1);
+  }, [orderedItems.length]);
+
+  const handleToggleExpand = useCallback((key: string) => {
+    // Single expand only: only one item expanded at a time
+    setExpandedKey((prev) => (prev === key ? null : key));
+  }, []);
+
+  const handleAlertClick = useCallback(() => {
+    setAttentionFilter((prev) => {
+      const next = !prev;
+      // Activating the filter forces All scope so hidden branches become visible.
+      // Deactivating resets scope back to Active -- the ScopeToggle pill must match reality.
+      setScope(next ? 'all' : 'active');
+      return next;
+    });
+  }, []);
+
+  // Keyboard navigation -- disabled while hidden (e.g. SessionDetail overlaid on top)
+  useWorkspaceKeyboard({
+    items: orderedItems,
+    focusedIndex,
+    setFocusedIndex,
+    expandedKey,
+    setExpandedKey,
+    scope,
+    setScope,
+    refetch,
+    archive,
+    setArchive,
+    disabled: hidden,
+  });
+
+  const hasAnySessions = (sessionData?.totalCount ?? 0) > 0;
+
+  if (sessionsLoading) {
+    return (
+      <div className={`flex items-center justify-center py-32 ${hidden ? 'hidden' : ''}`}>
+        <div className="text-[var(--text-muted)] text-sm">Loading workspace...</div>
+      </div>
+    );
+  }
+
+  if (sessionsError) {
+    return (
+      <div className={`text-[var(--error)] bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-4 text-sm ${hidden ? 'hidden' : ''}`}>
+        Failed to load workspace: {sessionsError.message}
+      </div>
+    );
+  }
+
+  // Archive view (inline SessionList)
+  if (archive !== null) {
+    return (
+      <div className={`space-y-4 ${hidden ? 'hidden' : ''}`}>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setArchive(null)}
+            className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors text-sm"
+          >
+            &larr; Back to Workspace
+          </button>
+          {archive.repoName && (
+            <span className="text-sm text-[var(--text-muted)] font-mono">{archive.repoName}</span>
+          )}
+        </div>
+        <SessionList
+          onSelectSession={wrappedSelectSession}
+          initialRepoRoot={archive.repoRoot ?? null}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-5 max-w-3xl ${hidden ? 'hidden' : ''}`}>
+      {!hasAnySessions ? (
+        <>
+          <FullEmptyState prompt={pickRandom(ACTION_PROMPTS)} />
+          <TipCard />
+        </>
+      ) : (
+        <>
+          {/* Alert strip */}
+          {needsAttentionCount > 0 && (
+            <AlertStrip
+              count={needsAttentionCount}
+              active={attentionFilter}
+              onFocusAttention={handleAlertClick}
+            />
+          )}
+
+          {/* Scope toggle */}
+          <ScopeToggle scope={scope} onChange={setScope} />
+
+          {/* Active section */}
+          <WorkspaceSection
+            kind="active"
+            items={activeItems}
+            expandedKey={expandedKey}
+            focusedIndex={focusedIndex}
+            focusedOffset={0}
+            worktreesFetching={worktreesFetching}
+            onToggle={handleToggleExpand}
+            onSelectSession={wrappedSelectSession}
+          />
+
+          {/* Recent / All branches section */}
+          {recentItems.length > 0 && (
+            <WorkspaceSection
+              kind="recent"
+              items={recentItems}
+              expandedKey={expandedKey}
+              focusedIndex={focusedIndex}
+              focusedOffset={activeItems.length}
+              worktreesFetching={worktreesFetching}
+              scopeLabel={scope === 'all' ? 'All branches' : 'Recent'}
+              onToggle={handleToggleExpand}
+              onSelectSession={wrappedSelectSession}
+            />
+          )}
+
+          {/* Archive links -- uses unfiltered archiveRepos so all repos are always reachable */}
+          <ArchiveLinks
+            repos={archiveRepos}
+            onOpen={(repoName, repoRoot) => setArchive({ repoName, repoRoot })}
+          />
+        </>
+      )}
+
+      <TipCard />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Workspace section (Active or Recent)
+// ---------------------------------------------------------------------------
+
+function WorkspaceSection({
+  kind,
+  items,
+  expandedKey,
+  focusedIndex,
+  focusedOffset,
+  worktreesFetching,
+  scopeLabel,
+  onToggle,
+  onSelectSession,
+}: {
+  readonly kind: SectionKind;
+  readonly items: readonly WorkspaceItem[];
+  readonly expandedKey: string | null;
+  readonly focusedIndex: number;
+  readonly focusedOffset: number;
+  readonly worktreesFetching: boolean;
+  readonly scopeLabel?: string;
+  readonly onToggle: (key: string) => void;
+  readonly onSelectSession: (sessionId: string) => void;
+}) {
+  if (items.length === 0 && kind === 'active') {
+    return <WorkspaceEmptyActive />;
+  }
+  if (items.length === 0) return null;
+
+  const label = scopeLabel ?? (kind === 'active' ? 'Active' : 'Recent');
+
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+        {label}
+      </h2>
+      <div className={kind === 'active' ? 'flex flex-col gap-3' : 'space-y-px'}>
+        {items.map((item, idx) => {
+          const key = `${item.branch}\0${item.repoRoot}`;
+          const isFocused = focusedIndex === focusedOffset + idx;
+          const isExpanded = expandedKey === key;
+
+          if (kind === 'active') {
+            return (
+              <FeaturedCard
+                key={key}
+                item={item}
+                isExpanded={isExpanded}
+                isFocused={isFocused}
+                worktreesFetching={worktreesFetching}
+                onToggle={() => onToggle(key)}
+                onSelectSession={onSelectSession}
+              />
+            );
+          }
+          return (
+            <CompactRow
+              key={key}
+              item={item}
+              isExpanded={isExpanded}
+              isFocused={isFocused}
+              worktreesFetching={worktreesFetching}
+              onToggle={() => onToggle(key)}
+              onSelectSession={onSelectSession}
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Featured card (Active section)
+// ---------------------------------------------------------------------------
+
+function FeaturedCard({
+  item,
+  isExpanded,
+  isFocused,
+  worktreesFetching,
+  onToggle,
+  onSelectSession,
+}: {
+  readonly item: WorkspaceItem;
+  readonly isExpanded: boolean;
+  readonly isFocused: boolean;
+  readonly worktreesFetching: boolean;
+  readonly onToggle: () => void;
+  readonly onSelectSession: (sessionId: string) => void;
+}) {
+  // Lifted here so showAll survives accordion collapse/reopen
+  const [showAll, setShowAll] = useState(false);
+  const session = item.primarySession;
+  const accent = session ? STATUS_ACCENT[session.status] : 'var(--border)';
+  const workflowLabel = session?.workflowName ?? session?.workflowId ?? null;
+  const excerpt = session?.recapSnippet ? excerptRecap(session.recapSnippet) : null;
+  const timeAgo = formatRelativeTime(item.activityMs);
+  const multiRepo = true; // always show repo badge in featured cards
+
+  return (
+    <div
+      className={`bg-[var(--bg-card)] border rounded-lg overflow-hidden transition-colors ${
+        isFocused ? 'border-[var(--accent)]' : 'border-[var(--border)]'
+      }`}
+    >
+      {/* Card header -- click to expand/collapse */}
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full text-left flex overflow-hidden hover:bg-[var(--bg-secondary)] transition-colors group"
+        aria-expanded={isExpanded}
+      >
+        {/* Status stripe */}
+        <div className="w-[3px] shrink-0 self-stretch" style={{ backgroundColor: accent }} />
+
+        <div className="flex-1 p-4 min-w-0">
+          {/* Header row: branch + repo badge + time */}
+          <div className="flex items-center gap-2 mb-2 min-w-0">
+            <span className="font-mono text-sm font-medium text-[var(--text-primary)] truncate flex-1">
+              {item.branch}
+            </span>
+            {multiRepo && (
+              <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] shrink-0">
+                {item.repoName}
+              </span>
+            )}
+            <span className="text-[10px] text-[var(--text-muted)] tabular-nums shrink-0">
+              {timeAgo}
+            </span>
+          </div>
+
+          {/* Status + workflow row */}
+          {session && (
+            <div className="flex items-center gap-2 mb-2">
+              <span
+                className="w-1.5 h-1.5 rounded-full shrink-0"
+                style={{ backgroundColor: accent }}
+                title={STATUS_DOT_LABEL[session.status]}
+              />
+              <span className="text-xs" style={{ color: accent }}>
+                {STATUS_DOT_LABEL[session.status]}
+              </span>
+              {workflowLabel && (
+                <>
+                  <span className="text-[var(--text-muted)] text-xs">·</span>
+                  <span className="text-xs text-[var(--text-muted)] truncate">
+                    {workflowLabel}
+                  </span>
+                </>
+              )}
+            </div>
+          )}
+
+          {/* Recap or commit message */}
+          {excerpt ? (
+            <p className="text-sm text-[var(--text-secondary)] leading-relaxed group-hover:text-[var(--text-primary)] transition-colors mb-3">
+              {excerpt}
+            </p>
+          ) : item.worktree?.headMessage ? (
+            <p className="text-sm text-[var(--text-muted)] leading-snug mb-3 truncate">
+              {item.worktree.headMessage}
+            </p>
+          ) : null}
+
+          {/* Footer: git badges + session count */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <GitBadges item={item} fetching={worktreesFetching} />
+
+            {session?.hasUnresolvedGaps && (
+              <span
+                title="This session flagged unresolved gaps -- open questions it could not answer."
+                className="text-xs px-1.5 py-0.5 rounded bg-[var(--warning)]/10 text-[var(--warning)] border border-[var(--warning)]/20 cursor-default"
+              >
+                &#x26A0; gaps
+              </span>
+            )}
+
+            {session?.health === 'corrupt' && (
+              <span
+                title="This session's event log may be incomplete -- some steps may not display correctly."
+                className="text-xs px-1.5 py-0.5 rounded bg-[var(--error)]/10 text-[var(--error)] border border-[var(--error)]/20 cursor-default"
+              >
+                &#x26A0;
+              </span>
+            )}
+
+            {item.allSessions.length > 0 && (
+              <span className="text-xs text-[var(--text-muted)] ml-auto">
+                {item.allSessions.length} session{item.allSessions.length !== 1 ? 's' : ''}{' '}
+                <span className="text-[10px]">{isExpanded ? '▴' : '▾'}</span>
+              </span>
+            )}
+          </div>
+        </div>
+      </button>
+
+      {/* Accordion: inline session list */}
+      {isExpanded && (
+        <SessionRowList
+          sessions={item.allSessions}
+          showAll={showAll}
+          onShowAll={() => setShowAll(true)}
+          onSelectSession={onSelectSession}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compact row (Recent section)
+// ---------------------------------------------------------------------------
+
+function CompactRow({
+  item,
+  isExpanded,
+  isFocused,
+  worktreesFetching,
+  onToggle,
+  onSelectSession,
+}: {
+  readonly item: WorkspaceItem;
+  readonly isExpanded: boolean;
+  readonly isFocused: boolean;
+  readonly worktreesFetching: boolean;
+  readonly onToggle: () => void;
+  readonly onSelectSession: (sessionId: string) => void;
+}) {
+  // Lifted here so showAll survives accordion collapse/reopen
+  const [showAll, setShowAll] = useState(false);
+  const session = item.primarySession;
+  const accent = session ? STATUS_ACCENT[session.status] : 'var(--border)';
+  const timeAgo = formatRelativeTime(item.activityMs);
+  const tipCount = item.allSessions.reduce((sum, s) => sum + (s.tipCount ?? 0), 0);
+
+  return (
+    <div className={isFocused ? 'ring-2 ring-[var(--accent)] ring-offset-1 rounded' : ''}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full text-left flex items-center gap-3 px-3 py-2 rounded hover:bg-[var(--bg-card)] transition-colors group"
+        aria-expanded={isExpanded}
+      >
+        {/* Status dot */}
+        <div
+          className="w-1.5 h-1.5 rounded-full shrink-0"
+          style={{ backgroundColor: accent }}
+          title={session ? STATUS_DOT_LABEL[session.status] : 'No sessions'}
+        />
+
+        {/* Branch name */}
+        <span className="font-mono text-sm text-[var(--text-secondary)] truncate flex-1 group-hover:text-[var(--text-primary)] transition-colors">
+          {item.branch}
+        </span>
+
+        {/* Repo badge (when multi-repo) */}
+        <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] shrink-0 hidden sm:inline">
+          {item.repoName}
+        </span>
+
+        {/* Git badges */}
+        <GitBadges item={item} fetching={worktreesFetching} compact />
+
+        {/* Tip count badge */}
+        {tipCount > 1 && (
+          <span
+            title={`${tipCount} execution paths -- the agent explored different routes or this session was resumed from multiple checkpoints`}
+            className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bg-tertiary)] text-[var(--text-muted)] shrink-0 tabular-nums"
+          >
+            {tipCount} tips
+          </span>
+        )}
+
+        {/* Time */}
+        <span className="text-[10px] text-[var(--text-muted)] tabular-nums shrink-0">
+          {timeAgo}
+        </span>
+
+        {/* Expand indicator */}
+        <span className="text-[10px] text-[var(--text-muted)] shrink-0">
+          {isExpanded ? '▴' : '▾'}
+        </span>
+      </button>
+
+      {/* Accordion */}
+      {isExpanded && (
+        <SessionRowList
+          sessions={item.allSessions}
+          showAll={showAll}
+          onShowAll={() => setShowAll(true)}
+          onSelectSession={onSelectSession}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Git badges
+// ---------------------------------------------------------------------------
+
+function GitBadges({
+  item,
+  fetching,
+  compact = false,
+}: {
+  readonly item: WorkspaceItem;
+  readonly fetching: boolean;
+  readonly compact?: boolean;
+}) {
+  if (fetching && item.worktree === undefined) {
+    // Show skeleton shimmer while worktree data loads
+    return (
+      <span className="flex gap-1">
+        <SkeletonBadge />
+      </span>
+    );
+  }
+
+  const wt = item.worktree;
+  if (!wt) return null;
+
+  const changedCount = wt.changedCount;
+  const aheadCount = wt.aheadCount;
+
+  if (changedCount === 0 && aheadCount === 0) {
+    // Nothing to show -- absence of badges already communicates "clean"
+    return null;
+  }
+
+  return (
+    <span className="flex items-center gap-1">
+      {changedCount > 0 && (
+        <span
+          title={`${changedCount} file${changedCount === 1 ? '' : 's'} edited but not yet committed`}
+          className={`text-xs px-1.5 py-0.5 rounded bg-orange-500/10 text-orange-400 border border-orange-500/20 tabular-nums${compact ? ' text-[10px]' : ''}`}
+        >
+          {changedCount} uncommitted
+        </span>
+      )}
+      {aheadCount > 0 && (
+        <span
+          title={`${aheadCount} commit${aheadCount === 1 ? '' : 's'} not yet pushed`}
+          className={`text-xs px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-400 border border-blue-500/20 tabular-nums${compact ? ' text-[10px]' : ''}`}
+        >
+          {aheadCount} unpushed
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton badge
+// ---------------------------------------------------------------------------
+
+function SkeletonBadge() {
+  return (
+    <span className="inline-block h-5 w-20 rounded bg-[var(--bg-tertiary)] animate-pulse" />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Session row list (accordion content)
+// ---------------------------------------------------------------------------
+
+const MAX_INLINE_SESSIONS = 5;
+
+function SessionRowList({
+  sessions,
+  showAll,
+  onShowAll,
+  onSelectSession,
+}: {
+  readonly sessions: readonly ConsoleSessionSummary[];
+  readonly showAll: boolean;
+  readonly onShowAll: () => void;
+  readonly onSelectSession: (sessionId: string) => void;
+}) {
+  const visible = showAll ? sessions : sessions.slice(0, MAX_INLINE_SESSIONS);
+
+  if (sessions.length === 0) {
+    return (
+      <div className="border-t border-[var(--border)] px-4 py-3">
+        <p className="text-xs text-[var(--text-muted)]">No sessions recorded for this branch.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-[var(--border)]">
+      {visible.map((session) => {
+        const accent = STATUS_ACCENT[session.status];
+        const label =
+          session.sessionTitle ??
+          session.workflowName ??
+          session.workflowId ??
+          'Unnamed session';
+        const timeAgo = formatRelativeTime(session.lastModifiedMs);
+
+        return (
+          <button
+            key={session.sessionId}
+            type="button"
+            onClick={() => onSelectSession(session.sessionId)}
+            className="w-full text-left flex items-center gap-3 px-4 py-2.5 hover:bg-[var(--bg-secondary)] transition-colors group"
+          >
+            <div
+              className="w-1.5 h-1.5 rounded-full shrink-0"
+              style={{ backgroundColor: accent }}
+              title={STATUS_DOT_LABEL[session.status]}
+            />
+            <span className="text-sm text-[var(--text-secondary)] truncate flex-1 group-hover:text-[var(--text-primary)] transition-colors">
+              {label}
+            </span>
+            {session.hasUnresolvedGaps && (
+              <span
+                title="Unresolved gaps"
+                className="text-xs text-[var(--warning)] shrink-0"
+              >
+                &#x26A0;
+              </span>
+            )}
+            <span className="text-[10px] text-[var(--text-muted)] tabular-nums shrink-0">
+              {timeAgo}
+            </span>
+          </button>
+        );
+      })}
+
+      {!showAll && sessions.length > MAX_INLINE_SESSIONS && (
+        <button
+          type="button"
+          onClick={onShowAll}
+          className="w-full text-left px-4 py-2 text-xs text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+        >
+          show {sessions.length - MAX_INLINE_SESSIONS} more &rarr;
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scope toggle
+// ---------------------------------------------------------------------------
+
+function ScopeToggle({
+  scope,
+  onChange,
+}: {
+  readonly scope: Scope;
+  readonly onChange: (scope: Scope) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      {(['active', 'all'] as Scope[]).map((s) => (
+        <button
+          key={s}
+          type="button"
+          onClick={() => onChange(s)}
+          className={`px-3 py-1 rounded-full text-xs font-medium transition-colors capitalize ${
+            scope === s
+              ? 'bg-[var(--bg-tertiary)] text-[var(--text-primary)]'
+              : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+          }`}
+        >
+          {s === 'active' ? 'Active' : 'All'}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Alert strip (clickable)
+// ---------------------------------------------------------------------------
+
+function AlertStrip({
+  count,
+  active,
+  onFocusAttention,
+}: {
+  readonly count: number;
+  readonly active: boolean;
+  readonly onFocusAttention: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onFocusAttention}
+      className={`w-full flex items-center gap-3 bg-[var(--bg-card)] border rounded-lg px-4 py-2.5 overflow-hidden text-left transition-colors hover:border-[var(--blocked)] ${
+        active ? 'border-[var(--blocked)]' : 'border-[var(--border)]'
+      }`}
+      style={{ borderLeftColor: 'var(--blocked)', borderLeftWidth: '3px' }}
+      title={active ? 'Click to show all branches' : 'Click to focus on sessions needing attention'}
+    >
+      <span className="text-sm font-medium" style={{ color: 'var(--blocked)' }}>
+        {count} session{count !== 1 ? 's' : ''} {count !== 1 ? 'need' : 'needs'} attention
+      </span>
+      <span className="text-xs text-[var(--text-muted)]">
+        {active ? '-- click to clear filter' : '-- click to focus'}
+      </span>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Archive links
+// ---------------------------------------------------------------------------
+
+function ArchiveLinks({
+  repos,
+  onOpen,
+}: {
+  // Pre-computed from the unfiltered join so all repos are always shown
+  // regardless of attention filter or scope.
+  readonly repos: ReadonlyArray<readonly [string, string]>;
+  readonly onOpen: (repoName: string | undefined, repoRoot: string | undefined) => void;
+}) {
+
+  // Always show at least the global link so users with only null-repoRoot sessions
+  // (pre-dating the repoRoot observation) can still reach the full archive.
+  return (
+    <div className="flex flex-col gap-1 pt-2 border-t border-[var(--border)]">
+      {repos.map(([repoRoot, repoName]) => (
+        <button
+          key={repoRoot}
+          type="button"
+          onClick={() => onOpen(repoName, repoRoot)}
+          className="text-xs text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors text-left"
+        >
+          All {repoName} sessions &rarr;
+        </button>
+      ))}
+      {/* Global link: always shown so null-repoRoot sessions are always reachable */}
+      {repos.length !== 1 && (
+        <button
+          type="button"
+          onClick={() => onOpen(undefined, undefined)}
+          className="text-xs text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors text-left"
+        >
+          All sessions &rarr;
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Workspace empty active state
+// ---------------------------------------------------------------------------
+
+function WorkspaceEmptyActive() {
+  return (
+    <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg px-4 py-6 text-center">
+      <p className="text-sm text-[var(--text-muted)]">
+        No active work. Start a workflow with your agent to see it here.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Full empty state (no sessions at all)
+// ---------------------------------------------------------------------------
+
+function FullEmptyState({ prompt }: { readonly prompt: ActionPrompt }) {
+  return (
+    <div className="flex flex-col items-center gap-8 py-20 text-center">
+      <div>
+        <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-3">
+          Ready when you are
+        </h2>
+        <p className="text-sm text-[var(--text-muted)] max-w-sm leading-relaxed">
+          Sessions appear here when your agent runs a workflow. Start one by telling your agent:
+        </p>
+      </div>
+
+      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl px-6 py-5 max-w-lg w-full text-left">
+        <p className="text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider mb-2">
+          Try this prompt
+        </p>
+        <p className="text-[var(--text-primary)] text-sm leading-relaxed">
+          "Use the{' '}
+          <span className="text-[var(--accent)] font-medium">{prompt.workflow}</span>
+          {' '}to {prompt.task}"
+        </p>
+      </div>
+
+      <p className="text-xs text-[var(--text-muted)]">
+        Prompts rotate each visit -- there are {ACTION_PROMPTS.length} to discover.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tip card with 60s rotation and fade transition
+// ---------------------------------------------------------------------------
+
+function TipCard() {
+  const [tipIndex, setTipIndex] = useState(() =>
+    Math.floor(Math.random() * DISCOVERY_TIPS.length),
+  );
+  const [fading, setFading] = useState(false);
+
+  useEffect(() => {
+    // Track the fade timeout so it can be cancelled if the component unmounts
+    // mid-fade. setInterval ignores return values so the timeout must be tracked
+    // outside the callback.
+    let fadeTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    const interval = setInterval(() => {
+      setFading(true);
+      fadeTimeout = setTimeout(() => {
+        setTipIndex((prev) => (prev + 1) % DISCOVERY_TIPS.length);
+        setFading(false);
+        fadeTimeout = null;
+      }, 300);
+    }, 60_000);
+
+    return () => {
+      clearInterval(interval);
+      if (fadeTimeout !== null) clearTimeout(fadeTimeout);
+    };
+  }, []);
+
+  return (
+    <div className="flex items-start gap-3 bg-[var(--bg-card)] border border-[var(--border)] rounded-lg px-4 py-3">
+      <div
+        className="w-0.5 shrink-0 self-stretch rounded-full"
+        style={{ backgroundColor: 'var(--accent)' }}
+      />
+      <div style={{ opacity: fading ? 0 : 1, transition: 'opacity 300ms' }}>
+        <span className="text-[10px] font-semibold text-[var(--accent)] uppercase tracking-widest">
+          Tip
+        </span>
+        <p className="text-sm text-[var(--text-secondary)] mt-1 leading-relaxed">
+          {DISCOVERY_TIPS[tipIndex]}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard navigation hook
+// ---------------------------------------------------------------------------
+
+interface KeyboardOptions {
+  readonly items: readonly WorkspaceItem[];
+  readonly focusedIndex: number;
+  readonly setFocusedIndex: (i: number) => void;
+  readonly expandedKey: string | null;
+  readonly setExpandedKey: (key: string | null) => void;
+  readonly scope: Scope;
+  readonly setScope: (scope: Scope) => void;
+  readonly refetch: () => void;
+  readonly archive: ArchiveState | null;
+  readonly setArchive: (state: ArchiveState | null) => void;
+  readonly disabled: boolean;
+}
+
+function useWorkspaceKeyboard({
+  items,
+  focusedIndex,
+  setFocusedIndex,
+  expandedKey,
+  setExpandedKey,
+  scope,
+  setScope,
+  refetch,
+  archive,
+  setArchive,
+  disabled,
+}: KeyboardOptions) {
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+
+  const expandedKeyRef = useRef(expandedKey);
+  expandedKeyRef.current = expandedKey;
+
+  const scopeRef = useRef(scope);
+  scopeRef.current = scope;
+
+  const focusedIndexRef = useRef(focusedIndex);
+  focusedIndexRef.current = focusedIndex;
+
+  const archiveRef = useRef(archive);
+  archiveRef.current = archive;
+
+  const disabledRef = useRef(disabled);
+  disabledRef.current = disabled;
+
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      // Skip when the workspace view is hidden behind SessionDetail
+      if (disabledRef.current) return;
+
+      // Skip if focus is inside an input or textarea (avoid interfering with typing)
+      const active = document.activeElement;
+      if (
+        active instanceof HTMLInputElement ||
+        active instanceof HTMLTextAreaElement ||
+        active instanceof HTMLSelectElement
+      ) {
+        return;
+      }
+
+      // Close archive on Escape
+      if (e.key === 'Escape' && archiveRef.current !== null) {
+        setArchive(null);
+        return;
+      }
+
+      const items = itemsRef.current;
+      const expandedKey = expandedKeyRef.current;
+      const focusedIndex = focusedIndexRef.current;
+
+      switch (e.key) {
+        case 'j':
+        case 'ArrowDown': {
+          e.preventDefault();
+          const next = Math.min(focusedIndex + 1, items.length - 1);
+          setFocusedIndex(next);
+          break;
+        }
+        case 'k':
+        case 'ArrowUp': {
+          e.preventDefault();
+          const prev = Math.max(focusedIndex - 1, 0);
+          setFocusedIndex(prev);
+          break;
+        }
+        case 'Enter':
+        case ' ': {
+          e.preventDefault();
+          if (focusedIndex >= 0 && focusedIndex < items.length) {
+            const item = items[focusedIndex];
+            const key = `${item.branch}\0${item.repoRoot}`;
+            setExpandedKey(expandedKey === key ? null : key);
+          }
+          break;
+        }
+        case 'Escape': {
+          if (expandedKey !== null) {
+            e.preventDefault();
+            setExpandedKey(null);
+          }
+          break;
+        }
+        case '/': {
+          e.preventDefault();
+          setArchive({ repoName: undefined, repoRoot: undefined });
+          break;
+        }
+        case 'r': {
+          e.preventDefault();
+          refetch();
+          break;
+        }
+        case 'a': {
+          e.preventDefault();
+          setScope(scopeRef.current === 'active' ? 'all' : 'active');
+          break;
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [setFocusedIndex, setExpandedKey, setScope, refetch, setArchive]);
+}

--- a/console/src/views/workspace-types.ts
+++ b/console/src/views/workspace-types.ts
@@ -1,0 +1,288 @@
+import type {
+  ConsoleSessionSummary,
+  ConsoleWorktreeSummary,
+  ConsoleRepoWorktrees,
+  ConsoleSessionStatus,
+} from '../api/types';
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+export type Scope = 'active' | 'all';
+
+/**
+ * 'active'  -- has a running, stalled, or blocked workflow (featured card)
+ * 'recent'  -- clean or uncommitted-only, touched recently (compact row)
+ * 'hidden'  -- clean, done, no activity within 30 days (omitted in Active scope)
+ */
+export type SectionKind = 'active' | 'recent' | 'hidden';
+
+/**
+ * One item per branch per repo -- the natural unit of work identity.
+ *
+ * repoRoot is always non-null here. Null-repoRoot sessions are excluded before
+ * the join and are only accessible via the archive link.
+ *
+ * activityMs is precomputed by joinSessionsAndWorktrees(); never recomputed
+ * in rendering components.
+ */
+export interface WorkspaceItem {
+  readonly branch: string;
+  readonly repoRoot: string;
+  readonly repoName: string;
+  /** Undefined when no git worktree exists for this branch. Git badges degrade to dash. */
+  readonly worktree: ConsoleWorktreeSummary | undefined;
+  /** The most relevant session for this branch per the priority order. */
+  readonly primarySession: ConsoleSessionSummary | undefined;
+  readonly allSessions: readonly ConsoleSessionSummary[];
+  /**
+   * max(primarySession.lastModifiedMs, worktree.headTimestampMs)
+   * Pre-computed here so components never need to recompute it.
+   */
+  readonly activityMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Priority order for selecting the primary session from a branch's sessions. */
+const STATUS_PRIORITY: Record<ConsoleSessionStatus, number> = {
+  in_progress: 0,
+  dormant: 0,      // treated same as in_progress for placement
+  blocked: 1,
+  complete_with_gaps: 2,
+  complete: 3,
+};
+
+// ---------------------------------------------------------------------------
+// Pure functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Selects the most representative session for a WorkspaceItem.
+ *
+ * Priority: in_progress/dormant (most recently updated) > blocked >
+ * complete_with_gaps > most recently modified (any status).
+ */
+export function selectPrimarySession(
+  sessions: readonly ConsoleSessionSummary[],
+): ConsoleSessionSummary | undefined {
+  if (sessions.length === 0) return undefined;
+  return [...sessions].sort((a, b) => {
+    const priorityDiff = STATUS_PRIORITY[a.status] - STATUS_PRIORITY[b.status];
+    if (priorityDiff !== 0) return priorityDiff;
+    return b.lastModifiedMs - a.lastModifiedMs;
+  })[0];
+}
+
+/**
+ * Determines which section a WorkspaceItem belongs to.
+ *
+ * Active  -- has in_progress, dormant, or blocked session
+ * Recent  -- uncommitted/unpushed changes OR (clean+done, activity within 30d)
+ * Hidden  -- clean, done, no activity within 30 days (omitted in Active scope)
+ */
+export function sectionFor(
+  item: WorkspaceItem,
+  scope: Scope,
+  nowMs: number,
+): SectionKind {
+  const status = item.primarySession?.status;
+  if (
+    status === 'in_progress' ||
+    status === 'dormant' ||
+    status === 'blocked'
+  ) {
+    return 'active';
+  }
+
+  const hasUncommitted = (item.worktree?.changedCount ?? 0) > 0;
+  const hasUnpushed = (item.worktree?.aheadCount ?? 0) > 0;
+  if (hasUncommitted || hasUnpushed) {
+    return 'recent';
+  }
+
+  const isRecent = nowMs - item.activityMs < THIRTY_DAYS_MS;
+  if (isRecent) {
+    return 'recent';
+  }
+
+  // Clean, done, no activity in 30 days
+  if (scope === 'all') {
+    // In All scope, include everything -- no time cutoff
+    return 'recent';
+  }
+  return 'hidden';
+}
+
+/** Numeric sort key for a section: active first, recent second. */
+function sectionOrder(section: SectionKind): number {
+  switch (section) {
+    case 'active': return 0;
+    case 'recent': return 1;
+    case 'hidden': return 2;
+  }
+}
+
+/** Numeric sort key for an item within a section. */
+function itemSortKey(item: WorkspaceItem): number {
+  const status = item.primarySession?.status;
+  switch (status) {
+    case 'in_progress':
+    case 'dormant':
+      return 0;
+    case 'blocked':
+      return 1;
+    default: {
+      const hasChanges =
+        (item.worktree?.changedCount ?? 0) > 0 ||
+        (item.worktree?.aheadCount ?? 0) > 0;
+      return hasChanges ? 2 : 3;
+    }
+  }
+}
+
+/**
+ * Sorts WorkspaceItems by section (active first) then by status group then by
+ * activityMs descending (most recently touched first within group).
+ *
+ * Returns a new array -- does not mutate the input.
+ */
+export function sortWorkspaceItems(
+  items: readonly WorkspaceItem[],
+  scope: Scope,
+  nowMs: number,
+): WorkspaceItem[] {
+  return [...items]
+    .filter((item) => sectionFor(item, scope, nowMs) !== 'hidden')
+    .sort((a, b) => {
+      const sectionDiff =
+        sectionOrder(sectionFor(a, scope, nowMs)) -
+        sectionOrder(sectionFor(b, scope, nowMs));
+      if (sectionDiff !== 0) return sectionDiff;
+
+      const keyDiff = itemSortKey(a) - itemSortKey(b);
+      if (keyDiff !== 0) return keyDiff;
+
+      return b.activityMs - a.activityMs;
+    });
+}
+
+/**
+ * Client-side join of sessions and worktrees into WorkspaceItems.
+ *
+ * - Sessions with repoRoot=null are excluded from the result. They are only
+ *   accessible via the global archive link.
+ * - Branches that exist only as worktrees (no sessions) are included.
+ * - Branches that exist only as sessions (no matching worktree) are included
+ *   with worktree=undefined.
+ *
+ * The join key is `branch + '\0' + repoRoot` to avoid collisions between repos
+ * that share branch names.
+ */
+export function joinSessionsAndWorktrees(
+  sessions: readonly ConsoleSessionSummary[],
+  worktreeRepos: readonly ConsoleRepoWorktrees[],
+): WorkspaceItem[] {
+  // Index worktrees by join key for O(1) lookup
+  const worktreeByKey = new Map<string, { wt: ConsoleWorktreeSummary; repoName: string }>();
+  for (const repo of worktreeRepos) {
+    for (const wt of repo.worktrees) {
+      if (wt.branch !== null) {
+        worktreeByKey.set(`${wt.branch}\0${repo.repoRoot}`, { wt, repoName: repo.repoName });
+      }
+    }
+  }
+
+  // Group sessions by join key, excluding null-repoRoot sessions
+  const sessionsByKey = new Map<string, ConsoleSessionSummary[]>();
+  for (const session of sessions) {
+    if (session.repoRoot === null || session.gitBranch === null) continue;
+    const key = `${session.gitBranch}\0${session.repoRoot}`;
+    const existing = sessionsByKey.get(key);
+    if (existing) {
+      existing.push(session);
+    } else {
+      sessionsByKey.set(key, [session]);
+    }
+  }
+
+  // Build repoName index from sessions for branches without worktrees
+  // Use the last segment of repoRoot as a fallback repoName
+  const repoNameByRoot = new Map<string, string>();
+  for (const repo of worktreeRepos) {
+    repoNameByRoot.set(repo.repoRoot, repo.repoName);
+  }
+
+  const items: WorkspaceItem[] = [];
+  const processedKeys = new Set<string>();
+
+  // Process all branches that have sessions
+  for (const [key, branchSessions] of sessionsByKey) {
+    const [branch, repoRoot] = key.split('\0') as [string, string];
+    const worktreeEntry = worktreeByKey.get(key);
+    const primarySession = selectPrimarySession(branchSessions);
+    const activityMs = Math.max(
+      primarySession?.lastModifiedMs ?? 0,
+      worktreeEntry?.wt.headTimestampMs ?? 0,
+    );
+    const repoName =
+      worktreeEntry?.repoName ??
+      repoNameByRoot.get(repoRoot) ??
+      repoRoot.split('/').at(-1) ??
+      repoRoot;
+
+    items.push({
+      branch,
+      repoRoot,
+      repoName,
+      worktree: worktreeEntry?.wt,
+      primarySession,
+      allSessions: branchSessions,
+      activityMs,
+    });
+    processedKeys.add(key);
+  }
+
+  // Process worktree-only branches (no sessions recorded yet)
+  for (const [key, { wt, repoName }] of worktreeByKey) {
+    if (processedKeys.has(key)) continue;
+    const [branch, repoRoot] = key.split('\0') as [string, string];
+    items.push({
+      branch,
+      repoRoot,
+      repoName,
+      worktree: wt,
+      primarySession: undefined,
+      allSessions: [],
+      activityMs: wt.headTimestampMs,
+    });
+  }
+
+  return items;
+}
+
+/**
+ * Returns the count of sessions that need attention (blocked or dormant).
+ * Used by AlertStrip.
+ */
+export function countNeedsAttention(items: readonly WorkspaceItem[]): number {
+  return items.reduce((count, item) => {
+    const status = item.primarySession?.status;
+    return status === 'blocked' || status === 'dormant' ? count + 1 : count;
+  }, 0);
+}
+
+/**
+ * Returns the count of sessions that have unresolved gaps across all items.
+ */
+export function countHasGaps(items: readonly WorkspaceItem[]): number {
+  return items.reduce((count, item) => {
+    const hasGap = item.allSessions.some((s) => s.hasUnresolvedGaps);
+    return hasGap ? count + 1 : count;
+  }, 0);
+}


### PR DESCRIPTION
## Summary

- Replaces Sessions as the default landing tab with a unified **Workspace** view that shows one card per branch, joining git worktree state and primary session data
- **Active section**: in_progress/dormant/blocked sessions as featured cards with recap headline, git badges (uncommitted/unpushed), and an inline accordion session list
- **Recent section**: uncommitted-only or clean+done within 30 days as compact rows
- Git badges degrade gracefully to nothing when no worktree data -- single rendering path, no conditional layout branch
- Scope toggle (Active/All), clickable alert strip to filter blocked/dormant, keyboard nav (j/k/Enter/Escape/r/a//), TipCard with 60s fade rotation
- Sessions and Worktrees tabs remain with a redirect banner; full removal is a follow-up PR
- Null-repoRoot sessions (pre-dating the repoRoot observation) excluded from main view, always reachable via archive links

## Test plan

- [ ] Open console -- Workspace is the default tab
- [ ] With worktrees: Active/Recent sections render correctly, git badges populated
- [ ] Without worktrees: git badges absent, layout identical
- [ ] Click featured card -- accordion expands inline with session list
- [ ] Click session row -- SessionDetail opens; Back restores scroll position and re-expands card
- [ ] Scope toggle Active <-> All: hidden branches appear, "Recent" becomes "All branches"
- [ ] Alert strip click -- filters to blocked/dormant; click again resets scope and clears filter
- [ ] TipCard -- wait 60s, tip changes with fade
- [ ] Keyboard: j/k navigate, Enter expand, Escape collapse, r refresh, a toggle scope
- [ ] Archive links: "All [repo] sessions" and "All sessions" open inline SessionList
- [ ] Sessions tab -- redirect banner visible, existing behavior intact
- [ ] Worktrees tab -- redirect banner visible, existing behavior intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)