### PR TITLE
chore: restrict dependabot groups to patch/minor only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,14 @@ updates:
       interval: weekly
       day: monday
     groups:
-      dependencies:
+      # Patch and minor updates only -- major versions require manual review
+      # because they often have breaking API changes (e.g. zod 3->4, TS 5->6)
+      patch-minor-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 5
 
   - package-ecosystem: npm
@@ -17,7 +22,10 @@ updates:
       interval: weekly
       day: monday
     groups:
-      console-dependencies:
+      patch-minor-console-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 5


### PR DESCRIPTION
Major version bumps require code changes (zod 3→4 broke CI). This limits grouped weekly PRs to patch + minor only so they auto-merge cleanly. Major upgrades will come as separate PRs for manual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)