### PR TITLE
fix(mcp): parallelize worktree filter, lazy workspace dir, reduce subprocess timeout

### DIFF
--- a/src/mcp/handlers/shared/request-workflow-reader.ts
+++ b/src/mcp/handlers/shared/request-workflow-reader.ts
@@ -222,6 +222,43 @@ export interface WorkflowReaderForRequestResult {
   readonly managedStoreError?: string;
 }
 
+/**
+ * Filters `allRoots` to only those that are in scope for the given `workspace`.
+ *
+ * A root is in scope if it is either:
+ * 1. An ancestor of (or equal to) `workspace` -- determined by lexical path comparison,
+ *    no subprocess needed.
+ * 2. A sibling worktree -- shares the same git common directory as `workspace`. This
+ *    covers the `git worktree add ../branch-name` pattern where neither directory is
+ *    an ancestor of the other but both belong to the same repository.
+ *
+ * The ancestor check runs first and incurs no subprocess cost. The git common-dir
+ * check is lazy: it is skipped entirely when all roots pass the ancestor check.
+ * Non-ancestor roots are checked in parallel to keep worst-case latency at
+ * max(one subprocess) rather than N * max(one subprocess).
+ *
+ * @throws never -- all errors from git subprocesses are caught inside `getGitCommonDir`
+ *   and surfaced as null. This function always resolves.
+ */
+export async function filterRememberedRootsForWorkspace(
+  allRoots: readonly string[],
+  workspace: string,
+): Promise<readonly string[]> {
+  const ancestorRoots = allRoots.filter((r) => isWorkspaceAncestor(r, workspace));
+  const nonAncestorRoots = allRoots.filter((r) => !isWorkspaceAncestor(r, workspace));
+
+  let siblingRoots: readonly string[] = [];
+  if (nonAncestorRoots.length > 0) {
+    const workspaceCommonDir = await getGitCommonDir(workspace);
+    if (workspaceCommonDir !== null) {
+      const commonDirResults = await Promise.all(nonAncestorRoots.map((r) => getGitCommonDir(r)));
+      siblingRoots = nonAncestorRoots.filter((_, i) => commonDirResults[i] === workspaceCommonDir);
+    }
+  }
+
+  return [...ancestorRoots, ...siblingRoots];
+}
+
 export async function createWorkflowReaderForRequest(
   options: RequestWorkflowReaderOptions,
 ): Promise<WorkflowReaderForRequestResult> {
@@ -234,27 +271,7 @@ export async function createWorkflowReaderForRequest(
   // Engineers who relied on cross-repo bleed should use `manage_workflow_source` instead.
   const resolvedWorkspace = path.resolve(workspaceDirectory);
 
-  // Scope remembered roots to those that are either:
-  // 1. An ancestor of (or equal to) the current workspace (existing ancestor check), OR
-  // 2. A sibling worktree -- shares the same git common dir as the workspace.
-  //
-  // Sibling worktrees are the default `git worktree add ../branch-name` pattern. They are
-  // not ancestors of each other lexically, but they share the same git repo. Excluding them
-  // would silently drop .workrail/workflows/ from engineers using linked worktrees.
-  //
-  // The ancestor check runs first (no subprocess). The git common-dir check only runs for
-  // roots that fail the ancestor check, so the common case (workspace inside remembered root)
-  // incurs zero git subprocess calls.
-  const workspaceCommonDir = await getGitCommonDir(resolvedWorkspace);
-  const rememberedRoots: string[] = [];
-  for (const root of allRememberedRoots) {
-    if (isWorkspaceAncestor(root, resolvedWorkspace)) {
-      rememberedRoots.push(root);
-    } else if (workspaceCommonDir !== null) {
-      const rootCommonDir = await getGitCommonDir(root);
-      if (rootCommonDir === workspaceCommonDir) rememberedRoots.push(root);
-    }
-  }
+  const rememberedRoots = await filterRememberedRootsForWorkspace(allRememberedRoots, resolvedWorkspace);
   const excludedByScope = allRememberedRoots.filter((root) => !rememberedRoots.includes(root));
 
   let discoveryResult: WorkflowRootDiscoveryResult;

--- a/src/mcp/handlers/shared/workspace-path-utils.ts
+++ b/src/mcp/handlers/shared/workspace-path-utils.ts
@@ -26,13 +26,15 @@ export function isWorkspaceAncestor(root: string, workspace: string): boolean {
  * against `dirPath` and then apply `fs.realpath` to normalize symlinks (e.g.
  * on macOS /var is a symlink to /private/var, causing string comparison to fail
  * even when both paths point to the same directory).
+ *
+ * @requires git >= 2.5 (`git worktree` and `--git-common-dir` were added in git 2.5)
  */
 export async function getGitCommonDir(dirPath: string): Promise<string | null> {
   try {
     const { stdout } = await execFileAsync(
       'git',
       ['-C', dirPath, 'rev-parse', '--git-common-dir'],
-      { encoding: 'utf-8', timeout: 5_000 },
+      { encoding: 'utf-8', timeout: 500 },
     );
     const raw = stdout.trim();
     if (!raw) return null;

--- a/tests/unit/mcp/request-workflow-reader.test.ts
+++ b/tests/unit/mcp/request-workflow-reader.test.ts
@@ -12,6 +12,7 @@ import {
   clearWalkCacheForTesting,
   resolveRequestWorkspaceDirectory,
   toProjectWorkflowDirectory,
+  filterRememberedRootsForWorkspace,
 } from '../../../src/mcp/handlers/shared/request-workflow-reader.js';
 import { getGitCommonDir } from '../../../src/mcp/handlers/shared/workspace-path-utils.js';
 import type { RememberedRootsStorePortV2 } from '../../../src/v2/ports/remembered-roots-store.port.js';
@@ -617,6 +618,98 @@ describe('createWorkflowReaderForRequest -- sibling worktree scoping', () => {
 
     const workflow = await reader.getWorkflowById('cross-repo-workflow');
     expect(workflow).toBeNull();
+
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterRememberedRootsForWorkspace unit tests
+// ---------------------------------------------------------------------------
+
+describe('filterRememberedRootsForWorkspace', () => {
+  it('returns empty array when no roots are provided', async () => {
+    const workspace = path.join(os.tmpdir(), 'workspace');
+    const result = await filterRememberedRootsForWorkspace([], workspace);
+    expect(result).toEqual([]);
+  });
+
+  it('returns all roots when all are ancestors of the workspace (no git call needed)', async () => {
+    // Use plain temp directories -- ancestor check is purely lexical, no subprocess.
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-filter-ancestor-'));
+    const workspace = path.join(tempRoot, 'repo', 'packages', 'app');
+    const root1 = path.resolve(tempRoot);
+    const root2 = path.resolve(path.join(tempRoot, 'repo'));
+
+    const result = await filterRememberedRootsForWorkspace([root1, root2], workspace);
+
+    expect(result).toContain(root1);
+    expect(result).toContain(root2);
+    expect(result).toHaveLength(2);
+
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('excludes a non-ancestor root that belongs to an unrelated repo', async () => {
+    // workspace is in repo-a; unrelatedRoot is repo-b (different directory, no git repo).
+    // Neither is an ancestor of the other, and they have no git common dir.
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-filter-unrelated-'));
+    const workspace = path.resolve(path.join(tempRoot, 'repo-a', 'packages', 'app'));
+    const unrelatedRoot = path.resolve(path.join(tempRoot, 'repo-b'));
+    // Create workspace dir so getGitCommonDir can stat it (it still returns null for non-git)
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.mkdirSync(unrelatedRoot, { recursive: true });
+
+    const result = await filterRememberedRootsForWorkspace([unrelatedRoot], workspace);
+
+    expect(result).toEqual([]);
+
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('includes a non-ancestor root that is a sibling worktree of the workspace', async () => {
+    // Create a real git repo with a linked worktree to exercise the git common-dir path.
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-filter-sibling-'));
+    const mainRepo = path.join(tempRoot, 'main-repo');
+    const siblingWorktree = path.join(tempRoot, 'sibling-worktree');
+    fs.mkdirSync(mainRepo);
+
+    try {
+      initGitRepoSync(mainRepo, { silent: true });
+      gitExecSync(mainRepo, ['commit', '--allow-empty', '-m', 'init'], { silent: true });
+      gitExecSync(mainRepo, ['worktree', 'add', siblingWorktree], { silent: true });
+
+      // mainRepo is remembered; siblingWorktree is the workspace.
+      // mainRepo is NOT an ancestor of siblingWorktree, but they share the same git common dir.
+      const result = await filterRememberedRootsForWorkspace(
+        [path.resolve(mainRepo)],
+        path.resolve(siblingWorktree),
+      );
+
+      expect(result).toContain(path.resolve(mainRepo));
+      expect(result).toHaveLength(1);
+    } finally {
+      try { gitExecSync(mainRepo, ['worktree', 'remove', '--force', siblingWorktree], { silent: true }); } catch { /* ignore */ }
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('returns only ancestor roots when workspace is not in a git repo (workspaceCommonDir is null)', async () => {
+    // Use plain temp directories (not git repos). Ancestor root is included; non-ancestor is excluded.
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-filter-nogit-'));
+    const workspace = path.join(tempRoot, 'repo', 'packages', 'app');
+    const ancestorRoot = path.resolve(tempRoot); // ancestor of workspace
+    const nonAncestorRoot = path.resolve(path.join(tempRoot, 'other-repo')); // not ancestor
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.mkdirSync(nonAncestorRoot);
+
+    const result = await filterRememberedRootsForWorkspace(
+      [ancestorRoot, nonAncestorRoot],
+      workspace,
+    );
+
+    expect(result).toContain(ancestorRoot);
+    expect(result).not.toContain(nonAncestorRoot);
 
     fs.rmSync(tempRoot, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary

Follow-up audit fixes for #323 (sibling worktree remembered-roots filter).

- **OP-1:** Parallelized non-ancestor root git subprocess calls with `Promise.all` -- worst case drops from N×latency to max(latency)
- **OP-2:** Reduced per-subprocess timeout from 5s to 500ms -- `git rev-parse --git-common-dir` is a trivially fast local operation
- **F2:** Lazy `getGitCommonDir(workspace)` -- only called when at least one root fails the ancestor check (skipped entirely for the common case of all ancestor roots)
- **CC-1:** Extracted `filterRememberedRootsForWorkspace()` as a standalone tested function
- Added `@requires git >= 2.5` JSDoc, 5 new unit tests for the extracted function

🤖 Generated with [Claude Code](https://claude.ai/claude-code)