### PR TITLE
fix(mcp): scope .workrail/workflows/ discovery to current workspace root

### DIFF
--- a/src/mcp/handlers/shared/request-workflow-reader.ts
+++ b/src/mcp/handlers/shared/request-workflow-reader.ts
@@ -8,6 +8,7 @@ import { SchemaValidatingCompositeWorkflowStorage } from '../../../infrastructur
 import type { RememberedRootsStorePortV2 } from '../../../v2/ports/remembered-roots-store.port.js';
 import type { ManagedSourceRecordV2, ManagedSourceStorePortV2 } from '../../../v2/ports/managed-source-store.port.js';
 import { withTimeout } from './with-timeout.js';
+import { isWorkspaceAncestor } from './workspace-path-utils.js';
 
 // ---------------------------------------------------------------------------
 // Walk skip list
@@ -226,10 +227,7 @@ export async function createWorkflowReaderForRequest(
   // from leaking into the workflow list when a user has visited those repos recently.
   // Engineers who relied on cross-repo bleed should use `manage_workflow_source` instead.
   const resolvedWorkspace = path.resolve(workspaceDirectory);
-  const rememberedRoots = allRememberedRoots.filter((root) => {
-    const rel = path.relative(path.resolve(root), resolvedWorkspace);
-    return rel.length === 0 || (!rel.startsWith('..') && !path.isAbsolute(rel));
-  });
+  const rememberedRoots = allRememberedRoots.filter((root) => isWorkspaceAncestor(root, resolvedWorkspace));
   if (process.env['WORKRAIL_DEV'] === '1' && allRememberedRoots.length !== rememberedRoots.length) {
     const excluded = allRememberedRoots.filter((r) => !rememberedRoots.includes(r));
     console.error(`[workrail] remembered-roots filter excluded ${excluded.length} root(s) not under workspace ${resolvedWorkspace}: ${excluded.join(', ')}`);

--- a/src/mcp/handlers/shared/request-workflow-reader.ts
+++ b/src/mcp/handlers/shared/request-workflow-reader.ts
@@ -220,7 +220,20 @@ export async function createWorkflowReaderForRequest(
 ): Promise<WorkflowReaderForRequestResult> {
   const workspaceDirectory = resolveRequestWorkspaceDirectory(options);
   const projectWorkflowDirectory = toProjectWorkflowDirectory(workspaceDirectory);
-  const rememberedRoots = await listRememberedRoots(options.rememberedRootsStore);
+  const allRememberedRoots = await listRememberedRoots(options.rememberedRootsStore);
+  // Filter to only roots that are ancestors of (or equal to) the current workspace.
+  // This prevents .workrail/workflows/ directories from unrelated repositories
+  // from leaking into the workflow list when a user has visited those repos recently.
+  // Engineers who relied on cross-repo bleed should use `manage_workflow_source` instead.
+  const resolvedWorkspace = path.resolve(workspaceDirectory);
+  const rememberedRoots = allRememberedRoots.filter((root) => {
+    const rel = path.relative(path.resolve(root), resolvedWorkspace);
+    return rel.length === 0 || (!rel.startsWith('..') && !path.isAbsolute(rel));
+  });
+  if (process.env['WORKRAIL_DEV'] === '1' && allRememberedRoots.length !== rememberedRoots.length) {
+    const excluded = allRememberedRoots.filter((r) => !rememberedRoots.includes(r));
+    console.error(`[workrail] remembered-roots filter excluded ${excluded.length} root(s) not under workspace ${resolvedWorkspace}: ${excluded.join(', ')}`);
+  }
 
   let discoveryResult: WorkflowRootDiscoveryResult;
   try {

--- a/src/mcp/handlers/shared/request-workflow-reader.ts
+++ b/src/mcp/handlers/shared/request-workflow-reader.ts
@@ -210,6 +210,12 @@ export interface WorkflowReaderForRequestResult {
   /** Managed source records whose paths are missing on disk; surfaced in staleRoots + catalog. */
   readonly staleManagedRecords: readonly ManagedSourceRecordV2[];
   /**
+   * Remembered roots that were filtered out because they are not ancestors of (or equal to)
+   * the current workspace. Mirrors the stalePaths pattern so callers can surface or log this
+   * information without relying on the WORKRAIL_DEV debug log.
+   */
+  readonly excludedByScope: readonly string[];
+  /**
    * Set when the managed source store could not be read (busy, IO error, or corrupted).
    * Callers should surface this as a warning so the agent knows managed sources were skipped.
    */
@@ -228,10 +234,7 @@ export async function createWorkflowReaderForRequest(
   // Engineers who relied on cross-repo bleed should use `manage_workflow_source` instead.
   const resolvedWorkspace = path.resolve(workspaceDirectory);
   const rememberedRoots = allRememberedRoots.filter((root) => isWorkspaceAncestor(root, resolvedWorkspace));
-  if (process.env['WORKRAIL_DEV'] === '1' && allRememberedRoots.length !== rememberedRoots.length) {
-    const excluded = allRememberedRoots.filter((r) => !rememberedRoots.includes(r));
-    console.error(`[workrail] remembered-roots filter excluded ${excluded.length} root(s) not under workspace ${resolvedWorkspace}: ${excluded.join(', ')}`);
-  }
+  const excludedByScope = allRememberedRoots.filter((root) => !isWorkspaceAncestor(root, resolvedWorkspace));
 
   let discoveryResult: WorkflowRootDiscoveryResult;
   try {
@@ -335,6 +338,7 @@ export async function createWorkflowReaderForRequest(
     stalePaths: allStalePaths,
     managedSourceRecords: activeManagedRecords,
     staleManagedRecords,
+    excludedByScope,
     ...(managedStoreError !== undefined ? { managedStoreError } : {}),
   };
 }

--- a/src/mcp/handlers/shared/workflow-source-visibility.ts
+++ b/src/mcp/handlers/shared/workflow-source-visibility.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import type { Workflow, WorkflowSourceInfo } from '../../../types/workflow.js';
 import type { ICompositeWorkflowStorage, IWorkflowReader } from '../../../types/storage.js';
 import type { RememberedRootRecordV2 } from '../../../v2/ports/remembered-roots-store.port.js';
+import { isWorkspaceAncestor } from './workspace-path-utils.js';
 
 export interface PublicWorkflowSource {
   readonly kind: WorkflowSourceInfo['kind'];
@@ -120,12 +121,7 @@ function deriveRootedSharingContext(
   const sourcePath = path.resolve(workflow.source.directoryPath);
   for (const record of rememberedRoots) {
     const rootPath = path.resolve(record.path);
-    const relative = path.relative(rootPath, sourcePath);
-    const isUnderRoot =
-      relative.length === 0 ||
-      (!relative.startsWith('..') && !path.isAbsolute(relative));
-
-    if (!isUnderRoot) continue;
+    if (!isWorkspaceAncestor(rootPath, sourcePath)) continue;
 
     return {
       kind: 'remembered_root',

--- a/src/mcp/handlers/shared/workspace-path-utils.ts
+++ b/src/mcp/handlers/shared/workspace-path-utils.ts
@@ -1,0 +1,10 @@
+import path from 'path';
+
+/**
+ * Returns true when root is an ancestor of (or equal to) workspace.
+ * Uses purely lexical path comparison -- does not follow symlinks.
+ */
+export function isWorkspaceAncestor(root: string, workspace: string): boolean {
+  const rel = path.relative(path.resolve(root), path.resolve(workspace));
+  return rel.length === 0 || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}

--- a/tests/unit/mcp-v2-remembered-roots.test.ts
+++ b/tests/unit/mcp-v2-remembered-roots.test.ts
@@ -137,10 +137,15 @@ async function writeWorkspaceWorkflow(workspaceRoot: string): Promise<void> {
 describe('stale remembered roots in tool responses', () => {
   it('list_workflows suppresses staleRoots in tagSummary (compact) mode, surfaces them in filtered mode', async () => {
     const dataRoot = await mkTempDir('workrail-stale-list-data-');
-    const workspaceRoot = await mkTempDir('workrail-stale-list-ws-');
+    // stalePath must be an ancestor of workspaceRoot to pass the scoping filter.
+    // Create workspaceRoot inside stalePath, then delete stalePath to make it stale.
+    const baseDir = await mkTempDir('workrail-stale-list-base-');
+    const stalePath = path.join(baseDir, 'remembered-root');
+    const workspaceRoot = path.join(stalePath, 'workspace');
+    await fs.mkdir(workspaceRoot, { recursive: true });
+    await fs.rm(stalePath, { recursive: true, force: true }); // make stalePath stale
     const { ctx, rememberedRootsStore } = await buildCtx(dataRoot);
 
-    const stalePath = path.join(os.tmpdir(), `wr-stale-${Date.now()}`); // never created
     const rememberRes = await rememberedRootsStore.rememberRoot(stalePath);
     expect(rememberRes.isOk()).toBe(true);
 
@@ -177,44 +182,60 @@ describe('stale remembered roots in tool responses', () => {
 
   it('inspect_workflow succeeds and includes staleRoots when a remembered root no longer exists', async () => {
     const dataRoot = await mkTempDir('workrail-stale-inspect-data-');
+    // Scenario: the user's workspace (workspaceRoot) was itself the remembered root.
+    // The workspace gets deleted (e.g., a git worktree is cleaned up). Now the remembered
+    // root is stale. The handler should still succeed using a bundled workflow.
+    // workspaceRoot IS an ancestor of itself (path.relative(root, root) = ''), so it passes
+    // the scoping filter even after deletion.
     const workspaceRoot = await mkTempDir('workrail-stale-inspect-ws-');
     const { ctx, rememberedRootsStore } = await buildCtx(dataRoot, workspaceRoot);
-    await writeWorkspaceWorkflow(workspaceRoot);
 
-    const stalePath = path.join(os.tmpdir(), `wr-stale-${Date.now()}`); // never created
-    const rememberRes = await rememberedRootsStore.rememberRoot(stalePath);
+    const staleRoot = workspaceRoot;
+    const rememberRes = await rememberedRootsStore.rememberRoot(staleRoot);
     expect(rememberRes.isOk()).toBe(true);
 
+    // Delete the workspace to make the remembered root stale
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+
     const result = await handleV2InspectWorkflow(
-      { workflowId: 'test-workflow', mode: 'metadata', workspacePath: workspaceRoot },
+      // Use a bundled workflow that is always available regardless of project files
+      { workflowId: 'coding-task-workflow-agentic', mode: 'metadata', workspacePath: workspaceRoot },
       ctx,
     );
 
     expect(result.type).toBe('success');
     const data = result.data as Record<string, unknown>;
     expect(Array.isArray(data.staleRoots)).toBe(true);
-    expect(data.staleRoots as string[]).toContain(path.resolve(stalePath));
+    expect(data.staleRoots as string[]).toContain(path.resolve(staleRoot));
   });
 
   it('start_workflow succeeds and includes staleRoots when a remembered root no longer exists', async () => {
     const dataRoot = await mkTempDir('workrail-stale-start-data-');
+    // Scenario: the user's workspace (workspaceRoot) was itself the remembered root.
+    // The workspace gets deleted (e.g., a git worktree is cleaned up). Now the remembered
+    // root is stale. The handler should still succeed using a bundled workflow.
+    // workspaceRoot IS an ancestor of itself (path.relative(root, root) = ''), so it passes
+    // the scoping filter even after deletion.
     const workspaceRoot = await mkTempDir('workrail-stale-start-ws-');
     const { ctx, rememberedRootsStore } = await buildCtx(dataRoot, workspaceRoot);
-    await writeWorkspaceWorkflow(workspaceRoot);
 
-    const stalePath = path.join(os.tmpdir(), `wr-stale-${Date.now()}`); // never created
-    const rememberRes = await rememberedRootsStore.rememberRoot(stalePath);
+    const staleRoot = workspaceRoot;
+    const rememberRes = await rememberedRootsStore.rememberRoot(staleRoot);
     expect(rememberRes.isOk()).toBe(true);
 
+    // Delete the workspace to make the remembered root stale
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+
     const result = await handleV2StartWorkflow(
-      { workflowId: 'test-workflow', workspacePath: workspaceRoot, goal: 'test workflow execution' },
+      // Use a bundled workflow that is always available regardless of project files
+      { workflowId: 'coding-task-workflow-agentic', workspacePath: workspaceRoot, goal: 'test workflow execution' },
       ctx,
     );
 
     expect(result.type).toBe('success');
     const data = result.data as Record<string, unknown>;
     expect(Array.isArray(data.staleRoots)).toBe(true);
-    expect(data.staleRoots as string[]).toContain(path.resolve(stalePath));
+    expect(data.staleRoots as string[]).toContain(path.resolve(staleRoot));
   });
 });
 

--- a/tests/unit/mcp/request-workflow-reader.test.ts
+++ b/tests/unit/mcp/request-workflow-reader.test.ts
@@ -162,8 +162,9 @@ describe('request-workflow-reader', () => {
 
   it('loads workflows from rooted .workrail/workflows under remembered roots', async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-rooted-reader-'));
-    const workspace = path.join(tempRoot, 'workspace');
+    // workspace must be inside rememberedRoot so the root is an ancestor and passes the filter
     const rememberedRoot = path.join(tempRoot, 'repo');
+    const workspace = path.join(rememberedRoot, 'workspace');
     fs.mkdirSync(workspace, { recursive: true });
     writeRootedWorkflow(rememberedRoot, ['packages', 'tools'], 'rooted-workflow', 'Rooted Workflow');
 
@@ -210,10 +211,12 @@ describe('request-workflow-reader', () => {
 
   it('returns stale paths without throwing when a remembered root no longer exists', async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-stale-roots-'));
-    const workspace = path.join(tempRoot, 'workspace');
-    const existingRoot = path.join(tempRoot, 'existing-repo');
-    const deletedRoot = path.join(tempRoot, 'deleted-worktree'); // never created
-    fs.mkdirSync(workspace, { recursive: true });
+    // Both roots must be ancestors of workspace to pass the scoping filter.
+    // deletedRoot (tempRoot/monorepo) is never created on disk -- it will be reported stale.
+    // existingRoot (tempRoot) always exists -- it is walked and reports workflows.
+    const existingRoot = tempRoot;
+    const deletedRoot = path.join(tempRoot, 'monorepo'); // never created
+    const workspace = path.join(tempRoot, 'monorepo', 'packages', 'app');
     writeRootedWorkflow(existingRoot, [], 'existing-workflow', 'Existing Workflow');
 
     const { reader, stalePaths } = await createWorkflowReaderForRequest({
@@ -237,10 +240,11 @@ describe('request-workflow-reader', () => {
 
   it('returns all stale when every remembered root is gone', async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-all-stale-'));
-    const workspace = path.join(tempRoot, 'workspace');
-    fs.mkdirSync(workspace, { recursive: true });
-    const gone1 = path.join(tempRoot, 'gone-1');
-    const gone2 = path.join(tempRoot, 'gone-2');
+    // Both gone roots must be ancestors of workspace to pass the scoping filter.
+    // Neither is created on disk -- both should be reported stale after the walk.
+    const gone1 = path.join(tempRoot, 'projects'); // never created
+    const gone2 = path.join(tempRoot, 'projects', 'monorepo'); // never created (child of gone1)
+    const workspace = path.join(tempRoot, 'projects', 'monorepo', 'packages', 'app');
 
     const { stalePaths } = await createWorkflowReaderForRequest({
       featureFlags: new StaticFeatureFlagProvider({
@@ -302,6 +306,32 @@ describe('request-workflow-reader', () => {
     // Workflow from present subdir is discovered
     expect(discovered).toContain(path.resolve(workflowsDir));
     // vanishedSubdir path is not in discovered (it didn't exist, was skipped silently)
+  });
+
+  it('does not discover .workrail/workflows from a remembered root unrelated to the workspace', async () => {
+    // Regression test for cross-repo bleed: visiting repo-b should not make its .workrail/workflows/
+    // appear when the current workspace is repo-a.
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-cross-repo-'));
+    const workspace = path.join(tempRoot, 'repo-a', 'packages', 'app');
+    const unrelatedRoot = path.join(tempRoot, 'repo-b');
+    fs.mkdirSync(workspace, { recursive: true });
+    writeRootedWorkflow(unrelatedRoot, [], 'cross-repo-workflow', 'Cross Repo Workflow');
+
+    const { reader } = await createWorkflowReaderForRequest({
+      featureFlags: new StaticFeatureFlagProvider({
+        v2Tools: true,
+        leanWorkflows: false,
+        agenticRoutines: false,
+        experimentalWorkflows: false,
+      }),
+      workspacePath: workspace,
+      rememberedRootsStore: rememberedRootsStore(unrelatedRoot),
+    });
+
+    const workflow = await reader.getWorkflowById('cross-repo-workflow');
+    expect(workflow).toBeNull();
+
+    fs.rmSync(tempRoot, { recursive: true, force: true });
   });
 });
 

--- a/tests/unit/mcp/v2-workflow-source-catalog-output.test.ts
+++ b/tests/unit/mcp/v2-workflow-source-catalog-output.test.ts
@@ -100,9 +100,10 @@ function buildCtxWithManagedStore(
 describe('v2 workflow source catalog output', () => {
   it('lists effective and shadowed sources for rooted-sharing overlap', async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-v2-source-catalog-'));
-    const workspace = path.join(tempRoot, 'workspace');
-    const projectDir = path.join(workspace, 'workflows');
+    // workspace must be inside rememberedRoot for the ancestor-scoping filter to include rememberedRoot
     const rememberedRoot = path.join(tempRoot, 'repo');
+    const workspace = path.join(rememberedRoot, 'workspace');
+    const projectDir = path.join(workspace, 'workflows');
     const rootedDir = path.join(rememberedRoot, 'packages', 'tools', '.workrail', 'workflows');
 
     writeWorkflow(projectDir, 'shared-workflow', 'Legacy Project Workflow');

--- a/tests/unit/mcp/v2-workflow-source-visibility-output.test.ts
+++ b/tests/unit/mcp/v2-workflow-source-visibility-output.test.ts
@@ -99,8 +99,9 @@ function buildCtx(rememberedRoots: RememberedRootsStorePortV2): ToolContext {
 describe('v2 workflow source visibility outputs', () => {
   it('surfaces rooted-sharing visibility on list_workflows results', async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-v2-visibility-list-'));
-    const workspace = path.join(tempRoot, 'workspace');
+    // workspace must be inside rememberedRoot for the ancestor-scoping filter to include rememberedRoot
     const rememberedRoot = path.join(tempRoot, 'repo');
+    const workspace = path.join(rememberedRoot, 'workspace');
     fs.mkdirSync(workspace, { recursive: true });
     writeRootedWorkflow(rememberedRoot, ['packages', 'tools'], 'rooted-workflow', 'Rooted Workflow');
 
@@ -131,8 +132,9 @@ describe('v2 workflow source visibility outputs', () => {
 
   it('surfaces migration guidance when a legacy project workflow overrides rooted sharing', async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-v2-visibility-inspect-'));
-    const workspace = path.join(tempRoot, 'workspace');
+    // workspace must be inside rememberedRoot for the ancestor-scoping filter to include rememberedRoot
     const rememberedRoot = path.join(tempRoot, 'repo');
+    const workspace = path.join(rememberedRoot, 'workspace');
     fs.mkdirSync(workspace, { recursive: true });
     writeProjectWorkflow(workspace, 'shared-workflow', 'Legacy Project Workflow');
     writeRootedWorkflow(rememberedRoot, ['packages', 'tools'], 'shared-workflow', 'Rooted Workflow');


### PR DESCRIPTION
## Summary

Fixes cross-repo workflow bleed in rooted sharing discovery.

`listRememberedRoots` returns every workspace visited in the past 30 days. Previously all of them were walked for `.workrail/workflows/`, causing a project's workflows to appear in unrelated repos. Now only roots that are ancestors-of-or-equal-to the current workspace are included.

**Tradeoff:** engineers who relied on cross-repo bleed (visiting repo A to see its `.workrail/workflows/` in repo B) will no longer see those workflows. This is correct behavior -- rooted sharing is project-scoped.

`manage_workflow_source` is unaffected (separate code path).

## Test plan

- [ ] `npx vitest run` -- passes
- [ ] `npm run build` -- clean
- [ ] New cross-repo bleed regression test: `request-workflow-reader.test.ts`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)