### PR TITLE
feat(engine): surface assessment and dimension purpose in prompt renderer

### DIFF
--- a/src/v2/durable-core/domain/prompt-renderer.ts
+++ b/src/v2/durable-core/domain/prompt-renderer.ts
@@ -321,9 +321,11 @@ function formatAssessmentRequirements(
       requirements.push(`Set assessmentId: "${assessment.id}" on the artifact so the engine can match it to the correct assessment.`);
     }
     requirements.push(`Assessment target: "${assessment.id}"`);
-    requirements.push(
-      `Dimensions: ${assessment.dimensions.map((dimension) => `${dimension.id} (${dimension.levels.join(' | ')})`).join(', ')}`
-    );
+    requirements.push(`Purpose: ${assessment.purpose}`);
+    requirements.push('Dimensions:');
+    for (const dimension of assessment.dimensions) {
+      requirements.push(`  ${dimension.id} (${dimension.levels.join(' | ')}): ${dimension.purpose}`);
+    }
     requirements.push('Use only canonical dimension levels. If the engine rejects the artifact, correct the submitted levels instead of inventing new ones.');
   }
   return requirements;

--- a/tests/unit/v2/prompt-renderer.test.ts
+++ b/tests/unit/v2/prompt-renderer.test.ts
@@ -264,8 +264,10 @@ describe('renderPendingPrompt', () => {
         expect(result.value.prompt).toContain('**ASSESSMENT REQUIREMENTS (System):**');
         expect(result.value.prompt).toContain('Provide an artifact with kind: "wr.assessment"');
         expect(result.value.prompt).toContain('Assessment target: "readiness_gate"');
-        expect(result.value.prompt).toContain('confidence (low | medium | high)');
-        expect(result.value.prompt).toContain('scope (partial | complete)');
+        expect(result.value.prompt).toContain('Purpose: Assess readiness.');
+        expect(result.value.prompt).toContain('Dimensions:');
+        expect(result.value.prompt).toContain('  confidence (low | medium | high): Confidence');
+        expect(result.value.prompt).toContain('  scope (partial | complete): Scope');
       }
     });
 


### PR DESCRIPTION
## Summary

- `formatAssessmentRequirements` in `prompt-renderer.ts` now renders `assessment.purpose` as a `Purpose:` line after the Assessment target line
- Each dimension is now rendered on its own indented line as `  <id> (<levels>): <purpose>` under a `Dimensions:` header, instead of a single comma-separated line
- Test assertions in `prompt-renderer.test.ts` updated to explicitly check for presence of purpose text

## Motivation

The agent rendering assessment gates only saw IDs and allowed levels -- not what the gate or dimension actually means. This caused the agent to make assessments without semantic context. Adding `purpose` text gives the agent the information it needs to rate accurately.

## Test plan

- [ ] `npx vitest run tests/unit/v2/prompt-renderer.test.ts` -- 21 tests pass
- [ ] `npx tsc --noEmit` -- clean
- [ ] `npm run validate:registry` -- all 5 variant(s) passed validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)