### PR TITLE
feat(phase2a): wire managed sources into catalog + composition (Slice 4)

### DIFF
--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -496,3 +496,136 @@ managedSourcesLockPath(): string {
 - `V2Dependencies.managedSourceStore` is optional and wired in production bootstrap
 - All 6 unit tests pass
 - `npm run build` passes with no type errors
+
+## 17. Slice 4 Technical Specification
+
+### Status
+
+In progress.
+
+### Problem statement
+
+After Slices 1-3, managed sources exist in the persistence layer but are invisible to the rest of the system. Attaching a workflow directory via `manage_workflow_source` has no effect on:
+- workflow resolution (workflows from that directory do not appear in `list_workflows`)
+- the source catalog (the directory does not appear in `list_workflows` `sources` output)
+
+This means Slice 3's attach operation is currently a no-op from the user's perspective. Slice 4 closes this gap by:
+1. Wiring managed source paths into the workflow composition
+2. Annotating catalog entries with `category: 'managed'` when the source was explicitly attached
+3. Preventing dual truth when a managed path is also a rooted-sharing discovered path (show ONE entry with explicit relationship)
+
+### Acceptance criteria
+
+- After attaching a workflow directory via `manage_workflow_source`, its workflows appear in `list_workflows` (workflow resolution includes managed paths)
+- After attaching, `list_workflows` with `includeSources: true` includes a catalog entry with `category: 'managed'` for the attached directory
+- The catalog entry for a managed source includes `managed: { addedAtMs: <epoch_ms> }`
+- When the same path is both managed AND discovered via remembered-roots (rooted-sharing): ONE catalog entry with `category: 'managed'` and `rootedSharing` context present (no dual entry)
+- Existing catalog behavior is unchanged: rooted-sharing entries without managed attachment remain `category: 'rooted_sharing'`; migration guidance still surfaces
+- `npm run build` passes with no type errors
+- All new and existing tests pass
+
+### Non-goals
+
+- Per-workflow `visibility.category` showing `'managed'` (catalog-level annotation is sufficient)
+- New MCP tools for querying managed sources
+- Managed source lifecycle (update, health, sync)
+- Breaking changes to existing enum values
+
+### Selected approach
+
+**Handler-level record collection + factory path injection (Approach D)**
+
+1. Handler (`handleV2ListWorkflows`, `handleV2InspectWorkflow`) lists managed records from `guard.ctx.v2.managedSourceStore` using a new `listManagedSourceRecords` helper
+2. Passes path array via new `managedPaths?: readonly string[]` option to `createWorkflowReaderForRequest`
+3. Factory deduplicates managed paths against already-discovered custom paths and appends the net-new ones to `customPaths`
+4. Handler passes managed records to `buildSourceCatalog`
+5. `buildSourceCatalog` passes records to `deriveSourceCatalogEntry`
+6. `deriveSourceCatalogEntry` annotates custom sources whose path matches a managed record with `category: 'managed'` + `managed: { addedAtMs }`; if also rooted-sharing, includes `rootedSharing` context too
+
+**Why this approach**: Consistent with existing pattern where handler fetches all dependencies (e.g., `listRememberedRootRecords` is called at handler scope, not inside factory). Factory responsibility stays pure. `WorkflowReaderForRequestResult` type unchanged.
+
+**Runner-up**: Factory-owns-fetch (A) -- same outcome but factory owns record fetching and returns records in result. Slightly less consistent with existing handler-fetches-dependencies pattern.
+
+### Files to change (4)
+
+1. `src/mcp/handlers/shared/request-workflow-reader.ts`
+   - Add `managedPaths?: readonly string[]` to `RequestWorkflowReaderOptions`
+   - Add `listManagedSourceRecords(store)` helper (returns `readonly ManagedSourceRecordV2[]`, throws on error)
+   - In `createWorkflowReaderForRequest`: deduplicate managed paths against discovered customPaths; append net-new
+
+2. `src/mcp/handlers/v2-workflow.ts`
+   - In `handleV2ListWorkflows`: call `listManagedSourceRecords`, pass paths to `createWorkflowReaderForRequest`, pass records to `buildSourceCatalog`
+   - In `handleV2InspectWorkflow`: call `listManagedSourceRecords`, pass paths to `createWorkflowReaderForRequest` (no catalog here)
+   - Extend `buildSourceCatalog` signature to accept `managedSourceRecords`
+   - Extend `deriveSourceCatalogEntry` to accept + use managed records
+
+3. `src/mcp/output-schemas.ts`
+   - Add `'managed'` to `V2WorkflowSourceCatalogEntrySchema.category` enum
+   - Add `managed: z.object({ addedAtMs: z.number().int().min(0) }).optional()` field
+
+4. `tests/unit/mcp/v2-workflow-source-catalog-output.test.ts`
+   - New test: attached managed source appears in catalog with `category: 'managed'`, `managed: { addedAtMs }`; its workflows appear in listing
+   - New test: managed source that is also a remembered root shows ONE catalog entry with `category: 'managed'` and `rootedSharing` context (dedup)
+   - New tests must use a modified `buildCtx` that includes `managedSourceStore: new InMemoryManagedSourceStoreV2()` in `v2` deps (existing `buildCtx` helper does not set `managedSourceStore`; write a new `buildCtxWithManagedStore` or extend via `as any` cast using the existing minimal context shape)
+   - Existing tests must remain green (no regression)
+
+### Key invariants
+
+**Deduplication logic in factory**:
+```
+const normalizedCustom = new Set(customPaths.map(p => path.resolve(p)));
+const additionalManaged = (options.managedPaths ?? []).filter(p => !normalizedCustom.has(path.resolve(p)));
+allCustomPaths = [...customPaths, ...additionalManaged];
+```
+
+**Catalog annotation logic for custom sources**:
+```
+const managedRecord = managedRecords.find(r => path.resolve(r.path) === path.resolve(source.directoryPath));
+const rootedSharing = deriveRootedSharingForPath(source.directoryPath, rememberedRootRecords);
+if (managedRecord) {
+  return { ..., category: 'managed', managed: { addedAtMs: managedRecord.addedAtMs }, ...(rootedSharing ? { rootedSharing } : {}) };
+}
+// existing rooted_sharing / external logic unchanged
+```
+
+**listManagedSourceRecords** throws on error (same pattern as `listRememberedRoots`).
+
+### Test design
+
+#### New tests in `tests/unit/mcp/v2-workflow-source-catalog-output.test.ts`
+
+**Test 1: managed source visibility**
+- Create temp dir with workflow files
+- Build ctx with `InMemoryManagedSourceStoreV2` pre-attached to that dir
+- Call `handleV2ListWorkflows({ workspacePath, includeSources: true }, ctx)`
+- Assert: workflow from managed dir appears in `result.data.workflows`
+- Assert: `result.data.sources` has entry with `category: 'managed'`, `managed.addedAtMs >= 0`, `effectiveWorkflowCount: 1`
+
+**Test 2: managed + rooted-sharing dedup (the dual-truth test)**
+- Create temp dir with workflow files
+- Set dir as both a managed source AND a remembered root (so discovery would find it)
+- Call `handleV2ListWorkflows({ workspacePath, includeSources: true }, ctx)`
+- Assert: sources has exactly ONE entry for that path (not two)
+- Assert: that entry has `category: 'managed'` and `rootedSharing` present
+
+**Regression**: all 4 existing catalog tests must still pass.
+
+### Risk register
+
+**Low -- Path normalization inconsistency**: If path.resolve() is not called consistently in the dedup set and in the managed record lookup, a path could appear twice. Mitigation: always call path.resolve() at both sites.
+
+**Low -- managedSourceStore null/undefined in test ctx**: Existing tests use a minimal ctx that doesn't include managedSourceStore. If `listManagedSourceRecords` is called unconditionally and the store is absent, it should return `[]` gracefully (not throw). Mitigation: `if (!store) return []` guard.
+
+**Low -- Stale path detection gap for managed sources**: Managed paths are added to `customPaths` AFTER `discoverRootedWorkflowDirectories`, so they bypass the stale detection mechanism. Non-existent managed paths won't appear in `staleRoots`. Graceful degradation handles missing filesystem paths silently (0-count entries). Acceptable for Slice 4; managed stale detection is future work.
+
+### PR packaging
+
+Single PR. All changes are in 4 files, purely additive, no breaking changes.
+
+### Philosophy alignment
+
+- **Architectural fixes over patches** -> satisfied: wires managed sources into composition properly, not a metadata overlay
+- **Make illegal states unrepresentable** -> satisfied: `managed` category in schema exactly represents the new state; no ambiguity
+- **Validate at boundaries, trust inside** -> satisfied: managed paths normalized at boundary; catalog logic trusts normalized values
+- **YAGNI with discipline** -> satisfied: no per-workflow visibility change, no new MCP tools; smallest change that makes attach useful
+- **Determinism over cleverness** -> satisfied: dedup is deterministic (path.resolve normalization); catalog order preserved

--- a/src/mcp/handlers/shared/request-workflow-reader.ts
+++ b/src/mcp/handlers/shared/request-workflow-reader.ts
@@ -6,6 +6,7 @@ import type { IFeatureFlagProvider } from '../../../config/feature-flags.js';
 import { createEnhancedMultiSourceWorkflowStorage } from '../../../infrastructure/storage/enhanced-multi-source-workflow-storage.js';
 import { SchemaValidatingCompositeWorkflowStorage } from '../../../infrastructure/storage/schema-validating-workflow-storage.js';
 import type { RememberedRootsStorePortV2 } from '../../../v2/ports/remembered-roots-store.port.js';
+import type { ManagedSourceRecordV2, ManagedSourceStorePortV2 } from '../../../v2/ports/managed-source-store.port.js';
 
 export interface RequestWorkflowReaderOptions {
   readonly featureFlags: IFeatureFlagProvider;
@@ -13,6 +14,7 @@ export interface RequestWorkflowReaderOptions {
   readonly resolvedRootUris?: readonly string[];
   readonly serverCwd?: string;
   readonly rememberedRootsStore?: RememberedRootsStorePortV2;
+  readonly managedSourceStore?: ManagedSourceStorePortV2;
 }
 
 export function hasRequestWorkspaceSignal(options: {
@@ -81,6 +83,7 @@ export async function discoverRootedWorkflowDirectories(
 export interface WorkflowReaderForRequestResult {
   readonly reader: IWorkflowReader;
   readonly stalePaths: readonly string[];
+  readonly managedSourceRecords: readonly ManagedSourceRecordV2[];
 }
 
 export async function createWorkflowReaderForRequest(
@@ -90,7 +93,18 @@ export async function createWorkflowReaderForRequest(
   const projectWorkflowDirectory = toProjectWorkflowDirectory(workspaceDirectory);
   const rememberedRoots = await listRememberedRoots(options.rememberedRootsStore);
   const { discovered: rootedWorkflowDirectories, stale: stalePaths } = await discoverRootedWorkflowDirectories(rememberedRoots);
-  const customPaths = rootedWorkflowDirectories.filter((directory) => directory !== projectWorkflowDirectory);
+  const rootedCustomPaths = rootedWorkflowDirectories.filter((directory) => directory !== projectWorkflowDirectory);
+
+  // Include managed source paths, deduplicating against already-discovered custom paths.
+  // Managed paths are added after rooted discovery so they don't affect the stale detection
+  // mechanism (which operates on remembered roots, not managed paths).
+  const managedSourceRecords = await listManagedSourceRecords(options.managedSourceStore);
+  const normalizedCustom = new Set(rootedCustomPaths.map((p) => path.resolve(p)));
+  const additionalManagedPaths = managedSourceRecords
+    .map((r) => r.path) // already normalized by the store
+    .filter((p) => !normalizedCustom.has(path.resolve(p)));
+  const customPaths = [...rootedCustomPaths, ...additionalManagedPaths];
+
   // Use the factory (rather than `new EnhancedMultiSourceWorkflowStorage`) so that
   // env-configured sources (WORKFLOW_GIT_REPOS, WORKFLOW_STORAGE_PATH, etc.) are included
   // in every request-scoped reader. This keeps the source catalog (list_workflows
@@ -107,7 +121,21 @@ export async function createWorkflowReaderForRequest(
     options.featureFlags ?? undefined,
   );
   const reader = new SchemaValidatingCompositeWorkflowStorage(storage);
-  return { reader, stalePaths };
+  return { reader, stalePaths, managedSourceRecords };
+}
+
+async function listManagedSourceRecords(
+  managedSourceStore: ManagedSourceStorePortV2 | undefined,
+): Promise<readonly ManagedSourceRecordV2[]> {
+  if (!managedSourceStore) return [];
+
+  const result = await managedSourceStore.list();
+  if (result.isErr()) {
+    const error = result.error;
+    throw new Error(`Failed to load managed workflow sources: ${error.code}: ${error.message}`);
+  }
+
+  return result.value;
 }
 
 async function listRememberedRoots(

--- a/src/mcp/handlers/v2-workflow.ts
+++ b/src/mcp/handlers/v2-workflow.ts
@@ -9,6 +9,7 @@ import type { V2InspectWorkflowInput, V2ListWorkflowsInput } from '../v2/tools.j
 import { V2WorkflowInspectOutputSchema, V2WorkflowListOutputSchema } from '../output-schemas.js';
 import type { StalenessSummary } from '../output-schemas.js';
 import type { RememberedRootRecordV2 } from '../../v2/ports/remembered-roots-store.port.js';
+import type { ManagedSourceRecordV2 } from '../../v2/ports/managed-source-store.port.js';
 import type { CryptoPortV2 } from '../../v2/durable-core/canonical/hashing.js';
 import type { PinnedWorkflowStorePortV2 } from '../../v2/ports/pinned-workflow-store.port.js';
 import type { Workflow } from '../../types/workflow.js';
@@ -128,10 +129,12 @@ export async function handleV2ListWorkflows(
         workspacePath: input.workspacePath,
         resolvedRootUris: guard.ctx.v2.resolvedRootUris,
         rememberedRootsStore: guard.ctx.v2.rememberedRootsStore,
+        managedSourceStore: guard.ctx.v2.managedSourceStore,
       })
-    : { reader: ctx.workflowService, stalePaths: [] as string[] };
+    : { reader: ctx.workflowService, stalePaths: [] as string[], managedSourceRecords: [] as ManagedSourceRecordV2[] };
   const workflowReader = readerResult.reader;
   const stalePaths = readerResult.stalePaths;
+  const managedSourceRecords = readerResult.managedSourceRecords;
 
   return ResultAsync.fromPromise(
     withTimeout(workflowReader.listWorkflowSummaries(), TIMEOUT_MS, 'list_workflows'),
@@ -172,7 +175,7 @@ export async function handleV2ListWorkflows(
         return okAsync(success(payload) as ToolResult<unknown>);
       }
       return ResultAsync.fromPromise(
-        withTimeout(buildSourceCatalog(workflowReader, rememberedRootRecords), TIMEOUT_MS, 'list_workflow_sources'),
+        withTimeout(buildSourceCatalog(workflowReader, rememberedRootRecords, managedSourceRecords), TIMEOUT_MS, 'list_workflow_sources'),
         (err) => mapUnknownErrorToToolError(err),
       ).map((sources) => {
         const payload = V2WorkflowListOutputSchema.parse({
@@ -210,8 +213,9 @@ export async function handleV2InspectWorkflow(
         workspacePath: input.workspacePath,
         resolvedRootUris: guard.ctx.v2.resolvedRootUris,
         rememberedRootsStore: guard.ctx.v2.rememberedRootsStore,
+        managedSourceStore: guard.ctx.v2.managedSourceStore,
       })
-    : { reader: ctx.workflowService, stalePaths: [] as string[] };
+    : { reader: ctx.workflowService, stalePaths: [] as string[], managedSourceRecords: [] as ManagedSourceRecordV2[] };
   const workflowReader = readerResult.reader;
   const stalePaths = readerResult.stalePaths;
 
@@ -389,6 +393,7 @@ interface SourceEntryData {
 async function buildSourceCatalog(
   workflowReader: import('../../types/storage.js').ICompositeWorkflowStorage,
   rememberedRootRecords: readonly RememberedRootRecordV2[],
+  managedSourceRecords: readonly ManagedSourceRecordV2[],
 ): Promise<ReadonlyArray<Record<string, unknown>>> {
   const instances = workflowReader.getStorageInstances();
 
@@ -412,7 +417,7 @@ async function buildSourceCatalog(
   const sourceEntryData = sourceEntryDataReversed.reverse();
 
   return sourceEntryData.map((data) =>
-    deriveSourceCatalogEntry({ ...data, rememberedRootRecords, sourceEntryData }),
+    deriveSourceCatalogEntry({ ...data, rememberedRootRecords, managedSourceRecords, sourceEntryData }),
   );
 }
 
@@ -421,9 +426,10 @@ function deriveSourceCatalogEntry(options: {
   readonly allIds: readonly string[];
   readonly effectiveIds: readonly string[];
   readonly rememberedRootRecords: readonly RememberedRootRecordV2[];
+  readonly managedSourceRecords: readonly ManagedSourceRecordV2[];
   readonly sourceEntryData: readonly SourceEntryData[];
 }): Record<string, unknown> {
-  const { source, allIds, effectiveIds, rememberedRootRecords, sourceEntryData } = options;
+  const { source, allIds, effectiveIds, rememberedRootRecords, managedSourceRecords, sourceEntryData } = options;
   const total = allIds.length;
   const effective = effectiveIds.length;
   const shadowed = total - effective;
@@ -452,6 +458,25 @@ function deriveSourceCatalogEntry(options: {
 
     case 'custom': {
       const rootedSharing = deriveRootedSharingForPath(source.directoryPath, rememberedRootRecords);
+      const managedRecord = managedSourceRecords.find(
+        (r) => path.resolve(r.path) === path.resolve(source.directoryPath),
+      );
+      if (managedRecord) {
+        // Explicitly attached managed source. Category is 'managed' regardless of whether
+        // it is also a rooted-sharing path. When both apply, include rootedSharing context
+        // so the relationship is visible without creating a second catalog entry (dual truth).
+        return {
+          sourceKey,
+          category: 'managed',
+          source: { kind: source.kind, displayName },
+          sourceMode: 'live_directory',
+          effectiveWorkflowCount: effective,
+          totalWorkflowCount: total,
+          shadowedWorkflowCount: shadowed,
+          managed: { addedAtMs: managedRecord.addedAtMs },
+          ...(rootedSharing ? { rootedSharing } : {}),
+        };
+      }
       const category = rootedSharing ? 'rooted_sharing' : 'external';
       const sourceMode = rootedSharing ? 'rooted_sharing' : 'live_directory';
       return { sourceKey, category, source: { kind: source.kind, displayName }, sourceMode, effectiveWorkflowCount: effective, totalWorkflowCount: total, shadowedWorkflowCount: shadowed, ...(rootedSharing ? { rootedSharing } : {}) };

--- a/src/mcp/output-schemas.ts
+++ b/src/mcp/output-schemas.ts
@@ -120,7 +120,7 @@ export const V2WorkflowSourceCatalogEntrySchema = z.object({
   sourceKey: z.string().min(1).describe(
     'Stable identifier for this source. Format: "{kind}:{absolutePath}" for filesystem sources (e.g. "project:/path/to/workflows", "custom:/path/to/.workrail/workflows"), or "built_in" for bundled sources.'
   ),
-  category: z.enum(['built_in', 'personal', 'legacy_project', 'rooted_sharing', 'external']),
+  category: z.enum(['built_in', 'personal', 'legacy_project', 'rooted_sharing', 'external', 'managed']),
   source: z.object({
     kind: z.enum(['bundled', 'user', 'project', 'custom', 'git', 'remote', 'plugin']),
     displayName: z.string().min(1),
@@ -133,6 +133,9 @@ export const V2WorkflowSourceCatalogEntrySchema = z.object({
     kind: z.literal('remembered_root'),
     rootPath: z.string().min(1),
     groupLabel: z.string().min(1),
+  }).optional(),
+  managed: z.object({
+    addedAtMs: z.number().int().min(0),
   }).optional(),
   migration: z.object({
     preferredSource: z.literal('rooted_sharing'),

--- a/tests/unit/mcp/v2-workflow-source-catalog-output.test.ts
+++ b/tests/unit/mcp/v2-workflow-source-catalog-output.test.ts
@@ -14,6 +14,7 @@ import { NodeCryptoV2 } from '../../../src/v2/infra/local/crypto/index.js';
 import { LocalPinnedWorkflowStoreV2 } from '../../../src/v2/infra/local/pinned-workflow-store/index.js';
 import { createTestValidationPipelineDeps } from '../../helpers/v2-test-helpers.js';
 import type { RememberedRootsStorePortV2 } from '../../../src/v2/ports/remembered-roots-store.port.js';
+import { InMemoryManagedSourceStoreV2 } from '../../../src/v2/infra/in-memory/managed-source-store/index.js';
 
 function writeWorkflow(dir: string, id: string, name: string): void {
   fs.mkdirSync(dir, { recursive: true });
@@ -76,6 +77,20 @@ function buildCtx(rememberedRoots: RememberedRootsStorePortV2): ToolContext {
       rememberedRootsStore: rememberedRoots,
       validationPipelineDeps: createTestValidationPipelineDeps(),
       resolvedRootUris: [],
+    },
+  } as any;
+}
+
+function buildCtxWithManagedStore(
+  rememberedRoots: RememberedRootsStorePortV2,
+  managedStore: InMemoryManagedSourceStoreV2,
+): ToolContext {
+  const base = buildCtx(rememberedRoots);
+  return {
+    ...base,
+    v2: {
+      ...(base.v2 as object),
+      managedSourceStore: managedStore,
     },
   } as any;
 }
@@ -226,5 +241,76 @@ describe('v2 workflow source catalog output', () => {
     if (result.type !== 'success') return;
     const data = result.data as Record<string, unknown>;
     expect(data.sources).toBeUndefined();
+  });
+
+  it('shows attached managed source as category=managed in catalog and its workflows in listing', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-v2-source-catalog-managed-'));
+    const workspace = path.join(tempRoot, 'workspace');
+    const managedDir = path.join(tempRoot, 'managed-workflows');
+
+    fs.mkdirSync(workspace, { recursive: true });
+    writeWorkflow(managedDir, 'managed-workflow', 'Managed Workflow');
+
+    const managedStore = new InMemoryManagedSourceStoreV2();
+    await managedStore.attach(managedDir);
+
+    const result = await handleV2ListWorkflows(
+      { workspacePath: workspace, includeSources: true },
+      buildCtxWithManagedStore(rememberedRootsStore(), managedStore),
+    );
+
+    expect(result.type).toBe('success');
+    if (result.type !== 'success') return;
+
+    const data = result.data as { workflows: Array<{ workflowId: string }>; sources: Array<Record<string, unknown>> };
+
+    // Workflow from managed directory appears in listing
+    expect(data.workflows.some((w) => w.workflowId === 'managed-workflow')).toBe(true);
+
+    // Catalog has a managed entry for the attached directory
+    const managedEntry = data.sources.find((s) => s.category === 'managed');
+    expect(managedEntry).toBeDefined();
+    expect(managedEntry!.sourceKey).toBe(`custom:${path.resolve(managedDir)}`);
+    expect(managedEntry!.sourceMode).toBe('live_directory');
+    expect(managedEntry!.effectiveWorkflowCount).toBe(1);
+    expect((managedEntry!.managed as { addedAtMs: number }).addedAtMs).toBeGreaterThanOrEqual(0);
+    // Not rooted-sharing -- no rootedSharing context expected
+    expect(managedEntry!.rootedSharing).toBeUndefined();
+  });
+
+  it('shows managed source that is also a remembered root as single catalog entry with managed category and rootedSharing context', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-v2-source-catalog-managed-rooted-'));
+    const workspace = path.join(tempRoot, 'workspace');
+    const rememberedRoot = path.join(tempRoot, 'repo');
+    // The rooted workflow directory discovered by the remembered root walk
+    const rootedDir = path.join(rememberedRoot, '.workrail', 'workflows');
+
+    fs.mkdirSync(workspace, { recursive: true });
+    writeWorkflow(rootedDir, 'shared-workflow', 'Shared Workflow');
+
+    // Attach the same path as a managed source
+    const managedStore = new InMemoryManagedSourceStoreV2();
+    await managedStore.attach(rootedDir);
+
+    const result = await handleV2ListWorkflows(
+      { workspacePath: workspace, includeSources: true },
+      buildCtxWithManagedStore(rememberedRootsStore(rememberedRoot), managedStore),
+    );
+
+    expect(result.type).toBe('success');
+    if (result.type !== 'success') return;
+
+    const sources = (result.data as { sources: Array<Record<string, unknown>> }).sources;
+
+    // Exactly one entry for this path -- no dual truth
+    const entriesForPath = sources.filter((s) => s.sourceKey === `custom:${path.resolve(rootedDir)}`);
+    expect(entriesForPath).toHaveLength(1);
+
+    const entry = entriesForPath[0]!;
+    expect(entry.category).toBe('managed');
+    // rootedSharing context is present (the relationship is explicit)
+    expect(entry.rootedSharing).toBeDefined();
+    expect((entry.rootedSharing as { kind: string }).kind).toBe('remembered_root');
+    expect(entry.managed).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

After Slice 3 shipped the `manage_workflow_source` MCP tool, attached paths had no visible effect: workflows from managed directories did not appear in `list_workflows` and the source catalog showed no managed entries. This PR closes that gap.

- **Composition**: `RequestWorkflowReaderOptions` gains `managedSourceStore`; managed paths are deduplicated against remembered-root-discovered paths and appended to `customPaths` so their workflows participate in workflow resolution
- **Catalog**: `deriveSourceCatalogEntry` annotates custom sources with `category='managed'` and `managed:{addedAtMs}` when the path matches a managed source record
- **Dual-truth prevention**: when a path is both managed and rooted-sharing, ONE catalog entry is produced with both contexts (no duplicate entry)
- **Schema**: `V2WorkflowSourceCatalogEntrySchema` gains `'managed'` in the `category` enum and an optional `managed` field
- **Tests**: 2 new tests -- attach then list shows `managed` catalog entry + workflows appear; managed+remembered-root path shows single entry with explicit relationship

## Test plan

- [ ] `npm run build` -- clean
- [ ] `npx vitest run tests/unit/mcp/v2-workflow-source-catalog-output.test.ts` -- 6/6 pass (4 existing + 2 new)
- [ ] `npx vitest run tests/architecture/` -- all pass
- [ ] `npx vitest run` -- 3622+ pass

## Notes

- No breaking changes: `managed` is a new enum value and new optional field; existing clients see no difference until they attach a managed source
- Follow-up: managed stale path detection (non-existent managed dirs should surface in `staleRoots`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)