### PR TITLE
feat: simplify assessment trigger to anyEqualsLevel and add authoring guidance

### DIFF
--- a/docs/authoring-v2.md
+++ b/docs/authoring-v2.md
@@ -256,14 +256,47 @@ Practical guidance:
 - write follow-up guidance as **same-step retry guidance**, not as a subflow or rewind instruction
 - prefer one strong follow-up trigger over multiple weak ones
 
+**Dimension design: orthogonality matters**
+
+The value of multi-dimensional assessments is that each dimension independently blocks advancement for a different reason. A dimension that restates existing workflow state adds ceremony without structure.
+
+Good dimensions are:
+- **Orthogonal**: each captures a distinct failure mode the others don't catch
+- **Independently checkable**: a `low` rating on one dimension alone justifies follow-up, regardless of the others
+- **Specific**: about a concrete, observable thing -- not "is the overall result good"
+
+Bad dimensions:
+- A single `confidence` dimension that mirrors the workflow's existing `recommendationConfidenceBand` -- it just restates what the workflow already knows
+- Multiple dimensions that all reduce to the same question phrased differently
+- Dimensions so correlated that one being low always implies the others are low too
+
+Example of orthogonal dimensions for an MR review handoff:
+- `evidence_quality` -- are findings grounded in specific code locations? (catches: weak analysis)
+- `coverage_completeness` -- are all relevant domains checked? (catches: blind spots)
+- `contradiction_resolution` -- are competing interpretations resolved? (catches: premature synthesis)
+
+Each catches a distinct failure mode. A review can have strong evidence but miss whole domains, or have good coverage with unresolved contradictions.
+
+**Consequence trigger**: use `anyEqualsLevel` to specify which level should block. WorkRail checks all submitted dimensions and fires the consequence if any of them equals that level. For single-dimension assessments this works the same as an exact match.
+
+```json
+{
+  "when": { "anyEqualsLevel": "low" },
+  "effect": { "kind": "require_followup", "guidance": "..." }
+}
+```
+
+**V1 limit**: at most one consequence per step.
+
 Good fit:
 
-- "Before handing off, assess whether the diagnosis is ready."
-- "If confidence is low, require follow-up and retry the same validation step."
+- "Before handing off, assess whether the diagnosis is ready -- coverage is complete, evidence is grounded, and contradictions are resolved."
+- "If evidence quality is low, require follow-up to anchor findings to specific code before retry."
 
 Bad fit:
 
 - generic five-level scores that never affect workflow behavior
+- a single `confidence` dimension that mirrors a confidence band the workflow already tracks
 - multiple interacting rule chains that really want a policy DSL
 - subflow-style recovery sequences masquerading as a single follow-up consequence
 

--- a/spec/authoring-spec.json
+++ b/spec/authoring-spec.json
@@ -3,7 +3,7 @@
   "version": 3,
   "title": "WorkRail Authoring Rules",
   "purpose": "Canonical current rules for authoring good WorkRail workflows. workflow.schema.json remains the source of truth for legal structure.",
-  "lastReviewed": "2026-03-21",
+  "lastReviewed": "2026-04-04",
   "principles": [
     "Schema defines what is valid. These rules define what is good.",
     "Prefer current authoring rules over design rationale or historical notes.",
@@ -927,6 +927,87 @@
           "antiPatterns": [
             "Confirming every draft or artifact creation by default",
             "Using requireConfirmation as a substitute for clear loop or rigor policy"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "assessment-gates",
+      "title": "Assessment gates",
+      "rules": [
+        {
+          "id": "assessment-use-for-bounded-judgment",
+          "status": "active",
+          "level": "recommended",
+          "scope": [
+            "workflow.assessments",
+            "step.assessmentRefs",
+            "step.assessmentConsequences"
+          ],
+          "rule": "Use assessment gates when a step needs the agent to submit a bounded, durable judgment before the workflow can safely advance -- not for generic scoring or ceremony.",
+          "why": "Assessment gates force explicit structured reasoning at a decision point and durably record the result. Generic scoring that never affects routing adds noise without value.",
+          "enforcement": ["advisory"],
+          "sourceRefs": [
+            {
+              "kind": "example",
+              "path": "workflows/mr-review-workflow.agentic.v2.json",
+              "note": "Uses a three-dimension readiness gate on the final validation step."
+            },
+            {
+              "kind": "example",
+              "path": "workflows/bug-investigation.agentic.v2.json",
+              "note": "Uses a single-dimension diagnosis readiness gate before handoff."
+            }
+          ],
+          "checks": [
+            "The assessment is at a step where a wrong answer would produce a bad handoff.",
+            "At least one dimension has a consequence that keeps the step pending and requires follow-up.",
+            "The assessment result is durably recorded and useful to a future resume agent."
+          ],
+          "antiPatterns": [
+            "Using assessments as a generic five-level scoring rubric with no routing consequence",
+            "Declaring an assessment but never referencing it from any step"
+          ]
+        },
+        {
+          "id": "assessment-dimension-orthogonality",
+          "status": "active",
+          "level": "required",
+          "scope": [
+            "workflow.assessments"
+          ],
+          "rule": "Each dimension in an assessment must capture a distinct failure mode that the other dimensions cannot catch. A dimension that restates existing workflow state (such as a generic 'confidence' dimension that mirrors the workflow's confidence band) adds ceremony without structure.",
+          "why": "The value of multiple dimensions is that each one independently blocks advancement for a different reason. Correlated or vague dimensions collapse to a single gate with extra steps.",
+          "enforcement": ["advisory"],
+          "checks": [
+            "Each dimension is independently checkable without needing to know the result of the others.",
+            "No dimension restates a context variable the workflow already computes (e.g. recommendationConfidenceBand).",
+            "A 'low' rating on any one dimension alone justifies a follow-up, regardless of the others."
+          ],
+          "antiPatterns": [
+            "A single 'confidence' dimension that mirrors the workflow's existing confidence band",
+            "Multiple dimensions that all reduce to 'did I do a good job overall'",
+            "Dimensions so correlated that one being low always means the others are low too"
+          ]
+        },
+        {
+          "id": "assessment-v1-constraints",
+          "status": "active",
+          "level": "required",
+          "scope": [
+            "step.assessmentRefs",
+            "step.assessmentConsequences"
+          ],
+          "rule": "V1 supports exactly one assessmentRef per step and at most one assessmentConsequences entry per step. Use anyEqualsLevel as the trigger -- the engine checks all submitted dimensions and fires if any equals that level.",
+          "why": "anyEqualsLevel is the only trigger form. It works for both single-dimension and multi-dimension assessments without requiring the author to choose between two forms.",
+          "enforcement": ["schema"],
+          "checks": [
+            "No more than one assessmentRefs entry per step.",
+            "No more than one assessmentConsequences entry per step.",
+            "The consequence uses anyEqualsLevel to declare which level blocks -- not a named dimension."
+          ],
+          "antiPatterns": [
+            "Trying to encode multiple consequences via workarounds"
           ]
         }
       ]

--- a/spec/workflow.schema.json
+++ b/spec/workflow.schema.json
@@ -1064,23 +1064,15 @@
     },
     "assessmentConsequenceTrigger": {
       "type": "object",
-      "description": "Exact-match trigger on one declared assessment dimension and one declared canonical level.",
+      "description": "Fires when ANY dimension in the submitted assessment equals the given level. The consequence blocks advancement until the agent addresses all dimensions that scored at that level.",
       "properties": {
-        "dimensionId": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 64
-        },
-        "equalsLevel": {
+        "anyEqualsLevel": {
           "type": "string",
           "minLength": 1,
           "maxLength": 64
         }
       },
-      "required": [
-        "dimensionId",
-        "equalsLevel"
-      ],
+      "required": ["anyEqualsLevel"],
       "additionalProperties": false
     },
     "assessmentConsequenceEffect": {

--- a/src/application/services/validation-engine.ts
+++ b/src/application/services/validation-engine.ts
@@ -919,24 +919,14 @@ export class ValidationEngine {
       for (const consequence of step.assessmentConsequences) {
         const trigger = consequence.when;
         const effect = consequence.effect;
-        const dimension = assessmentDefinition.dimensions.find(candidate => candidate.id === trigger.dimensionId);
 
-        if (!dimension) {
+        const allLevels = assessmentDefinition.dimensions.flatMap(d => d.levels);
+        if (!allLevels.includes(trigger.anyEqualsLevel)) {
           issues.push(
-            `${stepLabel}: assessment consequence references unknown dimension '${trigger.dimensionId}' for assessment '${assessmentDefinition.id}'`
+            `${stepLabel}: assessment consequence anyEqualsLevel '${trigger.anyEqualsLevel}' is not declared in any dimension of assessment '${assessmentDefinition.id}'`
           );
           suggestions.push(
-            `Use one of the declared dimensions for assessment '${assessmentDefinition.id}': ${assessmentDefinition.dimensions.map(d => d.id).join(', ')}`
-          );
-          continue;
-        }
-
-        if (!dimension.levels.includes(trigger.equalsLevel)) {
-          issues.push(
-            `${stepLabel}: assessment consequence references undeclared level '${trigger.equalsLevel}' for dimension '${trigger.dimensionId}'`
-          );
-          suggestions.push(
-            `Use one of the declared levels for dimension '${trigger.dimensionId}': ${dimension.levels.join(', ')}`
+            `Use a level declared in one of the dimensions: ${[...new Set(allLevels)].join(', ')}`
           );
         }
 

--- a/src/application/services/workflow-compiler.ts
+++ b/src/application/services/workflow-compiler.ts
@@ -325,15 +325,11 @@ export class WorkflowCompiler {
       }
 
       for (const consequence of assessmentConsequences) {
-        const dimension = assessment.dimensions.find(candidate => candidate.id === consequence.when.dimensionId);
-        if (!dimension) {
+        const trigger = consequence.when;
+        const allLevels = assessment.dimensions.flatMap(d => d.levels);
+        if (!allLevels.includes(trigger.anyEqualsLevel)) {
           return err(Err.invalidState(
-            `Step '${step.id}' declares consequence on unknown dimension '${consequence.when.dimensionId}' for assessment '${assessment.id}'`
-          ));
-        }
-        if (!dimension.levels.includes(consequence.when.equalsLevel)) {
-          return err(Err.invalidState(
-            `Step '${step.id}' declares consequence on unsupported level '${consequence.when.equalsLevel}' for dimension '${consequence.when.dimensionId}'. Declared levels: ${dimension.levels.join(', ')}`
+            `Step '${step.id}' declares consequence with anyEqualsLevel '${trigger.anyEqualsLevel}' that is not declared in any dimension of assessment '${assessment.id}'`
           ));
         }
         if (consequence.effect.kind !== 'require_followup') {

--- a/src/mcp/handlers/v2-advance-core/assessment-consequences.ts
+++ b/src/mcp/handlers/v2-advance-core/assessment-consequences.ts
@@ -4,7 +4,7 @@ import type { RecordedAssessmentV1 } from '../../../v2/durable-core/domain/asses
 export interface TriggeredAssessmentConsequenceV1 {
   readonly kind: 'require_followup';
   readonly assessmentId: string;
-  readonly triggerDimensionId: string;
+  readonly firstMatchedDimensionId: string;
   readonly triggerLevel: string;
   readonly guidance: string;
 }
@@ -19,18 +19,14 @@ export function evaluateAssessmentConsequences(args: {
   const consequence = args.step.assessmentConsequences[0];
   if (!consequence) return undefined;
 
-  const matchedDimension = args.recordedAssessment.dimensions.find(
-    dimension =>
-      dimension.dimensionId === consequence.when.dimensionId &&
-      dimension.level === consequence.when.equalsLevel,
-  );
-  if (!matchedDimension) return undefined;
+  const matched = args.recordedAssessment.dimensions.find(d => d.level === consequence.when.anyEqualsLevel);
+  if (!matched) return undefined;
 
   return {
     kind: 'require_followup',
     assessmentId: args.recordedAssessment.assessmentId,
-    triggerDimensionId: consequence.when.dimensionId,
-    triggerLevel: consequence.when.equalsLevel,
+    firstMatchedDimensionId: matched.dimensionId,
+    triggerLevel: consequence.when.anyEqualsLevel,
     guidance: consequence.effect.guidance,
   };
 }

--- a/src/mcp/handlers/v2-advance-core/index.ts
+++ b/src/mcp/handlers/v2-advance-core/index.ts
@@ -266,7 +266,7 @@ export function executeAdvanceCore(args: {
       assessmentFollowupRequired: v.triggeredAssessmentConsequence
         ? {
             assessmentId: v.triggeredAssessmentConsequence.assessmentId,
-            dimensionId: v.triggeredAssessmentConsequence.triggerDimensionId,
+            dimensionId: v.triggeredAssessmentConsequence.firstMatchedDimensionId,
             level: v.triggeredAssessmentConsequence.triggerLevel,
             guidance: v.triggeredAssessmentConsequence.guidance,
           }

--- a/src/mcp/handlers/v2-advance-core/outcome-blocked.ts
+++ b/src/mcp/handlers/v2-advance-core/outcome-blocked.ts
@@ -126,7 +126,7 @@ export function buildBlockedOutcome(args: {
       attemptId: String(attemptId),
       scope: { runId: String(runId), nodeId: String(currentNodeId) },
       assessmentId: validated.triggeredAssessmentConsequence.assessmentId,
-      dimensionId: validated.triggeredAssessmentConsequence.triggerDimensionId,
+      dimensionId: validated.triggeredAssessmentConsequence.firstMatchedDimensionId,
       level: validated.triggeredAssessmentConsequence.triggerLevel,
       guidance: validated.triggeredAssessmentConsequence.guidance,
       minted: { eventId: idFactory.mintEventId() },

--- a/src/types/workflow-definition.ts
+++ b/src/types/workflow-definition.ts
@@ -85,11 +85,16 @@ export interface AssessmentDefinition {
   readonly dimensions: readonly AssessmentDimensionDefinition[];
 }
 
+/**
+ * Trigger condition for an assessment consequence.
+ * Fires when ANY dimension in the submitted assessment equals anyEqualsLevel.
+ */
 export interface AssessmentConsequenceTriggerDefinition {
-  /** Declared dimension to inspect in the accepted canonical assessment. */
-  readonly dimensionId: string;
-  /** Canonical level that triggers the consequence. */
-  readonly equalsLevel: string;
+  /**
+   * Fires when ANY dimension in the submitted assessment equals this level.
+   * For single-dimension assessments this is equivalent to an exact match.
+   */
+  readonly anyEqualsLevel: string;
 }
 
 export interface AssessmentFollowupRequiredEffectDefinition {

--- a/tests/integration/v2/assessment-followup-retry-flow.test.ts
+++ b/tests/integration/v2/assessment-followup-retry-flow.test.ts
@@ -134,7 +134,7 @@ describe('Assessment follow-up retry flow (end-to-end)', () => {
             assessmentRefs: ['readiness_gate'],
             assessmentConsequences: [
               {
-                when: { dimensionId: 'confidence', equalsLevel: 'low' },
+                when: { anyEqualsLevel: 'low' },
                 effect: { kind: 'require_followup', guidance: 'Gather more context before proceeding.' },
               },
             ],

--- a/tests/integration/v2/assessment-step-context.test.ts
+++ b/tests/integration/v2/assessment-step-context.test.ts
@@ -115,7 +115,7 @@ const BASE_WORKFLOW = {
       assessmentRefs: ['readiness_gate'],
       assessmentConsequences: [
         {
-          when: { dimensionId: 'confidence', equalsLevel: 'low' },
+          when: { anyEqualsLevel: 'low' },
           effect: { kind: 'require_followup', guidance: 'Gather more context.' },
         },
       ],

--- a/tests/lifecycle/fixtures/test-artifact-loop-control.fixture.ts
+++ b/tests/lifecycle/fixtures/test-artifact-loop-control.fixture.ts
@@ -84,8 +84,7 @@ export const testArtifactLoopControlFixture: WorkflowFixture = {
         assessmentConsequences: [
           {
             when: {
-              dimensionId: 'confidence',
-              equalsLevel: 'low',
+              anyEqualsLevel: 'low',
             },
             effect: {
               kind: 'require_followup',

--- a/tests/unit/compiler/assessment-definition-validation.test.ts
+++ b/tests/unit/compiler/assessment-definition-validation.test.ts
@@ -152,7 +152,7 @@ describe('assessment declarations — validation engine', () => {
           assessmentRefs: ['readiness_gate'],
           assessmentConsequences: [
             {
-              when: { dimensionId: 'confidence', equalsLevel: 'low' },
+              when: { anyEqualsLevel: 'low' },
               effect: { kind: 'require_followup', guidance: 'Gather more context before proceeding.' },
             },
           ],
@@ -164,7 +164,7 @@ describe('assessment declarations — validation engine', () => {
     expect(result.valid).toBe(true);
   });
 
-  it('rejects a consequence that references an unknown assessment dimension', () => {
+  it('rejects a consequence that references an undeclared level', () => {
     const workflow = mkWorkflow({
       assessments: [
         {
@@ -181,7 +181,7 @@ describe('assessment declarations — validation engine', () => {
           assessmentRefs: ['readiness_gate'],
           assessmentConsequences: [
             {
-              when: { dimensionId: 'scope', equalsLevel: 'low' },
+              when: { anyEqualsLevel: 'unknown_level' },
               effect: { kind: 'require_followup', guidance: 'Gather more context before proceeding.' },
             },
           ],
@@ -192,7 +192,7 @@ describe('assessment declarations — validation engine', () => {
     const result = new ValidationEngine(new EnhancedLoopValidator()).validateWorkflow(workflow);
     expect(result.valid).toBe(false);
     expect(result.issues).toEqual(
-      expect.arrayContaining([expect.stringContaining("references unknown dimension 'scope'")])
+      expect.arrayContaining([expect.stringContaining("anyEqualsLevel 'unknown_level'")])
     );
   });
 });
@@ -303,7 +303,7 @@ describe('assessment declarations — workflow compiler', () => {
           assessmentRefs: ['readiness_gate'],
           assessmentConsequences: [
             {
-              when: { dimensionId: 'confidence', equalsLevel: 'medium' },
+              when: { anyEqualsLevel: 'medium' },
               effect: { kind: 'require_followup', guidance: 'Gather more context before proceeding.' },
             },
           ],
@@ -313,6 +313,6 @@ describe('assessment declarations — workflow compiler', () => {
 
     const result = compiler.compile(workflow);
     expect(result.isErr()).toBe(true);
-    expect(result._unsafeUnwrapErr().message).toContain("unsupported level 'medium'");
+    expect(result._unsafeUnwrapErr().message).toContain("anyEqualsLevel 'medium'");
   });
 });

--- a/tests/unit/mcp/assessment-consequences.test.ts
+++ b/tests/unit/mcp/assessment-consequences.test.ts
@@ -3,7 +3,7 @@ import { evaluateAssessmentConsequences } from '../../../src/mcp/handlers/v2-adv
 import type { WorkflowStepDefinition } from '../../../src/types/workflow-definition.js';
 import type { RecordedAssessmentV1 } from '../../../src/mcp/handlers/v2-advance-core/assessment-validation.js';
 
-describe('evaluateAssessmentConsequences', () => {
+describe('evaluateAssessmentConsequences -- single dimension (equivalent to exact match)', () => {
   const step: WorkflowStepDefinition = {
     id: 'step-1',
     title: 'Step 1',
@@ -11,13 +11,13 @@ describe('evaluateAssessmentConsequences', () => {
     assessmentRefs: ['readiness_gate'],
     assessmentConsequences: [
       {
-        when: { dimensionId: 'confidence', equalsLevel: 'low' },
+        when: { anyEqualsLevel: 'low' },
         effect: { kind: 'require_followup', guidance: 'Gather more context before proceeding.' },
       },
     ],
   };
 
-  it('returns a triggered follow-up consequence on exact match', () => {
+  it('fires when the single dimension equals the level', () => {
     const recordedAssessment: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
@@ -31,13 +31,13 @@ describe('evaluateAssessmentConsequences', () => {
     ).toEqual({
       kind: 'require_followup',
       assessmentId: 'readiness_gate',
-      triggerDimensionId: 'confidence',
+      firstMatchedDimensionId: 'confidence',
       triggerLevel: 'low',
       guidance: 'Gather more context before proceeding.',
     });
   });
 
-  it('returns undefined when the canonical level does not match', () => {
+  it('returns undefined when the dimension does not match', () => {
     const recordedAssessment: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
@@ -47,5 +47,100 @@ describe('evaluateAssessmentConsequences', () => {
     };
 
     expect(evaluateAssessmentConsequences({ step, recordedAssessment })).toBeUndefined();
+  });
+});
+
+describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
+  const stepWithAnyTrigger: WorkflowStepDefinition = {
+    id: 'step-review',
+    title: 'Review Gate',
+    prompt: 'Assess readiness.',
+    assessmentRefs: ['readiness_gate'],
+    assessmentConsequences: [
+      {
+        when: { anyEqualsLevel: 'low' },
+        effect: { kind: 'require_followup', guidance: 'Address all low dimensions before proceeding.' },
+      },
+    ],
+  };
+
+  it('fires when the first dimension is low', () => {
+    const recordedAssessment: RecordedAssessmentV1 = {
+      assessmentId: 'readiness_gate',
+      normalizationNotes: [],
+      dimensions: [
+        { dimensionId: 'evidence_quality', level: 'low', normalization: 'exact' },
+        { dimensionId: 'coverage_completeness', level: 'high', normalization: 'exact' },
+        { dimensionId: 'contradiction_resolution', level: 'high', normalization: 'exact' },
+      ],
+    };
+
+    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessment })).toEqual({
+      kind: 'require_followup',
+      assessmentId: 'readiness_gate',
+      firstMatchedDimensionId: 'evidence_quality',
+      triggerLevel: 'low',
+      guidance: 'Address all low dimensions before proceeding.',
+    });
+  });
+
+  it('fires when a non-first dimension is low', () => {
+    const recordedAssessment: RecordedAssessmentV1 = {
+      assessmentId: 'readiness_gate',
+      normalizationNotes: [],
+      dimensions: [
+        { dimensionId: 'evidence_quality', level: 'high', normalization: 'exact' },
+        { dimensionId: 'coverage_completeness', level: 'high', normalization: 'exact' },
+        { dimensionId: 'contradiction_resolution', level: 'low', normalization: 'exact' },
+      ],
+    };
+
+    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessment })).toEqual({
+      kind: 'require_followup',
+      assessmentId: 'readiness_gate',
+      firstMatchedDimensionId: 'contradiction_resolution',
+      triggerLevel: 'low',
+      guidance: 'Address all low dimensions before proceeding.',
+    });
+  });
+
+  it('returns the first matched dimension when multiple are low', () => {
+    const recordedAssessment: RecordedAssessmentV1 = {
+      assessmentId: 'readiness_gate',
+      normalizationNotes: [],
+      dimensions: [
+        { dimensionId: 'evidence_quality', level: 'low', normalization: 'exact' },
+        { dimensionId: 'coverage_completeness', level: 'low', normalization: 'exact' },
+        { dimensionId: 'contradiction_resolution', level: 'high', normalization: 'exact' },
+      ],
+    };
+
+    const result = evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessment });
+    expect(result?.firstMatchedDimensionId).toBe('evidence_quality');
+    expect(result?.triggerLevel).toBe('low');
+  });
+
+  it('does not fire when all dimensions are high', () => {
+    const recordedAssessment: RecordedAssessmentV1 = {
+      assessmentId: 'readiness_gate',
+      normalizationNotes: [],
+      dimensions: [
+        { dimensionId: 'evidence_quality', level: 'high', normalization: 'exact' },
+        { dimensionId: 'coverage_completeness', level: 'high', normalization: 'exact' },
+        { dimensionId: 'contradiction_resolution', level: 'high', normalization: 'exact' },
+      ],
+    };
+
+    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessment })).toBeUndefined();
+  });
+
+  it('does not fire when no dimensions are present', () => {
+    const recordedAssessment: RecordedAssessmentV1 = {
+      assessmentId: 'readiness_gate',
+      normalizationNotes: [],
+      dimensions: [],
+    };
+
+    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessment })).toBeUndefined();
   });
 });

--- a/workflows/bug-investigation.agentic.v2.json
+++ b/workflows/bug-investigation.agentic.v2.json
@@ -151,8 +151,7 @@
       "assessmentConsequences": [
         {
           "when": {
-            "dimensionId": "confidence",
-            "equalsLevel": "low"
+            "anyEqualsLevel": "low"
           },
           "effect": {
             "kind": "require_followup",

--- a/workflows/mr-review-workflow.agentic.v2.json
+++ b/workflows/mr-review-workflow.agentic.v2.json
@@ -1,7 +1,7 @@
 {
   "id": "mr-review-workflow-agentic",
   "name": "MR Review Workflow (Lean v2 \u2022 Notes-First \u2022 Evidence-Driven Reviewer Families)",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Lean v2 MR review workflow. Merges intake, missing-input gating, context gathering, and re-triage into one structured front phase, then drives review through a shared fact packet, parallel reviewer families, contradiction-driven synthesis, and evidence-first final validation.",
   "recommendedPreferences": {
     "recommendedAutonomy": "guided",
@@ -13,15 +13,22 @@
   "assessments": [
     {
       "id": "review_readiness_gate",
-      "purpose": "Assess whether the review recommendation is ready for final handoff.",
+      "purpose": "Assess whether the review is ready to hand off across three orthogonal dimensions. Each must be high independently -- strength in one cannot compensate for weakness in another.",
       "dimensions": [
         {
-          "id": "confidence",
-          "purpose": "How confident the agent is that the recommendation is supported by sufficient evidence and coherent findings.",
-          "levels": [
-            "low",
-            "high"
-          ]
+          "id": "evidence_quality",
+          "purpose": "Key findings are backed by specific code references, line numbers, or concrete observations -- not intuition or pattern-matching alone.",
+          "levels": ["low", "high"]
+        },
+        {
+          "id": "coverage_completeness",
+          "purpose": "All relevant review domains have been adequately checked for this change. No material blind spots remain unacknowledged.",
+          "levels": ["low", "high"]
+        },
+        {
+          "id": "contradiction_resolution",
+          "purpose": "Material contradictions and competing interpretations are resolved or explicitly acknowledged with a clear rationale for the chosen position.",
+          "levels": ["low", "high"]
         }
       ]
     }
@@ -251,12 +258,11 @@
       "assessmentConsequences": [
         {
           "when": {
-            "dimensionId": "confidence",
-            "equalsLevel": "low"
+            "anyEqualsLevel": "low"
           },
           "effect": {
             "kind": "require_followup",
-            "guidance": "Resolve the remaining recommendation uncertainty before handing off: either strengthen the evidence for the key findings, explicitly reconcile unresolved contradictions, or downgrade the confidence band and disclose the limitations clearly."
+            "guidance": "Address whichever dimensions scored low: evidence_quality low -- anchor each finding to a specific file, function, or line; remove findings without concrete grounding. coverage_completeness low -- investigate uncovered domains or explicitly acknowledge gaps in the ledger. contradiction_resolution low -- resolve each contradiction or explicitly state your position with rationale."
           }
         }
       ],

--- a/workflows/test-artifact-loop-control.json
+++ b/workflows/test-artifact-loop-control.json
@@ -59,8 +59,7 @@
       "assessmentConsequences": [
         {
           "when": {
-            "dimensionId": "confidence",
-            "equalsLevel": "low"
+            "anyEqualsLevel": "low"
           },
           "effect": {
             "kind": "require_followup",

--- a/workflows/workflow-for-workflows.v2.json
+++ b/workflows/workflow-for-workflows.v2.json
@@ -94,7 +94,15 @@
       "title": "MR Review Workflow (Outcome Baseline Example)",
       "source": "workflows/mr-review-workflow.agentic.v2.json",
       "resolveFrom": "package",
-      "purpose": "Strong example of hypothesis, neutral fact packet, reviewer families, contradiction synthesis, and final validation.",
+      "purpose": "Strong example of hypothesis, neutral fact packet, reviewer families, contradiction synthesis, final validation, and a three-dimension orthogonal assessment gate.",
+      "authoritative": false
+    },
+    {
+      "id": "bug-investigation-workflow",
+      "title": "Bug Investigation Workflow (Assessment Gate Example)",
+      "source": "workflows/bug-investigation.agentic.v2.json",
+      "resolveFrom": "package",
+      "purpose": "Simpler example of a single-dimension assessment gate on a final validation step before handoff.",
       "authoritative": false
     },
     {
@@ -229,7 +237,7 @@
         "procedure": [
           "Decide whether the authored workflow needs a hypothesis step, neutral fact packet, reviewer or validator families, contradiction loop, final validation bundle, or explicit blind-spot handling.",
           "Design the confidence model, blind-spot model, and state economy plan.",
-          "Decide the hard-gate dimensions that would make the authored workflow unsafe or unsatisfying if they fail.",
+          "Decide the hard-gate dimensions that would make the authored workflow unsafe or unsatisfying if they fail. If hard gates exist, implement them using the native `assessments` + `assessmentRefs` + `assessmentConsequences` schema fields rather than informal notes or `requireConfirmation` alone. Each dimension should capture a distinct orthogonal failure mode -- not restate the workflow's existing confidence band. See `mr-review-workflow.agentic.v2.json` and `bug-investigation.agentic.v2.json` as exemplars.",
           "Write the redesign triggers that should force architectural revision rather than cosmetic refinement."
         ],
         "outputRequired": {


### PR DESCRIPTION
## Summary

- **Single trigger form**: removes `dimensionId+equalsLevel` and standardizes on `anyEqualsLevel` -- fires when ANY submitted dimension equals the level. For single-dimension assessments the behavior is identical to the old exact match.
- **Clearer field name**: `triggerDimensionId` renamed to `firstMatchedDimensionId` to accurately reflect that it records the first matched dimension when multiple are low.
- **Assessment authoring guidance**: new `assessment-gates` rule group in `authoring-spec.json` (when to use, dimension orthogonality, anyEqualsLevel trigger). New dimension design section in `authoring-v2.md`. `workflow-for-workflows.v2.json` updated to name assessment gates as the implementation for hard-gate dimensions.
- **Workflows updated**: `bug-investigation.agentic.v2`, `mr-review-workflow.agentic.v2`, `test-artifact-loop-control`

## Test plan

- [ ] 3637/3641 tests passing (4 pre-existing skips)
- [ ] `npm run validate:registry` passes for all workflows
- [ ] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)