### PR TITLE
fix(console): version-aware primary election prevents stale assets

### DIFF
--- a/src/infrastructure/session/HttpServer.ts
+++ b/src/infrastructure/session/HttpServer.ts
@@ -15,6 +15,13 @@ import cors from 'cors';
 import open from 'open';
 import { execSync } from 'child_process';
 
+// Resolve package version at module load time.
+// __dirname is available in CommonJS (the compile target for this project).
+// The path resolves to src/infrastructure/session -> ../../../package.json.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const _pkg = require(path.join(__dirname, '../../../package.json')) as { version: string };
+const CURRENT_VERSION: string = _pkg.version;
+
 export type DashboardMode = { kind: 'unified' } | { kind: 'legacy' };
 export type BrowserBehavior = { kind: 'auto_open' } | { kind: 'manual' };
 
@@ -37,6 +44,8 @@ interface DashboardLock {
   lastHeartbeat: string; // Track last activity for TTL-based cleanup
   projectId: string;
   projectPath: string;
+  /** Package version of the process that owns the lock. Used to reclaim on upgrade. */
+  version?: string;
 }
 
 /**
@@ -439,7 +448,7 @@ export class HttpServer {
     });
     
     // Health check
-    this.app.get('/api/health', (req: Request, res: Response) => {
+    this.app.get('/api/health', (_req: Request, res: Response) => {
       res.json({
         success: true,
         status: 'healthy',
@@ -447,7 +456,8 @@ export class HttpServer {
         timestamp: new Date().toISOString(),
         isPrimary: this.isPrimary,
         pid: process.pid,
-        port: this.port
+        port: this.port,
+        version: CURRENT_VERSION
       });
     });
     
@@ -505,9 +515,10 @@ export class HttpServer {
         startedAt: new Date().toISOString(),
         lastHeartbeat: new Date().toISOString(),
         projectId: this.sessionManager.getProjectId(),
-        projectPath: this.sessionManager.getProjectPath()
+        projectPath: this.sessionManager.getProjectPath(),
+        version: CURRENT_VERSION
       };
-      
+
       await fs.writeFile(this.lockFile, JSON.stringify(lockData, null, 2), { flag: 'wx' });
       
       // Success! We are primary
@@ -539,7 +550,15 @@ export class HttpServer {
     if (!lockData.pid || !lockData.port || !lockData.startedAt) {
       return { reclaim: true, reason: 'invalid lock structure' };
     }
-    
+
+    // Version mismatch: a newer (or different) version should take over so the
+    // browser always gets up-to-date console assets from the running process.
+    // undefined means the lock was written by a pre-version-field build -- treat
+    // it the same as "wrong version" so the fix takes effect on first deployment.
+    if (lockData.version !== CURRENT_VERSION) {
+      return { reclaim: true, reason: `version mismatch (lock=${lockData.version}, current=${CURRENT_VERSION})` };
+    }
+
     // Stale by TTL (no heartbeat for 2+ minutes)
     const lastHeartbeat = new Date(lockData.lastHeartbeat || lockData.startedAt);
     const ageMinutes = (Date.now() - lastHeartbeat.getTime()) / 60000;
@@ -595,8 +614,21 @@ export class HttpServer {
         }
       } else {
         console.error(`[Dashboard] Lock reclaim needed: ${reason}`);
+
+        // SIGTERM the old process before reclaiming the port.
+        // Without this, the old process is still bound to port 3456 and
+        // startAsPrimary() throws EADDRINUSE, causing silent fallback to legacy mode.
+        // Mirror the graceful-shutdown pattern used in the !reclaim branch above.
+        try {
+          process.kill(lockData.pid, 0); // Throws if process is dead
+          console.error(`[Dashboard] Sending SIGTERM to old process (PID ${lockData.pid})`);
+          process.kill(lockData.pid, 'SIGTERM');
+          await new Promise(resolve => setTimeout(resolve, 2000)); // Wait 2s for graceful exit
+        } catch {
+          // Process already dead -- proceed to reclaim
+        }
       }
-      
+
       // ATOMIC RECLAIM: Write new lock to temp file, then rename
       // This prevents race where multiple processes try to reclaim simultaneously
       const tempPath = `${this.lockFile}.${process.pid}.${Date.now()}`;
@@ -606,7 +638,8 @@ export class HttpServer {
         startedAt: new Date().toISOString(),
         lastHeartbeat: new Date().toISOString(),
         projectId: this.sessionManager.getProjectId(),
-        projectPath: this.sessionManager.getProjectPath()
+        projectPath: this.sessionManager.getProjectPath(),
+        version: CURRENT_VERSION
       };
       
       try {
@@ -631,7 +664,7 @@ export class HttpServer {
         }
         
         console.error('[Dashboard] Lock reclaimed successfully');
-this.isPrimary = true;
+        this.isPrimary = true;
         this.setupPrimaryCleanup();
         this.heartbeat.start();
         return true;

--- a/src/v2/usecases/console-routes.ts
+++ b/src/v2/usecases/console-routes.ts
@@ -313,12 +313,24 @@ export function mountConsoleRoutes(app: Application, consoleService: ConsoleServ
 
   const consoleDist = resolveConsoleDist();
   if (consoleDist) {
-    // Serve console static assets under /console
-    app.use('/console', express.static(consoleDist));
+    // Serve console static assets under /console.
+    // index.html is served with no-cache so the browser always revalidates on
+    // version upgrades. Versioned asset files (JS/CSS with content hashes) can
+    // still be cached aggressively by the browser via their hash-in-filename.
+    app.use('/console', express.static(consoleDist, {
+      setHeaders(res, filePath) {
+        if (path.basename(filePath) === 'index.html') {
+          res.setHeader('Cache-Control', 'no-cache');
+        }
+      }
+    }));
 
     // SPA catch-all: any /console/* route serves index.html
     // (lets React handle client-side routing)
+    // Cache-Control: no-cache ensures the browser always revalidates index.html
+    // so a WorkRail upgrade is reflected immediately without a hard refresh.
     app.get('/console/*path', (_req: Request, res: Response) => {
+      res.setHeader('Cache-Control', 'no-cache');
       res.sendFile(path.join(consoleDist, 'index.html'));
     });
 

--- a/tests/integration/unified-dashboard.test.ts
+++ b/tests/integration/unified-dashboard.test.ts
@@ -86,6 +86,33 @@ describe('Unified Dashboard - Primary/Secondary Pattern', () => {
     expect(lockData.pid).toBe(process.pid);
   });
   
+  it('should reclaim lock when version field differs from current version', async () => {
+    // Write a lock file with a different version but a dead PID so that the
+    // SIGTERM branch is a no-op and the test completes without the 2-second wait.
+    const versionMismatchLock = {
+      pid: 999999, // Non-existent PID so kill() throws and we skip the 2s wait
+      port: 3456,
+      startedAt: new Date().toISOString(), // Fresh timestamp -- TTL would NOT trigger reclaim
+      lastHeartbeat: new Date().toISOString(),
+      projectId: 'test',
+      projectPath: path.join(os.tmpdir(), 'workrail-test'),
+      version: '0.0.0-old', // Deliberately different from the current package version
+    };
+
+    await fs.mkdir(path.dirname(lockFile), { recursive: true });
+    await fs.writeFile(lockFile, JSON.stringify(versionMismatchLock));
+
+    const url = await httpServer.start();
+
+    // Should reclaim the lock (version mismatch) and become primary
+    expect(url).toBe('http://localhost:3456');
+
+    // Verify the lock was overwritten with the current process info
+    const lockData = JSON.parse(await fs.readFile(lockFile, 'utf-8'));
+    expect(lockData.pid).toBe(process.pid);
+    expect(lockData.version).not.toBe('0.0.0-old');
+  });
+
   it('should fall back to legacy mode when unified dashboard disabled', async () => {
     // Force legacy mode
     httpServer.setConfig({

--- a/tests/unit/bug-fixes.test.ts
+++ b/tests/unit/bug-fixes.test.ts
@@ -366,24 +366,152 @@ describe('Bug #4: Lock File Atomic Operations', () => {
       startedAt?: string;
       lastHeartbeat?: string;
     }
-    
+
     const shouldReclaimLock = (lockData: DashboardLock): { reclaim: boolean; reason: string } => {
       if (!lockData.pid || !lockData.port || !lockData.startedAt) {
         return { reclaim: true, reason: 'invalid lock structure' };
       }
       return { reclaim: false, reason: 'valid' };
     };
-    
+
     // Test invalid lock (missing pid)
     const invalidLock: DashboardLock = {
       port: 3456,
       startedAt: new Date().toISOString(),
       lastHeartbeat: new Date().toISOString(),
     };
-    
+
     const invalidResult = shouldReclaimLock(invalidLock);
     expect(invalidResult.reclaim).toBe(true);
     expect(invalidResult.reason).toBe('invalid lock structure');
+  });
+
+  // ---- Version-aware reclaim tests (added to cover the version field) ----
+
+  it('should reclaim lock when version field differs from current version', () => {
+    const CURRENT_VERSION = '2.0.0';
+
+    interface DashboardLockWithVersion {
+      pid: number;
+      port: number;
+      startedAt: string;
+      lastHeartbeat: string;
+      version?: string;
+    }
+
+    const shouldReclaimLock = (lockData: DashboardLockWithVersion): { reclaim: boolean; reason: string } => {
+      if (!lockData.pid || !lockData.port || !lockData.startedAt) {
+        return { reclaim: true, reason: 'invalid lock structure' };
+      }
+      // Reclaim when version is absent (old lock file) or differs from current.
+      if (lockData.version !== CURRENT_VERSION) {
+        return { reclaim: true, reason: `version mismatch (lock=${lockData.version}, current=${CURRENT_VERSION})` };
+      }
+      const lastHeartbeat = new Date(lockData.lastHeartbeat || lockData.startedAt);
+      const ageMinutes = (Date.now() - lastHeartbeat.getTime()) / 60000;
+      if (ageMinutes > 2) {
+        return { reclaim: true, reason: `stale (${ageMinutes.toFixed(1)}min old)` };
+      }
+      return { reclaim: false, reason: 'valid' };
+    };
+
+    const versionMismatchLock: DashboardLockWithVersion = {
+      pid: 12345,
+      port: 3456,
+      startedAt: new Date().toISOString(),
+      lastHeartbeat: new Date().toISOString(),
+      version: '1.0.0', // Different from CURRENT_VERSION
+    };
+
+    const result = shouldReclaimLock(versionMismatchLock);
+    expect(result.reclaim).toBe(true);
+    expect(result.reason).toContain('version mismatch');
+    expect(result.reason).toContain('1.0.0');
+    expect(result.reason).toContain('2.0.0');
+  });
+
+  it('should not reclaim lock when version matches current version', () => {
+    const CURRENT_VERSION = '2.0.0';
+
+    interface DashboardLockWithVersion {
+      pid: number;
+      port: number;
+      startedAt: string;
+      lastHeartbeat: string;
+      version?: string;
+    }
+
+    const shouldReclaimLock = (lockData: DashboardLockWithVersion): { reclaim: boolean; reason: string } => {
+      if (!lockData.pid || !lockData.port || !lockData.startedAt) {
+        return { reclaim: true, reason: 'invalid lock structure' };
+      }
+      // Reclaim when version is absent (old lock file) or differs from current.
+      if (lockData.version !== CURRENT_VERSION) {
+        return { reclaim: true, reason: `version mismatch (lock=${lockData.version}, current=${CURRENT_VERSION})` };
+      }
+      const lastHeartbeat = new Date(lockData.lastHeartbeat || lockData.startedAt);
+      const ageMinutes = (Date.now() - lastHeartbeat.getTime()) / 60000;
+      if (ageMinutes > 2) {
+        return { reclaim: true, reason: `stale (${ageMinutes.toFixed(1)}min old)` };
+      }
+      return { reclaim: false, reason: 'valid' };
+    };
+
+    const sameVersionLock: DashboardLockWithVersion = {
+      pid: 12345,
+      port: 3456,
+      startedAt: new Date().toISOString(),
+      lastHeartbeat: new Date().toISOString(),
+      version: '2.0.0', // Same as CURRENT_VERSION
+    };
+
+    const result = shouldReclaimLock(sameVersionLock);
+    expect(result.reclaim).toBe(false);
+    expect(result.reason).toBe('valid');
+  });
+
+  it('should reclaim lock when version field is absent (old lock file written before version tracking)', () => {
+    const CURRENT_VERSION = '2.0.0';
+
+    interface DashboardLockWithVersion {
+      pid: number;
+      port: number;
+      startedAt: string;
+      lastHeartbeat: string;
+      version?: string;
+    }
+
+    const shouldReclaimLock = (lockData: DashboardLockWithVersion): { reclaim: boolean; reason: string } => {
+      if (!lockData.pid || !lockData.port || !lockData.startedAt) {
+        return { reclaim: true, reason: 'invalid lock structure' };
+      }
+      // Reclaim when version is absent (old lock file) or differs from current.
+      // undefined means the lock was written before version tracking was added --
+      // treat it as "wrong version" so the fix takes effect on first deployment.
+      if (lockData.version !== CURRENT_VERSION) {
+        return { reclaim: true, reason: `version mismatch (lock=${lockData.version}, current=${CURRENT_VERSION})` };
+      }
+      const lastHeartbeat = new Date(lockData.lastHeartbeat || lockData.startedAt);
+      const ageMinutes = (Date.now() - lastHeartbeat.getTime()) / 60000;
+      if (ageMinutes > 2) {
+        return { reclaim: true, reason: `stale (${ageMinutes.toFixed(1)}min old)` };
+      }
+      return { reclaim: false, reason: 'valid' };
+    };
+
+    // Old lock file written before version field was introduced
+    const oldFormatLock: DashboardLockWithVersion = {
+      pid: 12345,
+      port: 3456,
+      startedAt: new Date().toISOString(),
+      lastHeartbeat: new Date().toISOString(),
+      // version is absent
+    };
+
+    const result = shouldReclaimLock(oldFormatLock);
+    // Should reclaim: undefined version means pre-fix process owns the lock
+    expect(result.reclaim).toBe(true);
+    expect(result.reason).toContain('version mismatch');
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `version` field to `DashboardLock` so the primary election can detect when a newer WorkRail process starts alongside an older one
- New process now SIGTERMs the old primary and waits 2s before binding port 3456, preventing `EADDRINUSE` on version mismatch
- Old lock files (no `version` field) are treated as a version mismatch and reclaimed immediately -- fix works on first deployment, not just second
- Adds `Cache-Control: no-cache` to `index.html` responses to prevent browser caching of stale entry points
- Adds `version` to `/api/health` response

## Test plan

- [ ] Unit tests: version mismatch reclaims, same version does not, `undefined` version (old lock file) reclaims
- [ ] Integration test: write lock file with different version, server reclaims and becomes primary
- [ ] `npx vitest run` passes (3595 tests, pre-existing failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)