### PR TITLE
feat(engine): allow multiple assessmentRefs with a single consequence

### DIFF
--- a/docs/authoring-v2.md
+++ b/docs/authoring-v2.md
@@ -156,7 +156,7 @@ WorkRail v2 introduces several primitives for expressive workflows:
 - **AgentRole**: workflow and/or step-level stance/persona (not system prompt control).
 - **Extension points**: named slots declared with `extensionPoints` and referenced via `{{wr.bindings.slotId}}` tokens; resolved at compile time from project `.workrail/bindings.json` overrides or workflow defaults. Enables project-overridable delegation seams without forking workflow JSON.
 - **References**: workflow-declared pointers to external documents (schemas, specs, guides). Resolved at start time, delivered as a separate MCP content item. The agent reads the files itself if needed. See "Workflow references" section below.
-- **Assessments**: workflow-declared assessment shapes (`assessments`) that steps can reference with `assessmentRefs` and, in v1, use for one exact-match `require_followup` consequence via `assessmentConsequences`.
+- **Assessments**: workflow-declared assessment shapes (`assessments`) that steps can reference with one or more `assessmentRefs` and, in v1, use for one exact-match `require_followup` consequence via `assessmentConsequences` (fires if any dimension across any referenced assessment equals the trigger level).
 
 For detailed JSON syntax and examples, see: `docs/design/workflow-authoring-v2.md`.
 
@@ -229,14 +229,14 @@ Use them when:
 
 The v1 shape is:
 
-- declare a workflow-level assessment in `assessments`
-- reference it from a step with exactly one `assessmentRefs` entry
+- declare one or more workflow-level assessments in `assessments`
+- reference them from a step with one or more `assessmentRefs` entries
 - optionally declare one step-level `assessmentConsequences` rule
-- if the accepted canonical assessment exactly matches that rule, the engine returns a retryable same-step follow-up block
+- if any dimension across any referenced assessment matches that rule, the engine returns a retryable same-step follow-up block
 
 Important limits in v1:
 
-- one `assessmentRefs` entry per step
+- at least one `assessmentRefs` entry when `assessmentConsequences` is present; multiple refs are supported
 - at most one `assessmentConsequences` entry per step
 - one supported effect only: `require_followup`
 - exact-match trigger only: one declared dimension equals one declared canonical level

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -21,6 +21,7 @@ Canonical current rules for authoring good WorkRail workflows. workflow.schema.j
 - Then update this authoring spec so guidance matches the shipped behavior.
 - Then regenerate or update human-facing docs and examples derived from this spec.
 - Do not leave authoring guidance behind the runtime.
+- Increment `version` when any required-level rule is added, removed, or materially changed. Add a `changelog` entry for the new version.
 
 ## Quickstart
 ### start-from-real-sources
@@ -99,52 +100,6 @@ Canonical current rules for authoring good WorkRail workflows. workflow.schema.j
 
 **Source refs**
 - `spec/workflow.schema.json` (schema) — Legal workflow structure lives here.
-
-### assessment-definitions-hold-vocabulary-not-policy
-- **Level**: recommended
-- **Status**: active
-- **Scope**: workflow.assessments, step.assessment-refs, step.assessment-consequences
-- **Rule**: Put reusable judgment vocabulary in `assessments`, and put execution behavior in step-level `assessmentConsequences`.
-- **Why**: Shared assessment definitions should describe what can be judged, while step-local declarations decide what the workflow does with that judgment.
-- **Enforced by**: validator, compiler, advisory
-
-**Checks**
-- Use `assessments` for dimensions, levels, and purpose only.
-- Use `assessmentRefs` to opt a step into one declared assessment.
-- Use `assessmentConsequences` only on the step that should react to the assessment result.
-
-**Anti-patterns**
-- Encoding step-specific follow-up policy into a shared assessment definition
-- Reusing one assessment definition and expecting all referencing steps to inherit the same behavior implicitly
-
-**Source refs**
-- `spec/workflow.schema.json` (schema) — Assessment declarations and step usage fields.
-- `src/application/services/validation-engine.ts` (validator) — Enforces valid assessment refs and consequence shapes.
-- `src/application/services/workflow-compiler.ts` (runtime) — Fails fast on invalid assessment consequence declarations.
-
-### assessment-consequences-stay-narrow-in-v1
-- **Level**: required
-- **Status**: active
-- **Scope**: step.assessment-consequences, workflow.authoring, documentation.authoring
-- **Rule**: Author assessment consequences using only the shipped v1 shape: one exact-match trigger and one `require_followup` effect.
-- **Why**: The engine supports a deliberately narrow assessment consequence model today. Authoring ahead of that model would create drift and false expectations.
-- **Enforced by**: validator, compiler, advisory
-
-**Checks**
-- Declare at most one `assessmentRefs` entry per step.
-- Declare at most one `assessmentConsequences` entry per step.
-- Use one declared dimension and one declared canonical level for the trigger.
-- Use `require_followup` guidance that keeps the same step pending and retryable.
-
-**Anti-patterns**
-- Multiple consequence rules on one step
-- Scoring ladders or severity tables encoded as pseudo-policy
-- Follow-up wording that implies rewind or a new subflow when the engine still expects same-step retry
-
-**Source refs**
-- `spec/workflow.schema.json` (schema) — V1 legal assessment consequence structure.
-- `src/mcp/handlers/v2-advance-core/assessment-consequences.ts` (runtime) — Exact-match evaluation semantics.
-- `src/v2/durable-core/domain/reason-model.ts` (runtime) — Same-step follow-up blocker framing.
 
 ### runtime-behavior-beats-prose
 - **Level**: required
@@ -346,49 +301,6 @@ Canonical current rules for authoring good WorkRail workflows. workflow.schema.j
 - `src/application/services/compiler/feature-registry.ts` (runtime) — The registry rejects unknown feature IDs at compile time.
 
 
-## Workflow catalog fields
-### about-is-for-human-readers
-- **Level**: recommended
-- **Status**: active
-- **Scope**: workflow.about, documentation.authoring
-- **Rule**: Use `about` for a human-readable overview of the workflow for display in the console and other catalog UIs. Do not use `metaGuidance` as a substitute for `about`.
-- **Why**: `metaGuidance` is surfaced to agents at runtime. `about` is surfaced to humans browsing the catalog before they start a workflow. Mixing the two audiences produces text that serves neither well.
-- **Enforced by**: advisory; `workflow-for-workflows.v2.json` Phase 7a prompts for this field
-
-**Content guidance**
-Write `about` for a user deciding whether to use the workflow. Cover: what it does, when to use it, what it produces, and how to get good results. Markdown is supported. Aim for 100-400 words; longer is acceptable if the workflow is complex. The `description` field (one sentence, max 512 chars) handles the brief summary -- `about` is the detail.
-
-**Anti-patterns**
-- Writing `about` as a list of behavioral rules (that belongs in `metaGuidance`)
-- Writing `metaGuidance` as a usage guide for humans (that belongs in `about`)
-- Omitting `about` from a workflow that would be hard to evaluate from `description` alone
-
-### examples-are-for-catalog-discoverability
-- **Level**: recommended
-- **Status**: active
-- **Scope**: workflow.examples, documentation.authoring
-- **Rule**: Use `examples` for 2-6 short, concrete goal strings that illustrate what this workflow is used for. Write them as if they are real user goals a developer would actually type.
-- **Why**: `examples` serve two audiences: humans browsing the console catalog and agents selecting a workflow on the user's behalf. They appear in `list_workflows` MCP output so agents can communicate concrete goal phrasing to users. Vague or generic examples serve neither audience.
-- **Enforced by**: advisory; `workflow-for-workflows.v2.json` Phase 7a prompts for these fields
-
-**Content guidance**
-Each example should be specific enough to be informative and short enough to scan (10-120 characters). Prefer examples that would actually appear as a `goal` parameter when starting the workflow.
-
-**Good examples (for `coding-task-workflow-agentic`)**
-- "Implement JWT refresh token rotation in the auth service"
-- "Fix the race condition in the cache invalidation path when concurrent writes occur"
-- "Refactor the payment flow to use a Result type instead of throwing exceptions"
-
-**Bad examples**
-- "Implement a feature" -- applies to any coding workflow, adds no signal
-- "Review code" -- too generic, does not help an agent distinguish this from mr-review-workflow
-- "Use this when you need to implement something" -- written as an instruction, not a goal
-
-**Anti-patterns**
-- Generic examples that apply to many workflows
-- Phrasing as instructions ("use this when...") rather than goals
-- Fewer than 2 examples -- single examples do not show the range of applicable tasks
-
 ## Workflow references
 ### references-are-for-runtime-companion-material
 - **Level**: recommended
@@ -534,6 +446,63 @@ Each example should be specific enough to be informative and short enough to sca
 
 **Source refs**
 - `workflows/coding-task-workflow-agentic.lean.v2.json` (example) — Uses confirmation for real review barriers like MultiPR checkpoints.
+
+
+## Assessment gates
+### assessment-use-for-bounded-judgment
+- **Level**: recommended
+- **Status**: active
+- **Scope**: workflow.assessments, step.assessmentRefs, step.assessmentConsequences
+- **Rule**: Use assessment gates when a step needs the agent to submit a bounded, durable judgment before the workflow can safely advance -- not for generic scoring or ceremony.
+- **Why**: Assessment gates force explicit structured reasoning at a decision point and durably record the result. Generic scoring that never affects routing adds noise without value.
+- **Enforced by**: advisory
+
+**Checks**
+- The assessment is at a step where a wrong answer would produce a bad handoff.
+- At least one dimension has a consequence that keeps the step pending and requires follow-up.
+- The assessment result is durably recorded and useful to a future resume agent.
+
+**Anti-patterns**
+- Using assessments as a generic five-level scoring rubric with no routing consequence
+- Declaring an assessment but never referencing it from any step
+
+**Source refs**
+- `workflows/mr-review-workflow.agentic.v2.json` (example) — Uses a three-dimension readiness gate on the final validation step.
+- `workflows/bug-investigation.agentic.v2.json` (example) — Uses a single-dimension diagnosis readiness gate before handoff.
+
+### assessment-dimension-orthogonality
+- **Level**: required
+- **Status**: active
+- **Scope**: workflow.assessments
+- **Rule**: Each dimension in an assessment must capture a distinct failure mode that the other dimensions cannot catch. A dimension that restates existing workflow state (such as a generic 'confidence' dimension that mirrors the workflow's confidence band) adds ceremony without structure.
+- **Why**: The value of multiple dimensions is that each one independently blocks advancement for a different reason. Correlated or vague dimensions collapse to a single gate with extra steps.
+- **Enforced by**: advisory
+
+**Checks**
+- Each dimension is independently checkable without needing to know the result of the others.
+- No dimension restates a context variable the workflow already computes (e.g. recommendationConfidenceBand).
+- A 'low' rating on any one dimension alone justifies a follow-up, regardless of the others.
+
+**Anti-patterns**
+- A single 'confidence' dimension that mirrors the workflow's existing confidence band
+- Multiple dimensions that all reduce to 'did I do a good job overall'
+- Dimensions so correlated that one being low always means the others are low too
+
+### assessment-v1-constraints
+- **Level**: required
+- **Status**: active
+- **Scope**: step.assessmentRefs, step.assessmentConsequences
+- **Rule**: A step may declare one or more assessmentRefs and at most one assessmentConsequences entry. When assessmentConsequences is present, at least one ref is required. Use anyEqualsLevel as the trigger -- the engine checks all submitted dimensions across all referenced assessments and fires if any equals that level.
+- **Why**: Multiple refs allow composing separate orthogonal assessment definitions (e.g. quality-gate + coverage-gate) behind a single blocking consequence, without forcing unrelated dimensions into one monolithic definition.
+- **Enforced by**: schema
+
+**Checks**
+- At least one assessmentRefs entry when assessmentConsequences is present.
+- No more than one assessmentConsequences entry per step.
+- The consequence uses anyEqualsLevel to declare which level blocks -- not a named dimension.
+
+**Anti-patterns**
+- Trying to encode multiple consequences via workarounds
 
 
 ## Delegation and subagents
@@ -876,3 +845,4 @@ Each example should be specific enough to be informative and short enough to sca
 - `delegation.context-packet`: Structured context passed to subagents
 - `delegation.result-envelope`: Structured result shape returned by subagents
 - `legacy.patterns`: Older authoring patterns that should now be discouraged or avoided
+

--- a/docs/changelog-recent.md
+++ b/docs/changelog-recent.md
@@ -1,0 +1,201 @@
+# WorkRail: What Changed in the Last Month
+
+---
+
+WorkRail is the system that makes AI agents follow structured, step-by-step processes. Instead of letting an agent improvise its way through a code review or a bug investigation, WorkRail enforces a defined workflow: one step at a time, with gates, quality checks, and durable history.
+
+This document covers the meaningful changes from the past month -- what shipped, why it matters, and what it changes for your team.
+
+---
+
+## The New Engine Is Now the Default
+
+The original WorkRail engine was stateless -- every call was independent, and if a conversation ended mid-workflow, the work was gone. There was no way to resume, no branching, no loops, and no record of what had happened.
+
+A new engine was built to replace it. When an agent starts a workflow with the new engine, WorkRail creates a session and writes it to disk as an append-only event log. Every step taken, every blocked attempt, every branching path is recorded. Sessions survive across conversations, across days, across restarts. If a long-running workflow is interrupted, it can be resumed exactly where it left off -- even in a different conversation. The execution history is stored as a directed graph, which is what lets the console show a visual trace of everything the agent did.
+
+The new engine was developed while the original ran in production, then gradually rolled out. It is now the default for everyone. The original engine still exists in the codebase but is not actively developed and is not the path anyone is taking.
+
+A few other things shipped alongside this promotion to default:
+
+- Every workflow run now goes through a validation pass before the agent takes a single step, catching broken workflow definitions at startup rather than mid-run
+- The protocol agents use to communicate with WorkRail was simplified -- two tokens agents previously had to manage are merged into a single `continueToken`
+
+**What this means:** WorkRail is now resilient infrastructure. Long-running workflows that span hours or multiple conversations are reliable and resumable. The console can show your team a full history of what their agents did and why.
+
+---
+
+## Workflow Discovery Is Much Better
+
+Previously, when an agent asked "what workflows are available?", it got a flat list of names -- not useful if you don't already know what you're looking for.
+
+Workflows are now organized into eight visible categories: Coding & Development, Review & Audit, Investigation & Debugging, Design & Discovery, Documentation, Tickets & Planning, Learning & Personal, and Workflow Authoring. (There is also a Routines category used internally as building blocks for other workflows -- it's deliberately hidden from the user-facing catalog.) Discovery works in two steps:
+
+1. Agent asks -- gets a compact category overview (~500 tokens) with descriptions of when each category applies and example workflow IDs
+2. Agent picks a category -- gets only the workflows that match
+
+Workflows can belong to multiple categories. A workflow that generates test cases from tickets shows up under both Tickets & Planning and Coding & Development.
+
+A `workrail://tags` MCP resource lets agents read the full category catalog as a lightweight static read, without triggering a workflow list at all.
+
+**What this means for your team:** Agents make more accurate workflow choices when they understand the landscape. The Workflows tab in the console (covered below) also gives your team a visual catalog to browse before talking to their agent.
+
+---
+
+## Your Team's Workflows Are Now First-Class
+
+This is probably the most relevant change given that you've created workflows for your team.
+
+WorkRail now has a proper source management system. Previously, team workflows lived wherever you put them and agents had to know where to look. Now:
+
+- `list_workflows` tells agents where every workflow comes from: `built_in` (ships with WorkRail), `personal` (your own user directory), `rooted_sharing` (shared via a workspace root), or `external`
+- When workflows conflict or overlap, the system explains why one takes precedence
+- A `manage_workflow_source` tool lets agents register or unregister workflow directories, useful for sources that aren't in repos the agent already knows about
+
+**Important caveat on team sharing:** The registered sources are stored per-machine (`~/.workrail/`), not per-repo or per-team. Each developer and each CI environment manages its own list. There is no "attach once and everyone sees it" mechanism yet.
+
+**The good news:** If your team's workflows live in a `.workrail/workflows/` directory inside a repo that team members already use with WorkRail, auto-discovery handles it without any manual setup. The agent automatically walks workspace roots it knows about and finds `.workrail/workflows/` directories. For repos that have been used with `list_workflows` or `inspect_workflow` (passing `workspacePath`), the team workflows will already appear.
+
+**Action for you:** If you haven't already, the cleanest setup is to put your team workflows in `.workrail/workflows/` inside your shared repo. As long as team members run WorkRail with that repo's path as their workspace, the workflows appear automatically -- no `manage_workflow_source` call needed.
+
+---
+
+## Assessment Gates Now Support Multiple References
+
+A step can now declare multiple `assessmentRefs` alongside a single `assessmentConsequences` entry. The consequence fires if any dimension across any referenced assessment equals the trigger level.
+
+Previously, having a consequence required exactly one `assessmentRef`, which forced authors to cram unrelated dimensions into one monolithic assessment definition. With many-to-one, you can compose separate orthogonal assessment definitions -- one for quality, one for coverage, one for confidence -- and share a single blocking gate across all of them.
+
+```json
+{
+  "assessmentRefs": ["quality-gate", "coverage-gate"],
+  "assessmentConsequences": [
+    { "when": { "anyEqualsLevel": "low" }, "effect": { "kind": "require_followup", "guidance": "Address all low dimensions before proceeding." } }
+  ]
+}
+```
+
+**What this means for workflow authors:** No more monolithic assessment definitions. Compose narrow, reusable assessment vocabularies and combine them at the step level.
+
+**Breaking change:** `stepContext.assessments` in the `continue_workflow` response is now an **array** (one entry per `assessmentRef`), not a single object. If you read `stepContext.assessments.assessmentId` directly, update to `stepContext.assessments[0].assessmentId`. Sessions where an assessment step completed before this change will replay correctly -- the durable event log is unaffected.
+
+---
+
+## Agent Outputs Can Now Have Quality Checkpoints
+
+This is one of the most significant engine additions this month.
+
+Workflows can now declare **assessment criteria** -- named checkpoints where the agent self-evaluates its own output against a set of defined dimensions before the step can complete. For example, a bug investigation step can require that the agent rates its own confidence as `high` before the workflow advances. If the agent rates itself `low`, the engine keeps the step pending and requires a retry with improved output.
+
+It's worth being precise about how this works: the engine does not independently evaluate quality. It records the agent's own self-assessment and checks whether any dimension falls below the configured threshold. If the agent dishonestly rates its own output highly, the gate doesn't catch it. What assessment gates do is create a **structured self-evaluation checkpoint** -- they force the agent to explicitly commit to a quality rating, which in practice produces better outputs because the agent has to reason through its own confidence before proceeding.
+
+The `bug-investigation.agentic.v2.json` workflow uses this for confidence gating on the diagnosis step. The `mr-review-workflow.agentic.v2.json` workflow also uses it, with three dimensions: evidence quality, coverage completeness, and contradiction resolution.
+
+**What this means:** Workflows can create soft quality floors on agent outputs. Not a hard guarantee -- the agent self-reports -- but a forcing function that produces meaningfully better outputs in practice.
+
+---
+
+## New Bundled Workflows
+
+Four new structured workflows were added:
+
+### Production Readiness Audit
+Answers one question honestly: is this code actually ready for production? Goes beyond style and lint. Covers runtime operability, error handling, observability, security exposure, and technical debt. Produces an explicit verdict -- `ready`, `ready_with_conditions`, `not_ready`, or `inconclusive` -- with evidence requirements. The agent cannot just say "looks fine."
+
+### UI/UX Design Workflow
+Addresses the specific ways AI agents fail at design work: jumping to a single solution before understanding the problem, knowing UX laws but not applying them, ignoring accessibility, and skipping error states and edge cases. Forces the agent through: problem framing (before any solutions), multiple design directions (before converging on one), and parallel review by separate reviewer families for information architecture, UX laws, accessibility, edge cases, and content. Produces a design spec, not just suggestions.
+
+### Architecture Scalability Audit
+Scoped, evidence-driven audit across a subset of five dimensions the requester selects: `load` (handling more traffic), `data_volume` (handling more records), `team_org` (more developers working on the same code), `feature_extensibility` (adding features without rearchitecting), and `operational` (more deployments and environments). The user picks which dimensions apply -- not all five are always audited. Every finding must cite actual code. Produces per-dimension verdicts.
+
+### Cross-Platform Code Conversion
+Structured migration workflow for moving code between platforms (Android to iOS, server to client, etc.). Classifies work into three tiers: mechanical translation (parallelizable), adaptation (needs design consideration), and redesign (needs full attention). Delegates the mechanical parts to parallel subagents and focuses review effort on the hard cases.
+
+---
+
+## Workflow Authoring Got Significantly Better
+
+Since you've created workflows yourself, these changes are directly relevant.
+
+### `workflow-for-workflows.v2.json` was rebuilt
+
+The workflow used to create or modernize other workflows was significantly redesigned. The full phase structure now includes:
+
+1. Understanding and classifying the authoring task
+2. **Effectiveness targeting** -- defining what "good execution" looks like for this specific workflow before writing a single step
+3. Designing the workflow architecture (for non-trivial workflows)
+4. **Quality gate architecture** -- explicit decisions about what the workflow will enforce vs. leave to the agent
+5. Structural validation
+6. A quality gate loop with four phases run in sequence: **state-economy audit** (catching redundant context between steps), **execution simulation** (the agent simulates a run before declaring it done), **adversarial review** (a deliberate attempt to find failure modes), and a **redesign phase** if problems are found
+7. Final trust handoff with spec version stamp
+
+The result is that workflows produced through this process are more reliable and better calibrated.
+
+### References
+
+A workflow can declare external documents -- your team's coding standards, an architecture decision record, a product spec -- and WorkRail delivers pointers to them when the session starts and again when a session is resumed. (References are not re-sent on every step advance -- the agent is expected to read the files it needs from its initial context.) This gives the agent relevant background from the first step rather than burying it in a prompt halfway through the workflow.
+
+### Prompt fragments
+
+Instead of duplicating near-identical step prompts for "if the scope is small, do X; if large, do Y", workflow authors write one step with named conditional variants. The compiler inlines the right one at runtime based on context variables. Two concrete benefits: less maintenance for authors, and meaningfully less context sent to the agent on each step -- only the relevant variant is delivered, not all of them.
+
+### `about` and `examples` fields
+
+Every workflow now has two new optional fields that are purely for humans -- neither is visible to agents, only through the Workflows tab in the console:
+
+- `about`: a human-readable markdown description (what it does, when to use it, what it produces, how to get good results). Shown in the detail panel when you click a workflow.
+- `examples`: 2-6 short, concrete goal strings illustrating what the workflow is for. Shown alongside the description.
+
+All 22 non-test bundled workflows were backfilled with both fields. The authoring workflow now prompts for both during Phase 7a.
+
+**Action for you:** Your team's existing workflows don't have these fields yet. Adding them means anyone on the team can click your workflow in the console and immediately understand what it's for and when to reach for it. Two new fields in the JSON.
+
+### `goal` is now required on `start_workflow`
+
+When an agent starts a workflow, it must provide a `goal` -- a sentence describing what it's trying to accomplish. This is stored immediately as the session title. Omitting it causes a hard validation error before execution begins.
+
+Before this, sessions appeared in the console as random IDs until the agent produced output. Now you see "Review PR #47 for correctness and production risk" from the moment the session starts.
+
+**Action for you:** If your team has scripts or prompts that start workflows without a `goal` parameter, they need to be updated. The error is explicit about what's missing.
+
+---
+
+## The Console Is Now a Full Dashboard
+
+The browser-based console went from an early release to a complete workspace tool this month.
+
+### Workspace (default view)
+The main view organizes everything by git branch within each repo. It combines two things that used to require separate tabs: workflow session history and git worktree state. Each branch row shows the session title, workflow name, time ago, git state badges (uncommitted file count, unpushed commit count), and active worktree status. Clicking the badges expands a panel showing the actual files or commits.
+
+Active branches (with running or blocked sessions) sort to the top. Older clean branches show as compact rows below. Keyboard navigation throughout (j/k to move, Enter to open, / for the session archive).
+
+### Workflows tab
+A visual catalog of every available workflow. Eight category filter pills. Click any workflow for its full description, usage examples, and preconditions.
+
+---
+
+## Staleness Detection
+
+WorkRail can now detect when a workflow hasn't been reviewed against the current authoring spec. Three signal levels:
+
+- `none` -- validated against the current spec (has a version stamp and it's current)
+- `possible` -- no version stamp (was never run through `workflow-for-workflows`)
+- `likely` -- has a stamp, but the spec has been updated since the workflow was last reviewed
+
+This shows up in `list_workflows` output (agents see it) and in the CI registry validation check. It's shown only for non-built-in workflows -- built-in workflows ship with their own quality process and don't show staleness signals.
+
+**What this means for your team:** Your team's existing workflows will show as `possible` (no stamp) until they're run through `workflow-for-workflows.v2.json`. That's expected -- it's not an error, just a signal that they haven't been through the new quality gate. Over time, as you modernize them, they'll show `none`.
+
+---
+
+## What's Coming Next
+
+The things in active development or planned for the near term:
+
+- **Console execution trace** -- the console currently shows what nodes were created; it doesn't yet explain *why* the engine chose a particular path (skipped phases, fast paths, condition evaluations). That visibility is the next major console investment
+- **Dashboard artifacts** -- instead of agents writing markdown files to your repo during a workflow run, structured outputs would be submitted through the workflow and rendered directly in the console session view
+- **Broader workflow source onboarding** -- richer source health reporting, update/sync flows, and making team workflow setup even simpler
+
+---
+
+*Last updated: April 2026*

--- a/docs/reference/god-tier-workflow-validation.md
+++ b/docs/reference/god-tier-workflow-validation.md
@@ -117,8 +117,10 @@ Validation must check the authored workflow for:
 - function definition/call integrity
 - condition shape
 - confirmation rule shape
-- validation criteria shape
+- validation criteria shape (including context-aware condition integrity on individual rules)
 - output contract shape
+- assessment ref integrity: every `assessmentRef` on every step must resolve to a declared workflow-level assessment
+- assessment consequence shape: if `assessmentConsequences` is present, at least one `assessmentRef` must be declared; the `anyEqualsLevel` trigger value must exist in at least one dimension of at least one referenced assessment; at most one consequence per step
 - structural workflow invariants
 This layer catches bad authored input early, before normalization.
 ## Phase 4 — Executable Normalization Validation
@@ -148,6 +150,7 @@ Validation must prove the executable workflow compiles into runtime structures s
 - loop-body resolution
 - condition-source derivation
 - output contracts
+- assessment consequence compilation: all referenced assessments resolve, trigger levels are reachable across the combined dimension set, consequence effect kinds are supported
 - any other runtime compilation artifacts
 ### Required rule
 If compilation fails, validation fails.
@@ -186,6 +189,7 @@ Each execution-tested workflow should define or be paired with:
 - synthetic user answers
 - synthetic step outputs
 - branch-driving context values
+- synthetic assessment artifacts for steps with `assessmentRefs` (one `wr.assessment` artifact per ref, with canonical dimension levels)
 - expected terminal condition
 ## Required Execution Coverage
 At minimum, each runnable workflow should have:

--- a/spec/authoring-spec.json
+++ b/spec/authoring-spec.json
@@ -998,11 +998,11 @@
             "step.assessmentRefs",
             "step.assessmentConsequences"
           ],
-          "rule": "V1 supports exactly one assessmentRef per step and at most one assessmentConsequences entry per step. Use anyEqualsLevel as the trigger -- the engine checks all submitted dimensions and fires if any equals that level.",
-          "why": "anyEqualsLevel is the only trigger form. It works for both single-dimension and multi-dimension assessments without requiring the author to choose between two forms.",
+          "rule": "A step may declare one or more assessmentRefs and at most one assessmentConsequences entry. When assessmentConsequences is present, at least one ref is required. Use anyEqualsLevel as the trigger -- the engine checks all submitted dimensions across all referenced assessments and fires if any equals that level.",
+          "why": "Multiple refs allow composing separate orthogonal assessment definitions (e.g. quality-gate + coverage-gate) behind a single blocking consequence, without forcing unrelated dimensions into one monolithic definition.",
           "enforcement": ["schema"],
           "checks": [
-            "No more than one assessmentRefs entry per step.",
+            "At least one assessmentRefs entry when assessmentConsequences is present.",
             "No more than one assessmentConsequences entry per step.",
             "The consequence uses anyEqualsLevel to declare which level blocks -- not a named dimension."
           ],

--- a/spec/workflow.schema.json
+++ b/spec/workflow.schema.json
@@ -456,14 +456,13 @@
         },
         "assessmentRefs": {
           "type": "array",
-          "description": "References to workflow-level assessment definitions expected for this step. V1 supports exactly one assessmentRef per step.",
+          "description": "References to workflow-level assessment definitions expected for this step. When assessmentConsequences is present, at least one ref is required; multiple refs are supported and the consequence fires if any dimension across any referenced assessment equals the trigger level.",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 64
           },
           "minItems": 1,
-          "maxItems": 1,
           "uniqueItems": true
         },
         "assessmentConsequences": {

--- a/src/application/services/validation-engine.ts
+++ b/src/application/services/validation-engine.ts
@@ -902,9 +902,9 @@ export class ValidationEngine {
         return;
       }
 
-      if (!step.assessmentRefs || step.assessmentRefs.length !== 1) {
-        issues.push(`${stepLabel}: assessmentConsequences require exactly one assessmentRef on the same step`);
-        suggestions.push(`Add exactly one assessmentRef to ${stepLabel} before declaring assessmentConsequences`);
+      if (!step.assessmentRefs || step.assessmentRefs.length === 0) {
+        issues.push(`${stepLabel}: assessmentConsequences require at least one assessmentRef on the same step`);
+        suggestions.push(`Add at least one assessmentRef to ${stepLabel} before declaring assessmentConsequences`);
         return;
       }
 
@@ -913,17 +913,17 @@ export class ValidationEngine {
         suggestions.push(`Reduce assessmentConsequences on ${stepLabel} to a single declaration`);
       }
 
-      const assessmentDefinition = assessments.find(assessment => assessment.id === step.assessmentRefs?.[0]);
-      if (!assessmentDefinition) return;
+      const referencedDefinitions = assessments.filter(assessment => step.assessmentRefs!.includes(assessment.id));
+      if (referencedDefinitions.length === 0) return;
 
       for (const consequence of step.assessmentConsequences) {
         const trigger = consequence.when;
         const effect = consequence.effect;
 
-        const allLevels = assessmentDefinition.dimensions.flatMap(d => d.levels);
+        const allLevels = referencedDefinitions.flatMap(def => def.dimensions.flatMap(d => d.levels));
         if (!allLevels.includes(trigger.anyEqualsLevel)) {
           issues.push(
-            `${stepLabel}: assessment consequence anyEqualsLevel '${trigger.anyEqualsLevel}' is not declared in any dimension of assessment '${assessmentDefinition.id}'`
+            `${stepLabel}: assessment consequence anyEqualsLevel '${trigger.anyEqualsLevel}' is not declared in any dimension of any referenced assessment`
           );
           suggestions.push(
             `Use a level declared in one of the dimensions: ${[...new Set(allLevels)].join(', ')}`
@@ -1013,10 +1013,6 @@ export class ValidationEngine {
 
         // Validate assessmentRefs (cross-check against workflow-level declarations)
         validateAssessmentRefsForStep(typedStep, `Step '${step.id}'`);
-        if (typedStep.assessmentRefs !== undefined && typedStep.assessmentRefs.length > 1) {
-          issues.push(`Step '${step.id}': v1 assessment support allows exactly one assessmentRef per step`);
-          suggestions.push(`Reduce assessmentRefs on step '${step.id}' to a single assessment id`);
-        }
         validateAssessmentConsequencesForStep(typedStep, `Step '${step.id}'`);
 
         // Validate function calls for standard steps using workflow + step scopes

--- a/src/application/services/workflow-compiler.ts
+++ b/src/application/services/workflow-compiler.ts
@@ -305,16 +305,9 @@ export class WorkflowCompiler {
       const assessmentConsequences = typedStep.assessmentConsequences;
       if (!assessmentConsequences) continue;
 
-      if (!typedStep.assessmentRefs || typedStep.assessmentRefs.length !== 1) {
+      if (!typedStep.assessmentRefs || typedStep.assessmentRefs.length === 0) {
         return err(Err.invalidState(
-          `Step '${step.id}' declares assessmentConsequences but does not declare exactly one assessmentRef`
-        ));
-      }
-
-      const assessment = (workflow.definition.assessments ?? []).find(candidate => candidate.id === typedStep.assessmentRefs?.[0]);
-      if (!assessment) {
-        return err(Err.invalidState(
-          `Step '${step.id}' declares assessmentConsequences for unknown assessmentRef '${typedStep.assessmentRefs[0]}'`
+          `Step '${step.id}' declares assessmentConsequences but declares no assessmentRefs`
         ));
       }
 
@@ -324,12 +317,15 @@ export class WorkflowCompiler {
         ));
       }
 
+      const allLevelsAcrossRefs = (workflow.definition.assessments ?? [])
+        .filter(candidate => typedStep.assessmentRefs!.includes(candidate.id))
+        .flatMap(assessment => assessment.dimensions.flatMap(d => d.levels));
+
       for (const consequence of assessmentConsequences) {
         const trigger = consequence.when;
-        const allLevels = assessment.dimensions.flatMap(d => d.levels);
-        if (!allLevels.includes(trigger.anyEqualsLevel)) {
+        if (!allLevelsAcrossRefs.includes(trigger.anyEqualsLevel)) {
           return err(Err.invalidState(
-            `Step '${step.id}' declares consequence with anyEqualsLevel '${trigger.anyEqualsLevel}' that is not declared in any dimension of assessment '${assessment.id}'`
+            `Step '${step.id}' declares consequence with anyEqualsLevel '${trigger.anyEqualsLevel}' that is not declared in any dimension of any referenced assessment`
           ));
         }
         if (consequence.effect.kind !== 'require_followup') {
@@ -374,9 +370,9 @@ export class WorkflowCompiler {
         }
 
         if (bodyStep.assessmentConsequences) {
-          if (!bodyStep.assessmentRefs || bodyStep.assessmentRefs.length !== 1) {
+          if (!bodyStep.assessmentRefs || bodyStep.assessmentRefs.length === 0) {
             return err(Err.invalidState(
-              `Loop body step '${bodyStep.id}' in loop '${loop.id}' declares assessmentConsequences but does not declare exactly one assessmentRef`
+              `Loop body step '${bodyStep.id}' in loop '${loop.id}' declares assessmentConsequences but declares no assessmentRefs`
             ));
           }
         }

--- a/src/mcp/handlers/v2-advance-core/assessment-consequences.ts
+++ b/src/mcp/handlers/v2-advance-core/assessment-consequences.ts
@@ -11,24 +11,29 @@ export interface TriggeredAssessmentConsequenceV1 {
 
 export function evaluateAssessmentConsequences(args: {
   readonly step: WorkflowStepDefinition | undefined;
-  readonly recordedAssessment: RecordedAssessmentV1 | undefined;
+  readonly recordedAssessments: readonly RecordedAssessmentV1[];
 }): TriggeredAssessmentConsequenceV1 | undefined {
   if (!args.step?.assessmentConsequences || args.step.assessmentConsequences.length === 0) return undefined;
-  if (!args.recordedAssessment) return undefined;
+  if (args.recordedAssessments.length === 0) return undefined;
 
   const consequence = args.step.assessmentConsequences[0];
   if (!consequence) return undefined;
 
-  const matched = args.recordedAssessment.dimensions.find(d => d.level === consequence.when.anyEqualsLevel);
-  if (!matched) return undefined;
+  // Check all recorded assessments — fire on the first matching dimension found (in assessmentRefs order).
+  for (const recorded of args.recordedAssessments) {
+    const matched = recorded.dimensions.find(d => d.level === consequence.when.anyEqualsLevel);
+    if (matched) {
+      return {
+        kind: 'require_followup',
+        assessmentId: recorded.assessmentId,
+        firstMatchedDimensionId: matched.dimensionId,
+        triggerLevel: consequence.when.anyEqualsLevel,
+        guidance: consequence.effect.guidance,
+      };
+    }
+  }
 
-  return {
-    kind: 'require_followup',
-    assessmentId: args.recordedAssessment.assessmentId,
-    firstMatchedDimensionId: matched.dimensionId,
-    triggerLevel: consequence.when.anyEqualsLevel,
-    guidance: consequence.effect.guidance,
-  };
+  return undefined;
 }
 
 export function getDeclaredAssessmentConsequence(

--- a/src/mcp/handlers/v2-advance-core/assessment-validation.ts
+++ b/src/mcp/handlers/v2-advance-core/assessment-validation.ts
@@ -17,9 +17,10 @@ import type {
 export interface AssessmentValidationOutcome {
   readonly contractRef: typeof ASSESSMENT_CONTRACT_REF;
   readonly validation: ValidationResult;
-  readonly acceptedArtifact: AssessmentArtifactV1 | undefined;
-  readonly acceptedArtifactIndex: number | undefined;
-  readonly recordedAssessment: RecordedAssessmentV1 | undefined;
+  /** All recorded assessments, one per assessmentRef, in assessmentRefs order. */
+  readonly recordedAssessments: readonly RecordedAssessmentV1[];
+  /** All accepted artifacts with their original artifact-array indices, one per assessmentRef. */
+  readonly acceptedArtifacts: ReadonlyArray<{ readonly artifact: AssessmentArtifactV1; readonly artifactIndex: number }>;
 }
 
 function normalizeLevel(level: string, allowedLevels: readonly string[]): { readonly kind: 'exact'; readonly value: string } | { readonly kind: 'normalized'; readonly value: string; readonly note: string } | { readonly kind: 'ambiguous'; readonly message: string } | { readonly kind: 'invalid'; readonly message: string } {
@@ -59,47 +60,6 @@ function extractSubmittedRationale(value: AssessmentArtifactV1['dimensions'][str
   if (typeof value === 'string') return undefined;
   const trimmed = value.rationale?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : undefined;
-}
-
-function buildDefinitionLookup(
-  assessments: readonly AssessmentDefinition[] | undefined,
-  step: WorkflowStepDefinition,
-): { readonly definition: AssessmentDefinition | undefined; readonly issues: readonly string[]; readonly suggestions: readonly string[] } {
-  const refs = step.assessmentRefs ?? [];
-  if (refs.length === 0) {
-    return {
-      definition: undefined,
-      issues: [],
-      suggestions: [],
-    };
-  }
-
-  if (!assessments || assessments.length === 0) {
-    return {
-      definition: undefined,
-      issues: [`Step "${step.id}" expects assessment input, but the workflow declares no assessments.`],
-      suggestions: ['Update the workflow definition to declare the assessments referenced by this step.'],
-    };
-  }
-
-  if (refs.length > 1) {
-    return {
-      definition: undefined,
-      issues: [`Step "${step.id}" declares multiple assessmentRefs. Assessment boundary validation currently supports exactly one assessment per step.`],
-      suggestions: ['Reduce assessmentRefs to a single assessment for this step in v1.'],
-    };
-  }
-
-  const definition = assessments.find((assessment) => assessment.id === refs[0]);
-  if (!definition) {
-    return {
-      definition: undefined,
-      issues: [`Step "${step.id}" references undeclared assessment "${refs[0]}".`],
-      suggestions: [`Declare assessment "${refs[0]}" on the workflow or remove the step reference.`],
-    };
-  }
-
-  return { definition, issues: [], suggestions: [] };
 }
 
 function validateDimension(
@@ -151,77 +111,84 @@ function validateDimension(
   }
 }
 
-export function validateAssessmentForStep(args: {
-  readonly step: WorkflowStepDefinition;
-  readonly assessments: readonly AssessmentDefinition[] | undefined;
+/**
+ * Validate a single assessment artifact against its definition.
+ * Returns null when no matching artifact is found.
+ */
+function validateSingleAssessment(args: {
+  readonly definition: AssessmentDefinition;
   readonly artifacts: readonly unknown[];
-}): AssessmentValidationOutcome | undefined {
-  if (!args.step.assessmentRefs || args.step.assessmentRefs.length === 0) return undefined;
-
-  const lookup = buildDefinitionLookup(args.assessments, args.step);
-  if (!lookup.definition) {
-    return {
-      contractRef: ASSESSMENT_CONTRACT_REF,
-      acceptedArtifact: undefined,
-      acceptedArtifactIndex: undefined,
-      recordedAssessment: undefined,
-      validation: {
-        valid: false,
-        issues: [...lookup.issues],
-        suggestions: [...lookup.suggestions],
-      },
-    };
-  }
-
+  readonly isSingleRef: boolean;
+}): {
+  readonly issues: readonly string[];
+  readonly suggestions: readonly string[];
+  readonly warnings: readonly string[];
+  readonly acceptedArtifact: AssessmentArtifactV1 | undefined;
+  readonly acceptedArtifactIndex: number | undefined;
+  readonly recordedAssessment: RecordedAssessmentV1 | undefined;
+} {
   const assessmentArtifacts = args.artifacts
     .map((artifact, index) => ({ artifact, index }))
     .filter(({ artifact }) => typeof artifact === 'object' && artifact !== null && (artifact as Record<string, unknown>).kind === 'wr.assessment');
+
   if (assessmentArtifacts.length === 0) {
     return {
-      contractRef: ASSESSMENT_CONTRACT_REF,
+      issues: [`This step requires an assessment submission for "${args.definition.id}".`],
+      suggestions: [
+        `Provide an artifact with kind "wr.assessment" for assessment "${args.definition.id}".`,
+        `Include dimension values for: ${args.definition.dimensions.map((dimension) => `${dimension.id} (${dimension.levels.join(' | ')})`).join(', ')}.`,
+      ],
+      warnings: [],
       acceptedArtifact: undefined,
       acceptedArtifactIndex: undefined,
       recordedAssessment: undefined,
-      validation: {
-        valid: false,
-        issues: [`This step requires an assessment submission for "${lookup.definition.id}".`],
-        suggestions: [
-          `Provide an artifact with kind "wr.assessment" for assessment "${lookup.definition.id}".`,
-          `Include dimension values for: ${lookup.definition.dimensions.map((dimension) => `${dimension.id} (${dimension.levels.join(' | ')})`).join(', ')}.`,
-        ],
-      },
     };
   }
 
-  const acceptedCandidate = assessmentArtifacts[0]!;
-  const parsed = parseAssessmentArtifact(acceptedCandidate.artifact);
+  // For single-ref steps: accept the first artifact (backward compat — assessmentId is optional).
+  // For multi-ref steps: match by assessmentId only; unidentified artifacts are ambiguous.
+  const candidateEntry = args.isSingleRef
+    ? assessmentArtifacts[0]!
+    : assessmentArtifacts.find(({ artifact }) => {
+        const parsed = parseAssessmentArtifact(artifact);
+        return parsed?.assessmentId === args.definition.id;
+      });
+
+  if (!candidateEntry) {
+    return {
+      issues: [`Missing assessment artifact for "${args.definition.id}". Provide an artifact with kind "wr.assessment" and assessmentId "${args.definition.id}".`],
+      suggestions: [
+        `Include dimension values for: ${args.definition.dimensions.map((d) => `${d.id} (${d.levels.join(' | ')})`).join(', ')}.`,
+      ],
+      warnings: [],
+      acceptedArtifact: undefined,
+      acceptedArtifactIndex: undefined,
+      recordedAssessment: undefined,
+    };
+  }
+
+  const parsed = parseAssessmentArtifact(candidateEntry.artifact);
   if (!parsed) {
     return {
-      contractRef: ASSESSMENT_CONTRACT_REF,
+      issues: ['Assessment artifact is malformed or does not match the expected shape.'],
+      suggestions: [
+        `Use an artifact with kind "wr.assessment", a dimensions object, and canonical dimension values for assessment "${args.definition.id}".`,
+      ],
+      warnings: [],
       acceptedArtifact: undefined,
       acceptedArtifactIndex: undefined,
       recordedAssessment: undefined,
-      validation: {
-        valid: false,
-        issues: ['Assessment artifact is malformed or does not match the expected shape.'],
-        suggestions: [
-          `Use an artifact with kind "wr.assessment", a dimensions object, and canonical dimension values for assessment "${lookup.definition.id}".`,
-        ],
-      },
     };
   }
 
-  if (parsed.assessmentId && parsed.assessmentId !== lookup.definition.id) {
+  if (parsed.assessmentId && parsed.assessmentId !== args.definition.id) {
     return {
-      contractRef: ASSESSMENT_CONTRACT_REF,
+      issues: [`Assessment artifact targets "${parsed.assessmentId}", but this step expects "${args.definition.id}".`],
+      suggestions: [`Set assessmentId to "${args.definition.id}" or omit it and provide the correct dimensions.`],
+      warnings: [],
       acceptedArtifact: undefined,
       acceptedArtifactIndex: undefined,
       recordedAssessment: undefined,
-      validation: {
-        valid: false,
-        issues: [`Assessment artifact targets "${parsed.assessmentId}", but this step expects "${lookup.definition.id}".`],
-        suggestions: [`Set assessmentId to "${lookup.definition.id}" or omit it and provide the correct dimensions.`],
-      },
     };
   }
 
@@ -230,35 +197,112 @@ export function validateAssessmentForStep(args: {
   const warnings: string[] = [];
   const recordedDimensions: RecordedAssessmentDimensionV1[] = [];
 
-  for (const dimension of lookup.definition.dimensions) {
+  for (const dimension of args.definition.dimensions) {
     validateDimension(dimension, parsed, issues, suggestions, warnings, recordedDimensions);
   }
 
-  const allowedDimensionIds = new Set(lookup.definition.dimensions.map((dimension) => dimension.id));
+  const allowedDimensionIds = new Set(args.definition.dimensions.map((d) => d.id));
   for (const submittedDimensionId of Object.keys(parsed.dimensions)) {
     if (!allowedDimensionIds.has(submittedDimensionId)) {
-      issues.push(`Unknown assessment dimension "${submittedDimensionId}" for assessment "${lookup.definition.id}".`);
-      suggestions.push(`Remove "${submittedDimensionId}" and use only: ${lookup.definition.dimensions.map((dimension) => dimension.id).join(', ')}.`);
+      issues.push(`Unknown assessment dimension "${submittedDimensionId}" for assessment "${args.definition.id}".`);
+      suggestions.push(`Remove "${submittedDimensionId}" and use only: ${args.definition.dimensions.map((d) => d.id).join(', ')}.`);
     }
   }
 
+  const valid = issues.length === 0;
   return {
-    contractRef: ASSESSMENT_CONTRACT_REF,
-    acceptedArtifact: issues.length === 0 ? parsed : undefined,
-    acceptedArtifactIndex: issues.length === 0 ? acceptedCandidate.index : undefined,
-    recordedAssessment: issues.length === 0
+    issues,
+    suggestions,
+    warnings,
+    acceptedArtifact: valid ? parsed : undefined,
+    acceptedArtifactIndex: valid ? candidateEntry.index : undefined,
+    recordedAssessment: valid
       ? {
-          assessmentId: lookup.definition.id,
+          assessmentId: args.definition.id,
           summary: parsed.summary,
           dimensions: recordedDimensions,
           normalizationNotes: warnings,
         }
       : undefined,
+  };
+}
+
+export function validateAssessmentForStep(args: {
+  readonly step: WorkflowStepDefinition;
+  readonly assessments: readonly AssessmentDefinition[] | undefined;
+  readonly artifacts: readonly unknown[];
+}): AssessmentValidationOutcome | undefined {
+  if (!args.step.assessmentRefs || args.step.assessmentRefs.length === 0) return undefined;
+
+  const refs = args.step.assessmentRefs;
+
+  if (!args.assessments || args.assessments.length === 0) {
+    return {
+      contractRef: ASSESSMENT_CONTRACT_REF,
+      recordedAssessments: [],
+      acceptedArtifacts: [],
+      validation: {
+        valid: false,
+        issues: refs.map((ref) => `Step expects assessment input for "${ref}", but the workflow declares no assessments.`),
+        suggestions: ['Update the workflow definition to declare the assessments referenced by this step.'],
+      },
+    };
+  }
+
+  // Check all refs resolve to declared assessments.
+  const allIssues: string[] = [];
+  const allSuggestions: string[] = [];
+  const definitions: AssessmentDefinition[] = [];
+  for (const ref of refs) {
+    const definition = args.assessments.find((a) => a.id === ref);
+    if (!definition) {
+      allIssues.push(`Step references undeclared assessment "${ref}".`);
+      allSuggestions.push(`Declare assessment "${ref}" on the workflow or remove the step reference.`);
+    } else {
+      definitions.push(definition);
+    }
+  }
+
+  if (allIssues.length > 0) {
+    return {
+      contractRef: ASSESSMENT_CONTRACT_REF,
+      recordedAssessments: [],
+      acceptedArtifacts: [],
+      validation: { valid: false, issues: allIssues, suggestions: allSuggestions },
+    };
+  }
+
+  const isSingleRef = refs.length === 1;
+  const perRefResults = definitions.map((definition) =>
+    validateSingleAssessment({ definition, artifacts: args.artifacts, isSingleRef })
+  );
+
+  const combinedIssues = perRefResults.flatMap((r) => r.issues);
+  const combinedSuggestions = perRefResults.flatMap((r) => r.suggestions);
+  const combinedWarnings = perRefResults.flatMap((r) => r.warnings);
+  const allValid = combinedIssues.length === 0;
+
+  const recordedAssessments: RecordedAssessmentV1[] = [];
+  const acceptedArtifacts: Array<{ artifact: AssessmentArtifactV1; artifactIndex: number }> = [];
+
+  if (allValid) {
+    for (const result of perRefResults) {
+      if (result.recordedAssessment) recordedAssessments.push(result.recordedAssessment);
+      if (result.acceptedArtifact !== undefined && result.acceptedArtifactIndex !== undefined) {
+        acceptedArtifacts.push({ artifact: result.acceptedArtifact, artifactIndex: result.acceptedArtifactIndex });
+      }
+    }
+  }
+
+  return {
+    contractRef: ASSESSMENT_CONTRACT_REF,
+    recordedAssessments,
+    acceptedArtifacts,
     validation: {
-      valid: issues.length === 0,
-      issues,
-      suggestions,
-      warnings: warnings.length > 0 ? warnings : undefined,
+      valid: allValid,
+      issues: combinedIssues,
+      suggestions: combinedSuggestions,
+      ...(combinedWarnings.length > 0 ? { warnings: combinedWarnings } : {}),
     },
   };
 }

--- a/src/mcp/handlers/v2-advance-core/input-validation.ts
+++ b/src/mcp/handlers/v2-advance-core/input-validation.ts
@@ -10,8 +10,7 @@ import type { JsonValue, JsonObject } from '../../../v2/durable-core/canonical/j
 import type { V2ContinueWorkflowInput } from '../../v2/tools.js';
 import type { AssessmentDefinition, OutputContract, WorkflowStepDefinition } from '../../../types/workflow-definition.js';
 import type { ValidationCriteria } from '../../../types/validation.js';
-import type { AssessmentArtifactV1 } from '../../../v2/durable-core/schemas/artifacts/index.js';
-import type { RecordedAssessmentV1 } from '../../../v2/durable-core/domain/assessment-record.js';
+
 import type { TriggeredAssessmentConsequenceV1 } from './assessment-consequences.js';
 
 import { getStepById } from '../../../types/workflow.js';
@@ -38,8 +37,6 @@ export interface ValidatedAdvanceInputs {
   readonly outputContract: OutputContract | undefined;
   readonly notesMarkdown: string | undefined;
   readonly artifacts: readonly unknown[];
-  readonly assessmentArtifact: AssessmentArtifactV1 | undefined;
-  readonly recordedAssessment: RecordedAssessmentV1 | undefined;
   readonly triggeredAssessmentConsequence: TriggeredAssessmentConsequenceV1 | undefined;
   readonly stepAssessments: readonly AssessmentDefinition[];
   readonly autonomy: 'guided' | 'full_auto_stop_on_user_deps' | 'full_auto_never_stop';
@@ -113,7 +110,7 @@ export function validateAdvanceInputs(args: {
     : undefined;
   const triggeredAssessmentConsequence = evaluateAssessmentConsequences({
     step: typedStep,
-    recordedAssessment: assessmentValidation?.recordedAssessment,
+    recordedAssessments: assessmentValidation?.recordedAssessments ?? [],
   });
 
   // Auto-derive notesOptional.
@@ -167,8 +164,6 @@ export function validateAdvanceInputs(args: {
     outputContract,
     notesMarkdown: inputOutput?.notesMarkdown,
     artifacts: inputOutput?.artifacts ?? [],
-    assessmentArtifact: assessmentValidation?.acceptedArtifact,
-    recordedAssessment: assessmentValidation?.recordedAssessment,
     triggeredAssessmentConsequence,
     stepAssessments,
     autonomy,

--- a/src/mcp/handlers/v2-advance-core/outcome-blocked.ts
+++ b/src/mcp/handlers/v2-advance-core/outcome-blocked.ts
@@ -102,8 +102,15 @@ export function buildBlockedOutcome(args: {
       : [];
 
   const validated = args.v;
-  if (validated?.recordedAssessment && validated.assessmentValidation?.acceptedArtifactIndex !== undefined) {
-    const assessmentOutput = outputsToAppend[validated.assessmentValidation.acceptedArtifactIndex];
+  // Emit one assessment_recorded event per accepted assessment (one per assessmentRef).
+  // recordedAssessments[i] and acceptedArtifacts[i] are positionally aligned — built in the same loop.
+  const acceptedArtifacts = validated?.assessmentValidation?.acceptedArtifacts ?? [];
+  for (let i = 0; i < acceptedArtifacts.length; i++) {
+    const { artifactIndex } = acceptedArtifacts[i]!;
+    const recordedAssessment = validated?.assessmentValidation?.recordedAssessments[i];
+    if (!recordedAssessment) continue;
+
+    const assessmentOutput = outputsToAppend[artifactIndex];
     if (!assessmentOutput || assessmentOutput.outputChannel !== 'artifact') {
       return errAsync({ kind: 'invariant_violation' as const, message: 'Accepted assessment artifact did not produce a matching artifact output on blocked path.' } as const);
     }
@@ -113,7 +120,7 @@ export function buildBlockedOutcome(args: {
       attemptId: String(attemptId),
       artifactOutputId: String(assessmentOutput.outputId),
       scope: { runId: String(runId), nodeId: String(currentNodeId) },
-      assessment: validated.recordedAssessment,
+      assessment: recordedAssessment,
       minted: { eventId: idFactory.mintEventId() },
     });
     if (assessmentEventRes.isErr()) {

--- a/src/mcp/handlers/v2-advance-core/outcome-success.ts
+++ b/src/mcp/handlers/v2-advance-core/outcome-success.ts
@@ -194,8 +194,15 @@ export function buildSuccessOutcome(args: {
       return errAsync(artifactOutputsRes.error);
     }
 
-    if (v.recordedAssessment && v.assessmentArtifact && v.assessmentValidation?.acceptedArtifactIndex !== undefined) {
-      const assessmentOutput = artifactOutputsRes.value[v.assessmentValidation.acceptedArtifactIndex];
+    // Emit one assessment_recorded event per accepted assessment (one per assessmentRef).
+    // recordedAssessments[i] and acceptedArtifacts[i] are positionally aligned — built in the same loop.
+    const acceptedArtifacts = v.assessmentValidation?.acceptedArtifacts ?? [];
+    for (let i = 0; i < acceptedArtifacts.length; i++) {
+      const { artifactIndex } = acceptedArtifacts[i]!;
+      const recordedAssessment = v.assessmentValidation?.recordedAssessments[i];
+      if (!recordedAssessment) continue;
+
+      const assessmentOutput = artifactOutputsRes.value[artifactIndex];
       if (!assessmentOutput || assessmentOutput.outputChannel !== 'artifact') {
         return errAsync({
           kind: 'invariant_violation',
@@ -208,7 +215,7 @@ export function buildSuccessOutcome(args: {
         attemptId: String(attemptId),
         artifactOutputId: String(assessmentOutput.outputId),
         scope: { runId: String(runId), nodeId: String(currentNodeId) },
-        assessment: v.recordedAssessment,
+        assessment: recordedAssessment,
         minted: { eventId: idFactory.mintEventId() },
       });
       if (assessmentEventRes.isErr()) {

--- a/src/mcp/handlers/v2-execution/replay.ts
+++ b/src/mcp/handlers/v2-execution/replay.ts
@@ -32,7 +32,7 @@ import { attemptIdForNextNode, mintContinueAndCheckpointTokens } from '../v2-tok
 import { deriveNextIntent } from '../v2-state-conversion.js';
 import { EVENT_KIND } from '../../../v2/durable-core/constants.js';
 import { buildNextCall } from './index.js';
-import { projectAssessmentsV2, getLatestAssessmentForNode } from '../../../v2/projections/assessments.js';
+import { projectAssessmentsV2 } from '../../../v2/projections/assessments.js';
 import { assertOutput, assertContinueTokenPresence } from '../../assert-output.js';
 import { asSortedEventLog } from '../../../v2/durable-core/sorted-event-log.js';
 
@@ -232,7 +232,7 @@ export function buildAdvancedReplayResponse(args: {
 function buildStepContext(
   events: readonly DomainEventV1[],
   completedNodeId: NodeId,
-): { assessments?: { assessmentId: string; dimensions: { dimensionId: string; level: string; rationale?: string }[]; normalizationNotes: readonly string[] } } | undefined {
+): { assessments?: Array<{ assessmentId: string; dimensions: { dimensionId: string; level: string; rationale?: string }[]; normalizationNotes: readonly string[] }> } | undefined {
   const sortedEventsRes = asSortedEventLog(events);
   if (sortedEventsRes.isErr()) {
     console.warn(`[workrail:replay] stepContext events unsorted for node '${String(completedNodeId)}' — stepContext will be absent: ${sortedEventsRes.error.message}`);
@@ -244,11 +244,11 @@ function buildStepContext(
     return undefined;
   }
 
-  const recorded = getLatestAssessmentForNode(projection.value, String(completedNodeId));
-  if (!recorded) return undefined;
+  const allRecorded = projection.value.byNodeId[String(completedNodeId)];
+  if (!allRecorded || allRecorded.length === 0) return undefined;
 
   return {
-    assessments: {
+    assessments: allRecorded.map((recorded) => ({
       assessmentId: recorded.assessmentId,
       dimensions: recorded.dimensions.map((d) => ({
         dimensionId: d.dimensionId,
@@ -256,7 +256,7 @@ function buildStepContext(
         ...(d.rationale !== undefined ? { rationale: d.rationale } : {}),
       })),
       normalizationNotes: recorded.normalizationNotes,
-    },
+    })),
   };
 }
 

--- a/src/mcp/output-schemas.ts
+++ b/src/mcp/output-schemas.ts
@@ -399,29 +399,29 @@ export const V2BindingDriftWarningSchema = z.object({
  * Backward-looking: describes what happened during the step that just advanced.
  * Distinct from top-level fields, which are forward-looking (next pending step, tokens, intent).
  *
- * assessments: the assessment submitted and accepted for this step, if the step declared an
- * assessmentRef. Absent when no assessment was involved. Dimensions carry the normalized level
- * and optional rationale the agent recorded.
+ * assessments: one entry per assessmentRef declared on the step, in assessmentRefs order.
+ * Absent when no assessment was involved. Dimensions carry the normalized level and optional
+ * rationale the agent recorded.
  */
-export const V2StepContextSchema = z.object({
-  assessments: z
-    .object({
-      assessmentId: z.string().min(1),
-      dimensions: z.array(
-        z.object({
-          dimensionId: z.string().min(1),
-          level: z.string().min(1),
-          rationale: z.string().optional(),
-        })
-      ),
-      /**
-       * Non-empty when WorkRail normalized the agent's submitted levels (e.g. "HIGH" -> "high").
-       * Each entry explains one normalization applied. Empty array means all levels matched exactly.
-       * Agents can use this to correct their submissions in future steps.
-       */
-      normalizationNotes: z.array(z.string()).readonly(),
+const V2StepContextAssessmentSchema = z.object({
+  assessmentId: z.string().min(1),
+  dimensions: z.array(
+    z.object({
+      dimensionId: z.string().min(1),
+      level: z.string().min(1),
+      rationale: z.string().optional(),
     })
-    .optional(),
+  ),
+  /**
+   * Non-empty when WorkRail normalized the agent's submitted levels (e.g. "HIGH" -> "high").
+   * Each entry explains one normalization applied. Empty array means all levels matched exactly.
+   * Agents can use this to correct their submissions in future steps.
+   */
+  normalizationNotes: z.array(z.string()).readonly(),
+});
+
+export const V2StepContextSchema = z.object({
+  assessments: z.array(V2StepContextAssessmentSchema).optional(),
 });
 
 const V2ContinueWorkflowOkSchema = z.object({

--- a/src/v2/durable-core/domain/prompt-renderer.ts
+++ b/src/v2/durable-core/domain/prompt-renderer.ts
@@ -313,9 +313,13 @@ function formatAssessmentRequirements(
 ): readonly string[] {
   if (assessments.length === 0) return [];
 
+  const multiRef = assessments.length > 1;
   const requirements: string[] = [];
   for (const assessment of assessments) {
     requirements.push('Provide an artifact with kind: "wr.assessment"');
+    if (multiRef) {
+      requirements.push(`Set assessmentId: "${assessment.id}" on the artifact so the engine can match it to the correct assessment.`);
+    }
     requirements.push(`Assessment target: "${assessment.id}"`);
     requirements.push(
       `Dimensions: ${assessment.dimensions.map((dimension) => `${dimension.id} (${dimension.levels.join(' | ')})`).join(', ')}`

--- a/tests/integration/v2/assessment-step-context.test.ts
+++ b/tests/integration/v2/assessment-step-context.test.ts
@@ -163,11 +163,12 @@ describe('stepContext on continue_workflow ok response', () => {
       if (advanceRes.data.kind !== 'ok') return;
 
       expect(advanceRes.data.stepContext).toBeDefined();
-      expect(advanceRes.data.stepContext?.assessments?.assessmentId).toBe('readiness_gate');
-      expect(advanceRes.data.stepContext?.assessments?.dimensions).toHaveLength(1);
-      expect(advanceRes.data.stepContext?.assessments?.dimensions[0]?.dimensionId).toBe('confidence');
-      expect(advanceRes.data.stepContext?.assessments?.dimensions[0]?.level).toBe('high');
-      expect(advanceRes.data.stepContext?.assessments?.dimensions[0]?.rationale).toBe('Evidence is clear.');
+      expect(advanceRes.data.stepContext?.assessments).toHaveLength(1);
+      expect(advanceRes.data.stepContext?.assessments?.[0]?.assessmentId).toBe('readiness_gate');
+      expect(advanceRes.data.stepContext?.assessments?.[0]?.dimensions).toHaveLength(1);
+      expect(advanceRes.data.stepContext?.assessments?.[0]?.dimensions[0]?.dimensionId).toBe('confidence');
+      expect(advanceRes.data.stepContext?.assessments?.[0]?.dimensions[0]?.level).toBe('high');
+      expect(advanceRes.data.stepContext?.assessments?.[0]?.dimensions[0]?.rationale).toBe('Evidence is clear.');
     } finally {
       delete process.env.WORKRAIL_DATA_DIR;
     }
@@ -207,8 +208,8 @@ describe('stepContext on continue_workflow ok response', () => {
       expect(advanceRes.data.kind).toBe('ok');
       if (advanceRes.data.kind !== 'ok') return;
 
-      expect(advanceRes.data.stepContext?.assessments?.dimensions[0]?.level).toBe('high');
-      expect(advanceRes.data.stepContext?.assessments?.normalizationNotes.length).toBeGreaterThan(0);
+      expect(advanceRes.data.stepContext?.assessments?.[0]?.dimensions[0]?.level).toBe('high');
+      expect(advanceRes.data.stepContext?.assessments?.[0]?.normalizationNotes.length).toBeGreaterThan(0);
     } finally {
       delete process.env.WORKRAIL_DATA_DIR;
     }
@@ -247,7 +248,7 @@ describe('stepContext on continue_workflow ok response', () => {
       expect(advanceRes.data.kind).toBe('ok');
       if (advanceRes.data.kind !== 'ok') return;
 
-      expect(advanceRes.data.stepContext?.assessments?.normalizationNotes).toHaveLength(0);
+      expect(advanceRes.data.stepContext?.assessments?.[0]?.normalizationNotes).toHaveLength(0);
     } finally {
       delete process.env.WORKRAIL_DATA_DIR;
     }

--- a/tests/unit/compiler/assessment-definition-validation.test.ts
+++ b/tests/unit/compiler/assessment-definition-validation.test.ts
@@ -104,7 +104,7 @@ describe('assessment declarations — validation engine', () => {
     );
   });
 
-  it('rejects multiple assessmentRefs on a single step in v1', () => {
+  it('accepts multiple assessmentRefs on a single step', () => {
     const workflow = mkWorkflow({
       assessments: [
         {
@@ -129,10 +129,8 @@ describe('assessment declarations — validation engine', () => {
     });
 
     const result = new ValidationEngine(new EnhancedLoopValidator()).validateWorkflow(workflow);
-    expect(result.valid).toBe(false);
-    expect(result.issues).toEqual(
-      expect.arrayContaining([expect.stringContaining('exactly one assessmentRef per step')])
-    );
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
   });
 
   it('accepts a valid step-level follow-up consequence', () => {

--- a/tests/unit/compiler/assessment-definition-validation.test.ts
+++ b/tests/unit/compiler/assessment-definition-validation.test.ts
@@ -162,6 +162,78 @@ describe('assessment declarations — validation engine', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('accepts multiple assessmentRefs with a consequence whose trigger level exists only in the second assessment', () => {
+    const workflow = mkWorkflow({
+      assessments: [
+        {
+          id: 'quality_gate',
+          purpose: 'Quality gate.',
+          dimensions: [{ id: 'depth', purpose: 'Depth', levels: ['shallow', 'deep'] }],
+        },
+        {
+          id: 'coverage_gate',
+          purpose: 'Coverage gate.',
+          dimensions: [{ id: 'completeness', purpose: 'Completeness', levels: ['low', 'high'] }],
+        },
+      ],
+      steps: [
+        {
+          id: 'step-1',
+          title: 'Step 1',
+          prompt: 'Assess.',
+          assessmentRefs: ['quality_gate', 'coverage_gate'],
+          assessmentConsequences: [
+            {
+              when: { anyEqualsLevel: 'low' },
+              effect: { kind: 'require_followup', guidance: 'Fix low dimensions before proceeding.' },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = new ValidationEngine(new EnhancedLoopValidator()).validateWorkflow(workflow);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('rejects a multi-ref consequence whose trigger level exists in neither referenced assessment', () => {
+    const workflow = mkWorkflow({
+      assessments: [
+        {
+          id: 'quality_gate',
+          purpose: 'Quality gate.',
+          dimensions: [{ id: 'depth', purpose: 'Depth', levels: ['shallow', 'deep'] }],
+        },
+        {
+          id: 'coverage_gate',
+          purpose: 'Coverage gate.',
+          dimensions: [{ id: 'completeness', purpose: 'Completeness', levels: ['partial', 'complete'] }],
+        },
+      ],
+      steps: [
+        {
+          id: 'step-1',
+          title: 'Step 1',
+          prompt: 'Assess.',
+          assessmentRefs: ['quality_gate', 'coverage_gate'],
+          assessmentConsequences: [
+            {
+              when: { anyEqualsLevel: 'low' },
+              effect: { kind: 'require_followup', guidance: 'Fix before proceeding.' },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = new ValidationEngine(new EnhancedLoopValidator()).validateWorkflow(workflow);
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([expect.stringContaining("anyEqualsLevel 'low'")])
+    );
+  });
+
   it('rejects a consequence that references an undeclared level', () => {
     const workflow = mkWorkflow({
       assessments: [

--- a/tests/unit/mcp/assessment-consequences.test.ts
+++ b/tests/unit/mcp/assessment-consequences.test.ts
@@ -18,7 +18,7 @@ describe('evaluateAssessmentConsequences -- single dimension (equivalent to exac
   };
 
   it('fires when the single dimension equals the level', () => {
-    const recordedAssessment: RecordedAssessmentV1 = {
+    const recorded: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
       dimensions: [
@@ -27,7 +27,7 @@ describe('evaluateAssessmentConsequences -- single dimension (equivalent to exac
     };
 
     expect(
-      evaluateAssessmentConsequences({ step, recordedAssessment })
+      evaluateAssessmentConsequences({ step, recordedAssessments: [recorded] })
     ).toEqual({
       kind: 'require_followup',
       assessmentId: 'readiness_gate',
@@ -38,7 +38,7 @@ describe('evaluateAssessmentConsequences -- single dimension (equivalent to exac
   });
 
   it('returns undefined when the dimension does not match', () => {
-    const recordedAssessment: RecordedAssessmentV1 = {
+    const recorded: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
       dimensions: [
@@ -46,7 +46,7 @@ describe('evaluateAssessmentConsequences -- single dimension (equivalent to exac
       ],
     };
 
-    expect(evaluateAssessmentConsequences({ step, recordedAssessment })).toBeUndefined();
+    expect(evaluateAssessmentConsequences({ step, recordedAssessments: [recorded] })).toBeUndefined();
   });
 });
 
@@ -65,7 +65,7 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
   };
 
   it('fires when the first dimension is low', () => {
-    const recordedAssessment: RecordedAssessmentV1 = {
+    const recorded: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
       dimensions: [
@@ -75,7 +75,7 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
       ],
     };
 
-    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessment })).toEqual({
+    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] })).toEqual({
       kind: 'require_followup',
       assessmentId: 'readiness_gate',
       firstMatchedDimensionId: 'evidence_quality',
@@ -85,7 +85,7 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
   });
 
   it('fires when a non-first dimension is low', () => {
-    const recordedAssessment: RecordedAssessmentV1 = {
+    const recorded: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
       dimensions: [
@@ -95,7 +95,7 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
       ],
     };
 
-    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessment })).toEqual({
+    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] })).toEqual({
       kind: 'require_followup',
       assessmentId: 'readiness_gate',
       firstMatchedDimensionId: 'contradiction_resolution',
@@ -105,7 +105,7 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
   });
 
   it('returns the first matched dimension when multiple are low', () => {
-    const recordedAssessment: RecordedAssessmentV1 = {
+    const recorded: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
       dimensions: [
@@ -115,13 +115,13 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
       ],
     };
 
-    const result = evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessment });
+    const result = evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] });
     expect(result?.firstMatchedDimensionId).toBe('evidence_quality');
     expect(result?.triggerLevel).toBe('low');
   });
 
   it('does not fire when all dimensions are high', () => {
-    const recordedAssessment: RecordedAssessmentV1 = {
+    const recorded: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
       dimensions: [
@@ -131,16 +131,71 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
       ],
     };
 
-    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessment })).toBeUndefined();
+    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] })).toBeUndefined();
   });
 
   it('does not fire when no dimensions are present', () => {
-    const recordedAssessment: RecordedAssessmentV1 = {
+    const recorded: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
       dimensions: [],
     };
 
-    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessment })).toBeUndefined();
+    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] })).toBeUndefined();
+  });
+
+  it('fires on the first matching assessment when multiple refs are present', () => {
+    const qualityGate: RecordedAssessmentV1 = {
+      assessmentId: 'quality_gate',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'depth', level: 'high', normalization: 'exact' }],
+    };
+    const coverageGate: RecordedAssessmentV1 = {
+      assessmentId: 'coverage_gate',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'completeness', level: 'low', normalization: 'exact' }],
+    };
+    const stepMultiRef: WorkflowStepDefinition = {
+      id: 'multi-step',
+      title: 'Multi-ref Gate',
+      prompt: 'Assess.',
+      assessmentRefs: ['quality_gate', 'coverage_gate'],
+      assessmentConsequences: [
+        { when: { anyEqualsLevel: 'low' }, effect: { kind: 'require_followup', guidance: 'Fix before proceeding.' } },
+      ],
+    };
+
+    const result = evaluateAssessmentConsequences({ step: stepMultiRef, recordedAssessments: [qualityGate, coverageGate] });
+    expect(result).toEqual({
+      kind: 'require_followup',
+      assessmentId: 'coverage_gate',
+      firstMatchedDimensionId: 'completeness',
+      triggerLevel: 'low',
+      guidance: 'Fix before proceeding.',
+    });
+  });
+
+  it('does not fire when all dimensions across multiple refs are high', () => {
+    const qualityGate: RecordedAssessmentV1 = {
+      assessmentId: 'quality_gate',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'depth', level: 'high', normalization: 'exact' }],
+    };
+    const coverageGate: RecordedAssessmentV1 = {
+      assessmentId: 'coverage_gate',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'completeness', level: 'high', normalization: 'exact' }],
+    };
+    const stepMultiRef: WorkflowStepDefinition = {
+      id: 'multi-step',
+      title: 'Multi-ref Gate',
+      prompt: 'Assess.',
+      assessmentRefs: ['quality_gate', 'coverage_gate'],
+      assessmentConsequences: [
+        { when: { anyEqualsLevel: 'low' }, effect: { kind: 'require_followup', guidance: 'Fix before proceeding.' } },
+      ],
+    };
+
+    expect(evaluateAssessmentConsequences({ step: stepMultiRef, recordedAssessments: [qualityGate, coverageGate] })).toBeUndefined();
   });
 });

--- a/tests/unit/mcp/assessment-validation.test.ts
+++ b/tests/unit/mcp/assessment-validation.test.ts
@@ -46,9 +46,9 @@ describe('validateAssessmentForStep', () => {
 
     expect(result?.contractRef).toBe(ASSESSMENT_CONTRACT_REF);
     expect(result?.validation.valid).toBe(true);
-    expect(result?.acceptedArtifact).toBeDefined();
-    expect(result?.acceptedArtifactIndex).toBe(0);
-    expect(result?.recordedAssessment).toEqual({
+    expect(result?.acceptedArtifacts[0]?.artifact).toBeDefined();
+    expect(result?.acceptedArtifacts[0]?.artifactIndex).toBe(0);
+    expect(result?.recordedAssessments[0]).toEqual({
       assessmentId: 'readiness_gate',
       summary: undefined,
       normalizationNotes: [],
@@ -92,7 +92,7 @@ describe('validateAssessmentForStep', () => {
         expect.stringContaining('Normalized level "COMPLETE"'),
       ]),
     );
-    expect(result?.recordedAssessment?.dimensions).toEqual([
+    expect(result?.recordedAssessments[0]?.dimensions).toEqual([
       {
         dimensionId: 'confidence',
         level: 'high',

--- a/workflows/workflow-for-workflows.json
+++ b/workflows/workflow-for-workflows.json
@@ -1,8 +1,8 @@
 {
   "id": "workflow-for-workflows",
-  "name": "Progressive Workflow Creation Guide",
-  "version": "0.1.0",
-  "description": "Use this to author or modernize a WorkRail workflow. Guides through understanding the task, defining effectiveness targets, designing architecture and quality gates, drafting, validating, and handing off.",
+  "name": "Workflow Authoring Workflow (Quality Gate v2)",
+  "version": "2.4.0",
+  "description": "Use this to author or modernize a WorkRail workflow. Guides through understanding the task, defining effectiveness targets, designing architecture and quality gates, drafting, validating, assigning tags, and handing off.",
   "about": "## Workflow Authoring Workflow\n\nThis is the standard WorkRail workflow for creating a new workflow from scratch or modernizing an existing one. It is the trust gate for all other workflows: a workflow is not considered production-ready until it has passed through here.\n\n**What it does:**\nThe workflow walks through the full authoring lifecycle: understanding the task, choosing the right baseline and archetype, designing the phase and quality-gate architecture, drafting the workflow JSON, running structural validators, auditing state fields for bloat, simulating execution against real scenarios, running an adversarial quality review, and producing a final trust handoff. For modernization tasks it builds a value inventory first to ensure enforcement mechanisms, domain knowledge, and behavioral rules are preserved or equivalently replaced.\n\n**When to use it:**\n- You want to author a new WorkRail workflow for a recurring task or problem\n- You have an existing workflow that is outdated, uses legacy patterns (pseudo-DSL, regex validation, satisfaction-score loops), or produces shallow results\n- You want a workflow that will pass the WorkRail quality bar and be trusted to run in production\n\n**What it produces:**\nA validated, tagged workflow JSON file with a `validatedAgainstSpecVersion` stamp. A final trust handoff with readiness verdict, known failure modes, residual weaknesses, and testing guidance.\n\n**How to get good results:**\nDescribe the recurring task the workflow should solve, who will run it, and what a satisfying result looks like. For modernization, point to the existing workflow file. The workflow reads the schema and authoring spec itself  -- you do not need to know the JSON format in advance.",
   "examples": [
     "Create a new workflow for conducting weekly engineering retrospectives",
@@ -10,44 +10,34 @@
     "Author a workflow for triaging and prioritizing incoming support tickets",
     "Upgrade the code review workflow to add adversarial reviewer families and hard gates"
   ],
-  "clarificationPrompts": [
-    "What's your experience level with workflow creation? (New to this / Some experience / Very experienced)",
-    "What type of workflow are you creating? (e.g., coding, analysis, content creation, process management)",
-    "What recurring problem or task should this workflow solve?",
-    "Who is the intended audience for this workflow? (e.g., beginners, experts, specific roles)",
-    "Are there any specific constraints or requirements for this workflow?"
+  "recommendedPreferences": {
+    "recommendedAutonomy": "guided",
+    "recommendedRiskPolicy": "conservative"
+  },
+  "features": [
+    "wr.features.subagent_guidance"
   ],
   "preconditions": [
-    "User has a clear idea of the recurring task or problem the new workflow should solve.",
-    "The agent has access to 'create_file', 'edit_file', 'run_terminal_cmd', 'workflow_validate_json', and 'workflow_validate' tools."
+    "User has a recurring task or problem a workflow should solve, or an existing workflow that should be modernized.",
+    "Agent has access to file creation, editing, and terminal tools.",
+    "Agent can run workflow validators such as `npm run validate:registry` or equivalent."
   ],
   "metaGuidance": [
-    "fun adaptToPath(content) = 'Deliver {content} with appropriate depth based on learningPath: basic=detailed explanations, intermediate=efficient guidance, advanced=expert context.'",
-    "fun createWorkflowFile(template) = 'After getting filename, create file using {template}. Use adaptToPath() for explanations as you guide through structure.'",
-    "fun runValidation(depth) = 'Execute workflow_validate_json for validation. Use adaptToPath() for error explanations: basic=step-by-step teaching, intermediate=systematic analysis, advanced=architectural review.'",
-    "fun agentInstruct(action) = 'Agent: {action}. Confirm with user before proceeding with file modifications.'",
-    "fun useEditFile(purpose) = 'Use edit_file for {purpose}. Explain changes and validate with workflow_validate.'",
-    "fun teachFeature(feature, context) = 'Introduce {feature} progressively. Use adaptToPath() for explanation depth. Even basic users learn advanced features when {context} demands it.'",
-    "fun gatherDiscovery(focus) = 'Ask 2-3 focused questions about {focus}. Store responses in context.discoveryData. Be conversational and build on previous answers.'",
-    "fun analyzeGaps() = 'Review discoveryData for missing critical information. Identify next area to explore. Set context.questionFocus for next iteration.'",
-    "fun checkConvergence() = 'Evaluate if discovery is sufficient: clear problem, user needs, success criteria defined. Set context.discoveryComplete=true if ready.'",
-    "fun analyzeComplexity(data) = 'Score workflow complexity 1-10 based on {data}. Consider: number of steps, decision branches, integrations, error handling needs.'",
-    "fun suggestSteps(outline) = 'Expand {outline} into full step with prompt, agentRole, guidance using AI pattern recognition from similar workflows.'",
-    "fun visualizeWorkflow() = 'Generate Mermaid diagram showing complete workflow flow, decision points, loops, and context variable usage.'",
-    "fun getSchema() = 'Use workflow_get_schema to retrieve current schema. Reference when building workflow structure to ensure compliance.'",
-    "PROGRESSIVE LEARNING: adaptToPath() throughout - detailed for basic, balanced for intermediate, expert for advanced.",
-    "QUALITY FOCUS: All paths produce sophisticated workflows. Difference is in teaching approach, not final capability.",
-    "The goal is to create a *reusable template*, not a single-use script. Use placeholders like [User provides X] where appropriate.",
-    "Prompts should define goals and roles for the agent, not a rigid script. This allows the agent to use its intelligence to best achieve the task.",
-    "agentInstruct() before file modifications or commands.",
-    "Maintain a clear distinction between the workflow being created and this meta-workflow.",
-    "Save progress frequently by confirming file edits.",
-    "TOOL INTEGRATION: Use workflow_list/workflow_get for discovery, runValidation() for comprehensive checks, workflow_validate for step validation.",
-    "When validation fails, use detailed error messages to guide improvements rather than guessing at fixes.",
-    "teachFeature() progressively within each path based on use case needs.",
-    "When you see function calls like adaptToPath() or createWorkflowFile(), refer to the function definitions above for full instructions.",
-    "Phase 6 DSL Optimization: For intermediate/advanced users with complex workflows, consider Function Reference Pattern to reduce duplication.",
-    "SCHEMA FIRST: Always getSchema() at start of Phase 2 to ensure compliance with current workflow schema version and structure."
+    "REFERENCE HIERARCHY: treat workflow-schema as legal truth for structure. Treat authoring-spec as canonical current guidance for what makes a workflow good. Treat authoring-provenance as optional maintainer context only.",
+    "META DISTINCTION: you are authoring or modernizing a workflow, not executing one. Keep the authored workflow's concerns separate from this meta-workflow's execution.",
+    "QUALITY-GATE ROLE: this workflow is the trust gate for other workflows. It must optimize not only for validity and modern authoring, but also for task effectiveness, false-confidence resistance, and future maintainability.",
+    "DEFAULT BEHAVIOR: self-execute with tools. Only ask the user for business decisions about the workflow being authored or modernized, not things you can learn from the schema, authoring spec, or example workflows.",
+    "AUTHORED VOICE: prompts in the authored workflow must be user-voiced. No middleware narration, no pseudo-DSL, no tutorial framing, no teaching-product language.",
+    "BASELINE DISCIPLINE: choose both an authoring baseline and an outcome baseline whenever possible. Copy structural patterns, not domain language.",
+    "VALIDATION GATE: validate with real validators, not regex approximations. When validator output and authoring assumptions conflict, runtime wins.",
+    "DEEP REVIEW: authoring integrity and outcome effectiveness are separate concerns. A workflow is not ready unless both pass.",
+    "THOROUGH MODE: for complex or high-trust workflow work, prefer the deepest review path: state economy audit, execution simulation, adversarial review, and redesign if hard gates fail.",
+    "ARTIFACT STRATEGY: the workflow JSON file is the primary output. Intermediate notes go in output.notesMarkdown. Do not create extra planning artifacts unless the workflow is genuinely complex.",
+    "V2 DURABILITY: use output.notesMarkdown as the primary durable record. Do not mirror execution state into CONTEXT.md or markdown checkpoint files.",
+    "ANTI-PATTERNS TO AVOID IN AUTHORED WORKFLOWS: no pseudo-function metaGuidance, no learning-path branching, no satisfaction-score loops, no heavy clarification batteries, no regex-as-primary-validation, no celebration phases.",
+    "MODERNIZATION DISTINCTION: remove format problems (pseudo-DSL, regex, A/B phases). Preserve or equivalently replace behavioral mechanisms (forcing functions, hard gates, domain knowledge). Never silently drop a mechanism that prevents a real failure mode.",
+    "EQUIVALENT REPLACEMENT: a replacement only qualifies if it prevents the same failure mode with similar enforcement strength. A rubric suggestion is not equivalent to a hard gate. Document the tradeoff explicitly when the replacement is weaker.",
+    "NEVER COMMIT MARKDOWN FILES UNLESS USER EXPLICITLY ASKS."
   ],
   "references": [
     {
@@ -55,7 +45,7 @@
       "title": "Workflow JSON Schema",
       "source": "spec/workflow.schema.json",
       "resolveFrom": "package",
-      "purpose": "Canonical schema for validating structure and field semantics while authoring workflows.",
+      "purpose": "Canonical schema for validating structure and field semantics while authoring workflows. This is legal truth.",
       "authoritative": true
     },
     {
@@ -63,7 +53,7 @@
       "title": "Workflow Authoring Specification",
       "source": "spec/authoring-spec.json",
       "resolveFrom": "package",
-      "purpose": "Canonical authoring guidance, rule levels, and examples for composing workflows correctly.",
+      "purpose": "Canonical authoring guidance, rule levels, and examples for composing workflows correctly. This is current authoring truth.",
       "authoritative": true
     },
     {
@@ -71,491 +61,611 @@
       "title": "Workflow Authoring Provenance",
       "source": "spec/authoring-spec.provenance.json",
       "resolveFrom": "package",
-      "purpose": "Source-of-truth map showing what is canonical, derived, and non-canonical in workflow authoring guidance.",
+      "purpose": "Source-of-truth map showing what is canonical, derived, and non-canonical in workflow authoring guidance. Optional maintainer context.",
+      "authoritative": false
+    },
+    {
+      "id": "authoring-guide-v2",
+      "title": "Workflow Authoring Guide (v2)",
+      "source": "docs/authoring-v2.md",
+      "resolveFrom": "workspace",
+      "purpose": "Current v2 authoring principles, references guidance, and durable execution patterns.",
+      "authoritative": true
+    },
+    {
+      "id": "workflow-authoring-reference",
+      "title": "Workflow Authoring Reference",
+      "source": "docs/design/workflow-authoring-v2.md",
+      "resolveFrom": "workspace",
+      "purpose": "Detailed v2 workflow authoring patterns for loops, conditions, references, and workflow structure.",
+      "authoritative": true
+    },
+    {
+      "id": "routines-guide",
+      "title": "Routines Guide",
+      "source": "docs/design/routines-guide.md",
+      "resolveFrom": "workspace",
+      "purpose": "Current guide for deciding when to use delegation, direct execution, or template injection in authored workflows.",
+      "authoritative": false
+    },
+    {
+      "id": "lean-coding-workflow",
+      "title": "Lean Coding Workflow (Modern Authoring Baseline)",
+      "source": "workflows/coding-task-workflow-agentic.lean.v2.json",
+      "resolveFrom": "package",
+      "purpose": "Strong modern example for engine-native authoring patterns, loop semantics, prompt density, and bounded delegation.",
+      "authoritative": false
+    },
+    {
+      "id": "mr-review-workflow",
+      "title": "MR Review Workflow (Outcome Baseline Example)",
+      "source": "workflows/mr-review-workflow.agentic.v2.json",
+      "resolveFrom": "package",
+      "purpose": "Strong example of hypothesis, neutral fact packet, reviewer families, contradiction synthesis, final validation, and a three-dimension orthogonal assessment gate.",
+      "authoritative": false
+    },
+    {
+      "id": "bug-investigation-workflow",
+      "title": "Bug Investigation Workflow (Assessment Gate Example)",
+      "source": "workflows/bug-investigation.agentic.v2.json",
+      "resolveFrom": "package",
+      "purpose": "Simpler example of a single-dimension assessment gate on a final validation step before handoff.",
+      "authoritative": false
+    },
+    {
+      "id": "readiness-audit-workflow",
+      "title": "Production Readiness Audit (Audit Baseline Example)",
+      "source": "workflows/production-readiness-audit.json",
+      "resolveFrom": "package",
+      "purpose": "Example of a thorough evidence-driven audit workflow with explicit reviewer-family structure and confidence handling.",
       "authoritative": false
     }
   ],
   "steps": [
     {
-      "id": "phase-0-discovery-loop",
-      "type": "loop",
-      "title": "Phase 0: Adaptive Discovery & Requirements Analysis",
-      "loop": {
-        "type": "while",
-        "condition": {
-          "and": [
+      "id": "phase-0-understand-and-classify",
+      "title": "Phase 0: Understand and Classify the Authoring Task",
+      "promptBlocks": {
+        "goal": "Understand what workflow you are authoring or modernizing, and classify the task before you design anything.",
+        "constraints": [
+          [
             {
-              "var": "discoveryComplete",
-              "not_equals": true
-            },
-            {
-              "var": "discoveryIteration",
-              "lt": 5
+              "kind": "ref",
+              "refId": "wr.refs.notes_first_durability"
             }
-          ]
-        },
-        "maxIterations": 5
-      },
-      "body": [
-        {
-          "id": "discovery-iteration",
-          "title": "Discovery Iteration: Gathering Requirements",
-          "prompt": "gatherDiscovery(current focus area)\n\n**Current Focus:** Understanding the workflow requirements\n\nAgent: For iteration 1, ask the 3 core questions about problem, users, and success. For later iterations, ask targeted follow-ups based on context.questionFocus and context.focusedQuestions.\n\n**Core Questions (Iteration 1):**\n1. What specific, recurring task or problem will this workflow solve?\n2. Who will use this workflow and approximately how often?\n3. What does a successful outcome look like?\n\n**Follow-up Areas (Iterations 2+):**\n- Technical: Integration points, tools, error handling\n- Process: Decision branches, approvals, handoffs\n- Scale: Frequency, user count, growth expectations\n- Constraints: Time limits, compliance, resources",
-          "agentRole": "You are an adaptive discovery specialist. For iteration 1, ask the core questions. For subsequent iterations, analyze context.discoveryData to identify gaps and ask targeted follow-ups. Store all responses in context.discoveryData. Be conversational and acknowledge previous answers.",
-          "guidance": [
-            "ITERATION 1: Focus on problem, users, and success criteria only",
-            "ITERATION 2+: Based on problem type, explore: technical requirements OR process flows OR creative iterations OR data handling",
-            "BUILD CONTEXT: Reference previous answers when asking follow-ups",
-            "STAY FOCUSED: Maximum 3 questions per iteration to avoid overwhelming",
-            "CONVERGENCE: After each iteration, analyzeGaps() and checkConvergence()"
           ],
-          "requireConfirmation": false
+          "Explore first. Ask the user only what you genuinely cannot determine with tools and references.",
+          "Choose baselines as models, not templates. Copy structural patterns, not another workflow's domain voice."
+        ],
+        "procedure": [
+          "Read the schema, authoring spec, v2 authoring guides, and the strongest relevant example workflows.",
+          "Decide `authoringMode`: `create` or `modernize_existing`.",
+          "Classify the target workflow archetype: `review_audit`, `coding_execution`, `diagnostic_investigation`, `planning_design`, `linear_operational`, or `content_analysis`.",
+          "Classify `workflowComplexity`: Simple, Medium, or Complex. Classify `rigorMode`: QUICK, STANDARD, or THOROUGH.",
+          "Choose an `authoringBaseline` for engine-native authoring quality and an `outcomeBaseline` for the kind of job the authored workflow should perform. If no good baseline exists for one of them, set it to `none` and explain why.",
+          "If `authoringMode = modernize_existing`, build a value inventory BEFORE forming opinions about what to change. Read the original and classify each meaningful mechanism: (1) enforcement mechanisms (forcing functions, hard gates, required outputs), (2) domain knowledge (problem-specific principles the agent would not otherwise know), (3) behavioral rules (persistent constraints on how the agent works). This inventory is the preservation checklist.",
+          "If `authoringMode = modernize_existing`, identify what must stay the same about purpose, what feels stale, and what modernization constraints apply."
+        ],
+        "outputRequired": {
+          "notesMarkdown": "Task understanding, baseline choices, patterns to borrow or avoid, and any real open questions.",
+          "context": "Capture authoringMode, workflowArchetype, workflowComplexity, rigorMode, taskDescription, intendedAudience, successCriteria, domainConstraints, targetWorkflowPath, modernizationGoals, authoringBaseline, outcomeBaseline, baselineDecisionRationale, authoringPatternsToBorrow, outcomePatternsToBorrow, patternsToAvoid, openQuestions, and valueInventory (modernize_existing only)."
         },
-        {
-          "id": "discovery-analysis",
-          "title": "Analyzing Discovery Progress",
-          "prompt": "analyzeGaps() to identify what's still needed.\n\n**AI-Powered Analysis:**\n- Pattern recognition: Based on similar workflows, what requirements are commonly missed?\n- Implicit needs: What hasn't been stated but is likely needed?\n- Optimization opportunities: Where could this workflow benefit from advanced features?\n\nReview the discovery data collected so far and determine:\n1. What critical information is still missing?\n2. Which area should we explore next?\n3. Are we ready to proceed to synthesis?\n\ncheckConvergence() to determine if we have enough information.\n\nAgent: Use pattern recognition to suggest unexplored areas. Set context.questionFocus for next iteration. Increment context.discoveryIteration.",
-          "agentRole": "You are a discovery analyst. Review all collected data, identify critical gaps, and determine the next area to explore. Common follow-up areas: integration points, error handling, decision branches, constraints, scale/frequency, evolution needs.",
-          "guidance": [
-            "CHECK COMPLETENESS: Problem clarity, user needs, success criteria, basic constraints",
-            "IDENTIFY GAPS: What's critical but missing? Focus on one area at a time",
-            "SET FOCUS: Update questionFocus with specific area (e.g., 'integration requirements', 'error handling', 'decision points')",
-            "GENERATE QUESTIONS: Set context.focusedQuestions with 2-3 specific questions for next iteration",
-            "KNOW WHEN TO STOP: Don't over-analyze; 80% complete is often enough"
-          ],
-          "requireConfirmation": false
-        },
-        {
-          "id": "discovery-loop-decision",
-          "title": "Discovery Loop Decision",
-          "prompt": "**Provide a loop control decision artifact.**\n\nBased on the discovery analysis above, decide whether to continue gathering requirements or proceed to synthesis.\n\n**Decision logic:**\n- If critical information is still missing (problem unclear, user needs undefined, success criteria absent): decision = 'continue'\n- If discovery is 80%+ complete (clear problem, user needs, success criteria, basic constraints): decision = 'stop'\n\n**Output (exact format):**\nProvide a loop control artifact:\n```json\n{\n  \"artifacts\": [{\n    \"kind\": \"wr.loop_control\",\n    \"decision\": \"continue\",\n    \"metadata\": {\n      \"reason\": \"One sentence explaining why continuing or stopping\"\n    }\n  }]\n}\n```",
-          "agentRole": "You are a discovery analyst making an explicit go/no-go decision on whether enough requirements have been gathered.",
-          "requireConfirmation": false,
-          "outputContract": {
-            "contractRef": "wr.contracts.loop_control"
-          }
-        }
-      ]
-    },
-    {
-      "id": "discovery-synthesis",
-      "title": "Discovery Synthesis & Template Matching",
-      "prompt": "Excellent! I now have a comprehensive understanding of your workflow needs.\n\n**Discovery Summary:**\nAgent: Summarize the key findings from context.discoveryData in a structured format.\n\n**Next Steps:**\n1. I'll synthesize this into a refined problem statement\n2. Use workflow_list and workflow_get to find suitable templates\n3. getSchema() to ensure we build on the latest workflow structure\n4. Present recommendations based on structural patterns\n\nAgent: Create a concise problem statement. Search for workflows with similar patterns (not necessarily same domain). A 'bug investigation' workflow might be perfect for a 'customer complaint' workflow if they share similar structures.",
-      "agentRole": "You are a workflow synthesis expert. Compile all discovery data into a clear, actionable problem statement. Use workflow_list and workflow_get to find templates based on structural similarity. Present 2-3 best matches with explanations.",
-      "guidance": [
-        "SYNTHESIZE: Create clear, one-paragraph problem statement",
-        "PATTERN MATCH: Focus on workflow structure, not domain",
-        "RECOMMEND: Present 2-3 template options with rationale",
-        "CONFIRM: Get user agreement before proceeding to learning path selection"
-      ],
-      "askForFiles": true,
-      "requireConfirmation": true
-    },
-    {
-      "id": "phase-1-25-complexity-analysis",
-      "title": "Phase 1.25: Workflow Complexity Analysis",
-      "prompt": "Based on the discovery data, I'll analyze the workflow complexity to recommend the best learning path.\n\nanalyzeComplexity(discoveryData)\n\n**Complexity Factors Being Evaluated:**\n- Problem domain complexity (technical depth required)\n- Number of potential decision points\n- Integration requirements (tools, systems, APIs)\n- Error handling and recovery needs\n- Data transformation requirements\n- User expertise vs. task complexity gap\n\n**Scoring Guide:**\n- 1-3: Simple, linear workflows (Basic path ideal)\n- 4-7: Moderate complexity with some branching (Intermediate path recommended)\n- 8-10: Complex with multiple integrations/decisions (Advanced path beneficial)\n\nAgent: Calculate complexity score and set context.complexityScore. Determine context.recommendedPath based on score AND user experience. Explain reasoning.",
-      "agentRole": "You are a workflow complexity analyst. Evaluate the discovered requirements objectively. Consider technical complexity, decision density, integration needs, and error handling requirements. Balance complexity score with user's stated experience level.",
-      "guidance": [
-        "OBJECTIVE SCORING: Don't over-complicate simple workflows",
-        "FACTOR WEIGHTS: Integrations and branching logic add more complexity than step count",
-        "PATH MATCHING: Score 1-3\u2192basic, 4-7\u2192intermediate, 8-10\u2192advanced, but adjust for user experience",
-        "EXPLAIN REASONING: Always explain why you scored as you did",
-        "SET CONTEXT: Store complexityScore, recommendedPath, and complexityFactors in context"
-      ],
-      "requireConfirmation": false
-    },
-    {
-      "id": "phase-0-5-research",
-      "title": "Phase 0.5: Deep Research & Inspiration Gathering",
-      "prompt": "adaptToPath('Enhance your workflow with external knowledge! I'll generate a research prompt for deep analysis on your workflow type's best practices, patterns, and examples. Copy-paste it into ChatGPT/Claude/Gemini, then share the results. We'll synthesize key insights into your workflow ideas.')",
-      "agentRole": "You are a research specialist with expertise in generating targeted research prompts and synthesizing external knowledge. Generate a tailored prompt like: 'Research top 10 best practices for [workflow type] workflows, focusing on [problem]. Include real-world examples, step patterns, and innovations. Output in structured format: {insights: [], patterns: [], suggestedSteps: []}'. After user provides results, synthesize into workflow recommendations and store in context.researchInsights.",
-      "guidance": [
-        "Make research optional for basic path; mandatory for intermediate/advanced.",
-        "Store synthesized results in context variable 'researchInsights'.",
-        "Generate research prompts that target external best practices and innovations.",
-        "Focus on structural patterns that can be adapted to the user's specific domain."
-      ],
-      "runCondition": {
-        "or": [
-          {
-            "var": "learningPath",
-            "equals": "intermediate"
-          },
-          {
-            "var": "learningPath",
-            "equals": "advanced"
-          }
+        "verify": [
+          "The task is understood well enough to design the workflow without guessing blindly.",
+          "Both authoring and outcome baselines are explicit, or their absence is justified."
         ]
       },
       "requireConfirmation": true
     },
     {
-      "id": "phase-1-assessment",
-      "title": "Phase 1: Personalized Learning Path Selection",
-      "prompt": "Excellent! With a clear understanding of your goals, let's choose the best way to build your workflow.\n\n**Complexity Analysis Results:**\nAgent: Display the complexity score, recommended path, and key factors from context.\n\nPlease select your experience level with workflow creation:\n\n\ud83c\udf31 **Basic Path - \"Learn by Doing with Explanation\"**\n   - New to workflows or want thorough understanding\n   - Step-by-step guidance with detailed explanations\n   - Progressive introduction of advanced features with context\n   - Focus: Understanding concepts and building confidence\n\n\ud83d\ude80 **Intermediate Path - \"Balanced Guidance with Examples\"**\n   - Some experience with automation or process design\n   - Structured approach with practical examples\n   - Feature recommendations based on your use case\n   - Focus: Efficient workflow creation with best practices\n\n\ud83c\udfc6 **Advanced Path - \"Full Features with Expert Context\"**\n   - Experienced with workflow/automation tools\n   - Comprehensive feature access from the start\n   - Architectural guidance and performance considerations\n   - Focus: Sophisticated workflow engineering\n\nagentInstruct(set learningPath context variable to user's selection. Highlight which path matches the complexity analysis recommendation.)",
-      "agentRole": "You are a workflow education specialist and learning path advisor with expertise in adapting technical instruction to different experience levels. Your role is to help users choose the most appropriate learning approach based on their background and goals.",
-      "guidance": [
-        "PATH EXPLANATION: Clearly explain what each learning path offers so users can make an informed choice based on the discovery from Phase 0.",
-        "QUALITY FOCUS: All paths should result in high-quality workflows. The difference is in teaching approach, not final capability."
-      ],
-      "requireConfirmation": true
-    },
-    {
-      "id": "phase-1-5-ideation",
-      "title": "Phase 1.5: Brainstorm & Ideate Workflow Elements",
-      "prompt": "teachFeature(brainstorming, using researchInsights). Based on your goals and any research insights gathered, let's brainstorm innovative workflow elements!\n\nI'll generate 3-5 creative ideas for:\n- Unique step sequences that could make your workflow more effective\n- Advanced features that could enhance user experience\n- Innovative patterns adapted from other domains\n- Potential safeguards or quality checks\n\nAfter presenting ideas, we'll discuss pros/cons and refine based on your feedback.",
-      "agentRole": "You are an ideation expert specializing in workflow innovation. Use research insights (if available) and cross-domain thinking to propose creative, non-generic workflow designs. Present ideas with clear benefits and trade-offs. Store refined ideas in context.ideationNotes.",
-      "guidance": [
-        "Integrate 'researchInsights' if available from Phase 0.5",
-        "Propose both conventional and unconventional approaches",
-        "Explain how each idea addresses the user's specific goals",
-        "Store refined/selected ideas in 'ideationNotes' context variable"
-      ],
-      "requireConfirmation": true
-    },
-    {
-      "id": "phase-2-basic",
-      "runCondition": {
-        "var": "learningPath",
-        "equals": "basic"
+      "id": "phase-1-define-effectiveness-target",
+      "title": "Phase 1: Define the Effectiveness Target",
+      "promptBlocks": {
+        "goal": "Define what success should feel like for the authored workflow, not just what fields it should contain.",
+        "constraints": [
+          "Be specific about user satisfaction and dangerous false-confidence outcomes.",
+          "Distinguish a technically valid workflow from a satisfying one."
+        ],
+        "procedure": [
+          "State what result the authored workflow should reliably produce for its user.",
+          "List the criteria that would make the workflow feel genuinely satisfying in practice.",
+          "Name the biggest likely failure mode and the most dangerous false-confidence mode.",
+          "State what would make the workflow technically correct but still disappointing."
+        ],
+        "outputRequired": {
+          "notesMarkdown": "Effectiveness target, satisfaction criteria, failure modes, and false-confidence risks.",
+          "context": "Capture effectivenessTarget, userSatisfactionCriteria, primaryFailureMode, dangerousFalseConfidenceModes, likelyWeakOutcomeModes, and trustRisk."
+        },
+        "verify": [
+          "The authored workflow now has a clear outcome bar, not just an authoring bar."
+        ]
       },
-      "title": "Phase 2: Guided Workflow Creation (Basic Path)",
-      "prompt": "Let's create your workflow step-by-step with detailed explanations! \ud83c\udf31\n\n**STEP 0: Schema Foundation**\nFirst, I'll getSchema() to ensure we build on the current workflow structure.\n\n**STEP 1: Create Your Workflow File**\nWhat would you like to name your new workflow file? (e.g., `my-workflow.json`)\n\ncreateWorkflowFile(template from Phase 1)\n\n**STEP 2: Build the Structure Together**\nNow, let's go through each part of your workflow one by one:\n\n1.  **Basic Info** (`id`, `name`, `version`, `description`)\n    - (Agent: For each field, explain why it matters and help the user craft clear, descriptive content.)\n2.  **Setup Requirements** (`preconditions`)\n    - (Agent: Explain what preconditions are, why they prevent problems, and ask the user what's needed.)\n3.  **Global Rules** (`metaGuidance`)\n    - (Agent: Explain the difference between global rules and step-specific instructions, and ask for input.)\n4.  **The Action Steps** (`steps`)\n    - (Agent: Guide the user in creating simple, linear steps first. When user provides step outline, suggestSteps() to expand into full format. Analyze goal/research for needed features (e.g., conditions for branching, loops for repetition) and teachFeature() if appropriate.)\n5.  **Quality Integration**\n    - (Agent: useTools() to read docs like naming-conventions.md and suggest pattern integrations based on ideationNotes if available.)\n\n**AI ASSISTANCE:** When you describe a step briefly, I'll help expand it into a complete step with prompt, agentRole, and guidance!\n\n**LEARNING FOCUS:** We'll focus on understanding what each piece does and why it's useful.",
-      "agentRole": "You are a patient and thorough workflow education instructor specializing in teaching beginners. Your goal is to guide the user collaboratively. Ask for one piece of information at a time, explain the concepts, and wait for their input before proceeding. Your expertise lies in breaking down complex concepts into understandable steps, providing clear explanations for why each element matters, and building user confidence through hands-on learning.",
-      "guidance": [
-        "EXPLAIN EVERYTHING: This user is learning. Explain the purpose of each JSON field and workflow concept.",
-        "PROGRESSIVE FEATURES: Start with basics, introduce advanced features (conditional steps, context variables) when the use case needs them - with full explanations.",
-        "USE ANALOGIES: Compare workflow concepts to familiar things (recipes, instruction manuals, etc.).",
-        "ENCOURAGE QUESTIONS: Invite the user to ask about anything that's unclear.",
-        "QUALITY TEACHING: Even though this is the basic path, don't compromise on workflow quality - just explain more.",
-        "AI ASSIST: When user provides step outline, use suggestSteps() to expand into full format with all required fields"
-      ],
-      "validationCriteria": [
-        {
-          "type": "regex",
-          "pattern": "\"id\":\\s*\"[a-zA-Z0-9_-]+\"",
-          "message": "Workflow must have a valid id field with alphanumeric characters, underscores, or hyphens"
+      "requireConfirmation": false
+    },
+    {
+      "id": "phase-2-design-workflow-architecture",
+      "title": "Phase 2: Design the Workflow Architecture",
+      "runCondition": {
+        "var": "workflowComplexity",
+        "not_equals": "Simple"
+      },
+      "promptBlocks": {
+        "goal": "Decide the workflow architecture before you write JSON.",
+        "constraints": [
+          "Separate workflow architecture from quality-gate architecture. This phase is about the authored workflow itself.",
+          "Keep delegation bounded and keep ownership with the main agent."
+        ],
+        "procedure": [
+          "Decide the phase list, one-line goal for each phase, and overall ordering.",
+          "Identify meaningful input classifications that require different workflow paths. For each variant dimension, decide the branching mechanism: `runCondition` on separate steps (diverging paths), `promptFragments` (additive behavior on a shared base), or a separate workflow entirely. For each captured variable that drives branching, define its closed set of valid values — unexpected values are a common source of silent misbehavior.",
+          "Design loops with explicit exit rules, bounded maxIterations, and real reasons for another pass.",
+          "Decide confirmation gates, delegation vs template injection vs direct execution, promptFragments, references, artifacts, and metaGuidance.",
+          "If the authored workflow encodes domain knowledge tied to a specific version of an external system or codebase, decide how to handle staleness: prefer reading the codebase at runtime over hardcoding patterns, or explicitly document versioned assumptions so they surface as maintenance debt.",
+          "If `authoringMode = modernize_existing`, decide preserve-in-place, restructure, or rewrite. For each item in valueInventory, record: `preserved` (structurally present with equivalent enforcement), `replaced` (new mechanism prevents same failure mode  -- justify equivalence), or `dropped` (intentionally removed  -- justify the loss). Phase-level mapping alone is insufficient; track what was inside each restructured or removed phase."
+        ],
+        "outputRequired": {
+          "notesMarkdown": "Structured workflow outline, loop design, confirmation design, delegation design, artifact plan, and modernization mapping.",
+          "context": "Capture workflowOutline, loopDesign, confirmationDesign, delegationDesign, artifactPlan, contextModel, voiceStrategy, routineAudit, delegationBoundaries, templateInjectionPlan, modernizationStrategy, legacyMapping, behaviorPreservationNotes, and valuePreservationMap (modernize_existing only)."
         },
+        "verify": [
+          "The authored workflow architecture is coherent before JSON drafting begins."
+        ]
+      },
+      "promptFragments": [
         {
-          "type": "regex",
-          "pattern": "\"name\":\\s*\"[^\"]{3,}\"",
-          "message": "Workflow must have a descriptive name (at least 3 characters)"
-        },
-        {
-          "type": "regex",
-          "pattern": "\"description\":\\s*\"[^\"]{20,}\"",
-          "message": "Workflow must have a meaningful description (at least 20 characters)"
-        },
-        {
-          "type": "regex",
-          "pattern": "\"steps\":\\s*\\[",
-          "message": "Workflow must have a steps array with at least one step"
+          "id": "phase-2-simple-direct",
+          "when": {
+            "var": "workflowComplexity",
+            "equals": "Simple"
+          },
+          "text": "For Simple workflows, keep the architecture linear and compact. Do not invent loops or ceremony unless the task truly needs them."
         }
       ],
-      "hasValidation": true
+      "requireConfirmation": {
+        "or": [
+          {
+            "var": "workflowComplexity",
+            "not_equals": "Simple"
+          },
+          {
+            "var": "rigorMode",
+            "not_equals": "QUICK"
+          }
+        ]
+      }
     },
     {
-      "id": "phase-2-intermediate",
-      "runCondition": {
-        "var": "learningPath",
-        "equals": "intermediate"
+      "id": "phase-3-design-quality-architecture",
+      "title": "Phase 3: Design the Quality-Gate Architecture",
+      "promptBlocks": {
+        "goal": "Design how the authored workflow will avoid shallow results, false confidence, and state bloat.",
+        "constraints": [
+          "This phase is about the authored workflow's quality model, not its basic phase list.",
+          "Prefer explicit quality structure over hoping the agent will infer it."
+        ],
+        "procedure": [
+          "Decide whether the authored workflow needs a hypothesis step, neutral fact packet, reviewer or validator families, contradiction loop, final validation bundle, or explicit blind-spot handling.",
+          "Design the confidence model, blind-spot model, and state economy plan.",
+          "Decide the hard-gate dimensions that would make the authored workflow unsafe or unsatisfying if they fail. Choose the right enforcement mechanism for each gate: `assessments` + `assessmentRefs` + `assessmentConsequences` for bounded confidence judgments (each dimension captures a distinct orthogonal failure mode — see `mr-review-workflow.agentic.v2.json` and `bug-investigation.agentic.v2.json`); `validationCriteria` with context-aware conditions for completion-gating on structured checklists or required output content (the engine enforces that required content appears in the response before the step can complete, without a loop — conditions on individual rules can match the workflow's branching context); a re-verification loop for fix-and-verify cycles where the agent must act then prove the action worked. Do not default to a loop when `validationCriteria` is the right tool, or to `requireConfirmation` when a hard gate is needed.",
+          "Write the redesign triggers that should force architectural revision rather than cosmetic refinement."
+        ],
+        "outputRequired": {
+          "notesMarkdown": "Quality architecture, confidence model, blind-spot model, state economy plan, and hard-gate triggers.",
+          "context": "Capture qualityArchitecture, confidenceModel, blindSpotModel, stateEconomyPlan, reviewBundlePlan, qualityGateTriggers, and hardGateModel."
+        },
+        "verify": [
+          "The authored workflow has an explicit plan for false-confidence resistance and quality review."
+        ]
       },
-      "title": "Phase 2: Structured Workflow Development (Intermediate Path)",
-      "prompt": "Let's build your workflow with a structured approach and best practices! \ud83d\ude80\n\n**STEP 0: Schema & Foundation**\ngetSchema() to ensure compliance with current workflow structure.\n\n**STEP 1: Initialize Workflow File**\nWhat would you like to name your new workflow file?\n\ncreateWorkflowFile(template from Phase 1)\n\n**STEP 2: Core Structure Development**\nWe'll build your workflow systematically:\n\n1.  **Metadata & Identity** (`id`, `name`, `version`, `description`)\n    - Focus on discoverability and clear communication.\n2.  **Operational Requirements** (`preconditions`, `metaGuidance`)\n    - Define what's needed before starting and establish global rules.\n3.  **Step Architecture with AI Assistance**\n    - Design clear, actionable steps.\n    - When you outline a step, I'll suggestSteps() to expand it professionally.\n    - Analyze goal/research for needed features (e.g., loops for multi-item processing) and teachFeature() proactively.\n4.  **Context Variable Intelligence**\n    - I'll analyze your steps and suggest which context variables you'll need for data flow.\n5.  **Quality Patterns**\n    - useTools() to examine existing workflows and docs to suggest proven patterns from ideationNotes.\n\n**STEP 3: Enhanced Feature Recommendations**\nBased on your workflow's purpose, I may recommend specific features like:\n- **Clarification Prompts**: To gather better input upfront.\n- **Validation Criteria**: For automatic quality checks.\n- **Context Variables**: When you need information to flow between steps.\n- **Conditional Logic**: For workflows with decision points.\n\n(Agent: As you build the steps, proactively recommend these features where they seem appropriate, explaining the benefits. Integrate researchInsights and ideationNotes into recommendations.)\n\n**EFFICIENCY FOCUS:** We'll focus on building a professionally structured workflow with the right features for the job.",
-      "agentRole": "You are an experienced workflow development consultant with expertise in efficient workflow creation and best practices. You will act as a collaborator, guiding the user through the creation process efficiently. Your role is to guide users through structured development while recommending appropriate features and maintaining professional standards.",
-      "guidance": [
-        "STRUCTURED APPROACH: Follow a logical sequence with clear reasoning for each decision.",
-        "FEATURE RECOMMENDATIONS: Suggest appropriate features based on workflow type and use case.",
-        "BEST PRACTICES: Share proven patterns and explain why they work.",
-        "PRACTICAL EXAMPLES: Use real-world scenarios to illustrate concepts.",
-        "BALANCED DEPTH: Provide enough detail to understand without overwhelming with basics.",
-        "AI OPTIMIZATION: Use suggestSteps() to expand outlines; analyze steps to suggest context variables",
-        "PATTERN MATCHING: Leverage AI to identify similar workflow patterns and suggest optimizations"
-      ],
-      "validationCriteria": [
-        {
-          "type": "regex",
-          "pattern": "\"id\":\\s*\"[a-zA-Z0-9_-]+\"",
-          "message": "Workflow must have a valid id field with alphanumeric characters, underscores, or hyphens"
+      "requireConfirmation": {
+        "or": [
+          {
+            "var": "rigorMode",
+            "equals": "THOROUGH"
+          },
+          {
+            "var": "workflowComplexity",
+            "equals": "Complex"
+          }
+        ]
+      }
+    },
+    {
+      "id": "phase-4-draft-or-revise",
+      "title": "Phase 4: Draft or Revise the Workflow",
+      "promptBlocks": {
+        "goal": "Write the workflow JSON file using the architecture and quality model you already chose.",
+        "constraints": [
+          "The schema defines what is legal. The authoring spec defines what is good.",
+          "Write prompts in the user's voice. Vary prompt density by step needs rather than using one density everywhere.",
+          "If you are modernizing, preserve what still fits the workflow's purpose. Do not rewrite just because a workflow is old."
+        ],
+        "procedure": [
+          "If `authoringMode = create` and no filename was specified, ask the user for the filename before writing.",
+          "If `authoringMode = modernize_existing`, default to editing `targetWorkflowPath` unless there is a strong reason to create a new variant or file.",
+          "Write the workflow file. Keep protocol requirements explicit, loops bounded, confirmations meaningful, and metaGuidance clean."
+        ],
+        "outputRequired": {
+          "notesMarkdown": "Draft status and any notable authoring choices that are important to later review.",
+          "context": "Capture workflowFilePath and draftComplete."
         },
+        "verify": [
+          "The workflow file exists and reflects the chosen architecture rather than an improvised one."
+        ]
+      },
+      "promptFragments": [
         {
-          "type": "regex",
-          "pattern": "\"name\":\\s*\"[^\"]{3,}\"",
-          "message": "Workflow must have a descriptive name (at least 3 characters)"
-        },
-        {
-          "type": "regex",
-          "pattern": "\"description\":\\s*\"[^\"]{20,}\"",
-          "message": "Workflow must have a meaningful description (at least 20 characters)"
-        },
-        {
-          "type": "regex",
-          "pattern": "\"steps\":\\s*\\[",
-          "message": "Workflow must have a steps array with at least one step"
+          "id": "phase-4-simple-fast",
+          "when": {
+            "var": "workflowComplexity",
+            "equals": "Simple"
+          },
+          "text": "For Simple workflows, keep the file compact and linear. Do not create extra metaGuidance or loops unless the task truly needs them."
         }
       ],
-      "hasValidation": true
+      "requireConfirmation": false
     },
     {
-      "id": "phase-2-advanced",
-      "runCondition": {
-        "var": "learningPath",
-        "equals": "advanced"
-      },
-      "title": "Phase 2: Comprehensive Workflow Architecture (Advanced Path)",
-      "prompt": "Let's architect a sophisticated workflow with full feature utilization. \ud83c\udfc6\n\n**STEP 0: Schema & Architecture Foundation**\ngetSchema() to ensure we leverage all available features properly.\n\n**STEP 1: Rapid File Initialization**\nWhat filename shall we use for the new workflow?\n\ncreateWorkflowFile(template foundation) and shift to architectural decisions\n\n**STEP 2: Architectural Design with AI Enhancement**\nLet's discuss the high-level architecture:\n\n1.  **Core Architecture** (`id`, `name`, `version`, `description`)\n    - Semantic versioning strategy, namespace considerations, API documentation approach.\n2.  **Operational Design** (`preconditions`, `metaGuidance`, `contextVariables`)\n    - Comprehensive precondition modeling, sophisticated metaGuidance patterns.\n    - AI-powered context variable architecture based on data flow analysis.\n3.  **Advanced Step Design with Optimization**\n    - Trade-offs for conditional logic, validation strategy, performance.\n    - suggestSteps() with enterprise patterns when you provide high-level design.\n    - AI-suggested step ordering for optimal execution flow.\n4.  **Innovation Integration**\n    - useTools() to analyze existing enterprise workflows.\n    - AI-powered pattern recognition for non-obvious optimizations.\n    - Leverage researchInsights for cutting-edge approaches.\n\n**AI ARCHITECTURE ASSISTANT:** I'll analyze your design decisions and suggest:\n- Optimal step sequencing\n- Advanced validation criteria\n- Performance optimizations\n- Scalability considerations\n\n**MASTERY FOCUS:** Creating an enterprise-grade workflow with sophisticated, AI-enhanced architecture.",
-      "agentRole": "You are a senior workflow architect and systems design expert with deep expertise in enterprise-grade workflow engineering. Your role is to act as an architectural consultant. You will propose design patterns and discuss trade-offs with the user. Your role is to engage in sophisticated technical discussions, propose advanced design patterns, and help users create workflows that meet enterprise standards for scalability, maintainability, and performance.",
-      "guidance": [
-        "ARCHITECTURAL THINKING: Focus on design patterns, scalability, and maintainability.",
-        "FULL FEATURE ACCESS: Leverage the complete feature set appropriately for the use case.",
-        "PERFORMANCE AWARENESS: Consider efficiency and resource implications.",
-        "ENTERPRISE PATTERNS: Apply proven enterprise workflow patterns.",
-        "EXPERT CONTEXT: Assume understanding of complex concepts, focus on sophisticated applications.",
-        "AI ARCHITECTURE: Use AI to suggest optimal patterns, step ordering, and performance optimizations",
-        "INNOVATION ENGINE: Leverage AI pattern recognition for non-obvious workflow enhancements"
-      ],
-      "validationCriteria": [
-        {
-          "type": "regex",
-          "pattern": "\"id\":\\s*\"[a-zA-Z0-9_-]+\"",
-          "message": "Workflow must have a valid id field with alphanumeric characters, underscores, or hyphens"
-        },
-        {
-          "type": "regex",
-          "pattern": "\"name\":\\s*\"[^\"]{3,}\"",
-          "message": "Workflow must have a descriptive name (at least 3 characters)"
-        },
-        {
-          "type": "regex",
-          "pattern": "\"description\":\\s*\"[^\"]{20,}\"",
-          "message": "Workflow must have a meaningful description (at least 20 characters)"
-        },
-        {
-          "type": "regex",
-          "pattern": "\"steps\":\\s*\\[",
-          "message": "Workflow must have a steps array with at least one step"
-        }
-      ],
-      "hasValidation": true
-    },
-    {
-      "id": "phase-3-4-refinement-loop",
+      "id": "phase-5-validate",
       "type": "loop",
-      "title": "Phases 3-4: Iterative Validation & Refinement Loop",
+      "title": "Phase 5: Structural Validation Loop",
       "loop": {
         "type": "while",
-        "condition": {
-          "and": [
-            {
-              "var": "satisfactionScore",
-              "lt": 9
-            },
-            {
-              "var": "iterationCount",
-              "lt": 3
-            }
-          ]
+        "conditionSource": {
+          "kind": "artifact_contract",
+          "contractRef": "wr.contracts.loop_control",
+          "loopId": "validation_loop"
         },
         "maxIterations": 3
       },
       "body": [
         {
-          "id": "phase-3-basic",
-          "runCondition": {
-            "var": "learningPath",
-            "equals": "basic"
+          "id": "phase-5a-run-validation",
+          "title": "Run Validation",
+          "promptBlocks": {
+            "goal": "Run the real workflow validators against the drafted workflow.",
+            "constraints": [
+              "Do not rely on reading the JSON and eyeballing it.",
+              "If runtime and authoring assumptions conflict, runtime wins."
+            ],
+            "procedure": [
+              "Run the available validation tools or commands such as `npm run validate:registry`, schema validation, or the MCP validation surface.",
+              "If validation fails, list the actual errors, fix them in the workflow file, and re-run validation.",
+              "If validation passes cleanly, say so plainly."
+            ],
+            "outputRequired": {
+              "notesMarkdown": "Validation results, actual errors if any, and what was fixed.",
+              "context": "Capture validationErrors and validationPassed."
+            },
+            "verify": [
+              "Validation results are based on real validators, not approximations."
+            ]
           },
-          "title": "Phase 3: Learning Through Validation (Basic Path)",
-          "prompt": "Great! Your workflow draft is complete. Now let's make sure it works perfectly! \ud83c\udf31\n\n**UNDERSTANDING VALIDATION:**\nValidation is like proofreading - it catches mistakes before they cause problems. Our validation tool will check for issues with syntax, structure, and logic.\n\n**STEP 1: Run Your First Validation**\nrunValidation(basic) with detailed explanations\n\n**STEP 2: Learning from Errors (Don't worry - errors are normal!)**\nIf there are errors, I will guide you through them one at a time:\n1.  **Explain the error** in simple terms.\n2.  **Show you where** the problem is in the file.\n3.  **Explain why** it's a problem.\n4.  **Help you fix it** step-by-step.\n5.  Then, we'll **rerun validation** to see our progress.\n\n**LEARNING GOAL:** Our goal is to understand what makes a workflow valid and why each rule exists. Every error is a learning opportunity!",
-          "agentRole": "You are a supportive workflow validation instructor with expertise in teaching through problem-solving. Your goal is to run the validation tool and then guide the user through fixing any errors one by one, explaining each concept as you go. Your role is to turn validation errors into learning opportunities, explaining technical concepts in accessible terms while building user confidence in workflow creation.",
-          "guidance": [
-            "EDUCATIONAL APPROACH: Treat each error as a teaching moment. Explain what went wrong and why the rule exists.",
-            "STEP-BY-STEP FIXES: Guide through each fix individually, don't overwhelm with multiple changes.",
-            "ENCOURAGE LEARNING: Emphasize that errors are normal and part of the learning process.",
-            "EXPLAIN THE WHY: Help user understand the reasoning behind validation rules.",
-            "BUILD CONFIDENCE: Celebrate when validation passes and acknowledge progress."
+          "promptFragments": [
+            {
+              "id": "phase-5a-thorough",
+              "when": {
+                "var": "rigorMode",
+                "equals": "THOROUGH"
+              },
+              "text": "After structural validation passes, also check the workflow manually against required-level authoring-spec rules and fix any failures before moving on."
+            }
           ],
-          "requireConfirmation": true
+          "requireConfirmation": false
         },
         {
-          "id": "phase-3-intermediate",
-          "runCondition": {
-            "var": "learningPath",
-            "equals": "intermediate"
+          "id": "phase-5b-loop-decision",
+          "title": "Validation Loop Decision",
+          "promptBlocks": {
+            "goal": "Decide whether structural validation needs another pass.",
+            "constraints": [
+              "Use validator state, not vibes."
+            ],
+            "procedure": [
+              "If all errors are fixed and validation passes, stop.",
+              "If you fixed errors but have not re-validated yet, continue.",
+              "If you hit the iteration limit, stop and record what remains."
+            ],
+            "outputRequired": {
+              "artifact": "Emit a `wr.loop_control` artifact for `validation_loop` with `decision` set to `continue` or `stop`."
+            },
+            "verify": [
+              "The loop decision matches the actual validation state."
+            ]
           },
-          "title": "Phase 3: Systematic Validation & Quality Assurance (Intermediate Path)",
-          "prompt": "Time to validate and refine your workflow with systematic quality checks. \ud83d\ude80\n\n**STEP 1: Comprehensive Validation**\nrunValidation(intermediate) for systematic analysis\n\n**STEP 2: Error Pattern Analysis & Resolution**\nWhen issues are found, we will address them systematically:\n1.  **Categorize errors** by type (e.g., syntax, logic, reference).\n2.  **Identify patterns** that might indicate a recurring misunderstanding.\n3.  **Prioritize fixes**, starting with critical syntax errors.\n4.  **Apply fixes efficiently**, grouping related changes.\n5.  **Re-validate incrementally** to confirm progress.\n\n(Agent: Guide the user through this analysis and resolution process, explaining your reasoning at each step.)\n\n**EFFICIENCY FOCUS:** Our goal is systematic error resolution and pattern recognition for faster iteration.",
-          "agentRole": "You are a workflow quality assurance specialist with expertise in systematic validation and error pattern analysis. Your role is to run the validator, analyze the results for patterns, and then guide the user through a systematic fix process. Your role is to efficiently identify and resolve validation issues while teaching users to recognize and prevent common problems in future workflow development.",
-          "guidance": [
-            "SYSTEMATIC APPROACH: Handle errors methodically, grouping similar issues for efficient resolution.",
-            "PATTERN RECOGNITION: Help user identify common error patterns and prevention strategies.",
-            "PROFESSIONAL STANDARDS: Apply industry best practices for validation and quality assurance.",
-            "EFFICIENT ITERATION: Balance thoroughness with practical development speed.",
-            "QUALITY FOCUS: Ensure the workflow meets professional standards beyond just 'working'."
-          ],
-          "requireConfirmation": true
-        },
-        {
-          "id": "phase-3-advanced",
-          "runCondition": {
-            "var": "learningPath",
-            "equals": "advanced"
-          },
-          "title": "Phase 3: Advanced Validation & Architectural Review (Advanced Path)",
-          "prompt": "Let's execute a comprehensive validation with an eye for performance and architectural integrity. \ud83c\udfc6\n\n**STEP 1: Comprehensive Technical Validation**\nrunValidation(advanced) for architectural review\n\n**STEP 2: Advanced Error Analysis & Architectural Resolution**\nFor any issues found, we will perform a deep analysis:\n1.  **Root Cause Analysis**: Let's trace the errors back to their architectural source.\n2.  **Impact Assessment**: We'll evaluate the consequences for scalability and maintainability.\n3.  **Strategic Resolution**: I will help you fix the underlying patterns, not just the symptoms.\n4.  **Architectural Refinement**: We'll ensure the fixes align with our overall design principles.\n\n(Agent: Lead the user through this discussion, proposing and implementing fixes collaboratively.)\n\n**MASTERY FOCUS:** We will use validation feedback to refine architectural decisions and optimize for enterprise deployment.",
-          "agentRole": "You are a principal workflow architect and validation expert with deep expertise in enterprise-grade quality assurance. Your role is to run the validator and then lead an advanced analysis of the errors, connecting them back to architectural decisions. Your role is to conduct sophisticated technical analysis, identify architectural implications of validation issues, and guide strategic resolution that enhances overall workflow design.",
-          "guidance": [
-            "ARCHITECTURAL PERSPECTIVE: View validation through the lens of overall system design and long-term maintainability.",
-            "PERFORMANCE AWARENESS: Consider validation overhead and execution efficiency implications.",
-            "ENTERPRISE STANDARDS: Apply enterprise-grade quality gates and compliance requirements.",
-            "STRATEGIC THINKING: Fix root causes and patterns, not just individual errors.",
-            "OPTIMIZATION FOCUS: Use validation as an opportunity to refine and optimize the workflow architecture."
-          ],
-          "requireConfirmation": true
-        },
-        {
-          "id": "phase-4-basic",
-          "runCondition": {
-            "var": "learningPath",
-            "equals": "basic"
-          },
-          "title": "Phase 4: Simple Testing & Improvement (Basic Path)",
-          "prompt": "Excellent! Your workflow is technically sound. Now let's make sure it's clear and easy to use. \ud83c\udf31\n\n**STEP 1: Choose What to Test**\nFirst, which important step from your new workflow would you like to test? Pick one that is complex or that a user might struggle with.\n\n**STEP 2: Simple Persona Testing**\nOnce you've chosen a step, we'll test it by imagining different types of users:\n\n-   **The Beginner User:** Would someone new to this topic understand the instructions? Are there any technical words that need explaining?\n-   **The Busy User:** Could someone in a hurry misunderstand this? Is it too long or wordy?\n-   **The Adversarial LLM (Advanced Concept):** Is there any ambiguity an AI could exploit to produce a plausible but incorrect result? This helps make the prompt robust for AI agents.\n\n(Agent: For each persona, ask the user these questions and help them analyze the prompt.)\n\n**STEP 3: Make It Better**\nBased on what we find, I will help you:\n1.  **Understand the problems** we identified.\n2.  **Come up with specific improvements**.\n3.  **Make the changes** using `edit_file`.\n4.  **Check our work** with `workflow_validate`.\n\n**LEARNING GOAL:** Our goal is to understand how to make instructions clear for everyone.",
-          "agentRole": "You are a workflow usability specialist focused on clear communication and user experience design. Your role is to guide the user through testing one of their steps against simple personas and help them improve the clarity of the instructions.",
-          "guidance": [
-            "SIMPLE APPROACH: Focus on clarity and basic usability rather than complex edge cases.",
-            "EDUCATIONAL FOCUS: Explain why each test matters and what good instructions look like.",
-            "ENCOURAGE EMPATHY: Help user think about different types of people who might use their workflow.",
-            "PRACTICAL IMPROVEMENTS: Focus on concrete, actionable changes that clearly improve usability.",
-            "BUILD CONFIDENCE: Celebrate improvements and explain how testing makes workflows better."
-          ]
-        },
-        {
-          "id": "phase-4-intermediate",
-          "runCondition": {
-            "var": "learningPath",
-            "equals": "intermediate"
-          },
-          "title": "Phase 4: Systematic Testing & Quality Refinement (Intermediate Path)",
-          "prompt": "Your workflow is validated. Let's ensure it's robust and professional through comprehensive testing. \ud83d\ude80\n\n**STEP 1: Critical Step Selection**\nTo begin, please identify 1-2 critical steps from your workflow that are either complex, high-impact, or involve key user decisions.\n\n**STEP 2: Multi-Persona Analysis**\nFor each step you select, we will evaluate it from these strategic perspectives:\n\n-   **The Domain Expert:** Does the step leverage domain knowledge correctly? Are there unstated assumptions?\n-   **The Efficiency-Focused User:** Can the step be completed quickly without sacrificing quality? Are there bottlenecks?\n-   **The Adversarial LLM:** How could an AI exploit ambiguity in the prompt to produce a plausible but incorrect result?\n\n(Agent: Guide the user through this analysis, asking probing questions for each persona.)\n\n**STEP 3: Strategic Refinements**\nBased on our analysis, I will help you:\n1.  **Prioritize improvements** by impact.\n2.  **Implement targeted enhancements** using `edit_file`.\n3.  **Validate consistency** with `workflow_validate`.\n4.  **Document the rationale** for key design decisions.\n\n**PROFESSIONAL FOCUS:** Our goal is to balance efficiency, quality, and usability for real-world deployment.",
-          "agentRole": "You are a workflow quality engineer and strategic testing specialist with expertise in multi-persona analysis and systematic quality improvement. Your role is to guide the user through a systematic evaluation of a critical step against multiple strategic personas.",
-          "guidance": [
-            "STRATEGIC THINKING: Focus on improvements that have the highest impact on workflow effectiveness.",
-            "PROFESSIONAL STANDARDS: Apply industry best practices for user experience and process design.",
-            "BALANCED APPROACH: Consider trade-offs between different user needs and workflow goals.",
-            "SYSTEMATIC PROCESS: Use structured analysis to ensure comprehensive coverage of potential issues.",
-            "PRACTICAL DEPLOYMENT: Focus on refinements that matter for real-world workflow usage."
-          ]
-        },
-        {
-          "id": "phase-4-advanced",
-          "runCondition": {
-            "var": "learningPath",
-            "equals": "advanced"
-          },
-          "title": "Phase 4: Enterprise Testing & Architectural Refinement (Advanced Path)",
-          "prompt": "Let's execute sophisticated, enterprise-grade testing and optimization. \ud83c\udfc6\n\n**STEP 1: Strategic Component Selection**\nFirst, please identify the critical components in your workflow for analysis. Focus on high-complexity steps, key decision points, or integration touchpoints.\n\n**STEP 2: Advanced Multi-Dimensional Analysis**\nFor each component you choose, we will execute a comprehensive evaluation framework. I will lead you through discussions on:\n\n-   **Architectural Perspective:** Are the design patterns consistent? What are the scalability implications?\n-   **Performance & Efficiency:** Where are the potential bottlenecks? Is context variable usage optimal?\n-   **The Adversarial LLM:** How can we harden prompts against sophisticated misinterpretation by an AI agent seeking the path of least resistance?\n-   **Enterprise User Experience:** How does this work for multi-user collaboration or in enterprise environments?\n-   **Maintenance & Evolution:** How easy is this to maintain and extend?\n\n(Agent: Lead the user through this deep analysis, acting as an architectural consultant.)\n\n**STEP 3: Strategic Architectural Refinement**\nBased on our analysis, I will help you:\n1.  **Architect strategic improvements** that address systemic issues.\n2.  **Optimize for enterprise deployment** with sophisticated enhancements.\n3.  **Validate architectural integrity** using `workflow_validate`.\n4.  **Document our architectural decisions** and the rationale for them.\n\n**MASTERY OUTCOME:** Our goal is to create an enterprise-ready workflow optimized for scalability, maintainability, and sophisticated deployment scenarios.",
-          "agentRole": "You are a principal workflow architect and enterprise testing specialist with deep expertise in sophisticated multi-dimensional analysis and enterprise-grade optimization. Your role is to lead a multi-dimensional analysis of critical workflow components, focusing on architectural integrity and enterprise readiness.",
-          "guidance": [
-            "ARCHITECTURAL EXCELLENCE: Focus on sophisticated design patterns and enterprise-grade considerations.",
-            "PERFORMANCE OPTIMIZATION: Identify and address efficiency opportunities across all dimensions.",
-            "ENTERPRISE READINESS: Ensure the workflow meets sophisticated organizational deployment requirements.",
-            "STRATEGIC REFINEMENT: Make improvements that enhance long-term value and architectural integrity.",
-            "COMPREHENSIVE ANALYSIS: Apply enterprise-grade evaluation frameworks for thorough assessment."
-          ]
-        },
-        {
-          "id": "satisfaction-check",
-          "title": "Iteration Satisfaction Check & Loop Decision",
-          "prompt": "Let's assess your satisfaction with the workflow so far.\n\n**Rate your satisfaction (1-10):**\n- 10: Perfect! Ready to deploy\n- 8-9: Very good, minor tweaks only\n- 6-7: Good foundation, needs refinement\n- 4-5: Major improvements needed\n- 1-3: Significant rework required\n\n**Decision logic:**\n- Score 9+: decision = 'stop' (proceed to completion)\n- Score <9: decision = 'continue' (iterate again, up to 3 times total)\n\nAgent: Set context.satisfactionScore and increment context.iterationCount.\n\n**Provide a loop control artifact:**\n```json\n{\n  \"artifacts\": [{\n    \"kind\": \"wr.loop_control\",\n    \"decision\": \"continue\",\n    \"metadata\": {\n      \"reason\": \"Satisfaction score X/10 - [brief reason]\"\n    }\n  }]\n}\n```",
-          "agentRole": "You are a quality assessment specialist. Guide the user through evaluating their workflow objectively. Provide a loop control artifact with the decision.",
-          "requireConfirmation": false,
           "outputContract": {
             "contractRef": "wr.contracts.loop_control"
-          }
+          },
+          "requireConfirmation": false
         }
       ]
     },
     {
-      "id": "phase-5-completion",
-      "title": "Phase 5: Celebration & Growth",
-      "prompt": "\ud83c\udf89 **WORKFLOW CREATION COMPLETE!** \ud83c\udf89\n\n**STEP 1: Final Review**\nagentInstruct(review workflow name and description, then runValidation(final))\n\n**STEP 2: Path-Specific Celebration**\n\nagentInstruct(provide adaptToPath(celebration) based on learning path):\n\n**\ud83c\udf31 BASIC PATH:**\nCongratulations! You've created your first workflow with advanced features!\nLearned: Workflow structure, conditional steps, validation, clear guidance.\nNext: Try intermediate path for advanced patterns and sophisticated testing.\n\n**\ud83d\ude80 INTERMEDIATE PATH:**\nExcellent work! You've created a professionally structured workflow!\nMastered: Efficient authoring, strategic features, systematic validation, design patterns.\nNext: Consider Phase 6 optimization, create domain workflows, explore advanced logic.\n\n**\ud83c\udfc6 ADVANCED PATH:**\nOutstanding! You've demonstrated workflow architecture mastery!\nAchieved: Sophisticated design, enterprise validation, advanced patterns, expert engineering.\nNext: Lead design, contribute advanced templates, mentor others, explore innovations.\n\n**STEP 3: Documentation & Quality Metrics**\ncreateFile(README.md) with usage instructions generated from workflow content.\n\n**Quality Rubric - Rate your workflow:**\n- Clarity: How clear are the instructions? (1-10)\n- Adaptability: How well does it handle edge cases? (1-10)\n- Innovation: How creative is the approach? (1-10)\n- Maintainability: How easy to update? (1-10)\n\nAgent: If any score < 8, suggest specific improvements.\n\n**STEP 4: Completion**\nAgent: Confirm workflow is deployment-ready. For basic/intermediate users, offer level-up opportunities for future workflows.\n\n**UNIVERSAL TRUTH:** Workflow mastery continues with each template. Every workflow is an opportunity to improve!",
-      "guidance": [
-        "ADAPTIVE CELEBRATION: Match the celebration intensity and language to the user's learning path and achievement level.",
-        "GROWTH ORIENTATION: Always provide clear next steps that encourage continued learning and skill development.",
-        "PATH-SPECIFIC GUIDANCE: Tailor advice to the user's demonstrated skill level and learning journey.",
-        "LEVEL-UP OPPORTUNITIES: For basic and intermediate users, gently suggest trying higher complexity paths for future workflows.",
-        "UNIVERSAL PRINCIPLES: End with shared wisdom that applies to all workflow creators regardless of skill level."
-      ],
-      "validationCriteria": [
-        {
-          "type": "length",
-          "min": 500,
-          "message": "Final workflow should be comprehensive (at least 500 characters)"
-        },
-        {
-          "type": "regex",
-          "pattern": "\"steps\":\\s*\\[[^\\]]+\\]",
-          "message": "Final workflow must have at least one complete step"
-        }
-      ],
-      "hasValidation": true
-    },
-    {
-      "id": "phase-5-5-visual-preview",
-      "title": "Phase 5.5: Visual Workflow Preview",
-      "prompt": "Let's visualize your workflow to see the complete flow! \ud83c\udfa8\n\nvisualizeWorkflow() to generate a comprehensive diagram.\n\n**Creating Mermaid Diagram:**\nI'll generate a flowchart showing:\n- Complete step sequence\n- Decision branches (conditional steps)\n- Loop structures\n- Context variable flow\n- Learning path variations\n\nAgent: Use create_diagram to generate a Mermaid flowchart. Include:\n1. All workflow steps as nodes\n2. Conditional branches with decision labels\n3. Loop indicators with iteration info\n4. Context variables as data flow annotations\n5. Different colors for different phases or complexity levels\n\n**Example Structure:**\n```mermaid\nflowchart TD\n    Start([\"\ud83d\ude80 Workflow Start\"])\n    Discovery[\"Phase 0: Discovery Loop<br/>Gather Requirements\"]\n    Complexity[\"Phase 1.25: Complexity Analysis<br/>Score: context.complexityScore\"]\n    PathSelect{{\"Learning Path Selection<br/>Basic/Intermediate/Advanced\"}}\n    ...\n    End([\"\u2705 Workflow Complete\"])\n```\n\n**Benefits of Visualization:**\n- See the complete workflow structure at a glance\n- Verify logical flow and dependencies\n- Identify optimization opportunities\n- Great for documentation and team sharing",
-      "agentRole": "You are a workflow visualization expert. Create clear, comprehensive Mermaid diagrams that accurately represent the workflow structure, including all paths, conditions, and data flows.",
-      "guidance": [
-        "COMPLETE COVERAGE: Include every step, even conditional ones",
-        "CLEAR LABELING: Use descriptive labels for all nodes and edges",
-        "VISUAL HIERARCHY: Use subgraphs for loops and phases",
-        "DATA FLOW: Show context variable usage with annotations",
-        "ACCESSIBILITY: Ensure diagram is readable and well-organized"
-      ],
-      "requireConfirmation": false
-    },
-    {
-      "id": "phase-6-dsl-optimization",
-      "title": "Phase 6: Optimize with Function Reference Pattern (Advanced)",
-      "prompt": "**WORKFLOW OPTIMIZATION OPPORTUNITY** \ud83d\udd27\n\nYour workflow is complete and functional! Now let's make it more maintainable and efficient using the **Function Reference Pattern** - an advanced technique for reducing duplication.\n\n**STEP 1: Analyze for Duplication**\nLet's examine your workflow for repeated instruction patterns:\n- Look for similar phrases across multiple step prompts\n- Identify repeated tool usage instructions (edit_file, workflow_validate, etc.)\n- Find common guidance patterns that appear in multiple places\n\n**STEP 2: Identify Function Candidates**\nBased on your workflow, we might create functions like:\n```\nfun createFile(filename) = 'Use edit_file to create {filename}. Explain the structure as you build it.'\nfun runValidation() = 'Execute workflow_validate_json. Explain any errors found and guide through fixes step-by-step.'\nfun adaptToPath(content) = 'Deliver {content} with appropriate depth based on learningPath: basic=detailed explanations, intermediate=efficient guidance, advanced=expert context.'\n```\n\n**STEP 3: Implementation Decision**\nFunction references work best for workflows with:\n\u2705 10+ steps with shared patterns\n\u2705 Repeated instruction blocks\n\u2705 Long prompts hitting character limits\n\u2705 Team workflows needing consistency\n\n**Agent Instructions:**\n1. Analyze the created workflow for duplication patterns\n2. If suitable (complex workflow with repeated patterns), propose specific function definitions\n3. Show examples of how 2-3 steps would look with function references\n4. Calculate potential file size reduction\n5. Let user decide whether to implement this optimization\n\nThis is an **optional advanced technique** - the workflow is already complete and functional!",
-      "agentRole": "You are a workflow optimization specialist with expertise in the Function Reference Pattern (DSL approach). Your role is to analyze the completed workflow for duplication opportunities and guide the user through the decision of whether to apply this advanced optimization technique.",
-      "guidance": [
-        "PATTERN RECOGNITION: Look for repeated instruction blocks, tool usage patterns, and similar guidance across steps.",
-        "BENEFIT ANALYSIS: Calculate concrete benefits (file size reduction, consistency improvement, maintenance ease).",
-        "OPTIONAL OPTIMIZATION: Make it clear this is an advanced, optional technique - the workflow already works.",
-        "PRACTICAL EXAMPLES: Show concrete before/after examples from their actual workflow.",
-        "USER CHOICE: Let them decide based on their workflow complexity and maintenance needs."
-      ],
+      "id": "phase-5-escalation",
+      "title": "Validation Escalation",
       "runCondition": {
-        "or": [
-          {
-            "var": "learningPath",
-            "equals": "intermediate"
-          },
-          {
-            "var": "learningPath",
-            "equals": "advanced"
-          }
+        "var": "validationPassed",
+        "equals": false
+      },
+      "promptBlocks": {
+        "goal": "Do not silently continue with a structurally broken workflow.",
+        "constraints": [
+          "Present the situation honestly."
+        ],
+        "procedure": [
+          "List the remaining validation errors and assess their severity.",
+          "Present the options: proceed with known issues documented, or stop so the user can intervene manually."
         ]
       },
       "requireConfirmation": true
     },
     {
-      "id": "level-up-opportunity",
-      "runCondition": {
-        "var": "learningPath",
-        "not_equals": "advanced"
+      "id": "phase-6-quality-gate-loop",
+      "type": "loop",
+      "title": "Phase 6: Quality-Gate Loop",
+      "loop": {
+        "type": "while",
+        "conditionSource": {
+          "kind": "artifact_contract",
+          "contractRef": "wr.contracts.loop_control",
+          "loopId": "quality_gate_loop"
+        },
+        "maxIterations": 2
       },
-      "title": "\ud83d\ude80 Ready to Level Up?",
-      "prompt": "**OPTIONAL: Explore the Next Level**\n\nYou've successfully completed your workflow! Would you like to explore what the next learning path offers for your future workflows?\n\n**FOR BASIC PATH GRADUATES:**\nThe **Intermediate Path** offers:\n- More efficient workflow creation process\n- Advanced feature recommendations based on use case\n- Professional design patterns and best practices\n- Systematic validation and testing approaches\n\n**FOR INTERMEDIATE PATH GRADUATES:**\nThe **Advanced Path** offers:\n- Comprehensive feature utilization from the start\n- Enterprise-grade architectural considerations\n- Performance optimization and scalability patterns\n- Sophisticated testing and validation frameworks\n\n**Remember:** You can always return to your comfortable level - this is just an invitation to explore new possibilities when you're ready!\n\n**Agent Guidance:** If the user expresses interest, provide a brief preview of what they would experience in the next path level. If not interested, celebrate their current achievement and encourage them to practice at their current level.",
-      "guidance": [
-        "OPTIONAL EXPLORATION: Make it clear this is purely optional and they've already succeeded.",
-        "NO PRESSURE: Emphasize they can always return to their comfort level.",
-        "PREVIEW VALUE: Show concrete benefits of advancing without making current level seem inadequate.",
-        "RESPECT CHOICE: Whether they advance or stay, celebrate their decision and provide appropriate support."
+      "body": [
+        {
+          "id": "phase-6a-state-economy-audit",
+          "title": "State Economy Audit",
+          "promptBlocks": {
+            "goal": "Check whether every context field in the authored workflow earns its keep.",
+            "constraints": [
+              "A field is justified only if it materially affects routing, synthesis, confidence, or handoff quality.",
+              "Do not keep bookkeeping fields just because they sound organized."
+            ],
+            "procedure": [
+              "For each meaningful captured context field, record where it is set, where it is consumed, what decision or outcome it influences, and what gets worse if it is removed.",
+              "Classify each field as `keep`, `wire`, or `remove`.",
+              "Fix weak or unused fields directly in the workflow file."
+            ],
+            "outputRequired": {
+              "notesMarkdown": "State field audit with keep/wire/remove decisions and any fixes applied.",
+              "context": "Capture stateFieldAudit, unusedOrWeakFields, and stateEconomyPassed."
+            },
+            "verify": [
+              "Weak or unused fields are either wired meaningfully or removed."
+            ]
+          },
+          "requireConfirmation": false
+        },
+        {
+          "id": "phase-6b-execution-simulation",
+          "title": "Execution Simulation",
+          "promptBlocks": {
+            "goal": "Simulate what would happen if the authored workflow ran on the user's real task.",
+            "constraints": [
+              "This is about practical utility, not only context-flow correctness.",
+              "Flag places where the workflow would produce paperwork, generic output, or false confidence instead of value."
+            ],
+            "procedure": [
+              "Trace the authored workflow step by step against the user's actual task or the closest realistic scenario.",
+              "For each step, ask: what would the agent actually do, what context would it have, what would it likely produce, and what would the next step inherit?",
+              "Also trace at least one degraded or edge-case path  -- not just the happy path. Ask: what happens when a condition evaluates unexpectedly, a loop has nothing to iterate, a runCondition skips a phase, or the user provides minimal input? Quality gates that only protect the happy path are not quality gates.",
+              "Identify likely weak steps, likely unsatisfying outputs, and likely false-confidence modes.",
+              "For any loop in the workflow, explicitly check: does the exit condition have structural teeth (artifact contract, bounded maxIterations), or does it rely on prose instructions the engine cannot enforce?",
+              "Fix issues directly in the workflow file when the right improvement is clear."
+            ],
+            "outputRequired": {
+              "notesMarkdown": "Execution simulation findings, likely weak steps, unsatisfying outputs, false-confidence risks, and any fixes applied.",
+              "context": "Capture simulationFindings, likelyWeakSteps, likelyUnsatisfyingOutputs, falseConfidenceFindings, and outcomeEffectivenessPassed."
+            },
+            "verify": [
+              "The simulation judges likely usefulness, not just structural legality."
+            ]
+          },
+          "promptFragments": [
+            {
+              "id": "phase-6b-quick",
+              "when": {
+                "var": "rigorMode",
+                "equals": "QUICK"
+              },
+              "text": "For QUICK rigor, keep the simulation compact but still answer where the workflow would likely disappoint the user if it disappointed them at all."
+            },
+            {
+              "id": "phase-6b-modernize-check",
+              "when": {
+                "var": "authoringMode",
+                "equals": "modernize_existing"
+              },
+              "text": "For modernize_existing: after tracing the workflow forward, check each item in valueInventory. For each enforcement mechanism and domain knowledge item: would the modernized workflow produce the same behavior? Any item where the answer is no or weaker is a loss  -- fix it directly or record the accepted tradeoff with justification."
+            }
+          ],
+          "requireConfirmation": false
+        },
+        {
+          "id": "phase-6c-adversarial-quality-review",
+          "title": "Adversarial Quality Review",
+          "promptBlocks": {
+            "goal": "Review the authored workflow as a quality gate, not just as a valid JSON file.",
+            "constraints": [
+              "Authoring integrity and outcome effectiveness are separate concerns. Score both.",
+              "Reviewer-family or validator output is evidence, not authority."
+            ],
+            "procedure": [
+              "Score these dimensions 0-2 with one sentence of evidence each: `voiceClarity`, `ceremonyLevel`, `loopSoundness`, `delegationBoundedness`, `artifactClarity`, `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, `handoffUtility`, `rigorAdaptability` (0 = adapts to complexity/rigor levels, 2 = single-weight), `enforcementStrength` (0 = behavioral rules have structural teeth; 2 = important rules are prose-only with no enforcement mechanism), and `modernizationDiscipline` (0 = every valueInventory item preserved, equivalently replaced with justification, or dropped with justification; 2 = items missing or replaced with weaker versions without justification  -- score 0 for create mode).",
+              "If delegation is available and rigor is THOROUGH, run an adversarial review bundle with these lenses: `engine_native_reviewer`, `task_effectiveness_reviewer`, `state_economy_reviewer`, `false_confidence_reviewer`, `domain_fit_reviewer`, and `maintainer_reviewer`.",
+              "Synthesize what the review confirmed, what it challenged, and what changed your mind.",
+              "When scoring `falseConfidenceResistance`, explicitly check: do the workflow's quality gates protect edge cases and degraded paths, or only the happy path? A workflow that passes its own checks on ideal input but fails silently on minimal or unexpected input scores 2.",
+              "Set hard-gate failures whenever any of these are materially weak: `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, or `handoffUtility`.",
+              "Set `authoringIntegrityPassed = true` only if structural and authoring-quality dimensions are all acceptable. Set `outcomeEffectivenessPassed = true` only if the workflow is likely to achieve satisfying results for the user."
+            ],
+            "outputRequired": {
+              "notesMarkdown": "Quality review scores, adversarial review findings, hard-gate failures, and the current redesign severity.",
+              "context": "Capture reviewScores, hardGateFailures, authoringIntegrityPassed, outcomeEffectivenessPassed, qualityReviewSummary, and redesignSeverity."
+            },
+            "verify": [
+              "Hard gates reflect real user-trust risk, not cosmetic imperfections."
+            ]
+          },
+          "promptFragments": [
+            {
+              "id": "phase-6c-standard",
+              "when": {
+                "var": "rigorMode",
+                "equals": "STANDARD"
+              },
+              "text": "For STANDARD rigor, you may keep the review self-executed unless uncertainty remains material. If you do delegate, prefer a small adversarial bundle."
+            },
+            {
+              "id": "phase-6c-thorough",
+              "when": {
+                "var": "rigorMode",
+                "equals": "THOROUGH"
+              },
+              "text": "For THOROUGH rigor, assume the first review is not enough. Use adversarial reviewer lanes unless a hard limitation makes them impossible."
+            },
+            {
+              "id": "phase-6c-heritage-review",
+              "when": {
+                "var": "authoringMode",
+                "equals": "modernize_existing"
+              },
+              "text": "For modernize_existing: add a heritage_reviewer to the adversarial bundle. Its job is to check each valueInventory item and find what was lost or weakened  -- it ignores format improvements. It must answer: which enforcement mechanisms are now prose-only? Which domain knowledge items are absent? Which behavioral rules were removed without equivalent replacement? Heritage_reviewer findings drive enforcementStrength and modernizationDiscipline scores."
+            }
+          ],
+          "hasValidation": true,
+          "validationCriteria": [
+            { "type": "contains", "value": "voiceClarity", "message": "Review must score voiceClarity" },
+            { "type": "contains", "value": "ceremonyLevel", "message": "Review must score ceremonyLevel" },
+            { "type": "contains", "value": "loopSoundness", "message": "Review must score loopSoundness" },
+            { "type": "contains", "value": "delegationBoundedness", "message": "Review must score delegationBoundedness" },
+            { "type": "contains", "value": "artifactClarity", "message": "Review must score artifactClarity" },
+            { "type": "contains", "value": "taskEffectiveness", "message": "Review must score taskEffectiveness" },
+            { "type": "contains", "value": "falseConfidenceResistance", "message": "Review must score falseConfidenceResistance" },
+            { "type": "contains", "value": "stateMinimality", "message": "Review must score stateMinimality" },
+            { "type": "contains", "value": "coverageSharpness", "message": "Review must score coverageSharpness" },
+            { "type": "contains", "value": "domainFit", "message": "Review must score domainFit" },
+            { "type": "contains", "value": "handoffUtility", "message": "Review must score handoffUtility" },
+            { "type": "contains", "value": "rigorAdaptability", "message": "Review must score rigorAdaptability" },
+            { "type": "contains", "value": "enforcementStrength", "message": "Review must score enforcementStrength" },
+            {
+              "type": "contains",
+              "value": "modernizationDiscipline",
+              "condition": { "var": "authoringMode", "equals": "modernize_existing" },
+              "message": "Modernization reviews must score modernizationDiscipline"
+            }
+          ],
+          "requireConfirmation": false
+        },
+        {
+          "id": "phase-6d-redesign-and-revalidate",
+          "title": "Redesign and Revalidate",
+          "promptBlocks": {
+            "goal": "If hard gates fail, redesign the workflow instead of polishing around the problem.",
+            "constraints": [
+              "Minor cosmetic refinement is not enough when task effectiveness or false-confidence resistance is weak.",
+              "If structure changes, re-run real validators before leaving this step."
+            ],
+            "procedure": [
+              "If `authoringIntegrityPassed` and `outcomeEffectivenessPassed` are both true and `hardGateFailures` is empty, say that no redesign is needed.",
+              "Otherwise classify the needed redesign severity as `minor`, `architectural`, or `unsafe_to_ship` and apply the necessary fixes directly to the workflow file.",
+              "If the redesign changed structure, run the real validators again and update the validation state before leaving this step."
+            ],
+            "outputRequired": {
+              "notesMarkdown": "Redesign actions taken, why they were needed, and whether revalidation passed.",
+              "context": "Capture redesignApplied, validationPassed, and remainingConcerns."
+            },
+            "verify": [
+              "Structural redesign problems are handled as redesign problems, not cosmetic ones."
+            ]
+          },
+          "requireConfirmation": false
+        },
+        {
+          "id": "phase-6e-quality-loop-decision",
+          "title": "Quality Loop Decision",
+          "promptBlocks": {
+            "goal": "Decide whether the quality-gate loop needs another pass.",
+            "constraints": [
+              "Use hard gates and actual remaining concerns, not vibes."
+            ],
+            "procedure": [
+              "Continue if `authoringIntegrityPassed = false`.",
+              "Otherwise continue if `outcomeEffectivenessPassed = false`.",
+              "Otherwise continue if `hardGateFailures` is not empty.",
+              "Otherwise continue if `redesignSeverity` is `architectural` or `unsafe_to_ship` and you have not yet re-reviewed the redesigned workflow.",
+              "Otherwise continue if `validationPassed = false` after redesign.",
+              "Otherwise stop."
+            ],
+            "outputRequired": {
+              "artifact": "Emit a `wr.loop_control` artifact for `quality_gate_loop` with `decision` set to `continue` or `stop`."
+            },
+            "verify": [
+              "The workflow does not stop while hard trust problems remain."
+            ]
+          },
+          "outputContract": {
+            "contractRef": "wr.contracts.loop_control"
+          },
+          "requireConfirmation": false
+        }
       ]
+    },
+    {
+      "id": "phase-7a-assign-tags",
+      "title": "Phase 7a: Assign Tags",
+      "promptBlocks": {
+        "goal": "Register the workflow in the catalog: assign tags in spec/workflow-tags.json and write about and examples fields into the workflow JSON so humans and agents can discover and understand the workflow.",
+        "procedure": [
+          "Read spec/workflow-tags.json to see the available tags and their 'when' phrases.",
+          "Based on the workflow's purpose and description, select 1-3 tags from the closed set (coding, review_audit, investigation, design, documentation, tickets, learning, routines, authoring).",
+          "Add the workflow ID as a new entry under 'workflows' in spec/workflow-tags.json: { \"tags\": [\"<tag1>\"] }.",
+          "If the workflow is a test fixture or internal utility not meant for end-user discovery, add 'hidden': true.",
+          "Save the tags file. Do not modify any other field.",
+          "Write the 'about' field into the workflow JSON: a markdown string (100-400 words) written for a human deciding whether to use this workflow. Cover what it does, when to use it, what it produces, and how to get good results. This is a user-facing surface -- not agent instructions (use metaGuidance for that).",
+          "Write the 'examples' field into the workflow JSON: an array of 2-4 short, concrete goal strings (10-120 chars each) showing what this workflow is used for. Each example should be specific enough to be informative -- not generic ('implement a feature'). These appear in list_workflows output so agents can communicate concrete goal phrasing to users.",
+          "Skip 'about' and 'examples' only if the workflow is marked hidden: true."
+        ],
+        "constraints": [
+          "Only use tags from the closed set. Do not invent new tags.",
+          "If the workflow already has an entry in the tags file, update it rather than adding a duplicate.",
+          "Tags should reflect what the workflow does, not what it is named.",
+          "Write 'about' for humans, not agents -- do not copy metaGuidance or step prompt text into it.",
+          "Examples must be specific to this workflow; reject generic examples that would fit any workflow."
+        ],
+        "outputRequired": {
+          "notesMarkdown": "List the assigned tags with a one-line justification for each. Confirm about and examples were written."
+        }
+      },
+      "requireConfirmation": false
+    },
+    {
+      "id": "phase-7-final-trust-handoff",
+      "title": "Phase 7: Final Trust Handoff",
+      "promptBlocks": {
+        "goal": "Summarize the authored or modernized workflow as a trust decision, not just a file edit.",
+        "constraints": [
+          "Keep it concise. The workflow file is the deliverable, not the summary."
+        ],
+        "procedure": [
+          "Stamp the workflow file: read the current `version` from `spec/authoring-spec.json` and write `validatedAgainstSpecVersion: <N>` as a top-level field in the workflow JSON. Commit the change  -- the stamp has no effect if only saved locally.",
+          "State the workflow file path and name, whether it was created or modernized, and what it does in one sentence.",
+          "Summarize the step structure, loops, confirmations, and delegation profile.",
+          "Report validation status, authoring-integrity status, and outcome-effectiveness status.",
+          "Set a final `workflowReadinessVerdict`: `ready`, `ready_with_conditions`, or `not_ready`.",
+          "List the main improvements, residual weaknesses, trust risks if any, and how to test the workflow."
+        ],
+        "outputRequired": {
+          "notesMarkdown": "Final trust handoff covering readiness verdict, validation status, strengths, residual weaknesses, and testing guidance.",
+          "context": "Capture workflowReadinessVerdict, trustRiskSummary, knownFailureModes, and residualWeaknesses."
+        },
+        "verify": [
+          "The final handoff makes clear whether WorkRail should trust this workflow."
+        ]
+      },
+      "notesOptional": true,
+      "requireConfirmation": false
     }
-  ]
+  ],
+  "validatedAgainstSpecVersion": 3
 }


### PR DESCRIPTION
## Summary

- Steps can now declare 1..N `assessmentRefs` alongside one `assessmentConsequences` entry
- The consequence fires if any dimension across **any** referenced assessment equals the trigger level
- Previously a consequence required exactly one ref, forcing unrelated dimensions into monolithic assessment definitions — many-to-one lets authors compose separate orthogonal assessments (quality-gate + coverage-gate) behind a shared blocking gate

## What changed

- **Schema**: `assessmentRefs` `maxItems: 1` removed — no upper bound, compiler is the gatekeeper
- **Compiler**: constraint relaxed from `length !== 1` to `length === 0`; trigger level now validated across all referenced assessments
- **Validation engine**: same relaxation in all three locations; stale `length > 1` warning removed
- **Assessment validation**: validates each ref separately, returns `recordedAssessments[]` and `acceptedArtifacts[]` arrays
- **Consequence evaluation**: iterates all recorded assessments, fires on first match in `assessmentRefs` order
- **Event emission**: one `assessment_recorded` event per ref (in order)
- **Output schema**: `stepContext.assessments` is now an **array** — one entry per ref
- **Prompt renderer**: multi-ref steps now instruct the agent to set `assessmentId` on each artifact
- **Docs**: `authoring.md` regenerated, `authoring-v2.md` updated, `god-tier-workflow-validation.md` updated, `changelog-recent.md` entry added
- **workflow-for-workflows**: `validationCriteria` quality gate on adversarial review step, branching analysis and domain knowledge stability guidance in architecture phase, `validationCriteria` listed as a quality gate mechanism

## Breaking change

`stepContext.assessments` in `continue_workflow` response is now an array. Update `.assessments.x` to `.assessments[0].x`.

## Test plan

- [ ] CI passes on this branch
- [ ] `assessment-consequences.test.ts` includes multi-ref fire and no-fire cases
- [ ] `assessment-definition-validation.test.ts` includes multi-ref with consequence passing and failing
- [ ] `assessment-step-context.test.ts` updated to array shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)