### PR TITLE
docs: mark retrieval budget strengthening as complete

### DIFF
--- a/docs/roadmap/now-next-later.md
+++ b/docs/roadmap/now-next-later.md
@@ -8,7 +8,7 @@ This is the lightweight cross-cutting roadmap view for WorkRail.
 - ~~Expand lifecycle validation coverage to a realistic target~~ (done -- auto-walk smoke test covers all bundled workflows)
 - ~~Finish prompt vs supplement boundary alignment across runtime, docs, and planning~~ (done -- boundary is documented consistently across authoring locks, execution contract, and planning docs)
 - ~~Modernize `workflow-for-workflows.v2.json` so one canonical authoring workflow supports both creating and modernizing workflows~~ (done -- shipped in `#152`, tracked from issue `#151`)
-- Strengthen rehydrate and resume retrieval budgets with deterministic retrieval contracts and broader verification
+- ~~Strengthen rehydrate and resume retrieval budgets with deterministic retrieval contracts and broader verification~~ (done -- explicit tiered contracts, 24 KB recovery budget, 2 KB resume preview budget, tier-drop tests; shipped in `#144161e`)
 - ~~Modernize `workflow-for-workflows.v2.json` so one canonical authoring workflow supports both creating and modernizing workflows~~ (done -- modernization support landed earlier; the workflow has now been pushed further into a deeper quality gate with effectiveness, simulation, adversarial review, and redesign-loop phases)
 
 ## Next

--- a/docs/roadmap/open-work-inventory.md
+++ b/docs/roadmap/open-work-inventory.md
@@ -14,22 +14,18 @@ For explicit status on the major older planning docs themselves, see `docs/roadm
 
 ## Active partials
 
-### 1. Retrieval budget and recovery-surface strengthening
+### ~~1. Retrieval budget and recovery-surface strengthening~~ (done)
 
-- **Status**: active
-- **Why it is here**: the old budget system was too conservative for agent usefulness, especially on `rehydrate` and `resume_session`
-- **What was delivered so far**:
+- **Status**: complete
+- **What was delivered**:
   - explicit retrieval contracts for rehydrate and resume preview surfaces
   - deterministic tiering with `core` vs `tail` retention behavior
-  - larger bounded budgets for recovery packs and resume previews
+  - 24 KB recovery budget, 2 KB resume preview budget
   - stronger behavior tests covering tier dropping, bounded rendering, and usefulness-oriented scenarios
-- **Still open**:
-  - decide whether the current tier model needs refinement after more real usage
-  - finish broader doc/spec cleanup wherever the old budget story still leaks through
-  - decide whether checkpoint-related retrieval should stay as-is or follow the same contract pattern later
-- **Source docs**:
-  - `docs/design/v2-core-design-locks.md`
-  - `docs/reference/workflow-execution-contract.md`
+  - design-lock docs and MCP schema updated to match new budget values
+- **Remaining decisions** (parked, not blocking):
+  - whether the current tier model needs refinement after more real usage
+  - whether checkpoint-related retrieval should follow the same contract pattern later
 
 ### ~~2. Clean response formatting and supplement hardening~~ (done)
 


### PR DESCRIPTION
## Summary

- Marks retrieval budget strengthening as done in `now-next-later.md` and `open-work-inventory.md`
- Implementation was fully shipped (tiered contracts, 24KB/2KB budgets, tier-drop tests) but both planning docs still showed it as active

🤖 Generated with [Claude Code](https://claude.com/claude-code)