### PR TITLE
fix(mcp): fix multi-instance interference from shared state and listener leaks

### DIFF
--- a/src/infrastructure/session/HttpServer.ts
+++ b/src/infrastructure/session/HttpServer.ts
@@ -619,11 +619,22 @@ export class HttpServer {
         // Without this, the old process is still bound to port 3456 and
         // startAsPrimary() throws EADDRINUSE, causing silent fallback to legacy mode.
         // Mirror the graceful-shutdown pattern used in the !reclaim branch above.
+        //
+        // checkHealth() guard: confirm the process on this port is still a WorkRail
+        // instance before sending SIGTERM. A recycled PID (process.kill(pid,0) succeeds
+        // but the PID now belongs to an unrelated process) must not receive SIGTERM.
+        // If the port is no longer responding as WorkRail, the old process already
+        // exited -- skip SIGTERM and proceed directly to the atomic lock reclaim.
         try {
           process.kill(lockData.pid, 0); // Throws if process is dead
-          console.error(`[Dashboard] Sending SIGTERM to old process (PID ${lockData.pid})`);
-          process.kill(lockData.pid, 'SIGTERM');
-          await new Promise(resolve => setTimeout(resolve, 2000)); // Wait 2s for graceful exit
+          const isWorkRailOnPort = await this.checkHealth(lockData.port);
+          if (isWorkRailOnPort) {
+            console.error(`[Dashboard] Sending SIGTERM to old process (PID ${lockData.pid})`);
+            process.kill(lockData.pid, 'SIGTERM');
+            await new Promise(resolve => setTimeout(resolve, 2000)); // Wait 2s for graceful exit
+          } else {
+            console.error(`[Dashboard] PID ${lockData.pid} alive but not WorkRail on port ${lockData.port} -- reclaiming without SIGTERM`);
+          }
         } catch {
           // Process already dead -- proceed to reclaim
         }
@@ -900,8 +911,12 @@ export class HttpServer {
     // 1. FIRST: Stop heartbeat to prevent further lock file writes
     this.heartbeat.stop();
     
-    // 2. Stop all file watchers
+    // 2. Stop all file watchers (session manager + any route-level disposers, e.g. console SSE watcher)
     this.sessionManager.unwatchAll();
+    for (const dispose of this._routeDisposers) {
+      try { dispose(); } catch { /* ignore errors during shutdown */ }
+    }
+    this._routeDisposers.length = 0;
     
     // 3. Close server with timeout protection
     await new Promise<void>((resolve) => {
@@ -935,11 +950,21 @@ export class HttpServer {
    * Used by Console and other extensions that need to add routes
    * without coupling to the HttpServer class.
    *
+   * The installer may return a disposer (() => void) that will be called
+   * during stop() to clean up resources (e.g. FSWatcher instances).
+   * This keeps resource lifecycle tied to the server lifecycle rather than
+   * relying on process exit hooks, which accumulate across multiple mount calls.
+   *
    * Must be called before finalize().
    */
-  mountRoutes(installer: (app: Application) => void): void {
-    installer(this.app);
+  mountRoutes(installer: (app: Application) => (() => void) | void): void {
+    const disposer = installer(this.app);
+    if (disposer != null) {
+      this._routeDisposers.push(disposer);
+    }
   }
+
+  private readonly _routeDisposers: Array<() => void> = [];
 
   /**
    * Install the 404 catch-all handler.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -260,8 +260,11 @@ export interface ComposedServerInternal extends ComposedServer {
  * Those belong in the transport-specific entry points.
  */
 export async function composeServer(): Promise<ComposedServerInternal> {
-  // Bootstrap DI container
-  await bootstrap({ runtimeMode: { kind: 'production' } });
+  // Bootstrap DI container. No runtimeMode override -- detectRuntimeMode() in
+  // container.ts is the single source of truth (reads VITEST / NODE_ENV=test).
+  // Hardcoding 'production' here bypassed test isolation, causing NodeProcessSignals
+  // and NodeProcessTerminator to be used in tests instead of their noop/throwing variants.
+  await bootstrap();
 
   // Create tool context with all dependencies
   const ctx = await createToolContext();

--- a/src/mcp/transports/shutdown-hooks.ts
+++ b/src/mcp/transports/shutdown-hooks.ts
@@ -65,7 +65,10 @@ export function wireShutdownHooks(opts: ShutdownHookOptions): void {
 export function wireStdinShutdown(): void {
   const shutdownEvents = container.resolve<ShutdownEvents>(DI.Runtime.ShutdownEvents);
 
-  process.stdin.on('end', () => {
+  // process.stdin.once: stdin 'end' fires at most once per process lifetime.
+  // Using once prevents listener accumulation if wireStdinShutdown() is ever
+  // called more than once in the same process.
+  process.stdin.once('end', () => {
     console.error('[MCP] stdin closed, initiating shutdown');
     shutdownEvents.emit({ kind: 'shutdown_requested', signal: 'SIGHUP' });
   });

--- a/src/mcp/transports/stdio-entry.ts
+++ b/src/mcp/transports/stdio-entry.ts
@@ -6,11 +6,7 @@
  */
 
 import { composeServer } from '../server.js';
-import { container } from '../../di/container.js';
-import { DI } from '../../di/tokens.js';
-import type { ShutdownEvents } from '../../runtime/ports/shutdown-events.js';
-import type { ProcessSignals } from '../../runtime/ports/process-signals.js';
-import type { ProcessTerminator } from '../../runtime/ports/process-terminator.js';
+import { wireShutdownHooks, wireStdinShutdown } from './shutdown-hooks.js';
 
 const INITIAL_ROOTS_TIMEOUT_MS = 1000;
 
@@ -72,41 +68,18 @@ export async function startStdioServer(): Promise<void> {
     });
 
   // -------------------------------------------------------------------------
-  // Shutdown hooks
+  // Shutdown hooks -- canonical pattern shared with http-entry.ts
   // -------------------------------------------------------------------------
-  const shutdownEvents = container.resolve<ShutdownEvents>(DI.Runtime.ShutdownEvents);
-  const processSignals = container.resolve<ProcessSignals>(DI.Runtime.ProcessSignals);
-  const terminator = container.resolve<ProcessTerminator>(DI.Runtime.ProcessTerminator);
 
-  // Signal handlers: standard for long-running processes
-  processSignals.on('SIGINT', () => shutdownEvents.emit({ kind: 'shutdown_requested', signal: 'SIGINT' }));
-  processSignals.on('SIGTERM', () => shutdownEvents.emit({ kind: 'shutdown_requested', signal: 'SIGTERM' }));
-  processSignals.on('SIGHUP', () => shutdownEvents.emit({ kind: 'shutdown_requested', signal: 'SIGHUP' }));
-
-  // stdio-specific: Shut down when stdin closes (IDE disconnect).
+  // stdio-specific: shut down when stdin closes (IDE disconnect).
   // The MCP SDK's StdioServerTransport does not listen for stdin 'end',
   // so server.onclose never fires on disconnect. Without this, the HTTP
   // server keeps the process alive after stdin EOF, blocking client restart.
-  process.stdin.on('end', () => {
-    console.error('[MCP] stdin closed, initiating shutdown');
-    shutdownEvents.emit({ kind: 'shutdown_requested', signal: 'SIGHUP' });
-  });
+  wireStdinShutdown();
 
-  // Shutdown handler
-  let shutdownStarted = false;
-  shutdownEvents.onShutdown((event) => {
-    if (shutdownStarted) return;
-    shutdownStarted = true;
-
-    void (async () => {
-      try {
-        console.error(`[Shutdown] Requested by ${event.signal}. Stopping services...`);
-        await ctx.httpServer?.stop();
-        terminator.terminate({ kind: 'success' });
-      } catch (err) {
-        console.error('[Shutdown] Error while stopping services:', err);
-        terminator.terminate({ kind: 'failure' });
-      }
-    })();
+  wireShutdownHooks({
+    onBeforeTerminate: async () => {
+      await ctx.httpServer?.stop();
+    },
   });
 }

--- a/src/runtime/adapters/node-process-signals.ts
+++ b/src/runtime/adapters/node-process-signals.ts
@@ -6,6 +6,12 @@ import type { ProcessSignal, ProcessSignals } from '../ports/process-signals.js'
  */
 export class NodeProcessSignals implements ProcessSignals {
   on(signal: ProcessSignal, handler: () => void | Promise<void>): void {
+    // process.on (not process.once) is intentional. NodeProcessSignals is a
+    // shared DI singleton -- both HttpServer.setupPrimaryCleanup() and
+    // wireShutdownHooks() call on() for SIGINT/SIGTERM/SIGHUP. With process.once,
+    // the second caller's registrations would be silently dropped after the first
+    // signal fires. Double-invocation is prevented by the shutdownStarted latch
+    // in each caller, not by once-semantics at the OS listener level.
     process.on(signal as any, () => {
       void handler();
     });

--- a/src/v2/usecases/console-routes.ts
+++ b/src/v2/usecases/console-routes.ts
@@ -22,29 +22,13 @@ import { DEV_MODE } from '../../mcp/dev-mode.js';
 // clients. When the sessions directory changes (new session, status update,
 // recap written) all connected EventSource clients receive a 'change' event so
 // they can immediately re-fetch instead of waiting for the next poll interval.
+//
+// NOTE: sseClients and sseDebounceTimer are intentionally declared inside
+// mountConsoleRoutes() (not at module scope). Module-level state is shared
+// across all calls to mountConsoleRoutes(), causing SSE broadcasts from one
+// WorkRail instance's watcher to fire on a different instance's browser clients.
+// Closure scope makes shared state structurally impossible.
 // ---------------------------------------------------------------------------
-
-const sseClients = new Set<Response>();
-
-/**
- * Debounce a change notification so rapid successive writes (e.g. a sequence
- * of event appends in one continue_workflow call) collapse into one broadcast.
- */
-let sseDebounceTimer: ReturnType<typeof setTimeout> | null = null;
-function broadcastChange(): void {
-  if (sseDebounceTimer !== null) return; // already scheduled
-  sseDebounceTimer = setTimeout(() => {
-    sseDebounceTimer = null;
-    for (const client of sseClients) {
-      try {
-        client.write('data: {"type":"change"}\n\n');
-      } catch {
-        // Client already disconnected -- remove it
-        sseClients.delete(client);
-      }
-    }
-  }, 200);
-}
 
 /**
  * Watch the sessions directory and broadcast a change event whenever any file
@@ -54,7 +38,7 @@ function broadcastChange(): void {
  * On unsupported platforms the watcher silently degrades -- clients fall back
  * to their polling interval.
  */
-function watchSessionsDir(sessionsDir: string): (() => void) {
+function watchSessionsDir(sessionsDir: string, onChanged: () => void): (() => void) {
   // Create the directory if it doesn't exist yet (first run before any session)
   try { fs.mkdirSync(sessionsDir, { recursive: true }); } catch { /* ignore */ }
 
@@ -68,7 +52,7 @@ function watchSessionsDir(sessionsDir: string): (() => void) {
       // otherwise trigger unnecessary session refetches.
       // filename can be null on some platforms -- guard required.
       if (filename !== null && filename.endsWith('.jsonl')) {
-        broadcastChange();
+        onChanged();
       }
     });
     watcher.on('error', () => { /* ignore watch errors -- polling fallback covers gaps */ });
@@ -131,11 +115,36 @@ export function mountConsoleRoutes(
   consoleService: ConsoleService,
   workflowService?: WorkflowService,
   timingRingBuffer?: ToolCallTimingRingBuffer,
-): void {
-  // Start watching the sessions directory so SSE clients get notified of changes
-  const stopWatcher = watchSessionsDir(consoleService.getSessionsDir());
-  // Clean up watcher if the process exits gracefully
-  process.once('exit', stopWatcher);
+): () => void {
+  // SSE state: per-instance, not module-level (see comment block above).
+  const sseClients = new Set<Response>();
+  let sseDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Debounce a change notification so rapid successive writes (e.g. a sequence
+   * of event appends in one continue_workflow call) collapse into one broadcast.
+   */
+  function broadcastChange(): void {
+    if (sseDebounceTimer !== null) return; // already scheduled
+    sseDebounceTimer = setTimeout(() => {
+      sseDebounceTimer = null;
+      for (const client of sseClients) {
+        try {
+          client.write('data: {"type":"change"}\n\n');
+        } catch {
+          // Client already disconnected -- remove it
+          sseClients.delete(client);
+        }
+      }
+    }, 200);
+  }
+
+  // Start watching the sessions directory so SSE clients get notified of changes.
+  // stopWatcher is returned as a disposer -- the caller (HttpServer.mountRoutes)
+  // stores it and invokes it during stop(). process.once('exit') is intentionally
+  // NOT used here: it accumulates one listener per mountConsoleRoutes() call,
+  // causing MaxListenersExceededWarning on stderr which corrupts the MCP stdio channel.
+  const stopWatcher = watchSessionsDir(consoleService.getSessionsDir(), broadcastChange);
 
   // --- API routes ---
 
@@ -376,4 +385,6 @@ export function mountConsoleRoutes(
     });
     console.error('[Console] UI not found (run: cd console && npm run build)');
   }
+
+  return stopWatcher;
 }


### PR DESCRIPTION
## Summary

- Move `sseClients`/`sseDebounceTimer`/`broadcastChange` from module scope into `mountConsoleRoutes()` closure -- multiple WorkRail instances shared the same SSE client set, causing change events from one project's watcher to broadcast to another project's browser tabs
- Return a `() => void` disposer from `mountConsoleRoutes()` and call it in `HttpServer.stop()` -- replaces `process.once('exit', stopWatcher)` which accumulated one listener per call, emitting `MaxListenersExceededWarning` to stderr (the MCP stdio channel), corrupting JSON-RPC and causing disconnects
- Migrate `stdio-entry.ts` to `wireShutdownHooks()` + `wireStdinShutdown()` -- removes 30-line inline duplicate of the canonical pattern already in `http-entry.ts`
- Remove hardcoded `{ runtimeMode: { kind: 'production' } }` from `composeServer()` -- `detectRuntimeMode()` in `container.ts` is the single source of truth; the override was causing tests to get `NodeProcessSignals`/`NodeProcessTerminator` instead of their noop/throwing variants
- Add `checkHealth()` guard before SIGTERM in `reclaimStaleLock()` -- prevents sending SIGTERM to a recycled PID that no longer belongs to a WorkRail process

## Test plan

- [ ] `npx vitest run` passes (30 pre-existing failures unchanged, 3767 passing)
- [ ] `npx tsc --noEmit` clean
- [ ] Reload MCP server -- no more `MaxListenersExceededWarning` on stderr
- [ ] Multiple WorkRail instances running simultaneously no longer cause MCP disconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)