### PR TITLE
fix(phase2a): close env-path dedup gap and surface inspect_workflow warnings

### DIFF
--- a/src/mcp/handlers/shared/request-workflow-reader.ts
+++ b/src/mcp/handlers/shared/request-workflow-reader.ts
@@ -107,12 +107,15 @@ export async function createWorkflowReaderForRequest(
   // Paths that exist on disk are added to customPaths; paths that are missing are tracked
   // separately so callers can surface them in staleRoots and the source catalog.
   const { records: allManagedRecords, storeError: managedStoreError } = await listManagedSourceRecords(options.managedSourceStore);
-  // NOTE: normalizedCustom only covers paths from remembered-root discovery and does not
-  // include env-configured paths (WORKFLOW_STORAGE_PATH). If a managed source path matches
-  // an env-configured custom path, the managed path will still be appended to customPaths,
-  // creating a duplicate storage instance. This is a known gap -- fixing it would require
-  // reading WORKFLOW_STORAGE_PATH before factory creation, duplicating env-var logic.
-  const normalizedCustom = new Set(rootedCustomPaths.map((p) => path.resolve(p)));
+  // Build a dedup set from all paths already covered: rooted-discovered paths AND
+  // env-configured paths from WORKFLOW_STORAGE_PATH. The factory (createEnhancedMultiSourceWorkflowStorage)
+  // adds WORKFLOW_STORAGE_PATH entries to customPaths internally, so we must mirror that
+  // resolution here to avoid appending duplicate managed paths.
+  const envCustomPaths = parseWorkflowStoragePathEnv();
+  const normalizedCustom = new Set([
+    ...rootedCustomPaths.map((p) => path.resolve(p)),
+    ...envCustomPaths.map((p) => path.resolve(p)),
+  ]);
   const additionalManagedPaths: string[] = [];
   const activeManagedRecords: ManagedSourceRecordV2[] = [];
   const staleManagedRecords: ManagedSourceRecordV2[] = [];
@@ -156,6 +159,17 @@ export async function createWorkflowReaderForRequest(
     staleManagedRecords,
     ...(managedStoreError !== undefined ? { managedStoreError } : {}),
   };
+}
+
+/**
+ * Returns paths from the WORKFLOW_STORAGE_PATH environment variable, using the
+ * same parsing logic as EnhancedMultiSourceWorkflowStorage so the dedup set
+ * stays in sync with what the factory adds internally.
+ */
+function parseWorkflowStoragePathEnv(): readonly string[] {
+  const raw = process.env['WORKFLOW_STORAGE_PATH'];
+  if (!raw) return [];
+  return raw.split(path.delimiter).map((p) => p.trim()).filter((p) => p.length > 0);
 }
 
 interface ManagedSourceListResult {

--- a/src/mcp/handlers/v2-workflow.ts
+++ b/src/mcp/handlers/v2-workflow.ts
@@ -227,9 +227,12 @@ export async function handleV2InspectWorkflow(
         rememberedRootsStore: guard.ctx.v2.rememberedRootsStore,
         managedSourceStore: guard.ctx.v2.managedSourceStore,
       })
-    : { reader: ctx.workflowService, stalePaths: [] as string[], managedSourceRecords: [] as ManagedSourceRecordV2[], staleManagedRecords: [] as ManagedSourceRecordV2[] };
+    : { reader: ctx.workflowService, stalePaths: [] as string[], managedSourceRecords: [] as ManagedSourceRecordV2[], staleManagedRecords: [] as ManagedSourceRecordV2[], managedStoreError: undefined as string | undefined };
   const workflowReader = readerResult.reader;
   const stalePaths = readerResult.stalePaths;
+  const inspectWarnings = readerResult.managedStoreError
+    ? [`Managed workflow source store was temporarily unavailable (${readerResult.managedStoreError}). Managed sources were not loaded.`]
+    : undefined;
   // inspect_workflow returns a single workflow, not a source catalog. staleRoots is surfaced
   // in the response for parity with list_workflows, but staleManagedRecords is intentionally
   // unused here -- there is no catalog output to append stale entries to.
@@ -287,6 +290,7 @@ export async function handleV2InspectWorkflow(
               compiled: body,
               ...(visibility ? { visibility } : {}),
               ...(stalePaths.length > 0 ? { staleRoots: [...stalePaths] } : {}),
+              ...(inspectWarnings ? { warnings: inspectWarnings } : {}),
               ...(references != null && references.length > 0 ? { references } : {}),
               ...(() => {
                 const staleness = shouldShowStaleness(visibility?.category)

--- a/src/mcp/output-schemas.ts
+++ b/src/mcp/output-schemas.ts
@@ -177,6 +177,10 @@ export const V2WorkflowInspectOutputSchema = z.object({
     'Workflows from these paths were not included in this response. ' +
     'These paths will be rechecked on the next call.'
   ),
+  warnings: z.array(z.string()).optional().describe(
+    'Advisory messages about infrastructure issues that did not prevent a response but may have caused incomplete results. ' +
+    'Example: the managed source store was temporarily unavailable and managed sources were not loaded.'
+  ),
   references: z.array(z.object({
     id: z.string().min(1),
     title: z.string().min(1),

--- a/tests/unit/mcp/v2-workflow-source-catalog-output.test.ts
+++ b/tests/unit/mcp/v2-workflow-source-catalog-output.test.ts
@@ -402,4 +402,46 @@ describe('v2 workflow source catalog output', () => {
     expect(Array.isArray(data.warnings)).toBe(true);
     expect(data.warnings!.some((w) => w.includes('MANAGED_SOURCE_IO_ERROR'))).toBe(true);
   });
+
+  it('does not create duplicate catalog entry when managed source path matches WORKFLOW_STORAGE_PATH', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-v2-source-catalog-env-dedup-'));
+    const workspace = path.join(tempRoot, 'workspace');
+    const sharedDir = path.join(tempRoot, 'shared-workflows');
+
+    fs.mkdirSync(workspace, { recursive: true });
+    writeWorkflow(sharedDir, 'env-and-managed', 'Shared Workflow');
+
+    const managedStore = new InMemoryManagedSourceStoreV2();
+    await managedStore.attach(sharedDir);
+
+    const previousEnv = process.env['WORKFLOW_STORAGE_PATH'];
+    process.env['WORKFLOW_STORAGE_PATH'] = sharedDir;
+
+    try {
+      const result = await handleV2ListWorkflows(
+        { workspacePath: workspace, includeSources: true },
+        buildCtxWithManagedStore(rememberedRootsStore(), managedStore),
+      );
+
+      expect(result.type).toBe('success');
+      if (result.type !== 'success') return;
+
+      const data = result.data as { workflows: Array<{ workflowId: string }>; sources: Array<Record<string, unknown>> };
+
+      // Workflow appears exactly once in the listing (no duplicate)
+      const matches = data.workflows.filter((w) => w.workflowId === 'env-and-managed');
+      expect(matches).toHaveLength(1);
+
+      // Source catalog has exactly one entry for the shared dir
+      const sourceKey = `custom:${path.resolve(sharedDir)}`;
+      const catalogEntries = data.sources.filter((s) => s.sourceKey === sourceKey);
+      expect(catalogEntries).toHaveLength(1);
+    } finally {
+      if (previousEnv === undefined) {
+        delete process.env['WORKFLOW_STORAGE_PATH'];
+      } else {
+        process.env['WORKFLOW_STORAGE_PATH'] = previousEnv;
+      }
+    }
+  });
 });

--- a/tests/unit/mcp/v2-workflow-source-visibility-output.test.ts
+++ b/tests/unit/mcp/v2-workflow-source-visibility-output.test.ts
@@ -13,6 +13,8 @@ import { NodeCryptoV2 } from '../../../src/v2/infra/local/crypto/index.js';
 import { LocalPinnedWorkflowStoreV2 } from '../../../src/v2/infra/local/pinned-workflow-store/index.js';
 import { createTestValidationPipelineDeps } from '../../helpers/v2-test-helpers.js';
 import type { RememberedRootsStorePortV2 } from '../../../src/v2/ports/remembered-roots-store.port.js';
+import type { ManagedSourceStorePortV2 } from '../../../src/v2/ports/managed-source-store.port.js';
+import { errAsync } from 'neverthrow';
 import { createWorkflow } from '../../../src/types/workflow.js';
 import { createProjectDirectorySource } from '../../../src/types/workflow-source.js';
 
@@ -158,5 +160,37 @@ describe('v2 workflow source visibility outputs', () => {
           'Project-scoped ./workflows currently overrides rooted .workrail/workflows during migration. Prefer rooted sharing for new team-shared workflows.',
       },
     });
+  });
+
+  it('surfaces managed source store error as warnings in inspect_workflow response', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-v2-inspect-store-err-'));
+    const workspace = path.join(tempRoot, 'workspace');
+    writeProjectWorkflow(workspace, 'test-workflow', 'Test Workflow');
+
+    const failingStore: ManagedSourceStorePortV2 = {
+      list: () => errAsync({ code: 'MANAGED_SOURCE_IO_ERROR' as const, message: 'disk failure' }),
+      attach: () => errAsync({ code: 'MANAGED_SOURCE_IO_ERROR' as const, message: 'disk failure' }),
+      detach: () => errAsync({ code: 'MANAGED_SOURCE_IO_ERROR' as const, message: 'disk failure' }),
+    };
+
+    const ctx: ToolContext = {
+      ...buildCtx(rememberedRootsStore()),
+      v2: {
+        ...(buildCtx(rememberedRootsStore()).v2 as object),
+        managedSourceStore: failingStore,
+      },
+    } as any;
+
+    const result = await handleV2InspectWorkflow(
+      { workflowId: 'test-workflow', workspacePath: workspace, mode: 'metadata' },
+      ctx,
+    );
+
+    expect(result.type).toBe('success');
+    if (result.type !== 'success') return;
+
+    const data = result.data as { warnings?: string[] };
+    expect(Array.isArray(data.warnings)).toBe(true);
+    expect(data.warnings!.some((w) => w.includes('MANAGED_SOURCE_IO_ERROR'))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Two deferred fixes from the managed source stale detection work (follow-up to #213):

**Fix 1 -- Env-path dedup** (\`request-workflow-reader.ts\`): \`normalizedCustom\` previously only covered remembered-root discovered paths. If a managed source path matched a \`WORKFLOW_STORAGE_PATH\` env-configured path, both would be added to \`customPaths\`, creating duplicate storage instances and catalog entries. Now reads \`WORKFLOW_STORAGE_PATH\` using \`path.delimiter\` (matching \`EnhancedMultiSourceWorkflowStorage\` logic) and adds those paths to the dedup set before the managed records loop.

**Fix 2 -- inspect_workflow warnings** (\`v2-workflow.ts\`, \`output-schemas.ts\`): \`handleV2InspectWorkflow\` previously dropped managed source store errors silently. Now surfaces them as \`warnings[]\` in the inspect response, matching the behavior added to \`list_workflows\` in #213.

## Test plan

- [ ] New test: attach + WORKFLOW_STORAGE_PATH pointing to same dir -> one catalog entry, one workflow listing entry
- [ ] New test: failing managed source store -> warnings[] in inspect_workflow response
- [ ] 856 tests pass
- [ ] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)