### PR TITLE
feat(console): MVI architecture + MCP server stability

### DIFF
--- a/console/CLAUDE.md
+++ b/console/CLAUDE.md
@@ -1,0 +1,120 @@
+# Console Architecture Guide
+
+The WorkRail Console uses a strict MVI (Model-View-Intent) architecture adapted for React/TypeScript. Every view follows this layering. Do not introduce new views without following it.
+
+---
+
+## Layer Stack (bottom to top)
+
+```
+API hooks (React Query)
+    ↓
+Repository hook          useXxxRepository.ts       console/src/hooks/
+    ↓
+Use cases                xxx-use-cases.ts           console/src/views/
+    ↓
+Reducer                  xxx-reducer.ts             console/src/views/
+    ↓
+ViewModel hook           useXxxViewModel.ts         console/src/hooks/
+    ↓
+View (pure presenter)    XxxView.tsx                console/src/views/
+```
+
+---
+
+## Layer Rules
+
+### Repository hook (`useXxxRepository.ts`)
+- Wraps React Query hooks. Returns a clean domain interface -- no React Query types leak out.
+- Use `query.isLoading` (not `isFetching`) to avoid SSE-triggered loading flicker.
+- Maps API errors to typed domain errors at this boundary.
+- Filters data at the boundary (e.g. strip `routines` from workflow list here, not in the view).
+
+### Use cases (`xxx-use-cases.ts`)
+- Pure functions only. Zero React imports. No side effects.
+- Contains: filtering, sorting, grouping, aggregation, derived calculations.
+- **Add this file when** logic is complex enough to test independently (more than one line).
+- **Skip this file when** all derivations are trivial (one-line `find`, `filter`, `map`).
+
+### Reducer (`xxx-reducer.ts`)
+- Pure function: `reducer(state, event) -> state`. Zero React imports.
+- State and events are TypeScript discriminated unions (`readonly` everywhere).
+- Always end the `switch` with `default: return assertNever(event)` for exhaustiveness.
+- **Add this file when** there are 2+ interdependent state fields with non-trivial transition rules.
+- **Skip this file when** there is only one state field (use `useState` in the ViewModel instead).
+- Key invariant examples: scope change resets focusedIndex; tag/source change clears selectedWorkflowId; any filter change resets page to 0.
+
+### ViewModel hook (`useXxxViewModel.ts`)
+- The only place that calls React hooks AND mixes data concerns.
+- Calls the repository, wires `useReducer` (or `useState` for simple cases), calls use cases in `useMemo`.
+- Owns all side effects: keyboard listeners, focus management, scroll lock, body scroll.
+- Returns a `XxxViewState` **discriminated union**: `loading | error | ready` (and other states as needed).
+- Never returns `{ data: X | null; isLoading: boolean }` -- use a discriminated union instead.
+- Destructure individual stable values from the repository before using them as `useMemo` deps (the repository object itself is a new literal every render).
+- **Multi-repository ViewModels are valid**: a ViewModel may call multiple repositories when it needs to join data from two sources. Reference: `useWorkflowDetailViewModel` calls both `useWorkflowDetailRepository` (current workflow) and `useWorkflowsRepository` (adjacent workflow list for prev/next navigation).
+- **ViewModel hooks are not unit tested** under the current strategy -- only pure functions (reducers, use cases) have tests. ViewModel behavior is covered indirectly through integration. A future investment would be `@testing-library/react` `renderHook` tests for state transitions.
+
+### View (`XxxView.tsx`)
+- Pure presenter. Receives `{ viewModel: UseXxxViewModelResult }` as its only data prop.
+- Zero API hooks. Zero `useQuery`/`useMutation`. Zero business logic.
+- May call animation hooks (`useModalTransition`, `useAutoAnimate`) -- these are pure visual effects, not data.
+- May hold DOM refs (scroll container, panel ref for focus target) -- these are UI concerns.
+- Renders based on `viewModel.state.kind` discriminated union. Every `kind` must be handled.
+- **Inline sub-panel exception**: when a view renders a named sub-panel that is not a separate route (e.g. the archive panel in `WorkspaceView`, the workflow detail modal in `WorkflowsView`), the sub-panel's ViewModel may be called inside the parent view rather than AppShell. The parent view is the correct scoping boundary because the ViewModel lifetime should match the sub-panel's visibility. This is NOT a violation of the pure-presenter rule -- it is a documented exception for co-located sub-panels.
+
+---
+
+## Decision Criteria
+
+| Question | Answer → Action |
+|----------|----------------|
+| Does the view fetch data? | Yes → add repository hook |
+| Is there filtering/sorting/grouping logic? | Yes and non-trivial → add use cases file |
+| Are there 2+ state fields with rules between them? | Yes → add reducer |
+| Is there only one state field (a toggle or nullable)? | Yes → use `useState` in ViewModel, skip reducer |
+| Are there pure functions (use cases or reducer)? | Yes → add tests in `tests/unit/console-*.test.ts` |
+
+---
+
+## Reference Implementations
+
+When building a new view, read these first:
+
+| Layer | Reference file |
+|-------|---------------|
+| Repository | `console/src/hooks/useWorkspaceRepository.ts` |
+| Use cases | `console/src/views/workspace-types.ts` |
+| Reducer | `console/src/views/workspace-reducer.ts` |
+| ViewModel (complex) | `console/src/hooks/useWorkspaceViewModel.ts` |
+| ViewModel (simple, no reducer) | `console/src/hooks/useSessionDetailViewModel.ts` |
+| View | `console/src/views/WorkspaceView.tsx` |
+| Tests | `tests/unit/console-workspace-reducer.test.ts` |
+
+---
+
+## File Naming
+
+| Layer | Pattern | Location |
+|-------|---------|----------|
+| Repository | `use{Name}Repository.ts` | `console/src/hooks/` |
+| Use cases | `{name}-use-cases.ts` | `console/src/views/` |
+| Reducer | `{name}-reducer.ts` | `console/src/views/` |
+| ViewModel | `use{Name}ViewModel.ts` | `console/src/hooks/` |
+| Pure function tests | `console-{name}-reducer.test.ts` / `console-{name}-use-cases.test.ts` | `tests/unit/` |
+| ViewModel hook tests | `use{Name}ViewModel.test.tsx` | `console/src/hooks/__tests__/` |
+
+**Two test locations:**
+- **Pure function tests** (reducers, use cases) -- no React, run in the root `tests/unit/` directory via `npm run test:unit` from the repo root.
+- **ViewModel hook tests** -- require jsdom + React, live in `console/src/hooks/__tests__/`, run via `cd console && npx vitest run`. Uses `@testing-library/react` `renderHook` with `vi.mock` for repository boundaries.
+
+---
+
+## Common Mistakes to Avoid
+
+- **Calling API hooks in views** -- all data flows through the ViewModel.
+- **`data: X | null` + `isLoading: boolean`** -- use a discriminated union instead.
+- **`repo` object as `useMemo` dep** -- the repository returns a new object literal every render. Destructure the individual fields you need as deps.
+- **Side effects in reducers** -- reducers are pure. Navigation, fetch calls, focus management go in the ViewModel.
+- **`refetch_requested` as a reducer event** -- side effects are not events. Call the side effect directly (e.g. `onRefetch()`) instead of routing through the reducer.
+- **Tests co-located with source** -- all tests go in `tests/unit/console-*.test.ts`.
+- **Reducer for a single boolean/nullable** -- `useState` is correct for one field.

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -18,14 +18,55 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.2",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "@vitejs/plugin-react": "^5.1.4",
+        "@vitejs/plugin-react": "^5.2.0",
+        "jsdom": "^29.0.2",
         "tailwindcss": "^4.1.0",
         "typescript": "^5.9.3",
         "vite": "^7.1.9",
-        "vitest": "^4.1.2"
+        "vitest": "^4.1.4"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -58,6 +99,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -261,6 +303,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -307,6 +359,161 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -749,6 +956,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@formkit/auto-animate": {
@@ -1619,6 +1844,62 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1784,6 +2065,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1794,6 +2076,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1811,9 +2094,9 @@
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
-      "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1828,20 +2111,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1850,13 +2133,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.2",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1877,9 +2160,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1890,13 +2173,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.4",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1904,14 +2187,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1920,9 +2203,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1930,13 +2213,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1976,6 +2259,39 @@
         "d3-zoom": "^3.0.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2009,6 +2325,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -2029,6 +2355,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2153,6 +2480,20 @@
       "integrity": "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==",
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2216,6 +2557,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2264,6 +2606,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2280,6 +2636,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -2326,6 +2689,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
@@ -2345,6 +2715,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2532,6 +2915,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -2604,6 +3000,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isbot": {
       "version": "5.1.35",
       "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.35.tgz",
@@ -2629,6 +3032,58 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2937,6 +3392,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3099,6 +3564,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -3610,6 +4082,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -3630,6 +4115,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3666,6 +4152,21 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -3676,11 +4177,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3690,12 +4202,20 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -3767,6 +4287,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -3812,6 +4342,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3833,6 +4376,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.2.tgz",
       "integrity": "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3922,6 +4466,13 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -3987,6 +4538,52 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -4019,6 +4616,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unified": {
@@ -4182,6 +4789,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4252,19 +4860,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.2",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/runner": "4.1.2",
-        "@vitest/snapshot": "4.1.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4292,10 +4900,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.2",
-        "@vitest/browser-preview": "4.1.2",
-        "@vitest/browser-webdriverio": "4.1.2",
-        "@vitest/ui": "4.1.2",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4319,6 +4929,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -4331,6 +4947,54 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/why-is-node-running": {
@@ -4349,6 +5013,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/console/package.json
+++ b/console/package.json
@@ -21,12 +21,14 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@vitejs/plugin-react": "^5.1.4",
+    "@vitejs/plugin-react": "^5.2.0",
+    "jsdom": "^29.0.2",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.9.3",
     "vite": "^7.1.9",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.4"
   }
 }

--- a/console/src/AppShell.tsx
+++ b/console/src/AppShell.tsx
@@ -9,7 +9,12 @@ import { PerformanceView } from './views/PerformanceView';
 import { CutCornerBox } from './components/CutCornerBox';
 import { BracketBadge } from './components/BracketBadge';
 import { PathBreadcrumb } from './components/PathBreadcrumb';
-import { useSessionList } from './api/hooks';
+import { useWorkspaceViewModel } from './hooks/useWorkspaceViewModel';
+import { useSessionListViewModel } from './hooks/useSessionListViewModel';
+import { useWorkflowsViewModel } from './hooks/useWorkflowsViewModel';
+import { useWorkflowDetailViewModel } from './hooks/useWorkflowDetailViewModel';
+import { usePerformanceViewModel } from './hooks/usePerformanceViewModel';
+import { useSessionDetailViewModel } from './hooks/useSessionDetailViewModel';
 
 /**
  * AppShell is the root route component. It owns all view rendering directly,
@@ -62,12 +67,26 @@ export function AppShell() {
   const activeTag = new URLSearchParams(location.search).get('tag');
 
   // ---------------------------------------------------------------------------
-  // Telemetry badges
+  // Workspace ViewModel
   // ---------------------------------------------------------------------------
 
-  const { data: sessionData } = useSessionList();
-  const liveCount = sessionData?.sessions.filter(s => s.status === 'in_progress').length ?? 0;
-  const blockedCount = sessionData?.sessions.filter(s => s.status === 'blocked').length ?? 0;
+  // useWorkspaceViewModel is called here (not inside WorkspaceView) so the
+  // keyboard handler is disabled when hidden=true (SessionDetail overlaid).
+  const workspaceViewModel = useWorkspaceViewModel(isInSessionDetail);
+
+  // useSessionListViewModel is called here (not inside WorkspaceView) so that
+  // WorkspaceView remains a pure presenter. The archive panel is an inline
+  // sub-panel of WorkspaceView -- AppShell owns all ViewModels.
+  const sessionListViewModel = useSessionListViewModel({
+    onSelectSession: workspaceViewModel.onSelectSession,
+  });
+
+  // ---------------------------------------------------------------------------
+  // Telemetry badges -- derived from workspace ViewModel to avoid a second useSessionList call.
+  // ---------------------------------------------------------------------------
+
+  const liveCount = workspaceViewModel.state.kind === 'ready' ? workspaceViewModel.state.liveCount : 0;
+  const blockedCount = workspaceViewModel.state.kind === 'ready' ? workspaceViewModel.state.blockedCount : 0;
 
   // ---------------------------------------------------------------------------
   // Navigation handlers
@@ -84,20 +103,55 @@ export function AppShell() {
     [navigate],
   );
 
-  const handleSelectWorkflow = useCallback(
+  const handleBackFromWorkflow = useCallback(() => {
+    void navigate({ to: '/workflows', search: { tag: activeTag ?? undefined } });
+  }, [navigate, activeTag]);
+
+  const handleNavigateToWorkflow = useCallback(
     (id: string) => {
-      void navigate({
-        to: '/workflows/$workflowId',
-        params: { workflowId: id },
-        search: { tag: activeTag ?? undefined },
-      });
+      void navigate({ to: '/workflows/$workflowId', params: { workflowId: id }, search: { tag: activeTag ?? undefined } });
     },
     [navigate, activeTag],
   );
 
-  const handleBackFromWorkflow = useCallback(() => {
-    void navigate({ to: '/workflows', search: { tag: activeTag ?? undefined } });
-  }, [navigate, activeTag]);
+  // ---------------------------------------------------------------------------
+  // Workflows ViewModel
+  // ---------------------------------------------------------------------------
+
+  // useWorkflowsViewModel is called here so AppShell owns the URL <-> state sync.
+  // initialTag comes from the URL search param; onSelectTag navigates to update the URL.
+  const workflowsViewModel = useWorkflowsViewModel({
+    initialTag: activeTag,
+    onSelectTag: handleSelectTag,
+  });
+
+  // ---------------------------------------------------------------------------
+  // WorkflowDetail ViewModel
+  // ---------------------------------------------------------------------------
+
+  // Called unconditionally (hooks rules). workflowId is null when not on the
+  // workflow detail route, which disables the underlying query and keeps state
+  // at 'loading' so the keyboard handler is never installed.
+  const workflowDetailViewModel = useWorkflowDetailViewModel({
+    workflowId,
+    activeTag,
+    onBack: handleBackFromWorkflow,
+    onNavigateToWorkflow: handleNavigateToWorkflow,
+  });
+
+  // ---------------------------------------------------------------------------
+  // SessionDetail ViewModel
+  // ---------------------------------------------------------------------------
+
+  // Called unconditionally (hooks rules). The underlying useSessionDetail query
+  // has enabled: !!sessionId, so an empty string triggers no network request.
+  const sessionDetailViewModel = useSessionDetailViewModel(sessionId ?? '');
+
+  // ---------------------------------------------------------------------------
+  // Performance ViewModel
+  // ---------------------------------------------------------------------------
+
+  const performanceViewModel = usePerformanceViewModel();
 
   // ---------------------------------------------------------------------------
   // Tab activation flicker
@@ -302,10 +356,11 @@ export function AppShell() {
           hidden={activeTab === 'workflows' || activeTab === 'perf'}
         >
           {/* WorkspaceView is always mounted -- hidden via CSS only so scroll
-              position in scrollYRef survives back-navigation from SessionDetail */}
-          <WorkspaceView hidden={isInSessionDetail} />
+              position in scrollYRef and expandStateRef survive back-navigation
+              from SessionDetail and SSE-driven remounts of child components. */}
+          <WorkspaceView viewModel={workspaceViewModel} sessionListViewModel={sessionListViewModel} hidden={isInSessionDetail} />
           {isInSessionDetail && sessionId && (
-            <SessionDetail sessionId={sessionId} />
+            <SessionDetail viewModel={sessionDetailViewModel} />
           )}
         </div>
 
@@ -317,16 +372,9 @@ export function AppShell() {
             aria-labelledby="tab-workflows"
           >
             {isOnWorkflowDetail && workflowId ? (
-              <WorkflowDetail
-                workflowId={workflowId}
-                onBack={handleBackFromWorkflow}
-              />
+              <WorkflowDetail viewModel={workflowDetailViewModel} />
             ) : (
-              <WorkflowsView
-                selectedTag={activeTag}
-                onSelectTag={handleSelectTag}
-                onSelectWorkflow={handleSelectWorkflow}
-              />
+              <WorkflowsView viewModel={workflowsViewModel} />
             )}
           </div>
         )}
@@ -338,7 +386,7 @@ export function AppShell() {
             role="tabpanel"
             aria-labelledby="tab-perf"
           >
-            <PerformanceView />
+            <PerformanceView viewModel={performanceViewModel} />
           </div>
         )}
       </main>

--- a/console/src/hooks/__tests__/usePerformanceViewModel.test.tsx
+++ b/console/src/hooks/__tests__/usePerformanceViewModel.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Integration tests for usePerformanceViewModel.
+ *
+ * Tests state transitions and sort order interaction.
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { usePerformanceViewModel } from '../usePerformanceViewModel';
+import type { ToolCallTiming } from '../../api/types';
+
+// ---------------------------------------------------------------------------
+// Fake data
+// ---------------------------------------------------------------------------
+
+function makeTiming(toolName: string, durationMs: number, outcome: ToolCallTiming['outcome'] = 'success'): ToolCallTiming {
+  return {
+    toolName,
+    startedAtMs: Date.now() - durationMs,
+    durationMs,
+    outcome,
+  };
+}
+
+const OBSERVATIONS: ToolCallTiming[] = [
+  makeTiming('list_workflows', 120),
+  makeTiming('start_workflow', 350),
+  makeTiming('continue_workflow', 80, 'error'),
+];
+
+// ---------------------------------------------------------------------------
+// Mock repository
+// ---------------------------------------------------------------------------
+
+vi.mock('../usePerformanceRepository', () => ({
+  usePerformanceRepository: vi.fn(() => ({
+    kind: 'loading',
+  })),
+}));
+
+import { usePerformanceRepository } from '../usePerformanceRepository';
+const mockUseRepo = vi.mocked(usePerformanceRepository);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('usePerformanceViewModel', () => {
+  beforeEach(() => {
+    mockUseRepo.mockReturnValue({ kind: 'loading' });
+  });
+
+  describe('state transitions', () => {
+    it('returns loading when repository is loading', () => {
+      const { result } = renderHook(() => usePerformanceViewModel());
+      expect(result.current.state.kind).toBe('loading');
+    });
+
+    it('returns devModeOff when dev mode is off', () => {
+      mockUseRepo.mockReturnValue({ kind: 'devModeOff' });
+      const { result } = renderHook(() => usePerformanceViewModel());
+      expect(result.current.state.kind).toBe('devModeOff');
+    });
+
+    it('returns error when repository has an error', () => {
+      mockUseRepo.mockReturnValue({ kind: 'error', message: 'fetch failed', retry: vi.fn() });
+      const { result } = renderHook(() => usePerformanceViewModel());
+      expect(result.current.state.kind).toBe('error');
+      if (result.current.state.kind === 'error') {
+        expect(result.current.state.message).toBe('fetch failed');
+      }
+    });
+
+    it('returns ready with derived stats when observations are available', () => {
+      mockUseRepo.mockReturnValue({ kind: 'ready', observations: OBSERVATIONS });
+      const { result } = renderHook(() => usePerformanceViewModel());
+      expect(result.current.state.kind).toBe('ready');
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.sorted).toHaveLength(3);
+        expect(result.current.state.errorCount).toBe(1);
+        expect(result.current.state.maxDuration).toBe(350);
+      }
+    });
+  });
+
+  describe('sort order', () => {
+    it('initial sort order is recent', () => {
+      mockUseRepo.mockReturnValue({ kind: 'ready', observations: OBSERVATIONS });
+      const { result } = renderHook(() => usePerformanceViewModel());
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.sortOrder).toBe('recent');
+      }
+    });
+
+    it('onSortChange updates the sort order and re-sorts observations', () => {
+      mockUseRepo.mockReturnValue({ kind: 'ready', observations: OBSERVATIONS });
+      const { result } = renderHook(() => usePerformanceViewModel());
+
+      act(() => {
+        if (result.current.state.kind === 'ready') {
+          result.current.state.onSortChange('slowest');
+        }
+      });
+
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.sortOrder).toBe('slowest');
+        // Sorted by slowest: start_workflow (350ms) should be first
+        expect(result.current.state.sorted[0]?.toolName).toBe('start_workflow');
+      }
+    });
+  });
+});

--- a/console/src/hooks/__tests__/useSessionDetailViewModel.test.tsx
+++ b/console/src/hooks/__tests__/useSessionDetailViewModel.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Integration tests for useSessionDetailViewModel.
+ *
+ * Tests state transitions and the node selection toggle.
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useSessionDetailViewModel } from '../useSessionDetailViewModel';
+import type { ConsoleSessionDetail } from '../../api/types';
+
+// ---------------------------------------------------------------------------
+// Fake data
+// ---------------------------------------------------------------------------
+
+const FAKE_SESSION: ConsoleSessionDetail = {
+  sessionId: 'sess-001',
+  sessionTitle: 'Fix auth bug',
+  health: 'healthy',
+  runs: [
+    {
+      runId: 'run-001',
+      workflowId: 'wf-coding',
+      workflowName: 'Coding Task',
+      workflowHash: null,
+      preferredTipNodeId: null,
+      status: 'complete',
+      hasUnresolvedCriticalGaps: false,
+      executionTraceSummary: null,
+      nodes: [{ nodeId: 'node-001', nodeKind: 'step', parentNodeId: null, createdAtEventIndex: 0, isPreferredTip: true, isTip: true, stepLabel: null, hasRecap: false, hasFailedValidations: false, hasGaps: false, hasArtifacts: false }],
+      edges: [],
+      tipNodeIds: ['node-001'],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Mock repository
+// ---------------------------------------------------------------------------
+
+vi.mock('../useSessionDetailRepository', () => ({
+  useSessionDetailRepository: vi.fn(() => ({
+    data: FAKE_SESSION,
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+import { useSessionDetailRepository } from '../useSessionDetailRepository';
+const mockUseRepo = vi.mocked(useSessionDetailRepository);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useSessionDetailViewModel', () => {
+  beforeEach(() => {
+    mockUseRepo.mockReturnValue({ data: FAKE_SESSION, isLoading: false, error: null });
+  });
+
+  describe('state transitions', () => {
+    it('returns loading when repository is loading', () => {
+      mockUseRepo.mockReturnValue({ data: undefined, isLoading: true, error: null });
+      const { result } = renderHook(() => useSessionDetailViewModel('sess-001'));
+      expect(result.current.state.kind).toBe('loading');
+    });
+
+    it('returns error when repository has an error', () => {
+      mockUseRepo.mockReturnValue({ data: undefined, isLoading: false, error: new Error('not found') });
+      const { result } = renderHook(() => useSessionDetailViewModel('sess-001'));
+      expect(result.current.state.kind).toBe('error');
+    });
+
+    it('returns ready when data is available', () => {
+      const { result } = renderHook(() => useSessionDetailViewModel('sess-001'));
+      expect(result.current.state.kind).toBe('ready');
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.sessionId).toBe('sess-001');
+        expect(result.current.state.data).toEqual(FAKE_SESSION);
+      }
+    });
+  });
+
+  describe('node selection', () => {
+    it('selectedNode is null initially', () => {
+      const { result } = renderHook(() => useSessionDetailViewModel('sess-001'));
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.selectedNode).toBeNull();
+      }
+    });
+
+    it('onSelectNode sets the selected node', () => {
+      const { result } = renderHook(() => useSessionDetailViewModel('sess-001'));
+      act(() => { result.current.onSelectNode('run-001', 'node-001'); });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.selectedNode).toEqual({ runId: 'run-001', nodeId: 'node-001' });
+      }
+    });
+
+    it('onSelectNode toggles off when same node is selected again', () => {
+      const { result } = renderHook(() => useSessionDetailViewModel('sess-001'));
+      act(() => { result.current.onSelectNode('run-001', 'node-001'); });
+      act(() => { result.current.onSelectNode('run-001', 'node-001'); });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.selectedNode).toBeNull();
+      }
+    });
+
+    it('onCloseNode clears the selected node', () => {
+      const { result } = renderHook(() => useSessionDetailViewModel('sess-001'));
+      act(() => { result.current.onSelectNode('run-001', 'node-001'); });
+      act(() => { result.current.onCloseNode(); });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.selectedNode).toBeNull();
+      }
+    });
+
+    it('selectedRun is populated when a node is selected', () => {
+      const { result } = renderHook(() => useSessionDetailViewModel('sess-001'));
+      act(() => { result.current.onSelectNode('run-001', 'node-001'); });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.selectedRun?.runId).toBe('run-001');
+      }
+    });
+
+    it('selectedRun is null when no node is selected', () => {
+      const { result } = renderHook(() => useSessionDetailViewModel('sess-001'));
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.selectedRun).toBeNull();
+      }
+    });
+  });
+});

--- a/console/src/hooks/__tests__/useSessionListViewModel.test.tsx
+++ b/console/src/hooks/__tests__/useSessionListViewModel.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Integration tests for useSessionListViewModel.
+ *
+ * Tests state transitions, filtering, sorting, pagination, and
+ * page reset invariant (any filter change resets page to 0).
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useSessionListViewModel } from '../useSessionListViewModel';
+import type { ConsoleSessionSummary } from '../../api/types';
+
+// ---------------------------------------------------------------------------
+// Fake data
+// ---------------------------------------------------------------------------
+
+function makeSession(overrides: Partial<ConsoleSessionSummary> = {}): ConsoleSessionSummary {
+  return {
+    sessionId: `sess-${Math.random().toString(36).slice(2, 8)}`,
+    sessionTitle: 'Test session',
+    workflowId: 'wf-coding',
+    workflowName: 'Coding Task',
+    workflowHash: null,
+    runId: null,
+    status: 'complete',
+    health: 'healthy',
+    nodeCount: 3,
+    edgeCount: 2,
+    tipCount: 1,
+    hasUnresolvedGaps: false,
+    recapSnippet: null,
+    gitBranch: 'main',
+    repoRoot: '/repos/myapp',
+    lastModifiedMs: Date.now(),
+    ...overrides,
+  };
+}
+
+const SESSIONS = [
+  makeSession({ sessionId: 'sess-001', sessionTitle: 'Fix auth bug', status: 'in_progress' }),
+  makeSession({ sessionId: 'sess-002', sessionTitle: 'Add dark mode', status: 'complete' }),
+  makeSession({ sessionId: 'sess-003', sessionTitle: 'Write tests', status: 'blocked' }),
+];
+
+// ---------------------------------------------------------------------------
+// Mock repository
+// ---------------------------------------------------------------------------
+
+vi.mock('../useSessionListRepository', () => ({
+  useSessionListRepository: vi.fn(() => ({
+    sessions: SESSIONS,
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+import { useSessionListRepository } from '../useSessionListRepository';
+const mockUseRepo = vi.mocked(useSessionListRepository);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useSessionListViewModel', () => {
+  const onSelectSession = vi.fn();
+
+  beforeEach(() => {
+    mockUseRepo.mockReturnValue({ sessions: SESSIONS, isLoading: false, error: null });
+    onSelectSession.mockReset();
+  });
+
+  describe('state transitions', () => {
+    it('returns loading when repository is loading', () => {
+      mockUseRepo.mockReturnValue({ sessions: undefined, isLoading: true, error: null });
+      const { result } = renderHook(() => useSessionListViewModel({ onSelectSession }));
+      expect(result.current.state.kind).toBe('loading');
+    });
+
+    it('returns error when repository has an error', () => {
+      mockUseRepo.mockReturnValue({ sessions: undefined, isLoading: false, error: new Error('fail') });
+      const { result } = renderHook(() => useSessionListViewModel({ onSelectSession }));
+      expect(result.current.state.kind).toBe('error');
+    });
+
+    it('returns ready with sessions when data is available', () => {
+      const { result } = renderHook(() => useSessionListViewModel({ onSelectSession }));
+      expect(result.current.state.kind).toBe('ready');
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.flatPageSessions.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('status filter', () => {
+    it('processed.total reflects the count of filtered sessions', () => {
+      const { result } = renderHook(() => useSessionListViewModel({ onSelectSession }));
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.processed.total).toBe(3);
+      }
+    });
+
+    it('status_changed filters sessions and resets page to 0', () => {
+      const { result } = renderHook(() => useSessionListViewModel({ onSelectSession }));
+
+      // Navigate to page 1 first
+      act(() => { result.current.dispatch({ type: 'page_changed', page: 1 }); });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.page).toBe(1);
+      }
+
+      // Change filter -- page must reset
+      act(() => { result.current.dispatch({ type: 'status_changed', statusFilter: 'in_progress' }); });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.page).toBe(0);
+        expect(result.current.state.statusFilter).toBe('in_progress');
+        // Only in_progress sessions visible
+        const ids = result.current.state.flatPageSessions.map(s => s.sessionId);
+        expect(ids).toContain('sess-001');
+        expect(ids).not.toContain('sess-002');
+      }
+    });
+  });
+
+  describe('search', () => {
+    it('search_changed updates rawSearch and resets page', () => {
+      const { result } = renderHook(() => useSessionListViewModel({ onSelectSession }));
+
+      act(() => { result.current.dispatch({ type: 'page_changed', page: 1 }); });
+      act(() => { result.current.dispatch({ type: 'search_changed', value: 'auth' }); });
+
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.page).toBe(0);
+        expect(result.current.state.rawSearch).toBe('auth');
+      }
+    });
+  });
+
+  describe('sort', () => {
+    it('sort_changed updates sort field and resets page', () => {
+      const { result } = renderHook(() => useSessionListViewModel({ onSelectSession }));
+
+      act(() => { result.current.dispatch({ type: 'page_changed', page: 1 }); });
+      act(() => { result.current.dispatch({ type: 'sort_changed', sort: 'status' }); });
+
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.page).toBe(0);
+        expect(result.current.state.sort).toBe('status');
+      }
+    });
+  });
+
+  describe('page invariant', () => {
+    it('page_changed updates page without resetting filter state', () => {
+      const { result } = renderHook(() => useSessionListViewModel({ onSelectSession }));
+
+      act(() => { result.current.dispatch({ type: 'status_changed', statusFilter: 'complete' }); });
+      act(() => { result.current.dispatch({ type: 'page_changed', page: 2 }); });
+
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.page).toBe(2);
+        expect(result.current.state.statusFilter).toBe('complete');
+      }
+    });
+  });
+});

--- a/console/src/hooks/__tests__/useWorkflowDetailViewModel.test.tsx
+++ b/console/src/hooks/__tests__/useWorkflowDetailViewModel.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Integration tests for useWorkflowDetailViewModel.
+ *
+ * Tests state transitions, adjacent workflow navigation, and
+ * the getAdjacentWorkflows use case integration.
+ */
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useWorkflowDetailViewModel } from '../useWorkflowDetailViewModel';
+import type { ConsoleWorkflowSummary, ConsoleWorkflowDetail } from '../../api/types';
+
+// ---------------------------------------------------------------------------
+// Fake data
+// ---------------------------------------------------------------------------
+
+function makeWorkflowSummary(id: string): ConsoleWorkflowSummary {
+  return {
+    id,
+    name: `Workflow ${id}`,
+    description: "",
+    version: '1.0.0',
+    tags: ['coding'],
+    source: { kind: 'bundled', displayName: 'WorkRail' },
+    stepCount: 3,
+  };
+}
+
+const WF_A = makeWorkflowSummary('wf-a');
+const WF_B = makeWorkflowSummary('wf-b');
+const WF_C = makeWorkflowSummary('wf-c');
+const WORKFLOW_LIST = [WF_A, WF_B, WF_C];
+
+const WORKFLOW_DETAIL: ConsoleWorkflowDetail = {
+  id: 'wf-b',
+  name: 'Workflow wf-b',
+  description: 'A test workflow',
+  version: '1.0.0',
+  tags: ['coding'],
+  source: { kind: 'bundled', displayName: 'WorkRail' },
+  stepCount: 3,
+};
+
+// ---------------------------------------------------------------------------
+// Mock repositories
+// ---------------------------------------------------------------------------
+
+vi.mock('../useWorkflowDetailRepository', () => ({
+  useWorkflowDetailRepository: vi.fn(() => ({
+    kind: 'loading',
+    refetch: vi.fn(),
+  })),
+}));
+
+vi.mock('../useWorkflowsRepository', () => ({
+  useWorkflowsRepository: vi.fn(() => ({
+    workflows: WORKFLOW_LIST,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}));
+
+import { useWorkflowDetailRepository } from '../useWorkflowDetailRepository';
+import { useWorkflowsRepository } from '../useWorkflowsRepository';
+const mockUseDetailRepo = vi.mocked(useWorkflowDetailRepository);
+const mockUseListRepo = vi.mocked(useWorkflowsRepository);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeParams(workflowId: string | null = 'wf-b') {
+  return {
+    workflowId,
+    activeTag: null,
+    onBack: vi.fn(),
+    onNavigateToWorkflow: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useWorkflowDetailViewModel', () => {
+  beforeEach(() => {
+    mockUseDetailRepo.mockReturnValue({ kind: 'loading' });
+    mockUseListRepo.mockReturnValue({ workflows: WORKFLOW_LIST, isLoading: false, error: null, refetch: vi.fn() });
+  });
+
+  describe('state transitions', () => {
+    it('returns loading when detail repository is loading', () => {
+      const { result } = renderHook(() => useWorkflowDetailViewModel(makeParams()));
+      expect(result.current.state.kind).toBe('loading');
+    });
+
+    it('returns not_found when detail returns 404', () => {
+      mockUseDetailRepo.mockReturnValue({ kind: 'not_found' });
+      const { result } = renderHook(() => useWorkflowDetailViewModel(makeParams()));
+      expect(result.current.state.kind).toBe('not_found');
+    });
+
+    it('returns error when detail fetch fails', () => {
+      mockUseDetailRepo.mockReturnValue({ kind: 'error', message: 'Network error', refetch: vi.fn() });
+      const { result } = renderHook(() => useWorkflowDetailViewModel(makeParams()));
+      expect(result.current.state.kind).toBe('error');
+    });
+
+    it('returns ready with workflow data when fetch succeeds', () => {
+      mockUseDetailRepo.mockReturnValue({ kind: 'ready', detail: WORKFLOW_DETAIL, refetch: vi.fn() });
+      const { result } = renderHook(() => useWorkflowDetailViewModel(makeParams('wf-b')));
+      expect(result.current.state.kind).toBe('ready');
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.name).toBe('Workflow wf-b');
+      }
+    });
+  });
+
+  describe('adjacent navigation (getAdjacentWorkflows use case)', () => {
+    beforeEach(() => {
+      mockUseDetailRepo.mockReturnValue({ kind: 'ready', detail: WORKFLOW_DETAIL, refetch: vi.fn() });
+    });
+
+    it('middle workflow has both onPrev and onNext', () => {
+      const { result } = renderHook(() => useWorkflowDetailViewModel(makeParams('wf-b')));
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.onPrev).not.toBeNull();
+        expect(result.current.state.onNext).not.toBeNull();
+      }
+    });
+
+    it('first workflow has null onPrev', () => {
+      const detailA = { ...WORKFLOW_DETAIL, id: 'wf-a', name: 'Workflow wf-a' };
+      mockUseDetailRepo.mockReturnValue({ kind: 'ready', detail: detailA, refetch: vi.fn() });
+      const { result } = renderHook(() => useWorkflowDetailViewModel(makeParams('wf-a')));
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.onPrev).toBeNull();
+        expect(result.current.state.onNext).not.toBeNull();
+      }
+    });
+
+    it('last workflow has null onNext', () => {
+      const detailC = { ...WORKFLOW_DETAIL, id: 'wf-c', name: 'Workflow wf-c' };
+      mockUseDetailRepo.mockReturnValue({ kind: 'ready', detail: detailC, refetch: vi.fn() });
+      const { result } = renderHook(() => useWorkflowDetailViewModel(makeParams('wf-c')));
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.onPrev).not.toBeNull();
+        expect(result.current.state.onNext).toBeNull();
+      }
+    });
+
+    it('onPrev calls onNavigateToWorkflow with the previous workflow id', () => {
+      const onNavigate = vi.fn();
+      const { result } = renderHook(() =>
+        useWorkflowDetailViewModel({ ...makeParams('wf-b'), onNavigateToWorkflow: onNavigate })
+      );
+      if (result.current.state.kind === 'ready') {
+        result.current.state.onPrev?.();
+        expect(onNavigate).toHaveBeenCalledWith('wf-a');
+      }
+    });
+
+    it('onNext calls onNavigateToWorkflow with the next workflow id', () => {
+      const onNavigate = vi.fn();
+      const { result } = renderHook(() =>
+        useWorkflowDetailViewModel({ ...makeParams('wf-b'), onNavigateToWorkflow: onNavigate })
+      );
+      if (result.current.state.kind === 'ready') {
+        result.current.state.onNext?.();
+        expect(onNavigate).toHaveBeenCalledWith('wf-c');
+      }
+    });
+  });
+
+  describe('loading state with optimistic cache', () => {
+    it('loading state includes cached partial from workflow list', () => {
+      // Detail is still loading, but workflow list is available
+      const { result } = renderHook(() => useWorkflowDetailViewModel(makeParams('wf-b')));
+      if (result.current.state.kind === 'loading') {
+        expect(result.current.state.cached).toEqual(WF_B);
+      }
+    });
+  });
+});

--- a/console/src/hooks/__tests__/useWorkflowsViewModel.test.tsx
+++ b/console/src/hooks/__tests__/useWorkflowsViewModel.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Integration tests for useWorkflowsViewModel.
+ *
+ * Key scenarios tested:
+ * - State transitions (loading → ready → error)
+ * - initialTag sync when URL changes after mount (the stale-tag bug regression test)
+ * - Workflow selection opens modal (selectedWorkflowId)
+ * - Tag/source filter changes clear selectedWorkflowId
+ * - Filtering derived state (filteredWorkflows, flatWorkflows)
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useWorkflowsViewModel } from '../useWorkflowsViewModel';
+import type { ConsoleWorkflowSummary } from '../../api/types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeWorkflow(id: string, tags: string[] = []): ConsoleWorkflowSummary {
+  return {
+    id,
+    name: `Workflow ${id}`,
+    description: "",
+    version: '1.0.0',
+    tags,
+    source: { kind: 'bundled', displayName: 'WorkRail' },
+    stepCount: 3,
+  };
+}
+
+const WF_CODING = makeWorkflow('wf-coding', ['coding']);
+const WF_REVIEW = makeWorkflow('wf-review', ['review']);
+const WF_PLAIN = makeWorkflow('wf-plain', []);
+const WORKFLOWS = [WF_CODING, WF_REVIEW, WF_PLAIN];
+
+// ---------------------------------------------------------------------------
+// Mock repository
+// ---------------------------------------------------------------------------
+
+vi.mock('../useWorkflowsRepository', () => ({
+  useWorkflowsRepository: vi.fn(() => ({
+    workflows: WORKFLOWS,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}));
+
+import { useWorkflowsRepository } from '../useWorkflowsRepository';
+const mockUseRepo = vi.mocked(useWorkflowsRepository);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeParams(overrides: Partial<Parameters<typeof useWorkflowsViewModel>[0]> = {}) {
+  return {
+    initialTag: null,
+    onSelectTag: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useWorkflowsViewModel', () => {
+  beforeEach(() => {
+    mockUseRepo.mockReturnValue({
+      workflows: WORKFLOWS,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  describe('state transitions', () => {
+    it('returns loading when repository is loading', () => {
+      mockUseRepo.mockReturnValue({ workflows: undefined, isLoading: true, error: null, refetch: vi.fn() });
+      const { result } = renderHook(() => useWorkflowsViewModel(makeParams()));
+      expect(result.current.state.kind).toBe('loading');
+    });
+
+    it('returns error when repository has an error', () => {
+      mockUseRepo.mockReturnValue({ workflows: undefined, isLoading: false, error: new Error('fetch failed'), refetch: vi.fn() });
+      const { result } = renderHook(() => useWorkflowsViewModel(makeParams()));
+      expect(result.current.state.kind).toBe('error');
+    });
+
+    it('returns ready with all workflows when no filter', () => {
+      const { result } = renderHook(() => useWorkflowsViewModel(makeParams()));
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.flatWorkflows).toHaveLength(3);
+      }
+    });
+  });
+
+  describe('tag filtering', () => {
+    it('filters workflows by initialTag', () => {
+      const { result } = renderHook(() => useWorkflowsViewModel(makeParams({ initialTag: 'coding' })));
+      if (result.current.state.kind === 'ready') {
+        const ids = result.current.state.flatWorkflows.map(w => w.id);
+        expect(ids).toContain('wf-coding');
+        expect(ids).not.toContain('wf-review');
+      }
+    });
+
+    it('tag_changed event updates filtered list', () => {
+      const { result } = renderHook(() => useWorkflowsViewModel(makeParams()));
+      act(() => {
+        result.current.dispatch({ type: 'tag_changed', tag: 'review' });
+      });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.flatWorkflows.map(w => w.id)).toContain('wf-review');
+        expect(result.current.state.flatWorkflows.map(w => w.id)).not.toContain('wf-coding');
+      }
+    });
+
+    it('tag_changed clears selectedWorkflowId', () => {
+      const { result } = renderHook(() => useWorkflowsViewModel(makeParams()));
+
+      // Select a workflow first
+      act(() => {
+        result.current.dispatch({ type: 'workflow_selected', id: 'wf-coding' });
+      });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.selectedWorkflowId).toBe('wf-coding');
+      }
+
+      // Change tag -- should clear selection
+      act(() => {
+        result.current.dispatch({ type: 'tag_changed', tag: 'review' });
+      });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.selectedWorkflowId).toBeNull();
+      }
+    });
+
+    it('tag_changed calls onSelectTag callback for URL sync', () => {
+      const onSelectTag = vi.fn();
+      const { result } = renderHook(() => useWorkflowsViewModel(makeParams({ onSelectTag })));
+      act(() => {
+        result.current.dispatch({ type: 'tag_changed', tag: 'coding' });
+      });
+      expect(onSelectTag).toHaveBeenCalledWith('coding');
+    });
+  });
+
+  describe('initialTag reactivity (regression: stale tag on URL back-navigation)', () => {
+    it('syncs to new initialTag after mount when URL changes', () => {
+      let tag: string | null = 'coding';
+      const { result, rerender } = renderHook(() =>
+        useWorkflowsViewModel(makeParams({ initialTag: tag }))
+      );
+
+      // Simulate browser Back -- URL changes to different tag
+      tag = 'review';
+      rerender();
+
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.selectedTag).toBe('review');
+      }
+    });
+
+    it('syncs to null initialTag when user navigates to unfiltered URL', () => {
+      let tag: string | null = 'coding';
+      const { result, rerender } = renderHook(() =>
+        useWorkflowsViewModel(makeParams({ initialTag: tag }))
+      );
+
+      tag = null;
+      rerender();
+
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.selectedTag).toBeNull();
+      }
+    });
+  });
+
+  describe('modal selection', () => {
+    it('workflow_selected event sets selectedWorkflowId', () => {
+      const { result } = renderHook(() => useWorkflowsViewModel(makeParams()));
+      act(() => {
+        result.current.dispatch({ type: 'workflow_selected', id: 'wf-coding' });
+      });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.selectedWorkflowId).toBe('wf-coding');
+      }
+    });
+
+    it('modal_closed event clears selectedWorkflowId', () => {
+      const { result } = renderHook(() => useWorkflowsViewModel(makeParams()));
+      act(() => {
+        result.current.dispatch({ type: 'workflow_selected', id: 'wf-coding' });
+        result.current.dispatch({ type: 'modal_closed' });
+      });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.selectedWorkflowId).toBeNull();
+      }
+    });
+  });
+});

--- a/console/src/hooks/__tests__/useWorkspaceViewModel.test.tsx
+++ b/console/src/hooks/__tests__/useWorkspaceViewModel.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * Integration tests for useWorkspaceViewModel.
+ *
+ * Uses renderHook with vi.mock to inject fake repository data.
+ * Tests state transitions, derived state correctness, and side effects.
+ *
+ * Pattern: fake repository data → renderHook → assert WorkspaceViewState.
+ * No mocking of internal implementation details -- only the repository boundary.
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useWorkspaceViewModel } from '../useWorkspaceViewModel';
+
+// ---------------------------------------------------------------------------
+// Fake repository data
+// ---------------------------------------------------------------------------
+
+const FAKE_REPO_LOADING = {
+  sessions: undefined,
+  worktreeRepos: [],
+  isLoading: true,
+  error: null,
+  refetch: vi.fn(),
+  worktreesFetching: false,
+  liveCount: 0,
+  blockedCount: 0,
+};
+
+const FAKE_REPO_ERROR = {
+  sessions: undefined,
+  worktreeRepos: [],
+  isLoading: false,
+  error: new Error('Network failure'),
+  refetch: vi.fn(),
+  worktreesFetching: false,
+  liveCount: 0,
+  blockedCount: 0,
+};
+
+const FAKE_REPO_READY = {
+  sessions: [
+    {
+      sessionId: 'sess-001',
+      sessionTitle: 'Fix auth bug',
+      workflowId: 'wf-coding',
+      workflowName: 'Coding Task',
+      workflowHash: null,
+      runId: null,
+      status: 'in_progress' as const,
+      health: 'healthy' as const,
+      nodeCount: 3,
+      edgeCount: 2,
+      tipCount: 1,
+      hasUnresolvedGaps: false,
+      recapSnippet: null,
+      gitBranch: 'feature/auth-fix',
+      repoRoot: '/repos/myapp',
+      lastModifiedMs: Date.now() - 1000,
+    },
+  ],
+  worktreeRepos: [
+    {
+      repoName: 'myapp',
+      repoRoot: '/repos/myapp',
+      worktrees: [
+        {
+          path: '/repos/myapp',
+          name: 'feature/auth-fix',
+          branch: 'feature/auth-fix',
+          headHash: 'abc123',
+          headMessage: 'fix: auth',
+          headTimestampMs: Date.now() - 1000,
+          changedCount: 2,
+          changedFiles: [],
+          aheadCount: 0,
+          unpushedCommits: [],
+          isMerged: false,
+          activeSessionCount: 1,
+          enrichment: null,
+        },
+      ],
+    },
+  ],
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+  worktreesFetching: false,
+  liveCount: 1,
+  blockedCount: 0,
+};
+
+// ---------------------------------------------------------------------------
+// Mock repository + navigation
+// ---------------------------------------------------------------------------
+
+vi.mock('../useWorkspaceRepository', () => ({
+  useWorkspaceRepository: vi.fn(() => FAKE_REPO_LOADING),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+import { useWorkspaceRepository } from '../useWorkspaceRepository';
+const mockUseRepo = vi.mocked(useWorkspaceRepository);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useWorkspaceViewModel', () => {
+  beforeEach(() => {
+    mockUseRepo.mockReturnValue(FAKE_REPO_LOADING);
+  });
+
+  describe('state transitions', () => {
+    it('returns loading state when repository is loading', () => {
+      mockUseRepo.mockReturnValue(FAKE_REPO_LOADING);
+      const { result } = renderHook(() => useWorkspaceViewModel());
+      expect(result.current.state.kind).toBe('loading');
+    });
+
+    it('returns error state when repository has an error', () => {
+      mockUseRepo.mockReturnValue(FAKE_REPO_ERROR);
+      const { result } = renderHook(() => useWorkspaceViewModel());
+      expect(result.current.state.kind).toBe('error');
+      if (result.current.state.kind === 'error') {
+        expect(result.current.state.message).toBe('Network failure');
+      }
+    });
+
+    it('returns ready state with derived data when repository has sessions', () => {
+      mockUseRepo.mockReturnValue(FAKE_REPO_READY);
+      const { result } = renderHook(() => useWorkspaceViewModel());
+      expect(result.current.state.kind).toBe('ready');
+    });
+
+    it('ready state includes liveCount and blockedCount from repository', () => {
+      mockUseRepo.mockReturnValue({ ...FAKE_REPO_READY, liveCount: 2, blockedCount: 1 });
+      const { result } = renderHook(() => useWorkspaceViewModel());
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.liveCount).toBe(2);
+        expect(result.current.state.blockedCount).toBe(1);
+      }
+    });
+
+    it('ready state has hasAnySessions true when sessions exist', () => {
+      mockUseRepo.mockReturnValue(FAKE_REPO_READY);
+      const { result } = renderHook(() => useWorkspaceViewModel());
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.hasAnySessions).toBe(true);
+      }
+    });
+
+    it('ready state has hasAnySessions false when sessions list is empty', () => {
+      mockUseRepo.mockReturnValue({ ...FAKE_REPO_READY, sessions: [] });
+      const { result } = renderHook(() => useWorkspaceViewModel());
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.hasAnySessions).toBe(false);
+      }
+    });
+  });
+
+  describe('scope interaction', () => {
+    it('initial scope is active', () => {
+      mockUseRepo.mockReturnValue(FAKE_REPO_READY);
+      const { result } = renderHook(() => useWorkspaceViewModel());
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.scope).toBe('active');
+      }
+    });
+
+    it('scope_changed event updates scope', () => {
+      mockUseRepo.mockReturnValue(FAKE_REPO_READY);
+      const { result } = renderHook(() => useWorkspaceViewModel());
+
+      act(() => {
+        result.current.dispatch({ type: 'scope_changed', scope: 'all' });
+      });
+
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.scope).toBe('all');
+      }
+    });
+
+    it('scope_changed resets focusedIndex to -1', () => {
+      mockUseRepo.mockReturnValue(FAKE_REPO_READY);
+      const { result } = renderHook(() => useWorkspaceViewModel());
+
+      // First focus an item
+      act(() => {
+        result.current.dispatch({ type: 'focus_moved', index: 0 });
+      });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.focusedIndex).toBe(0);
+      }
+
+      // Then change scope -- focus should reset
+      act(() => {
+        result.current.dispatch({ type: 'scope_changed', scope: 'all' });
+      });
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.focusedIndex).toBe(-1);
+      }
+    });
+  });
+
+  describe('archive panel', () => {
+    it('archive is null initially', () => {
+      mockUseRepo.mockReturnValue(FAKE_REPO_READY);
+      const { result } = renderHook(() => useWorkspaceViewModel());
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.archive).toBeNull();
+      }
+    });
+
+    it('archive_opened event sets archive state', () => {
+      mockUseRepo.mockReturnValue(FAKE_REPO_READY);
+      const { result } = renderHook(() => useWorkspaceViewModel());
+
+      act(() => {
+        result.current.dispatch({ type: 'archive_opened', repoName: 'myapp' });
+      });
+
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.archive).toEqual({ repoName: 'myapp' });
+      }
+    });
+
+    it('archive_closed event clears archive state', () => {
+      mockUseRepo.mockReturnValue(FAKE_REPO_READY);
+      const { result } = renderHook(() => useWorkspaceViewModel());
+
+      act(() => {
+        result.current.dispatch({ type: 'archive_opened', repoName: 'myapp' });
+        result.current.dispatch({ type: 'archive_closed' });
+      });
+
+      if (result.current.state.kind === 'ready') {
+        expect(result.current.state.archive).toBeNull();
+      }
+    });
+  });
+
+  describe('disabled prop', () => {
+    it('returns correct state regardless of disabled prop', () => {
+      mockUseRepo.mockReturnValue(FAKE_REPO_READY);
+      const { result } = renderHook(() => useWorkspaceViewModel(true));
+      expect(result.current.state.kind).toBe('ready');
+    });
+  });
+});

--- a/console/src/hooks/useModalTransition.ts
+++ b/console/src/hooks/useModalTransition.ts
@@ -1,0 +1,214 @@
+/**
+ * Hook that encapsulates all CRT/glitch animation state for the workflow modal.
+ *
+ * Extracted from WorkflowsView to separate pure visual effects from data state.
+ * The hook owns: scanlineKey, crtOffset, glitchY, glitchY2, glitchW, glitchW2,
+ * contentAnimClass, borderFlashing, and the transition timing logic.
+ *
+ * The caller owns: selectedWorkflowId (data state), flatWorkflows (derived data).
+ * The hook never reads workflow data -- it only receives callbacks from the caller.
+ */
+import { useState, useRef, type RefObject } from 'react';
+import type { ConsoleWorkflowSummary } from '../api/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ModalScanlineProps {
+  /** Increments on each transition; used as React key to remount the scanline element. */
+  readonly key: number;
+  readonly crtOffset: number;
+  readonly glitchY: number;
+  readonly glitchY2: number;
+  readonly glitchW: number;
+  readonly glitchW2: number;
+}
+
+export interface ModalTransitionState {
+  /** True during an active transition animation. */
+  readonly isAnimating: boolean;
+  /** CSS class applied to the modal content area for enter/exit animations. */
+  readonly contentAnimClass: string;
+  /** True briefly during a transition for the border flash effect. */
+  readonly borderFlashing: boolean;
+  /**
+   * Scanline overlay props. null when no transition has fired yet (key=0).
+   * The scanline element is only rendered when key > 0.
+   */
+  readonly scanline: ModalScanlineProps | null;
+}
+
+export interface UseModalTransitionResult {
+  readonly state: ModalTransitionState;
+  /**
+   * Start a transition to the workflow at nextIndex.
+   * @param nextIndex    - index into flatWorkflows
+   * @param direction    - 'prev' | 'next' for enter/exit animation direction
+   * @param axis         - 'horizontal' | 'vertical' for animation axis
+   * @param onMidpoint   - called at 80ms midpoint with the next workflow ID; caller
+   *                       should update selectedWorkflowId here
+   * @param scrollRef    - ref to the scrollable container (reset to top on transition)
+   * @param flatWorkflows - current workflow list (used to find the workflow ID)
+   */
+  readonly startTransition: (
+    nextIndex: number,
+    direction: 'prev' | 'next',
+    axis: 'horizontal' | 'vertical',
+    onMidpoint: (nextId: string) => void,
+    scrollRef: RefObject<HTMLDivElement | null>,
+    flatWorkflows: readonly ConsoleWorkflowSummary[],
+  ) => void;
+  /**
+   * Navigate to the previous or next workflow in the list. Handles the
+   * pending-nav queue for rapid key presses during animation.
+   * @param selectedWorkflowId - current workflow ID
+   * @param flatWorkflows       - current workflow list
+   * @param direction           - nav direction
+   * @param axis                - animation axis
+   * @param onMidpoint          - called at 80ms with next workflow ID
+   * @param scrollRef           - scrollable container ref
+   */
+  readonly navigate: (
+    selectedWorkflowId: string | null,
+    flatWorkflows: readonly ConsoleWorkflowSummary[],
+    direction: 'prev' | 'next',
+    axis: 'horizontal' | 'vertical',
+    onMidpoint: (nextId: string) => void,
+    scrollRef: RefObject<HTMLDivElement | null>,
+  ) => void;
+  /**
+   * Ref that tracks the current workflow ID post-transition for use inside
+   * setTimeout callbacks. Caller must keep this in sync on every ID change.
+   */
+  readonly selectedWorkflowIdRef: RefObject<string | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useModalTransition(): UseModalTransitionResult {
+  const [scanlineKey, setScanlineKey] = useState(0);
+  const [crtOffset, setCrtOffset] = useState(0);
+  const [glitchY, setGlitchY] = useState(38);
+  const [glitchY2, setGlitchY2] = useState(62);
+  const [glitchW, setGlitchW] = useState(3);
+  const [glitchW2, setGlitchW2] = useState(2);
+  const [contentAnimClass, setContentAnimClass] = useState('');
+  const [borderFlashing, setBorderFlashing] = useState(false);
+
+  // Tracks isAnimating imperatively to avoid double-render on rapid key presses
+  const isAnimatingRef = useRef(false);
+  // Pending navigation index queued while an animation is in progress
+  const pendingNavRef = useRef<number | null>(null);
+  // Tracks the post-transition workflow ID for use in setTimeout callbacks.
+  // Avoids stale closure over the selectedWorkflowId state value.
+  const selectedWorkflowIdRef = useRef<string | null>(null);
+
+  // startTransitionRef allows startTransition to call itself recursively via
+  // the timeout callback without creating a stale closure.
+  const startTransitionRef = useRef<UseModalTransitionResult['startTransition'] | null>(null);
+
+  const startTransition: UseModalTransitionResult['startTransition'] = (
+    nextIndex,
+    direction,
+    axis,
+    onMidpoint,
+    scrollRef,
+    flatWorkflows,
+  ) => {
+    isAnimatingRef.current = true;
+    setBorderFlashing(true);
+    setScanlineKey((k: number) => k + 1);
+    setCrtOffset(Math.floor(Math.random() * 4));
+    setGlitchY(5 + Math.floor(Math.random() * 80));
+    setGlitchY2(5 + Math.floor(Math.random() * 80));
+    setGlitchW(2 + Math.floor(Math.random() * 40)); // 2-42px
+    setGlitchW2(2 + Math.floor(Math.random() * 25)); // 2-27px
+
+    const exitClass =
+      axis === 'horizontal'
+        ? direction === 'next'
+          ? 'modal-content--exit-h-next'
+          : 'modal-content--exit-h-prev'
+        : direction === 'next'
+        ? 'modal-content--exit-v-next'
+        : 'modal-content--exit-v-prev';
+    setContentAnimClass(exitClass);
+
+    // Reset modal scroll position immediately
+    if (scrollRef.current) scrollRef.current.scrollTop = 0;
+
+    // At midpoint (80ms), swap the workflow ID and start enter animation.
+    // The caller provides onMidpoint to update selectedWorkflowId.
+    const nextId = flatWorkflows[nextIndex]!.id;
+    setTimeout(() => {
+      onMidpoint(nextId);
+      const enterClass =
+        axis === 'horizontal'
+          ? direction === 'next'
+            ? 'modal-content--enter-h-next'
+            : 'modal-content--enter-h-prev'
+          : direction === 'next'
+          ? 'modal-content--enter-v-next'
+          : 'modal-content--enter-v-prev';
+      setContentAnimClass(enterClass);
+      setBorderFlashing(false);
+    }, 80);
+
+    // After full animation (240ms), clear animation state and process pending nav.
+    // Use selectedWorkflowIdRef (not closed-over state) for the post-transition value.
+    setTimeout(() => {
+      setContentAnimClass('');
+      isAnimatingRef.current = false;
+      if (pendingNavRef.current !== null) {
+        const pending = pendingNavRef.current;
+        pendingNavRef.current = null;
+        const cur = flatWorkflows.findIndex((w) => w.id === selectedWorkflowIdRef.current);
+        const dir = pending > cur ? 'next' : 'prev';
+        startTransitionRef.current?.(pending, dir, 'horizontal', onMidpoint, scrollRef, flatWorkflows);
+      }
+    }, 240);
+  };
+
+  // Keep the ref in sync so the timeout callback always calls the latest version
+  startTransitionRef.current = startTransition;
+
+  const navigate: UseModalTransitionResult['navigate'] = (
+    selectedWorkflowId,
+    flatWorkflows,
+    direction,
+    axis,
+    onMidpoint,
+    scrollRef,
+  ) => {
+    if (flatWorkflows.length <= 1) return;
+    const current = flatWorkflows.findIndex((w) => w.id === selectedWorkflowId);
+    if (current === -1) return;
+
+    const nextIndex =
+      direction === 'next'
+        ? (current + 1) % flatWorkflows.length
+        : (current - 1 + flatWorkflows.length) % flatWorkflows.length;
+
+    if (isAnimatingRef.current) {
+      pendingNavRef.current = nextIndex;
+      return;
+    }
+
+    startTransition(nextIndex, direction, axis, onMidpoint, scrollRef, flatWorkflows);
+  };
+
+  const state: ModalTransitionState = {
+    isAnimating: isAnimatingRef.current,
+    contentAnimClass,
+    borderFlashing,
+    scanline:
+      scanlineKey > 0
+        ? { key: scanlineKey, crtOffset, glitchY, glitchY2, glitchW, glitchW2 }
+        : null,
+  };
+
+  return { state, startTransition, navigate, selectedWorkflowIdRef };
+}

--- a/console/src/hooks/usePerformanceRepository.ts
+++ b/console/src/hooks/usePerformanceRepository.ts
@@ -1,0 +1,48 @@
+/**
+ * Repository hook for performance tool call data.
+ *
+ * Wraps usePerfToolCalls() from the API layer and returns clean domain types.
+ * Callers receive PerformanceRepoData -- they never see raw React Query objects
+ * or the PerfToolCallsResult discriminated union from the API.
+ *
+ * Loading detection: delegates to the existing usePerfToolCalls hook which
+ * already handles the isLoading / isError / devModeOff / data states correctly.
+ */
+import type { ToolCallTiming } from '../api/types';
+import { usePerfToolCalls } from '../api/hooks';
+
+// ---------------------------------------------------------------------------
+// Domain type returned by this repository
+// ---------------------------------------------------------------------------
+
+export type PerformanceRepoData =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'devModeOff' }
+  | { readonly kind: 'error'; readonly message: string; readonly retry: () => void }
+  | { readonly kind: 'ready'; readonly observations: readonly ToolCallTiming[] };
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns clean performance domain data from the API layer.
+ *
+ * This hook is the repository layer: it owns the data-fetching boundary.
+ * All React Query details are encapsulated in usePerfToolCalls and never
+ * leak to callers.
+ */
+export function usePerformanceRepository(): PerformanceRepoData {
+  const result = usePerfToolCalls();
+
+  switch (result.state) {
+    case 'loading':
+      return { kind: 'loading' };
+    case 'devModeOff':
+      return { kind: 'devModeOff' };
+    case 'error':
+      return { kind: 'error', message: result.message, retry: result.retry };
+    case 'data':
+      return { kind: 'ready', observations: result.data.observations };
+  }
+}

--- a/console/src/hooks/usePerformanceViewModel.ts
+++ b/console/src/hooks/usePerformanceViewModel.ts
@@ -1,0 +1,112 @@
+/**
+ * ViewModel hook for PerformanceView.
+ *
+ * Orchestrates the repository layer and use cases into a single
+ * PerformanceViewState discriminated union for the UI to render.
+ *
+ * Owns:
+ * - Repository data (via usePerformanceRepository)
+ * - UI interaction state: sortOrder (via useState -- single simple toggle)
+ * - Derived display data (via performance-use-cases, wrapped in useMemo)
+ *
+ * Does NOT own:
+ * - JSX, styling, or formatting beyond the data contract
+ */
+import { useState, useMemo } from 'react';
+import { usePerformanceRepository } from './usePerformanceRepository';
+import {
+  sortObservations,
+  computeMaxDuration,
+  computeErrorCount,
+  computeAvgMs,
+  computeLastCallMs,
+  computeCountLabel,
+  SORT_OPTIONS,
+  OUTCOME_CONFIG,
+  type SortOrder,
+  type SortOption,
+  type Outcome,
+} from '../views/performance-use-cases';
+import type { ToolCallTiming } from '../api/types';
+
+// Re-export types the presenter needs so it imports from one place.
+export type { SortOrder, SortOption, Outcome };
+export { SORT_OPTIONS, OUTCOME_CONFIG };
+
+// ---------------------------------------------------------------------------
+// View state
+// ---------------------------------------------------------------------------
+
+export type PerformanceViewState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'devModeOff' }
+  | { readonly kind: 'error'; readonly message: string; readonly retry: () => void }
+  | {
+      readonly kind: 'ready';
+      /** Sorted observations ready for rendering. */
+      readonly sorted: readonly ToolCallTiming[];
+      /** Maximum durationMs in the sorted list; used to scale the duration bar. */
+      readonly maxDuration: number;
+      /** Count of error-outcome observations. */
+      readonly errorCount: number;
+      /** Average durationMs rounded to nearest integer, or null when list is empty. */
+      readonly avgMs: number | null;
+      /** Most recent startedAtMs, or null when list is empty. */
+      readonly lastCallMs: number | null;
+      /** Human-readable count label (e.g. "42 recorded"). */
+      readonly countLabel: string;
+      /** Active sort order. */
+      readonly sortOrder: SortOrder;
+      /** Setter for sort order -- passed through so the presenter can dispatch changes. */
+      readonly onSortChange: (order: SortOrder) => void;
+    };
+
+// ---------------------------------------------------------------------------
+// Hook result
+// ---------------------------------------------------------------------------
+
+export interface UsePerformanceViewModelResult {
+  readonly state: PerformanceViewState;
+}
+
+// ---------------------------------------------------------------------------
+// ViewModel hook
+// ---------------------------------------------------------------------------
+
+export function usePerformanceViewModel(): UsePerformanceViewModelResult {
+  const repo = usePerformanceRepository();
+  const [sortOrder, setSortOrder] = useState<SortOrder>('recent');
+
+  const state = useMemo((): PerformanceViewState => {
+    if (repo.kind === 'loading') return { kind: 'loading' };
+    if (repo.kind === 'devModeOff') return { kind: 'devModeOff' };
+    if (repo.kind === 'error') {
+      return { kind: 'error', message: repo.message, retry: repo.retry };
+    }
+
+    const { observations } = repo;
+    const sorted = sortObservations(observations, sortOrder);
+    const maxDuration = computeMaxDuration(sorted);
+    const errorCount = computeErrorCount(observations);
+    const avgMs = computeAvgMs(observations);
+    const lastCallMs = computeLastCallMs(observations);
+    const countLabel = computeCountLabel(observations.length);
+
+    return {
+      kind: 'ready',
+      sorted,
+      maxDuration,
+      errorCount,
+      avgMs,
+      lastCallMs,
+      countLabel,
+      sortOrder,
+      onSortChange: setSortOrder,
+    };
+  // setSortOrder is stable (from useState), safe to omit from deps.
+  // repo.retry is a new function each render but stable enough for a callback ref.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repo, sortOrder]);
+
+  return { state };
+}

--- a/console/src/hooks/useSessionDetailRepository.ts
+++ b/console/src/hooks/useSessionDetailRepository.ts
@@ -1,0 +1,52 @@
+/**
+ * Repository hook for session detail data.
+ *
+ * Wraps the useSessionDetail React Query hook and returns clean domain types.
+ * Callers receive SessionDetailRepoData -- they never see raw React Query objects.
+ *
+ * Loading detection: uses query.isLoading (NOT query.isFetching).
+ * isLoading is only true when there is no cached data.
+ * isFetching is also true during background refetches (every 5s via refetchInterval),
+ * which would incorrectly reset the view to a loading state on every poll cycle.
+ */
+import type { ConsoleSessionDetail } from '../api/types';
+import { useSessionDetail } from '../api/hooks';
+
+// ---------------------------------------------------------------------------
+// Domain type returned by this repository
+// ---------------------------------------------------------------------------
+
+export interface SessionDetailRepoData {
+  /** Session detail data. Undefined only during the initial fetch (no cached data). */
+  readonly data: ConsoleSessionDetail | undefined;
+  /**
+   * True only during the initial fetch (no cached data exists yet).
+   * False during background refetches where stale data remains visible.
+   */
+  readonly isLoading: boolean;
+  /** Non-null only when the session detail query has failed. */
+  readonly error: Error | null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns clean session detail domain data from React Query.
+ *
+ * This hook is the repository layer: it owns the data-fetching boundary.
+ * All React Query details (staleTime, refetchInterval, query keys) are
+ * encapsulated here and never leak to callers.
+ */
+export function useSessionDetailRepository(sessionId: string): SessionDetailRepoData {
+  const query = useSessionDetail(sessionId);
+
+  return {
+    data: query.data,
+    // Use isLoading (not isFetching) to avoid flickering back to loading state
+    // during the 5s poll refetches where stale data is still visible.
+    isLoading: query.isLoading,
+    error: query.error instanceof Error ? query.error : null,
+  };
+}

--- a/console/src/hooks/useSessionDetailViewModel.ts
+++ b/console/src/hooks/useSessionDetailViewModel.ts
@@ -1,0 +1,111 @@
+/**
+ * ViewModel hook for SessionDetail.
+ *
+ * Orchestrates the repository layer into a single SessionDetailViewState
+ * discriminated union for the UI to render.
+ *
+ * Owns:
+ * - Repository data (via useSessionDetailRepository)
+ * - UI interaction state (selectedNode toggle via useState)
+ * - Derived display data (selectedRun lookup via useMemo)
+ * - Interaction handlers (onSelectNode, onCloseNode)
+ *
+ * Does NOT own:
+ * - Any JSX rendering
+ * - API hooks directly (accessed via repository only)
+ *
+ * No reducer needed: the only interaction state is a single selectedNode
+ * toggle with no multi-event state machine. useState is sufficient.
+ */
+import { useState, useCallback, useMemo } from 'react';
+import { useSessionDetailRepository } from './useSessionDetailRepository';
+import type { ConsoleSessionDetail, ConsoleDagRun } from '../api/types';
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+export interface SelectedNode {
+  readonly runId: string;
+  readonly nodeId: string;
+}
+
+// ---------------------------------------------------------------------------
+// View state
+// ---------------------------------------------------------------------------
+
+export type SessionDetailViewState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | {
+      readonly kind: 'ready';
+      /** The session ID, always available for child components like NodeDetailSection. */
+      readonly sessionId: string;
+      /** Full session detail data. */
+      readonly data: ConsoleSessionDetail;
+      /** Currently selected node, or null if none is selected. */
+      readonly selectedNode: SelectedNode | null;
+      /**
+       * The run containing the selected node, or null if no node is selected
+       * or the run cannot be found.
+       */
+      readonly selectedRun: ConsoleDagRun | null;
+    };
+
+// ---------------------------------------------------------------------------
+// Hook result
+// ---------------------------------------------------------------------------
+
+export interface UseSessionDetailViewModelResult {
+  readonly state: SessionDetailViewState;
+  /**
+   * Select or deselect a node. Calling with the currently selected runId+nodeId
+   * toggles it off (deselects). Calling with a different node selects it.
+   */
+  readonly onSelectNode: (runId: string, nodeId: string) => void;
+  /** Explicitly close the node detail panel (sets selectedNode to null). */
+  readonly onCloseNode: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useSessionDetailViewModel(sessionId: string): UseSessionDetailViewModelResult {
+  const repo = useSessionDetailRepository(sessionId);
+  const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
+
+  const onSelectNode = useCallback((runId: string, nodeId: string) => {
+    setSelectedNode((prev) =>
+      prev?.runId === runId && prev?.nodeId === nodeId ? null : { runId, nodeId },
+    );
+  }, []);
+
+  const onCloseNode = useCallback(() => {
+    setSelectedNode(null);
+  }, []);
+
+  // Derive selectedRun from selectedNode + data.runs
+  const { isLoading, error, data } = repo;
+
+  const selectedRun = useMemo((): ConsoleDagRun | null => {
+    if (!data || !selectedNode) return null;
+    return data.runs.find((r) => r.runId === selectedNode.runId) ?? null;
+  }, [data, selectedNode]);
+
+  const state = useMemo((): SessionDetailViewState => {
+    if (isLoading) return { kind: 'loading' };
+    if (error) return { kind: 'error', message: error.message };
+    if (!data) return { kind: 'loading' };
+
+    return {
+      kind: 'ready',
+      sessionId,
+      data,
+      selectedNode,
+      selectedRun,
+    };
+  }, [isLoading, error, data, sessionId, selectedNode, selectedRun]);
+
+  return { state, onSelectNode, onCloseNode };
+}

--- a/console/src/hooks/useSessionListRepository.ts
+++ b/console/src/hooks/useSessionListRepository.ts
@@ -1,0 +1,63 @@
+/**
+ * Repository hook for session list data.
+ *
+ * Wraps useSessionList() from the API layer and returns clean domain types.
+ * Callers receive SessionListRepoData -- they never see raw React Query objects.
+ *
+ * Loading detection: uses query.isLoading (NOT query.isFetching).
+ * isLoading is only true when there is no cached data.
+ * isFetching is also true during SSE-triggered background refetches, which
+ * would incorrectly reset the view to a loading state on every server event.
+ *
+ * SSE subscription: NOT subscribed here. useWorkspaceRepository already
+ * maintains the server-sent event connection that invalidates the sessions
+ * cache. Adding a second subscription here would create a redundant SSE
+ * connection since both hooks share the same ['sessions'] React Query key.
+ *
+ * React Query deduplication: useSessionList() uses queryKey ['sessions'].
+ * Since useWorkspaceRepository also calls useSessionList(), React Query will
+ * deduplicate the network request -- no double fetch occurs.
+ */
+import type { ConsoleSessionSummary } from '../api/types';
+import { useSessionList } from '../api/hooks';
+
+// ---------------------------------------------------------------------------
+// Domain type returned by this repository
+// ---------------------------------------------------------------------------
+
+export interface SessionListRepoData {
+  /**
+   * Session list data. Undefined only during the initial fetch (no cached data).
+   */
+  readonly sessions: readonly ConsoleSessionSummary[] | undefined;
+  /**
+   * True only during the initial fetch (no cached data exists yet).
+   * False during SSE-triggered background refetches where stale data remains visible.
+   */
+  readonly isLoading: boolean;
+  /** Non-null only when the sessions query has failed with no recoverable data. */
+  readonly error: Error | null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns clean session list domain data from React Query.
+ *
+ * This hook is the repository layer: it owns the data-fetching boundary.
+ * All React Query details (staleTime, refetchInterval, query keys) are
+ * encapsulated here and never leak to callers.
+ */
+export function useSessionListRepository(): SessionListRepoData {
+  const query = useSessionList();
+
+  return {
+    sessions: query.data?.sessions,
+    // Use isLoading (not isFetching) to avoid flickering back to loading state
+    // during SSE-triggered background refetches where stale data is still visible.
+    isLoading: query.isLoading,
+    error: query.error instanceof Error ? query.error : null,
+  };
+}

--- a/console/src/hooks/useSessionListViewModel.ts
+++ b/console/src/hooks/useSessionListViewModel.ts
@@ -1,0 +1,256 @@
+/**
+ * ViewModel hook for SessionList.
+ *
+ * Orchestrates the repository layer, use cases, and reducer into a single
+ * SessionListViewState discriminated union for the UI to render.
+ *
+ * Owns:
+ * - Repository data (via useSessionListRepository)
+ * - UI interaction state (via sessionListReducer + useReducer)
+ * - Debouncing of the search field (useDebounce -- 200ms)
+ * - Derived display data (statusCounts, processed groups, flatPageSessions)
+ * - Keyboard navigation for the flat (non-grouped) list (useGridKeyNav)
+ *
+ * Does NOT own:
+ * - SSE subscription (handled by useWorkspaceRepository)
+ * - Navigation to session detail (injected via onSelectSession parameter)
+ * - SessionGroup per-group collapse/pagination state (pure UI sub-component)
+ *
+ * Debounce design:
+ * - The reducer stores `rawSearch` (real-time input value).
+ * - The ViewModel debounces rawSearch internally and uses only the debounced
+ *   value in the useMemo filter pipeline to avoid expensive recomputation on
+ *   every keystroke.
+ * - The ViewState exposes `rawSearch` for the input field binding. Callers
+ *   must NOT bind the input to the debounced value.
+ *
+ * Keyboard nav design:
+ * - useGridKeyNav is called unconditionally (React hooks rule).
+ * - count=0 when isGrouped=true -- the hook handles count=0 safely.
+ * - onActivate uses a flatPageSessionsRef to avoid stale closures.
+ */
+import {
+  useReducer,
+  useMemo,
+  useEffect,
+  useRef,
+  useCallback,
+  useState,
+} from 'react';
+import { useSessionListRepository } from './useSessionListRepository';
+import {
+  sessionListReducer,
+  createInitialSessionListState,
+  type SessionListEvent,
+} from '../views/session-list-reducer';
+import {
+  filterSessions,
+  sortSessions,
+  groupSessions,
+  computeStatusCounts,
+  PAGE_SIZE,
+  type SortField,
+  type GroupBy,
+  type StatusFilter,
+  SORT_AXES,
+  GROUP_AXES,
+  STATUS_FILTER_OPTIONS,
+} from '../views/session-list-use-cases';
+import { useGridKeyNav, type UseGridKeyNavResult } from './useGridKeyNav';
+import type { ConsoleSessionSummary } from '../api/types';
+
+// ---------------------------------------------------------------------------
+// Debounce hook (internal)
+// ---------------------------------------------------------------------------
+
+function useDebounce<T>(value: T, delayMs: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setDebouncedValue(value), delayMs);
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, [value, delayMs]);
+
+  return debouncedValue;
+}
+
+// ---------------------------------------------------------------------------
+// View state
+// ---------------------------------------------------------------------------
+
+export type SessionListViewState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | {
+      readonly kind: 'ready';
+      /** Raw (undebounced) search value -- bind the <input> to this field. */
+      readonly rawSearch: string;
+      readonly sort: SortField;
+      readonly groupBy: GroupBy;
+      readonly statusFilter: StatusFilter;
+      readonly page: number;
+      readonly totalPages: number;
+      readonly isGrouped: boolean;
+      readonly processed: {
+        readonly groups: readonly { readonly label: string; readonly sessions: readonly ConsoleSessionSummary[] }[];
+        readonly total: number;
+        readonly filtered: number;
+      };
+      readonly statusCounts: Record<StatusFilter, number>;
+      /** Flat sessions for the current page -- only populated when !isGrouped. */
+      readonly flatPageSessions: readonly ConsoleSessionSummary[];
+      /** Props to spread onto each session card for keyboard navigation. */
+      readonly getSessionNavProps: UseGridKeyNavResult['getItemProps'];
+      /** Props to spread onto the session list container for keyboard navigation. */
+      readonly sessionContainerProps: UseGridKeyNavResult['containerProps'];
+      /** Available sort options. */
+      readonly sortAxes: typeof SORT_AXES;
+      /** Available group options. */
+      readonly groupAxes: typeof GROUP_AXES;
+      /** Available status filter options. */
+      readonly statusFilterOptions: typeof STATUS_FILTER_OPTIONS;
+    };
+
+// ---------------------------------------------------------------------------
+// Hook result
+// ---------------------------------------------------------------------------
+
+export interface UseSessionListViewModelResult {
+  readonly state: SessionListViewState;
+  readonly dispatch: (event: SessionListEvent) => void;
+  /** Navigate to a session. Injected from the caller; presentation does not own navigation. */
+  readonly onSelectSession: (sessionId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Parameters
+// ---------------------------------------------------------------------------
+
+export interface UseSessionListViewModelParams {
+  /** Called when the user selects a session (navigation is the caller's concern). */
+  readonly onSelectSession: (sessionId: string) => void;
+  /**
+   * Optional search string to pre-seed the search field
+   * (e.g. branch name from worktree click-through).
+   */
+  readonly initialSearch?: string;
+}
+
+// ---------------------------------------------------------------------------
+// ViewModel hook
+// ---------------------------------------------------------------------------
+
+export function useSessionListViewModel({
+  onSelectSession,
+  initialSearch = '',
+}: UseSessionListViewModelParams): UseSessionListViewModelResult {
+  const repo = useSessionListRepository();
+  const [interactionState, dispatch] = useReducer(
+    sessionListReducer,
+    undefined,
+    () => createInitialSessionListState(initialSearch),
+  );
+
+  // Debounce the raw search value for the filter/sort/group pipeline.
+  // The raw value drives the input display; debouncedSearch drives the pipeline.
+  const debouncedSearch = useDebounce(interactionState.rawSearch, 200);
+
+  // Stable ref to flatPageSessions to avoid stale closure in onActivate callback.
+  // Updated every render so the callback always accesses the current list.
+  const flatPageSessionsRef = useRef<readonly ConsoleSessionSummary[]>([]);
+
+  // Stable onActivate callback -- reads from ref to avoid stale closure.
+  const onActivate = useCallback(
+    (i: number) => {
+      const session = flatPageSessionsRef.current[i];
+      if (session) onSelectSession(session.sessionId);
+    },
+    [onSelectSession],
+  );
+
+  // Destructure stable scalar values from repo to prevent useMemo re-running
+  // when repo object identity changes (new literal every render).
+  const { sessions, isLoading, error } = repo;
+
+  // Compute status counts from the FULL unfiltered session list.
+  // Invariant: status filter pills show counts for all sessions, regardless
+  // of the active filter. Must use `sessions` not `filteredSessions`.
+  const statusCounts = useMemo(() => {
+    if (!sessions) return {} as Record<StatusFilter, number>;
+    return computeStatusCounts(sessions);
+  }, [sessions]);
+
+  // Main data pipeline: filter -> sort -> group -> paginate
+  const processed = useMemo(() => {
+    if (!sessions) return null;
+    const filtered = filterSessions(sessions, debouncedSearch, interactionState.statusFilter);
+    const sorted = sortSessions(filtered, interactionState.sort);
+    const groups = groupSessions(sorted, interactionState.groupBy);
+    return { groups, total: sessions.length, filtered: filtered.length };
+  }, [sessions, debouncedSearch, interactionState.statusFilter, interactionState.sort, interactionState.groupBy]);
+
+  const isGrouped = interactionState.groupBy !== 'none';
+  const totalPages = processed ? Math.ceil(processed.filtered / PAGE_SIZE) : 0;
+  const pageStart = interactionState.page * PAGE_SIZE;
+  const pageEnd = pageStart + PAGE_SIZE;
+
+  // Flat sessions for the current page (non-grouped path only).
+  const flatPageSessions = useMemo(() => {
+    if (!processed || isGrouped) return [];
+    return processed.groups[0]?.sessions.slice(pageStart, pageEnd) ?? [];
+  }, [processed, isGrouped, pageStart, pageEnd]);
+
+  // Keep ref current for stable onActivate callback.
+  flatPageSessionsRef.current = flatPageSessions;
+
+  // Keyboard navigation for the flat session list.
+  // Called unconditionally -- count=0 when isGrouped=true (safe per useGridKeyNav impl).
+  const { getItemProps: getSessionNavProps, containerProps: sessionContainerProps } = useGridKeyNav({
+    count: flatPageSessions.length,
+    cols: 1,
+    onActivate,
+  });
+
+  // Construct the discriminated view state
+  const state = useMemo((): SessionListViewState => {
+    if (isLoading) return { kind: 'loading' };
+    if (error) return { kind: 'error', message: error.message };
+    if (!processed) return { kind: 'loading' };
+
+    return {
+      kind: 'ready',
+      rawSearch: interactionState.rawSearch,
+      sort: interactionState.sort,
+      groupBy: interactionState.groupBy,
+      statusFilter: interactionState.statusFilter,
+      page: interactionState.page,
+      totalPages,
+      isGrouped,
+      processed,
+      statusCounts,
+      flatPageSessions,
+      getSessionNavProps,
+      sessionContainerProps,
+      sortAxes: SORT_AXES,
+      groupAxes: GROUP_AXES,
+      statusFilterOptions: STATUS_FILTER_OPTIONS,
+    };
+  }, [
+    isLoading,
+    error,
+    processed,
+    interactionState,
+    totalPages,
+    isGrouped,
+    statusCounts,
+    flatPageSessions,
+    getSessionNavProps,
+    sessionContainerProps,
+  ]);
+
+  return { state, dispatch, onSelectSession };
+}

--- a/console/src/hooks/useWorkflowDetailRepository.ts
+++ b/console/src/hooks/useWorkflowDetailRepository.ts
@@ -1,0 +1,74 @@
+/**
+ * Repository hook for workflow detail data.
+ *
+ * Wraps useWorkflowDetail() from the API layer and returns clean domain types.
+ * Callers receive WorkflowDetailRepoData -- they never see raw React Query objects.
+ *
+ * HttpError handling: HTTP 404 is mapped to the `not_found` variant at this
+ * boundary so callers never need to inspect HttpError directly. All other
+ * errors are mapped to the `error` variant with a human-readable message.
+ *
+ * Enabled guard: uses `enabled: !!workflowId` internally (via the underlying
+ * useWorkflowDetail hook) so passing null or empty string triggers no network
+ * request and returns `{ kind: 'loading' }` until a real ID is provided.
+ */
+import type { ConsoleWorkflowDetail } from '../api/types';
+import { useWorkflowDetail, HttpError } from '../api/hooks';
+
+// ---------------------------------------------------------------------------
+// Domain type returned by this repository
+// ---------------------------------------------------------------------------
+
+export type WorkflowDetailRepoData =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'not_found' }
+  | { readonly kind: 'error'; readonly message: string; readonly refetch: () => void }
+  | { readonly kind: 'ready'; readonly detail: ConsoleWorkflowDetail; readonly refetch: () => void };
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns clean workflow detail domain data from React Query.
+ *
+ * This hook is the repository layer: it owns the data-fetching boundary.
+ * All React Query details (staleTime, query keys, HttpError) are encapsulated
+ * here and never leak to callers.
+ *
+ * Pass null or empty string when no workflow is selected -- the query is
+ * disabled and `{ kind: 'loading' }` is returned without triggering a fetch.
+ */
+export function useWorkflowDetailRepository(
+  workflowId: string | null,
+): WorkflowDetailRepoData {
+  const query = useWorkflowDetail(workflowId);
+
+  // Map the stable refetch to a plain () => void so callers
+  // don't need to handle the React Query return value.
+  const refetch = (): void => { void query.refetch(); };
+
+  if (query.isLoading) return { kind: 'loading' };
+
+  if (query.error) {
+    // Map 404 to a typed not_found state so the view can render a
+    // "workflow not found" message without inspecting HttpError directly.
+    if (query.error instanceof HttpError && query.error.status === 404) {
+      return { kind: 'not_found' };
+    }
+    return {
+      kind: 'error',
+      message: query.error instanceof Error
+        ? query.error.message
+        : 'Could not load workflow details.',
+      refetch,
+    };
+  }
+
+  if (query.data) {
+    return { kind: 'ready', detail: query.data, refetch };
+  }
+
+  // No data and no error -- still loading (query disabled or pending).
+  return { kind: 'loading' };
+}

--- a/console/src/hooks/useWorkflowDetailViewModel.ts
+++ b/console/src/hooks/useWorkflowDetailViewModel.ts
@@ -1,0 +1,199 @@
+/**
+ * ViewModel hook for WorkflowDetail.
+ *
+ * Orchestrates the repository layer into a single WorkflowDetailViewState
+ * discriminated union for the UI to render.
+ *
+ * Owns:
+ * - Repository data (via useWorkflowDetailRepository)
+ * - Adjacent workflow list for prev/next navigation (via useWorkflowsRepository)
+ * - Optimistic partial header data while detail loads (from workflows list cache)
+ * - Keyboard navigation: ArrowLeft/ArrowRight for prev/next workflow
+ *   (document-level listener, only installed when kind === 'ready')
+ * - Derived display data: name, description, tags, source, activeTagLabel
+ *
+ * Does NOT own:
+ * - URL navigation (injected via onBack and onNavigateToWorkflow callbacks)
+ * - JSX rendering
+ */
+import { useMemo, useEffect, useRef } from 'react';
+import { useWorkflowDetailRepository } from './useWorkflowDetailRepository';
+import { useWorkflowsRepository } from './useWorkflowsRepository';
+import { getAdjacentWorkflows } from '../views/workflow-detail-use-cases';
+import type { ConsoleWorkflowDetail, ConsoleWorkflowSummary, ConsoleWorkflowSourceInfo } from '../api/types';
+import { TAG_DISPLAY } from '../config/tags';
+
+// ---------------------------------------------------------------------------
+// View state
+// ---------------------------------------------------------------------------
+
+export type WorkflowDetailViewState =
+  | {
+      readonly kind: 'loading';
+      /**
+       * Optimistic partial data from the cached workflow list.
+       * Present when the list cache is warm -- allows the view to render the
+       * header (name, tags, source) while the detail fetch is still in-flight.
+       * Absent during a cold load with no cached data.
+       */
+      readonly cached: ConsoleWorkflowSummary | null;
+      readonly activeTagLabel: string | null;
+      readonly onBack: () => void;
+    }
+  | { readonly kind: 'not_found'; readonly onBack: () => void }
+  | { readonly kind: 'error'; readonly message: string; readonly onBack: () => void; readonly onRetry: () => void }
+  | {
+      readonly kind: 'ready';
+      readonly workflow: ConsoleWorkflowDetail;
+      readonly name: string;
+      readonly description: string | null;
+      readonly tags: readonly string[];
+      readonly source: ConsoleWorkflowSourceInfo | null;
+      readonly activeTagLabel: string | null;
+      readonly adjacentWorkflows: readonly ConsoleWorkflowSummary[];
+      /** Null when this is the first workflow in the adjacent list. */
+      readonly onPrev: (() => void) | null;
+      /** Null when this is the last workflow in the adjacent list. */
+      readonly onNext: (() => void) | null;
+      readonly onBack: () => void;
+    };
+
+// ---------------------------------------------------------------------------
+// Hook result
+// ---------------------------------------------------------------------------
+
+export interface UseWorkflowDetailViewModelResult {
+  readonly state: WorkflowDetailViewState;
+}
+
+// ---------------------------------------------------------------------------
+// Parameters
+// ---------------------------------------------------------------------------
+
+export interface UseWorkflowDetailViewModelParams {
+  /**
+   * The workflow to display. Pass null or empty string when no workflow is
+   * selected -- the query is disabled and the state stays at 'loading'.
+   */
+  readonly workflowId: string | null;
+  /** Active tag filter from the URL, used to derive the breadcrumb label. */
+  readonly activeTag?: string | null;
+  /** Navigate back to the workflows list (preserving tag filter). */
+  readonly onBack: () => void;
+  /** Navigate to an adjacent workflow detail page. */
+  readonly onNavigateToWorkflow: (id: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// ViewModel hook
+// ---------------------------------------------------------------------------
+
+export function useWorkflowDetailViewModel({
+  workflowId,
+  activeTag,
+  onBack,
+  onNavigateToWorkflow,
+}: UseWorkflowDetailViewModelParams): UseWorkflowDetailViewModelResult {
+  const repo = useWorkflowDetailRepository(workflowId);
+
+  // useWorkflowsRepository provides the full non-routines workflow list.
+  // Used for two purposes:
+  //   1. Adjacent workflow list to derive onPrev / onNext
+  //   2. Optimistic partial data (cached list entry) to show header fields
+  //      while the detail fetch is still in-flight.
+  const listRepo = useWorkflowsRepository();
+  const workflows = listRepo.workflows;
+
+  // Refs for keyboard handler -- updated each render so the handler always
+  // calls the latest callbacks without needing to reinstall.
+  const onPrevRef = useRef<(() => void) | null>(null);
+  const onNextRef = useRef<(() => void) | null>(null);
+  const onNavigateToWorkflowRef = useRef(onNavigateToWorkflow);
+  onNavigateToWorkflowRef.current = onNavigateToWorkflow;
+
+  // Derive adjacent navigation via pure use case. adjacentWorkflows is the
+  // full non-routines list in catalog order (no tag filter applied -- navigate
+  // across all workflows, not just the current tag filter).
+  const adjacentWorkflows: readonly ConsoleWorkflowSummary[] = workflows ?? [];
+  const { prevWorkflow, nextWorkflow } = useMemo(
+    () => getAdjacentWorkflows(workflowId, adjacentWorkflows),
+    [workflowId, adjacentWorkflows],
+  );
+
+  const onPrev = prevWorkflow
+    ? (): void => onNavigateToWorkflowRef.current(prevWorkflow.id)
+    : null;
+  const onNext = nextWorkflow
+    ? (): void => onNavigateToWorkflowRef.current(nextWorkflow.id)
+    : null;
+
+  // Keep refs current so the keyboard handler always calls the latest callbacks.
+  onPrevRef.current = onPrev;
+  onNextRef.current = onNext;
+
+  // Document-level keyboard handler: ArrowLeft / ArrowRight navigate to
+  // prev / next workflow. Installed only when state is 'ready'.
+  // Uses a single stable effect with refs to prevent stale closures.
+  const isReady = repo.kind === 'ready';
+  useEffect(() => {
+    if (!isReady) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        onPrevRef.current?.();
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        onNextRef.current?.();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isReady]);
+
+  const state = useMemo((): WorkflowDetailViewState => {
+    // Optimistic partial data from the cached workflow list. Used to populate
+    // header fields (name, description, tags, source) while the detail fetch
+    // is still loading, giving the user immediate visual feedback.
+    const cachedPartial = workflows?.find((w) => w.id === workflowId) ?? undefined;
+
+    const activeTagLabel = activeTag ? (TAG_DISPLAY[activeTag] ?? activeTag) : null;
+
+    if (repo.kind === 'not_found') return { kind: 'not_found', onBack };
+    if (repo.kind === 'error') return { kind: 'error', message: repo.message, onBack, onRetry: repo.refetch };
+
+    if (repo.kind === 'ready') {
+      const detail = repo.detail;
+
+      // Derive display fields with detail as primary source and cached partial
+      // as fallback. Both should have the same values once detail loads, but
+      // the fallback prevents a flash of missing data during the fetch.
+      const name = detail.name ?? cachedPartial?.name ?? workflowId ?? '';
+      const description = detail.description ?? cachedPartial?.description ?? null;
+      const tags = detail.tags ?? cachedPartial?.tags ?? [];
+      const source = detail.source ?? cachedPartial?.source ?? null;
+
+      return {
+        kind: 'ready',
+        workflow: detail,
+        name,
+        description,
+        tags,
+        source,
+        activeTagLabel,
+        adjacentWorkflows,
+        onPrev,
+        onNext,
+        onBack,
+      };
+    }
+
+    // kind === 'loading': include cached partial data so the view can render
+    // the header optimistically while the detail fetch is still in-flight.
+    return { kind: 'loading', cached: cachedPartial ?? null, activeTagLabel, onBack };
+  }, [repo, workflows, workflowId, activeTag, adjacentWorkflows, onPrev, onNext, onBack]);
+
+  return { state };
+}

--- a/console/src/hooks/useWorkflowsRepository.ts
+++ b/console/src/hooks/useWorkflowsRepository.ts
@@ -1,0 +1,56 @@
+/**
+ * Repository hook for workflows catalog data.
+ *
+ * Wraps useWorkflowList() from the API layer and returns clean domain types.
+ * Callers receive WorkflowsRepoData -- they never see raw React Query objects.
+ *
+ * The 'routines' tag exclusion happens here so all downstream consumers
+ * (use cases, ViewModel, view) receive a pre-filtered list.
+ */
+import type { ConsoleWorkflowSummary } from '../api/types';
+import { useWorkflowList } from '../api/hooks';
+
+// ---------------------------------------------------------------------------
+// Domain type returned by this repository
+// ---------------------------------------------------------------------------
+
+export interface WorkflowsRepoData {
+  /**
+   * Workflow list, excluding 'routines' workflows.
+   * Undefined only during the initial fetch (no cached data).
+   */
+  readonly workflows: readonly ConsoleWorkflowSummary[] | undefined;
+  /**
+   * True only during the initial fetch (no cached data exists yet).
+   */
+  readonly isLoading: boolean;
+  /** Non-null only when the workflows query has failed with no recoverable data. */
+  readonly error: Error | null;
+  /** Triggers an immediate re-fetch of workflow data. */
+  readonly refetch: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns clean workflows domain data from React Query.
+ *
+ * This hook is the repository layer: it owns the data-fetching boundary.
+ * All React Query details (staleTime, query keys) are encapsulated here
+ * and never leak to callers.
+ */
+export function useWorkflowsRepository(): WorkflowsRepoData {
+  const query = useWorkflowList();
+
+  return {
+    // Filter out 'routines' at the boundary so downstream consumers never
+    // see them. Routines are implementation building blocks for workflow
+    // authors, not user-facing catalog entries.
+    workflows: query.data?.workflows.filter((w) => !w.tags.includes('routines')),
+    isLoading: query.isLoading,
+    error: query.error instanceof Error ? query.error : null,
+    refetch: query.refetch,
+  };
+}

--- a/console/src/hooks/useWorkflowsViewModel.ts
+++ b/console/src/hooks/useWorkflowsViewModel.ts
@@ -1,0 +1,246 @@
+/**
+ * ViewModel hook for WorkflowsView.
+ *
+ * Orchestrates the repository layer, use cases, and reducer into a single
+ * WorkflowsViewState discriminated union for the UI to render.
+ *
+ * Owns:
+ * - Repository data (via useWorkflowsRepository)
+ * - UI interaction state (via workflowsReducer + useReducer)
+ * - Derived display data (availableTags, availableSources, filteredWorkflows, flatWorkflows)
+ * - Keyboard ownership:
+ *     Escape           -> this ViewModel (dispatches modal_closed)
+ *     ArrowLeft/Right  -> WorkflowsView (requires modalTransition.navigate, which ViewModel does not own)
+ *     Grid j/k/arrows  -> useGridKeyNav in WorkflowsView (catalog nav, no modal)
+ * - Focus management (blur trigger element on modal open, restore on close)
+ * - Body scroll lock when modal is open
+ * - triggerRef: ref to the focused element before modal opens
+ *
+ * Does NOT own:
+ * - useModalTransition -- stays in WorkflowsView since it's pure animation state
+ * - scrollRef -- stays in WorkflowsView (pure UI concern)
+ * - modalPanelRef -- stays in WorkflowsView (rAF focus target)
+ *
+ * Tag handling:
+ * - selectedTag is URL-driven. The ViewModel accepts initialTag as a parameter and
+ *   calls onSelectTag when the tag changes so AppShell can sync the URL.
+ */
+import {
+  useReducer,
+  useMemo,
+  useEffect,
+  useRef,
+  useCallback,
+  type RefObject,
+} from 'react';
+import { useWorkflowsRepository } from './useWorkflowsRepository';
+import {
+  workflowsReducer,
+  INITIAL_WORKFLOWS_STATE,
+  type WorkflowsEvent,
+} from '../views/workflows-reducer';
+import {
+  getAvailableTags,
+  getAvailableSources,
+  filterWorkflows,
+  flattenWorkflows,
+  type WorkflowSourceOption,
+} from '../views/workflows-use-cases';
+import type { ConsoleWorkflowSummary } from '../api/types';
+
+// ---------------------------------------------------------------------------
+// View state
+// ---------------------------------------------------------------------------
+
+export type WorkflowsViewState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string; readonly onRetry: () => void }
+  | {
+      readonly kind: 'ready';
+      readonly selectedWorkflowId: string | null;
+      readonly selectedTag: string | null;
+      readonly selectedSource: string | null;
+      readonly hintVisible: boolean;
+      readonly availableTags: readonly string[];
+      readonly availableSources: readonly WorkflowSourceOption[];
+      readonly filteredWorkflows: readonly ConsoleWorkflowSummary[];
+      readonly flatWorkflows: readonly ConsoleWorkflowSummary[];
+    };
+
+// ---------------------------------------------------------------------------
+// Hook result
+// ---------------------------------------------------------------------------
+
+export interface UseWorkflowsViewModelResult {
+  readonly state: WorkflowsViewState;
+  readonly dispatch: (event: WorkflowsEvent) => void;
+  /** Ref to the element that triggered the modal open. Restored focus on close. */
+  readonly triggerRef: RefObject<HTMLElement | null>;
+  /**
+   * Call this instead of dispatching workflow_selected directly.
+   * Captures the trigger element for focus restoration and blurs it before
+   * opening the modal (so blur does not fire after the modal is visible).
+   */
+  readonly onCardSelect: (id: string, triggerEl: HTMLButtonElement) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Parameters
+// ---------------------------------------------------------------------------
+
+export interface UseWorkflowsViewModelParams {
+  /** Initial tag from the URL search param. Initializes the reducer's selectedTag. */
+  readonly initialTag: string | null;
+  /**
+   * Called when the user changes the tag filter so AppShell can sync the URL.
+   * The ViewModel dispatches tag_changed AND calls this callback.
+   */
+  readonly onSelectTag: (tag: string | null) => void;
+}
+
+// ---------------------------------------------------------------------------
+// ViewModel hook
+// ---------------------------------------------------------------------------
+
+export function useWorkflowsViewModel({
+  initialTag,
+  onSelectTag,
+}: UseWorkflowsViewModelParams): UseWorkflowsViewModelResult {
+  const repo = useWorkflowsRepository();
+
+  const [interactionState, dispatch] = useReducer(workflowsReducer, {
+    ...INITIAL_WORKFLOWS_STATE,
+    selectedTag: initialTag,
+  });
+
+  // Keep selectedTag in sync with URL-driven initialTag.
+  // useWorkflowsViewModel is mounted unconditionally in AppShell (not inside the
+  // workflows tab conditional), so it never remounts on tab switch. The reducer
+  // seeds from initialTag once; this effect keeps it reactive to external navigation
+  // (e.g. browser back/forward or direct link to /workflows?tag=foo).
+  useEffect(() => {
+    if (initialTag !== interactionState.selectedTag) {
+      dispatch({ type: 'tag_changed', tag: initialTag });
+    }
+    // dispatch is stable (useReducer guarantee); interactionState.selectedTag is read
+    // inside the effect body, not as a dep, to avoid re-firing after the dispatch itself.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialTag]);
+
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  // Stable callback: capture trigger element, blur it, then dispatch workflow_selected.
+  // Blur must happen before dispatch so it does not fire after the modal becomes visible
+  // and confuse focus management. (See design-review-findings.md, Yellow finding.)
+  const onCardSelect = useCallback((id: string, triggerEl: HTMLButtonElement) => {
+    triggerRef.current = triggerEl;
+    triggerEl.blur();
+    dispatch({ type: 'workflow_selected', id });
+  }, []);
+
+  // Focus management: move focus into the modal on open, restore to trigger on close.
+  // modalPanelRef lives in the view -- the view passes it as a focus target via rAF.
+  // Here we only handle the restore-to-trigger path.
+  useEffect(() => {
+    if (!interactionState.selectedWorkflowId && triggerRef.current) {
+      const el = triggerRef.current;
+      triggerRef.current = null;
+      el.focus();
+    }
+  }, [interactionState.selectedWorkflowId]);
+
+  // Body scroll lock when modal is open.
+  // Setting overflow:hidden alone resets scroll to top -- position:fixed preserves it.
+  useEffect(() => {
+    if (!interactionState.selectedWorkflowId) return;
+
+    const scrollY = window.scrollY;
+    document.body.style.overflow = 'hidden';
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = '100%';
+
+    return () => {
+      document.body.style.overflow = '';
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.width = '';
+      window.scrollTo(0, scrollY);
+    };
+  }, [interactionState.selectedWorkflowId]);
+
+  // Keyboard: Escape closes the modal.
+  // ArrowLeft/ArrowRight navigation is handled in the view because it requires
+  // access to modalTransition.navigate (which the ViewModel does not own).
+  useEffect(() => {
+    if (!interactionState.selectedWorkflowId) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') dispatch({ type: 'modal_closed' });
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [interactionState.selectedWorkflowId]);
+
+  // Derive display data from repo + interaction state.
+  // Computed before the hint effect so flatWorkflows.length is readable without
+  // a duplicate filter/flatten computation.
+  const { isLoading, error, workflows } = repo;
+
+  const state = useMemo((): WorkflowsViewState => {
+    if (isLoading) return { kind: 'loading' };
+    if (error) return { kind: 'error', message: error.message, onRetry: repo.refetch };
+    if (!workflows) return { kind: 'loading' };
+
+    const availableTags = getAvailableTags(workflows);
+    const availableSources = getAvailableSources(workflows);
+    const filteredWorkflows = filterWorkflows(
+      workflows,
+      interactionState.selectedTag,
+      interactionState.selectedSource,
+    );
+    const flat = flattenWorkflows(filteredWorkflows, interactionState.selectedTag);
+
+    return {
+      kind: 'ready',
+      selectedWorkflowId: interactionState.selectedWorkflowId,
+      selectedTag: interactionState.selectedTag,
+      selectedSource: interactionState.selectedSource,
+      hintVisible: interactionState.hintVisible,
+      availableTags,
+      availableSources,
+      filteredWorkflows,
+      flatWorkflows: flat,
+    };
+  }, [
+    isLoading,
+    error,
+    workflows,
+    interactionState,
+    repo.refetch,
+  ]);
+
+  // Hint auto-dismiss: show hint briefly when modal opens with multiple workflows.
+  // Reads flatWorkflows.length from the already-computed state rather than
+  // duplicating the filter/flatten pipeline.
+  // Cleanup cancels the timer if the modal closes before 3s to prevent a stale
+  // dispatch from hiding the hint on the next open.
+  const flatWorkflowsLength = state.kind === 'ready' ? state.flatWorkflows.length : 0;
+  useEffect(() => {
+    if (!interactionState.selectedWorkflowId || flatWorkflowsLength <= 1) return;
+    const id = setTimeout(() => dispatch({ type: 'hint_dismissed' }), 3000);
+    return () => clearTimeout(id);
+  }, [interactionState.selectedWorkflowId, flatWorkflowsLength]);
+
+  // Wrap dispatch to intercept tag_changed events and call onSelectTag for URL sync.
+  const wrappedDispatch = useCallback(
+    (event: WorkflowsEvent) => {
+      if (event.type === 'tag_changed') {
+        onSelectTag(event.tag);
+      }
+      dispatch(event);
+    },
+    [onSelectTag],
+  );
+
+  return { state, dispatch: wrappedDispatch, triggerRef, onCardSelect };
+}

--- a/console/src/hooks/useWorkspaceRepository.ts
+++ b/console/src/hooks/useWorkspaceRepository.ts
@@ -1,0 +1,84 @@
+/**
+ * Repository hook for workspace data.
+ *
+ * Wraps React Query hooks (useSessionList, useWorktreeList, useWorkspaceEvents)
+ * and returns clean domain types. Callers receive WorkspaceRepoData -- they
+ * never see raw React Query objects.
+ *
+ * Loading detection: uses query.isLoading (NOT query.isFetching).
+ * isLoading is only true when there is no cached data.
+ * isFetching is also true during SSE-triggered background refetches, which
+ * would incorrectly reset the view to a loading state on every server event.
+ *
+ * SSE subscription: useWorkspaceEvents() is called here to maintain the
+ * server-sent event connection that invalidates the sessions cache in
+ * real time. It must be called in the repository so the subscription
+ * lifetime is tied to the WorkspaceView's mount lifetime.
+ */
+import type { ConsoleSessionSummary, ConsoleRepoWorktrees } from '../api/types';
+import { useSessionList, useWorktreeList, useWorkspaceEvents } from '../api/hooks';
+
+// ---------------------------------------------------------------------------
+// Domain type returned by this repository
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceRepoData {
+  /** Session list data. Undefined only during the initial fetch (no cached data). */
+  readonly sessions: readonly ConsoleSessionSummary[] | undefined;
+  /** Worktree repos. Defaults to empty array while loading. */
+  readonly worktreeRepos: readonly ConsoleRepoWorktrees[];
+  /**
+   * True only during the initial fetch (no cached data exists yet).
+   * False during SSE-triggered background refetches where stale data remains visible.
+   */
+  readonly isLoading: boolean;
+  /** Non-null only when the sessions query has failed with no recoverable data. */
+  readonly error: Error | null;
+  /** Triggers an immediate re-fetch of session data. */
+  readonly refetch: () => void;
+  /** True while the worktrees enrichment fetch is in progress. */
+  readonly worktreesFetching: boolean;
+  /** Count of sessions currently in progress. 0 when sessions are not yet loaded. */
+  readonly liveCount: number;
+  /** Count of sessions currently blocked. 0 when sessions are not yet loaded. */
+  readonly blockedCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns clean workspace domain data from React Query.
+ *
+ * This hook is the repository layer: it owns the data-fetching boundary.
+ * All React Query details (staleTime, refetchInterval, query keys) are
+ * encapsulated here and never leak to callers.
+ */
+export function useWorkspaceRepository(): WorkspaceRepoData {
+  const sessionsQuery = useSessionList();
+  const worktreesQuery = useWorktreeList();
+
+  // Subscribe to server-sent events. This call has no return value;
+  // its side effect is to invalidate the sessions cache when the server
+  // reports a change. Must be called here (not in the ViewModel) so the
+  // SSE connection lifetime is tied to this hook's mount lifetime.
+  // In practice this is AppShell's lifetime (never unmounts), which is
+  // the intended behavior -- the workspace stays live for the entire session.
+  useWorkspaceEvents();
+
+  const sessions = sessionsQuery.data?.sessions;
+
+  return {
+    sessions,
+    worktreeRepos: worktreesQuery.data?.repos ?? [],
+    // Use isLoading (not isFetching) to avoid flickering back to loading state
+    // during SSE-triggered background refetches where stale data is still visible.
+    isLoading: sessionsQuery.isLoading,
+    error: sessionsQuery.error instanceof Error ? sessionsQuery.error : null,
+    refetch: sessionsQuery.refetch,
+    worktreesFetching: worktreesQuery.isFetching,
+    liveCount: sessions?.filter((s) => s.status === 'in_progress').length ?? 0,
+    blockedCount: sessions?.filter((s) => s.status === 'blocked').length ?? 0,
+  };
+}

--- a/console/src/hooks/useWorkspaceViewModel.ts
+++ b/console/src/hooks/useWorkspaceViewModel.ts
@@ -1,0 +1,290 @@
+/**
+ * ViewModel hook for WorkspaceView.
+ *
+ * Orchestrates the repository layer, use cases, and reducer into a single
+ * WorkspaceViewState discriminated union for the UI to render.
+ *
+ * Owns:
+ * - Repository data (via useWorkspaceRepository)
+ * - UI interaction state (via workspaceReducer + useReducer)
+ * - Derived display data (via buildRepoGroups in useMemo)
+ * - Keyboard navigation (via useWorkspaceKeyboard helper)
+ * - Scroll position ref (captured before navigation, restored on return)
+ * - Side effects: repo.refetch() called directly when 'r' key is pressed
+ *
+ * Does NOT own:
+ * - expandStateRef (UI concern -- kept in WorkspaceView to survive SSE remounts)
+ */
+import {
+  useReducer,
+  useMemo,
+  useEffect,
+  useRef,
+  useCallback,
+  type RefObject,
+} from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { useWorkspaceRepository } from './useWorkspaceRepository';
+import {
+  workspaceReducer,
+  INITIAL_WORKSPACE_STATE,
+  type WorkspaceEvent,
+  type ArchiveState,
+} from '../views/workspace-reducer';
+import {
+  buildRepoGroups,
+  type RepoGroup,
+  type WorkspaceItem,
+  type Scope,
+} from '../views/workspace-types';
+
+// ---------------------------------------------------------------------------
+// View state
+// ---------------------------------------------------------------------------
+
+export type WorkspaceViewState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | {
+      readonly kind: 'ready';
+      readonly scope: Scope;
+      readonly focusedIndex: number;
+      readonly archive: ArchiveState | null;
+      readonly repoGroups: readonly RepoGroup[];
+      readonly orderedItems: readonly WorkspaceItem[];
+      readonly archiveRepos: ReadonlyArray<readonly [string, string]>;
+      readonly dormantHiddenCount: number;
+      readonly worktreesFetching: boolean;
+      readonly hasAnySessions: boolean;
+      /** Count of sessions currently in progress. Derived from repository sessions. */
+      readonly liveCount: number;
+      /** Count of sessions currently blocked. Derived from repository sessions. */
+      readonly blockedCount: number;
+    };
+
+// ---------------------------------------------------------------------------
+// Hook result
+// ---------------------------------------------------------------------------
+
+export interface UseWorkspaceViewModelResult {
+  readonly state: WorkspaceViewState;
+  readonly dispatch: (event: WorkspaceEvent) => void;
+  /** Scroll Y position captured before session-detail navigation. Restored on return. */
+  readonly scrollYRef: RefObject<number>;
+  /** Navigate to a session detail page. Captures scroll position before navigating. */
+  readonly onSelectSession: (sessionId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Internal keyboard hook
+// ---------------------------------------------------------------------------
+
+interface WorkspaceKeyboardOptions {
+  readonly items: readonly WorkspaceItem[];
+  readonly focusedIndex: number;
+  readonly scope: Scope;
+  readonly archive: ArchiveState | null;
+  readonly dispatch: (event: WorkspaceEvent) => void;
+  readonly onSelectSession: (sessionId: string) => void;
+  /** Called when the user presses 'r'. Side effect; not dispatched as an event. */
+  readonly onRefetch: () => void;
+  readonly disabled: boolean;
+}
+
+/**
+ * Installs a document-level keydown handler for workspace keyboard navigation.
+ *
+ * Keys:
+ *   j / ArrowDown  -> focus_moved (next item)
+ *   k / ArrowUp    -> focus_moved (prev item)
+ *   Enter / Space  -> navigate to focused item's primary session
+ *   /              -> archive_opened (global archive)
+ *   r              -> calls onRefetch() directly (side effect, not an event)
+ *   a              -> scope_changed (toggle active <-> all)
+ *   Escape         -> archive_closed (when archive is open)
+ *
+ * Skips when modifier keys are held or when focus is in a form control.
+ */
+function useWorkspaceKeyboard({
+  items,
+  focusedIndex,
+  scope,
+  archive,
+  dispatch,
+  onSelectSession,
+  onRefetch,
+  disabled,
+}: WorkspaceKeyboardOptions): void {
+  // Refs prevent stale closures inside the stable event listener
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+  const focusedIndexRef = useRef(focusedIndex);
+  focusedIndexRef.current = focusedIndex;
+  const scopeRef = useRef(scope);
+  scopeRef.current = scope;
+  const archiveRef = useRef(archive);
+  archiveRef.current = archive;
+  const disabledRef = useRef(disabled);
+  disabledRef.current = disabled;
+  const dispatchRef = useRef(dispatch);
+  dispatchRef.current = dispatch;
+  const onSelectSessionRef = useRef(onSelectSession);
+  onSelectSessionRef.current = onSelectSession;
+  const onRefetchRef = useRef(onRefetch);
+  onRefetchRef.current = onRefetch;
+
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      if (disabledRef.current) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      const active = document.activeElement;
+      if (
+        active instanceof HTMLInputElement ||
+        active instanceof HTMLTextAreaElement ||
+        active instanceof HTMLSelectElement
+      ) {
+        return;
+      }
+
+      const items = itemsRef.current;
+      const focusedIndex = focusedIndexRef.current;
+
+      switch (e.key) {
+        case 'j':
+        case 'ArrowDown': {
+          e.preventDefault();
+          dispatchRef.current({
+            type: 'focus_moved',
+            index: Math.min(focusedIndex + 1, items.length - 1),
+          });
+          break;
+        }
+        case 'k':
+        case 'ArrowUp': {
+          e.preventDefault();
+          dispatchRef.current({
+            type: 'focus_moved',
+            index: Math.max(focusedIndex - 1, 0),
+          });
+          break;
+        }
+        case 'Enter':
+        case ' ': {
+          e.preventDefault();
+          if (focusedIndex >= 0 && focusedIndex < items.length) {
+            const item = items[focusedIndex];
+            const sessionId = item?.primarySession?.sessionId;
+            if (sessionId) {
+              onSelectSessionRef.current(sessionId);
+            }
+          }
+          break;
+        }
+        case 'Escape': {
+          if (archiveRef.current !== null) {
+            dispatchRef.current({ type: 'archive_closed' });
+          }
+          break;
+        }
+        case '/': {
+          e.preventDefault();
+          dispatchRef.current({ type: 'archive_opened', repoName: undefined });
+          break;
+        }
+        case 'r': {
+          e.preventDefault();
+          onRefetchRef.current();
+          break;
+        }
+        case 'a': {
+          e.preventDefault();
+          dispatchRef.current({
+            type: 'scope_changed',
+            scope: scopeRef.current === 'active' ? 'all' : 'active',
+          });
+          break;
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+// ---------------------------------------------------------------------------
+// ViewModel hook
+// ---------------------------------------------------------------------------
+
+export function useWorkspaceViewModel(disabled = false): UseWorkspaceViewModelResult {
+  const navigate = useNavigate();
+  const repo = useWorkspaceRepository();
+  const [interactionState, dispatch] = useReducer(workspaceReducer, INITIAL_WORKSPACE_STATE);
+
+  const scrollYRef = useRef<number>(0);
+
+  const onSelectSession = useCallback(
+    (sessionId: string) => {
+      scrollYRef.current = window.scrollY;
+      void navigate({ to: '/session/$sessionId', params: { sessionId } });
+    },
+    [navigate],
+  );
+
+  // dispatch from useReducer is stable by React spec -- no need to wrap.
+  const wrappedDispatch = dispatch;
+
+  // Derive display data from repo + interaction state
+  const repoGroupsResult = useMemo(() => {
+    if (!repo.sessions) return null;
+    return buildRepoGroups(
+      repo.sessions,
+      repo.worktreeRepos,
+      interactionState.scope,
+      Date.now(),
+    );
+  }, [repo.sessions, repo.worktreeRepos, interactionState.scope]);
+
+  // Install keyboard navigation handler
+  useWorkspaceKeyboard({
+    items: repoGroupsResult?.orderedItems ?? [],
+    focusedIndex: interactionState.focusedIndex,
+    scope: interactionState.scope,
+    archive: interactionState.archive,
+    dispatch: wrappedDispatch,
+    onSelectSession,
+    onRefetch: repo.refetch,
+    disabled,
+  });
+
+  // Destructure stable scalar values from repo so the state memo only
+  // re-runs when specific values change -- not whenever the repo object
+  // identity changes (which is every render since it's a new literal).
+  const { isLoading, error, worktreesFetching, sessions, liveCount, blockedCount } = repo;
+
+  // Construct the discriminated view state from repo data + interaction state
+  const state: WorkspaceViewState = useMemo((): WorkspaceViewState => {
+    if (isLoading) return { kind: 'loading' };
+    if (error) return { kind: 'error', message: error.message };
+    if (!repoGroupsResult) return { kind: 'loading' };
+
+    return {
+      kind: 'ready',
+      scope: interactionState.scope,
+      focusedIndex: interactionState.focusedIndex,
+      archive: interactionState.archive,
+      repoGroups: repoGroupsResult.repoGroups,
+      orderedItems: repoGroupsResult.orderedItems,
+      archiveRepos: repoGroupsResult.archiveRepos,
+      dormantHiddenCount: repoGroupsResult.dormantHiddenCount,
+      worktreesFetching,
+      hasAnySessions: (sessions?.length ?? 0) > 0,
+      liveCount,
+      blockedCount,
+    };
+  }, [isLoading, error, worktreesFetching, sessions, repoGroupsResult, interactionState, liveCount, blockedCount]);
+
+  return { state, dispatch: wrappedDispatch, scrollYRef, onSelectSession };
+}

--- a/console/src/views/PerformanceView.tsx
+++ b/console/src/views/PerformanceView.tsx
@@ -1,10 +1,15 @@
-import { useState, useMemo } from 'react';
-import { usePerfToolCalls } from '../api/hooks';
 import type { ToolCallTiming } from '../api/types';
 import { formatRelativeTime } from '../utils/time';
+import {
+  SORT_OPTIONS,
+  OUTCOME_CONFIG,
+  computeBarWidth,
+  type Outcome,
+} from './performance-use-cases';
+import type { UsePerformanceViewModelResult } from '../hooks/usePerformanceViewModel';
 
 // ---------------------------------------------------------------------------
-// Column configuration (A1)
+// Column configuration
 // Drives thead rendering; TimingRow still renders hardcoded cells but this
 // documents the column contract and makes header generation extend-safe.
 // ---------------------------------------------------------------------------
@@ -24,50 +29,29 @@ const COLUMNS: readonly ColumnDef[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Sort configuration (A2)
+// Props
 // ---------------------------------------------------------------------------
 
-type SortOrder = 'recent' | 'slowest';
-
-interface SortOption {
-  readonly value: SortOrder;
-  readonly label: string;
-  readonly compareFn: (a: ToolCallTiming, b: ToolCallTiming) => number;
+interface Props {
+  /**
+   * ViewModel result from usePerformanceViewModel().
+   * PerformanceView is a pure presentational component -- it does not fetch data.
+   */
+  readonly viewModel: UsePerformanceViewModelResult;
 }
 
-const SORT_OPTIONS: readonly SortOption[] = [
-  { value: 'recent', label: 'Recent first', compareFn: (a, b) => b.startedAtMs - a.startedAtMs },
-  { value: 'slowest', label: 'Slowest first', compareFn: (a, b) => b.durationMs - a.durationMs },
-];
-
 // ---------------------------------------------------------------------------
-// Outcome configuration (M6 single source of truth)
+// PerformanceView -- pure presenter
 // ---------------------------------------------------------------------------
 
-type Outcome = 'success' | 'error' | 'unknown_tool';
+export function PerformanceView({ viewModel }: Props) {
+  const { state } = viewModel;
 
-const OUTCOME_CONFIG: Record<
-  Outcome,
-  { readonly color: string; readonly label: string; readonly isError: boolean }
-> = {
-  success: { color: 'var(--success)', label: 'OK', isError: false },
-  error: { color: 'var(--error)', label: 'Error', isError: true },
-  unknown_tool: { color: 'var(--warning)', label: 'Unknown', isError: true },
-};
-
-// ---------------------------------------------------------------------------
-// PerformanceView
-// ---------------------------------------------------------------------------
-
-export function PerformanceView() {
-  const result = usePerfToolCalls();
-  const [sortOrder, setSortOrder] = useState<SortOrder>('recent');
-
-  if (result.state === 'loading') {
+  if (state.kind === 'loading') {
     return <PerfSkeleton />;
   }
 
-  if (result.state === 'devModeOff') {
+  if (state.kind === 'devModeOff') {
     return (
       <div className="flex items-center justify-center py-16">
         <p className="text-sm text-[var(--text-muted)] text-center">
@@ -77,13 +61,13 @@ export function PerformanceView() {
     );
   }
 
-  if (result.state === 'error') {
+  if (state.kind === 'error') {
     return (
       <div className="space-y-3 py-8 text-center">
-        <p className="text-sm text-[var(--error)]">{result.message}</p>
+        <p className="text-sm text-[var(--error)]">{state.message}</p>
         <button
           type="button"
-          onClick={result.retry}
+          onClick={state.retry}
           className="text-sm text-[var(--accent)] hover:text-[var(--accent-hover)] transition-colors"
         >
           Try again
@@ -92,57 +76,17 @@ export function PerformanceView() {
     );
   }
 
-  const { observations } = result.data;
-
-  return (
-    <PerfContent
-      observations={observations}
-      sortOrder={sortOrder}
-      onSortChange={setSortOrder}
-    />
-  );
-}
-
-// ---------------------------------------------------------------------------
-// PerfContent -- populated + empty state
-// ---------------------------------------------------------------------------
-
-function PerfContent({
-  observations,
-  sortOrder,
-  onSortChange,
-}: {
-  readonly observations: readonly ToolCallTiming[];
-  readonly sortOrder: SortOrder;
-  readonly onSortChange: (order: SortOrder) => void;
-}) {
-  const sorted = useMemo(() => {
-    // A2: find the matching SortOption and use its compareFn
-    const option = SORT_OPTIONS.find((o) => o.value === sortOrder)!;
-    return [...observations].sort(option.compareFn);
-  }, [observations, sortOrder]);
-
-  // M2: use reduce to avoid Math.max(...spread) latent crash on large arrays
-  const maxDuration = useMemo(
-    () => sorted.reduce((max, o) => Math.max(max, o.durationMs), 0),
-    [sorted],
-  );
-
-  const errorCount = observations.filter((o) => OUTCOME_CONFIG[o.outcome].isError).length;
-
-  const avgMs =
-    observations.length > 0
-      ? Math.round(observations.reduce((sum, o) => sum + o.durationMs, 0) / observations.length)
-      : null;
-
-  // M2: use reduce to avoid Math.max(...spread) latent crash on large arrays
-  const lastCallMs =
-    observations.length > 0
-      ? observations.reduce((max, o) => Math.max(max, o.startedAtMs), 0)
-      : null;
-
-  // M4: show truncation indicator when ring buffer contains more than the window
-  const countLabel = `${observations.length} recorded`;
+  // state.kind === 'ready'
+  const {
+    sorted,
+    maxDuration,
+    errorCount,
+    avgMs,
+    lastCallMs,
+    countLabel,
+    sortOrder,
+    onSortChange,
+  } = state;
 
   return (
     <div className="space-y-3">
@@ -225,8 +169,7 @@ function TimingRow({
 }) {
   // M6: derive isError from OUTCOME_CONFIG (single source of truth)
   const isErrorRow = OUTCOME_CONFIG[obs.outcome].isError;
-  const barWidth =
-    maxDuration > 0 ? Math.round((obs.durationMs / maxDuration) * 120) : 0;
+  const barWidth = computeBarWidth(obs.durationMs, maxDuration);
 
   return (
     <tr

--- a/console/src/views/SessionDetail.tsx
+++ b/console/src/views/SessionDetail.tsx
@@ -1,19 +1,17 @@
-import { useState, useCallback } from 'react';
-import { useSessionDetail } from '../api/hooks';
 import { RunLineageDag } from '../components/RunLineageDag';
 import { StatusBadge } from '../components/StatusBadge';
 import { HealthBadge } from '../components/HealthBadge';
 import { NodeDetailSection } from '../components/NodeDetailSection';
 import { CutCornerBox } from '../components/CutCornerBox';
 import type { ConsoleSessionDetail, ConsoleDagRun } from '../api/types';
+import type { UseSessionDetailViewModelResult } from '../hooks/useSessionDetailViewModel';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
 
 interface Props {
-  sessionId: string;
-}
-
-interface SelectedNode {
-  runId: string;
-  nodeId: string;
+  readonly viewModel: UseSessionDetailViewModelResult;
 }
 
 // ---------------------------------------------------------------------------
@@ -97,36 +95,26 @@ function HintBanner({ runs }: { runs: readonly ConsoleDagRun[] }) {
 }
 
 // ---------------------------------------------------------------------------
-// SessionDetail
+// SessionDetail -- pure presenter
 // ---------------------------------------------------------------------------
 
-export function SessionDetail({ sessionId }: Props) {
-  const { data, isLoading, error } = useSessionDetail(sessionId);
-  const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
+export function SessionDetail({ viewModel }: Props) {
+  const { state, onSelectNode, onCloseNode } = viewModel;
 
-  const handleNodeClick = useCallback((runId: string, nodeId: string) => {
-    setSelectedNode((prev) =>
-      prev?.runId === runId && prev?.nodeId === nodeId ? null : { runId, nodeId },
-    );
-  }, []);
-
-  if (isLoading) {
+  if (state.kind === 'loading') {
     return <div className="text-[var(--text-secondary)]">Loading session...</div>;
   }
 
-  if (error) {
+  if (state.kind === 'error') {
     return (
       <div className="text-[var(--error)] bg-[var(--bg-card)] rounded-lg p-4">
-        Failed to load session: {error.message}
+        Failed to load session: {state.message}
       </div>
     );
   }
 
-  if (!data) return null;
-
-  const selectedRun = selectedNode
-    ? (data.runs.find((r) => r.runId === selectedNode.runId) ?? null)
-    : null;
+  // state.kind === 'ready'
+  const { sessionId, data, selectedNode, selectedRun } = state;
 
   return (
     <>
@@ -148,7 +136,7 @@ export function SessionDetail({ sessionId }: Props) {
                   selectedNodeId={
                     selectedNode?.runId === run.runId ? selectedNode.nodeId : null
                   }
-                  onNodeClick={handleNodeClick}
+                  onNodeClick={onSelectNode}
                 />
               ))}
             </div>
@@ -174,7 +162,7 @@ export function SessionDetail({ sessionId }: Props) {
             Node detail
           </span>
           <button
-            onClick={() => setSelectedNode(null)}
+            onClick={onCloseNode}
             className="text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors text-xl leading-none px-1"
             aria-label="Close"
           >

--- a/console/src/views/SessionList.tsx
+++ b/console/src/views/SessionList.tsx
@@ -1,232 +1,29 @@
-import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { useSessionList } from '../api/hooks';
+import { useState, useEffect } from 'react';
 import { StatusBadge } from '../components/StatusBadge';
 import { HealthBadge } from '../components/HealthBadge';
 import { MetaChip } from '../components/MetaChip';
 import { ConsoleCard } from '../components/ConsoleCard';
-import type { ConsoleSessionSummary, ConsoleSessionStatus } from '../api/types';
+import type { ConsoleSessionSummary } from '../api/types';
 import { formatRelativeTime } from '../utils/time';
-import { useGridKeyNav, type UseGridKeyNavResult } from '../hooks/useGridKeyNav';
+import type { UseGridKeyNavResult } from '../hooks/useGridKeyNav';
+import type { UseSessionListViewModelResult } from '../hooks/useSessionListViewModel';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
 
 interface Props {
-  onSelectSession: (sessionId: string) => void;
-  /** Pre-seed the search field (e.g. branch name from worktree click-through). */
-  initialSearch?: string;
+  viewModel: UseSessionListViewModelResult;
 }
 
 // ---------------------------------------------------------------------------
-// Sort / group axis definitions
-//
-// Adding a new sort or group axis requires a single entry in SORT_AXES or
-// GROUP_AXES -- no edits to switch statements or separate type unions.
+// SessionList -- pure presenter
 // ---------------------------------------------------------------------------
 
-type StatusFilter = 'all' | ConsoleSessionStatus;
+export function SessionList({ viewModel }: Props) {
+  const { state, dispatch, onSelectSession } = viewModel;
 
-const STATUS_SORT_ORDER: Record<ConsoleSessionStatus, number> = {
-  in_progress: 0,
-  blocked: 1,
-  dormant: 2,
-  complete_with_gaps: 3,
-  complete: 4,
-};
-
-// Parameterised so that `value` is inferred as a literal type rather than
-// widened to `string`. This lets TypeScript catch typos in SortField/GroupBy
-// assignments at compile time.
-interface SortAxisDef<V extends string> {
-  readonly value: V;
-  readonly label: string;
-  readonly compareFn: (a: ConsoleSessionSummary, b: ConsoleSessionSummary) => number;
-}
-
-interface GroupAxisDef<V extends string> {
-  readonly value: V;
-  readonly label: string;
-  // Returns the group key for a session, or null for the "ungrouped" sentinel.
-  readonly keyFn: ((s: ConsoleSessionSummary) => string) | null;
-  // Optional comparator for group labels. Defaults to localeCompare.
-  readonly groupCompareFn?: (a: string, b: string) => number;
-}
-
-const SORT_AXES = [
-  {
-    value: 'recent' as const,
-    label: 'Recent',
-    compareFn: (a: ConsoleSessionSummary, b: ConsoleSessionSummary) => b.lastModifiedMs - a.lastModifiedMs,
-  },
-  {
-    value: 'status' as const,
-    label: 'Status',
-    compareFn: (a: ConsoleSessionSummary, b: ConsoleSessionSummary) =>
-      STATUS_SORT_ORDER[a.status] - STATUS_SORT_ORDER[b.status] || b.lastModifiedMs - a.lastModifiedMs,
-  },
-  {
-    value: 'workflow' as const,
-    label: 'Workflow',
-    compareFn: (a: ConsoleSessionSummary, b: ConsoleSessionSummary) =>
-      (a.workflowName ?? a.workflowId ?? '').localeCompare(b.workflowName ?? b.workflowId ?? '') ||
-      b.lastModifiedMs - a.lastModifiedMs,
-  },
-  {
-    value: 'nodes' as const,
-    label: 'Node count',
-    compareFn: (a: ConsoleSessionSummary, b: ConsoleSessionSummary) =>
-      b.nodeCount - a.nodeCount || b.lastModifiedMs - a.lastModifiedMs,
-  },
-] as const satisfies readonly SortAxisDef<string>[];
-
-const GROUP_AXES = [
-  { value: 'none' as const, label: 'No grouping', keyFn: null },
-  { value: 'workflow' as const, label: 'Workflow', keyFn: (s: ConsoleSessionSummary) => s.workflowName ?? s.workflowId ?? 'Unknown workflow' },
-  {
-    value: 'status' as const,
-    label: 'Status',
-    keyFn: (s: ConsoleSessionSummary) => s.status,
-    // Sort status groups by severity order rather than alphabetically.
-    groupCompareFn: (a: string, b: string) =>
-      (STATUS_SORT_ORDER[a as ConsoleSessionStatus] ?? 99) - (STATUS_SORT_ORDER[b as ConsoleSessionStatus] ?? 99),
-  },
-  { value: 'branch' as const, label: 'Branch', keyFn: (s: ConsoleSessionSummary) => s.gitBranch ?? 'No branch' },
-] as const satisfies readonly GroupAxisDef<string>[];
-
-type SortField = (typeof SORT_AXES)[number]['value'];
-type GroupBy = (typeof GROUP_AXES)[number]['value'];
-
-const STATUS_FILTER_OPTIONS: { value: StatusFilter; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: 'in_progress', label: 'In Progress' },
-  { value: 'dormant', label: 'Dormant' },
-  { value: 'complete', label: 'Complete' },
-  { value: 'complete_with_gaps', label: 'Gaps' },
-  { value: 'blocked', label: 'Blocked' },
-];
-
-const PAGE_SIZE = 25;
-
-// ---------------------------------------------------------------------------
-// Pure helpers
-// ---------------------------------------------------------------------------
-
-function filterSessions(
-  sessions: readonly ConsoleSessionSummary[],
-  search: string,
-  statusFilter: StatusFilter,
-): ConsoleSessionSummary[] {
-  let filtered = [...sessions];
-
-  if (statusFilter !== 'all') {
-    filtered = filtered.filter((s) => s.status === statusFilter);
-  }
-
-  if (search.trim()) {
-    const q = search.toLowerCase();
-    filtered = filtered.filter((s) =>
-      (s.sessionTitle ?? '').toLowerCase().includes(q) ||
-      (s.workflowName ?? '').toLowerCase().includes(q) ||
-      (s.workflowId ?? '').toLowerCase().includes(q) ||
-      s.sessionId.toLowerCase().includes(q) ||
-      (s.gitBranch ?? '').toLowerCase().includes(q)
-    );
-  }
-
-  return filtered;
-}
-
-function sortSessions(sessions: ConsoleSessionSummary[], sort: SortField): ConsoleSessionSummary[] {
-  const axis = SORT_AXES.find((a) => a.value === sort) ?? SORT_AXES[0];
-  return [...sessions].sort(axis.compareFn);
-}
-
-function groupSessions(
-  sessions: ConsoleSessionSummary[],
-  groupBy: GroupBy,
-): { label: string; sessions: ConsoleSessionSummary[] }[] {
-  const axis = GROUP_AXES.find((a) => a.value === groupBy) ?? GROUP_AXES[0];
-  if (!axis.keyFn) return [{ label: '', sessions }];
-
-  const groups = new Map<string, ConsoleSessionSummary[]>();
-
-  for (const s of sessions) {
-    const key = axis.keyFn(s);
-    const list = groups.get(key) ?? [];
-    list.push(s);
-    groups.set(key, list);
-  }
-
-  // Cast to the base interface to access the optional groupCompareFn field.
-  // `as const satisfies` narrows each element to its exact literal shape, so
-  // the optional field is only present in the union members that define it.
-  const compareFn = (axis as GroupAxisDef<string>).groupCompareFn ?? ((a: string, b: string) => a.localeCompare(b));
-  return Array.from(groups.entries())
-    .sort(([a], [b]) => compareFn(a, b))
-    .map(([label, groupedSessions]) => ({ label, sessions: groupedSessions }));
-}
-
-// ---------------------------------------------------------------------------
-// Debounce hook
-// Separates UI-responsive input state from the computationally expensive
-// filter/sort/group pipeline. Delays are applied only to the search field.
-// ---------------------------------------------------------------------------
-
-function useDebounce<T>(value: T, delayMs: number): T {
-  const [debouncedValue, setDebouncedValue] = useState(value);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    if (timerRef.current !== null) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setDebouncedValue(value), delayMs);
-    return () => {
-      if (timerRef.current !== null) clearTimeout(timerRef.current);
-    };
-  }, [value, delayMs]);
-
-  return debouncedValue;
-}
-
-// ---------------------------------------------------------------------------
-// Components
-// ---------------------------------------------------------------------------
-
-export function SessionList({ onSelectSession, initialSearch = '' }: Props) {
-  const { data, isLoading, error } = useSessionList();
-
-  const [search, setSearch] = useState(initialSearch);
-  const [sort, setSort] = useState<SortField>('recent');
-  const [groupBy, setGroupBy] = useState<GroupBy>('none');
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
-  const [page, setPage] = useState(0);
-
-  // Debounce the search input so that filter/sort/group computation does not
-  // fire on every keystroke. The raw `search` value drives the input display;
-  // `debouncedSearch` drives the data pipeline.
-  const debouncedSearch = useDebounce(search, 200);
-
-  // Reset page when filters change
-  const handleSearchChange = useCallback((v: string) => { setSearch(v); setPage(0); }, []);
-  const handleSortChange = useCallback((v: SortField) => { setSort(v); setPage(0); }, []);
-  const handleGroupChange = useCallback((v: GroupBy) => { setGroupBy(v); setPage(0); }, []);
-  const handleStatusChange = useCallback((v: StatusFilter) => { setStatusFilter(v); setPage(0); }, []);
-
-  const processed = useMemo(() => {
-    if (!data) return { groups: [], total: 0, filtered: 0 };
-    const filtered = filterSessions(data.sessions, debouncedSearch, statusFilter);
-    const sorted = sortSessions(filtered, sort);
-    const groups = groupSessions(sorted, groupBy);
-    return { groups, total: data.sessions.length, filtered: filtered.length };
-  }, [data, debouncedSearch, statusFilter, sort, groupBy]);
-
-  // Status counts for filter pills
-  const statusCounts = useMemo(() => {
-    if (!data) return {} as Record<StatusFilter, number>;
-    const counts: Record<string, number> = { all: data.sessions.length };
-    for (const s of data.sessions) {
-      counts[s.status] = (counts[s.status] ?? 0) + 1;
-    }
-    return counts as Record<StatusFilter, number>;
-  }, [data]);
-
-  if (isLoading) {
+  if (state.kind === 'loading') {
     return (
       <div className="flex items-center justify-center py-20">
         <div className="text-[var(--text-secondary)] text-sm">Loading sessions...</div>
@@ -234,15 +31,34 @@ export function SessionList({ onSelectSession, initialSearch = '' }: Props) {
     );
   }
 
-  if (error) {
+  if (state.kind === 'error') {
     return (
       <div className="text-[var(--error)] bg-[var(--bg-card)] rounded-lg p-4">
-        Failed to load sessions: {error.message}
+        Failed to load sessions: {state.message}
       </div>
     );
   }
 
-  if (!data || data.sessions.length === 0) {
+  // state.kind === 'ready'
+  const {
+    rawSearch,
+    sort,
+    groupBy,
+    statusFilter,
+    page,
+    totalPages,
+    isGrouped,
+    processed,
+    statusCounts,
+    flatPageSessions,
+    getSessionNavProps,
+    sessionContainerProps,
+    sortAxes,
+    groupAxes,
+    statusFilterOptions,
+  } = state;
+
+  if (processed.total === 0) {
     return (
       <div className="text-center py-16">
         <p className="text-[var(--text-secondary)] text-lg">No v2 sessions found</p>
@@ -252,25 +68,6 @@ export function SessionList({ onSelectSession, initialSearch = '' }: Props) {
       </div>
     );
   }
-
-  // Flatten groups for pagination when not grouped
-  const isGrouped = groupBy !== 'none';
-  const pageStart = page * PAGE_SIZE;
-  const pageEnd = pageStart + PAGE_SIZE;
-  const totalPages = Math.ceil(processed.filtered / PAGE_SIZE);
-
-  // Flat visible sessions for the current page (non-grouped path only).
-  const flatPageSessions = isGrouped ? [] : (processed.groups[0]?.sessions.slice(pageStart, pageEnd) ?? []);
-
-  // Issue #7: Keyboard navigation for the flat session list (cols=1, single column).
-  const { getItemProps: getSessionNavProps, containerProps: sessionContainerProps } = useGridKeyNav({
-    count: flatPageSessions.length,
-    cols: 1,
-    onActivate: useCallback((i: number) => {
-      onSelectSession(flatPageSessions[i].sessionId);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [flatPageSessions, onSelectSession]),
-  });
 
   return (
     <div className="space-y-4">
@@ -292,14 +89,14 @@ export function SessionList({ onSelectSession, initialSearch = '' }: Props) {
         <div className="relative flex-1 min-w-[200px] max-w-[360px]">
           <input
             type="text"
-            value={search}
-            onChange={(e) => handleSearchChange(e.target.value)}
+            value={rawSearch}
+            onChange={(e) => dispatch({ type: 'search_changed', value: e.target.value })}
             placeholder="Search sessions..."
             className="w-full bg-[var(--bg-secondary)] border border-[var(--border)] rounded-md px-3 py-1.5 text-sm text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)] transition-colors"
           />
-          {search && (
+          {rawSearch && (
             <button
-              onClick={() => handleSearchChange('')}
+              onClick={() => dispatch({ type: 'search_changed', value: '' })}
               className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text-primary)] text-xs"
             >
               clear
@@ -311,29 +108,29 @@ export function SessionList({ onSelectSession, initialSearch = '' }: Props) {
         <ToolbarSelect
           label="Sort"
           value={sort}
-          options={SORT_AXES}
-          onChange={handleSortChange}
+          options={sortAxes}
+          onChange={(v) => dispatch({ type: 'sort_changed', sort: v })}
         />
 
         {/* Group */}
         <ToolbarSelect
           label="Group"
           value={groupBy}
-          options={GROUP_AXES}
-          onChange={handleGroupChange}
+          options={groupAxes}
+          onChange={(v) => dispatch({ type: 'group_changed', groupBy: v })}
         />
       </div>
 
       {/* Status filter pills */}
       <div className="flex flex-wrap gap-1.5">
-        {STATUS_FILTER_OPTIONS.map((opt) => {
+        {statusFilterOptions.map((opt) => {
           const count = statusCounts[opt.value] ?? 0;
           if (opt.value !== 'all' && count === 0) return null;
           const active = statusFilter === opt.value;
           return (
             <button
               key={opt.value}
-              onClick={() => handleStatusChange(opt.value)}
+              onClick={() => dispatch({ type: 'status_changed', statusFilter: opt.value })}
               className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors cursor-pointer ${
                 active
                   ? 'bg-[var(--accent)] text-white'
@@ -380,7 +177,7 @@ export function SessionList({ onSelectSession, initialSearch = '' }: Props) {
 
           {/* Pagination */}
           {totalPages > 1 && (
-            <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+            <Pagination page={page} totalPages={totalPages} onPageChange={(p) => dispatch({ type: 'page_changed', page: p })} />
           )}
         </>
       )}
@@ -431,9 +228,9 @@ function SessionGroup({
   onSelectSession,
 }: {
   label: string;
-  sessions: ConsoleSessionSummary[];
-  sort: SortField;
-  statusFilter: StatusFilter;
+  sessions: readonly ConsoleSessionSummary[];
+  sort: string;
+  statusFilter: string;
   onSelectSession: (id: string) => void;
 }) {
   const [collapsed, setCollapsed] = useState(false);
@@ -449,9 +246,10 @@ function SessionGroup({
   void sort;
   void statusFilter;
 
-  const totalPages = Math.ceil(sessions.length / PAGE_SIZE);
-  const pageStart = page * PAGE_SIZE;
-  const pageEnd = pageStart + PAGE_SIZE;
+  const PAGE_SIZE_LOCAL = 25;
+  const totalPages = Math.ceil(sessions.length / PAGE_SIZE_LOCAL);
+  const pageStart = page * PAGE_SIZE_LOCAL;
+  const pageEnd = pageStart + PAGE_SIZE_LOCAL;
   const visibleSessions = sessions.slice(pageStart, pageEnd);
 
   return (

--- a/console/src/views/WorkflowDetail.tsx
+++ b/console/src/views/WorkflowDetail.tsx
@@ -1,43 +1,93 @@
 import { useState } from 'react';
 import { PathBreadcrumb } from '../components/PathBreadcrumb';
-import { useQueryClient } from '@tanstack/react-query';
-import { useWorkflowDetail, HttpError } from '../api/hooks';
 import { MarkdownView } from '../components/MarkdownView';
-import type { ConsoleWorkflowListResponse, ConsoleWorkflowSummary, ConsoleWorkflowDetail as WorkflowDetailData } from '../api/types';
-import { TAG_DISPLAY } from '../config/tags';
+import type { ConsoleWorkflowDetail as WorkflowDetailData, ConsoleWorkflowSourceInfo } from '../api/types';
+import type { UseWorkflowDetailViewModelResult } from '../hooks/useWorkflowDetailViewModel';
 
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
 
 interface Props {
-  readonly workflowId: string;
-  readonly activeTag?: string | null;
-  readonly onBack: () => void;
+  readonly viewModel: UseWorkflowDetailViewModelResult;
 }
 
 // ---------------------------------------------------------------------------
 // WorkflowDetail
 // ---------------------------------------------------------------------------
 
-export function WorkflowDetail({ workflowId, activeTag, onBack }: Props) {
-  const queryClient = useQueryClient();
+export function WorkflowDetail({ viewModel }: Props) {
+  const { state } = viewModel;
 
-  // Optimistic partial data: use cached list entry while detail fetch completes.
-  const listData = queryClient.getQueryData<ConsoleWorkflowListResponse>(['workflows']);
-  const cached: ConsoleWorkflowSummary | undefined = listData?.workflows.find(
-    (w) => w.id === workflowId,
-  );
+  if (state.kind === 'not_found') {
+    return (
+      <div className="space-y-5 max-w-3xl">
+        <DetailError
+          message=""
+          is404={true}
+          onRetry={() => undefined}
+          onBack={state.onBack}
+        />
+      </div>
+    );
+  }
 
-  const { data: detail, isLoading, isError, error, refetch } = useWorkflowDetail(workflowId);
+  if (state.kind === 'error') {
+    return (
+      <div className="space-y-5 max-w-3xl">
+        <DetailError
+          message={state.message}
+          is404={false}
+          onRetry={state.onRetry}
+          onBack={state.onBack}
+        />
+      </div>
+    );
+  }
 
-  const activeTagLabel = activeTag ? (TAG_DISPLAY[activeTag] ?? activeTag) : null;
+  if (state.kind === 'loading') {
+    const { cached, activeTagLabel, onBack } = state;
+    return (
+      <div className="space-y-5 max-w-3xl">
+        <PathBreadcrumb
+          segments={
+            activeTagLabel
+              ? [{ label: 'Workflows', onClick: onBack }, { label: activeTagLabel }]
+              : [{ label: 'Workflows', onClick: onBack }]
+          }
+        />
+        {cached ? (
+          <>
+            <WorkflowHeader
+              name={cached.name}
+              description={cached.description}
+              tags={cached.tags}
+              source={cached.source}
+              stepCount={undefined}
+            />
+            <div className="space-y-4">
+              <SectionSkeleton />
+            </div>
+          </>
+        ) : (
+          <DetailSkeleton />
+        )}
+      </div>
+    );
+  }
 
-  // Use detail data when available, fall back to cached list data for header fields.
-  const name = detail?.name ?? cached?.name ?? workflowId;
-  const description = detail?.description ?? cached?.description ?? null;
-  const tags = detail?.tags ?? cached?.tags ?? [];
-  const source = detail?.source ?? cached?.source ?? null;
+  // kind === 'ready'
+  const {
+    workflow,
+    name,
+    description,
+    tags,
+    source,
+    activeTagLabel,
+    onPrev,
+    onNext,
+    onBack,
+  } = state;
 
   return (
     <div className="space-y-5 max-w-3xl">
@@ -51,80 +101,116 @@ export function WorkflowDetail({ workflowId, activeTag, onBack }: Props) {
       />
 
       {/* Header */}
-      <div className="border border-[var(--border)] px-5 py-5 console-blueprint-grid">
-        {/* Designation label */}
-        <p className="font-mono text-[10px] uppercase tracking-[0.35em] text-[var(--text-muted)] mb-2">
-          // Workflow
-        </p>
+      <WorkflowHeader
+        name={name}
+        description={description}
+        tags={tags}
+        source={source}
+        stepCount={workflow.stepCount}
+      />
 
-        {/* Title */}
-        <h2
-          className="font-mono text-xl font-bold uppercase tracking-[0.08em] leading-tight mb-3"
-          style={{
-            color: 'var(--accent)',
-            textShadow: '0 0 24px rgba(244,196,48,0.45), 0 0 48px rgba(244,196,48,0.15)',
-          }}
-        >
-          {name}
-        </h2>
-
-        {/* Badges row -- step count inline with tags */}
-        <div className="flex flex-wrap items-center gap-2">
-          {detail && detail.stepCount != null && detail.stepCount > 0 && (
-            <span className="font-mono text-[10px] px-1.5 py-0.5 border border-[var(--border)] text-[var(--text-secondary)]">
-              {detail.stepCount} step{detail.stepCount !== 1 ? 's' : ''}
-            </span>
-          )}
-          {tags.filter((t) => t !== 'routines').map((tag) => (
-            <span
-              key={tag}
-              aria-hidden="true"
-              className="font-mono text-[10px] px-1.5 py-0.5 bg-[var(--bg-secondary)] text-[var(--text-muted)]"
+      {/* Adjacent navigation */}
+      {(onPrev ?? onNext) && (
+        <div className="flex items-center gap-4">
+          {onPrev && (
+            <button
+              type="button"
+              onClick={onPrev}
+              className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors"
             >
-              {TAG_DISPLAY[tag] ?? tag}
-            </span>
-          ))}
-          {source && (
-            <span
-              aria-hidden="true"
-              className="font-mono text-[10px] px-1.5 py-0.5 border border-[var(--border)] text-[var(--text-muted)]"
-            >
-              src: {source.displayName}
-            </span>
+              {'<'} PREV
+            </button>
           )}
-        </div>
-
-        {/* Short description */}
-        {description && (
-          <p className="text-sm text-[var(--text-secondary)] leading-relaxed mt-3">
-            {description}
-          </p>
-        )}
-      </div>
-
-      {/* Detail sections -- loading, error, or content */}
-      {isLoading && !cached ? (
-        <DetailSkeleton />
-      ) : isError ? (
-        <DetailError
-          message={error instanceof Error ? error.message : 'Could not load workflow details.'}
-          is404={error instanceof HttpError && error.status === 404}
-          onRetry={() => void refetch()}
-          onBack={onBack}
-        />
-      ) : detail ? (
-        <DetailContent detail={detail} name={name} />
-      ) : (
-        // Optimistic state: cached partial data shown, detail still loading
-        <div className="space-y-4">
-          <SectionSkeleton />
+          {onNext && (
+            <button
+              type="button"
+              onClick={onNext}
+              className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors"
+            >
+              NEXT {'>'}
+            </button>
+          )}
         </div>
       )}
+
+      {/* Detail content */}
+      <DetailContent detail={workflow} name={name} />
 
       {/* Second back link at bottom */}
       <PathBreadcrumb
         segments={[{ label: 'Workflows', onClick: onBack }]}
       />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Workflow header (shared between loading-with-cache and ready states)
+// ---------------------------------------------------------------------------
+
+function WorkflowHeader({
+  name,
+  description,
+  tags,
+  source,
+  stepCount,
+}: {
+  readonly name: string;
+  readonly description: string | null;
+  readonly tags: readonly string[];
+  readonly source: ConsoleWorkflowSourceInfo | null;
+  readonly stepCount: number | undefined;
+}) {
+  return (
+    <div className="border border-[var(--border)] px-5 py-5 console-blueprint-grid">
+      {/* Designation label */}
+      <p className="font-mono text-[10px] uppercase tracking-[0.35em] text-[var(--text-muted)] mb-2">
+        // Workflow
+      </p>
+
+      {/* Title */}
+      <h2
+        className="font-mono text-xl font-bold uppercase tracking-[0.08em] leading-tight mb-3"
+        style={{
+          color: 'var(--accent)',
+          textShadow: '0 0 24px rgba(244,196,48,0.45), 0 0 48px rgba(244,196,48,0.15)',
+        }}
+      >
+        {name}
+      </h2>
+
+      {/* Badges row -- step count inline with tags */}
+      <div className="flex flex-wrap items-center gap-2">
+        {stepCount != null && stepCount > 0 && (
+          <span className="font-mono text-[10px] px-1.5 py-0.5 border border-[var(--border)] text-[var(--text-secondary)]">
+            {stepCount} step{stepCount !== 1 ? 's' : ''}
+          </span>
+        )}
+        {tags.filter((t) => t !== 'routines').map((tag) => (
+          <span
+            key={tag}
+            aria-hidden="true"
+            className="font-mono text-[10px] px-1.5 py-0.5 bg-[var(--bg-secondary)] text-[var(--text-muted)]"
+          >
+            {tag}
+          </span>
+        ))}
+        {source && (
+          <span
+            aria-hidden="true"
+            className="font-mono text-[10px] px-1.5 py-0.5 border border-[var(--border)] text-[var(--text-muted)]"
+          >
+            src: {source.displayName}
+          </span>
+        )}
+      </div>
+
+      {/* Short description */}
+      {description && (
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed mt-3">
+          {description}
+        </p>
+      )}
     </div>
   );
 }
@@ -181,7 +267,7 @@ function DetailContent({
                   style={{ backgroundColor: 'var(--accent)' }}
                 />
                 <span className="text-sm text-[var(--text-secondary)] leading-relaxed">
-                  "{example}"
+                  &quot;{example}&quot;
                 </span>
               </li>
             ))}

--- a/console/src/views/WorkflowsView.tsx
+++ b/console/src/views/WorkflowsView.tsx
@@ -1,21 +1,21 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useWorkflowList } from '../api/hooks';
+import { useCallback, useEffect, useRef } from 'react';
 import type { ConsoleWorkflowSummary } from '../api/types';
+import { useModalTransition } from '../hooks/useModalTransition';
 import { CATALOG_TAGS, TAG_DISPLAY } from '../config/tags';
 import { SectionHeader } from '../components/SectionHeader';
 import { ConsoleCard } from '../components/ConsoleCard';
 import { CutCornerBox, cutCornerPath } from '../components/CutCornerBox';
 import { WorkflowDetail } from './WorkflowDetail';
 import { useGridKeyNav, type UseGridKeyNavResult } from '../hooks/useGridKeyNav';
+import type { UseWorkflowsViewModelResult } from '../hooks/useWorkflowsViewModel';
+import { useWorkflowDetailViewModel } from '../hooks/useWorkflowDetailViewModel';
 
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
 
 interface Props {
-  readonly selectedTag: string | null;
-  readonly onSelectTag: (tag: string | null) => void;
-  readonly onSelectWorkflow: (workflowId: string) => void;
+  readonly viewModel: UseWorkflowsViewModelResult;
 }
 
 // ---------------------------------------------------------------------------
@@ -31,6 +31,9 @@ interface WorkflowGroup {
 /**
  * Groups workflows by their first recognized non-routines tag, in CATALOG_TAGS order.
  * Workflows with no recognized tag are placed in an "Other" group at the end.
+ *
+ * This is a UI grouping helper (not a use case) because it directly references
+ * CATALOG_TAGS, a UI configuration constant.
  */
 function groupWorkflowsByTag(workflows: readonly ConsoleWorkflowSummary[]): WorkflowGroup[] {
   const knownTagIds = new Set(CATALOG_TAGS.map((t) => t.id));
@@ -64,188 +67,161 @@ function groupWorkflowsByTag(workflows: readonly ConsoleWorkflowSummary[]): Work
 // WorkflowsView
 // ---------------------------------------------------------------------------
 
-export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onSelectWorkflow }: Props) {
-  const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
-  const [selectedSource, setSelectedSource] = useState<string | null>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
+export function WorkflowsView({ viewModel }: Props) {
+  const { state, dispatch, triggerRef, onCardSelect } = viewModel;
+
+  // modalPanelRef: focus target for rAF when modal opens. Pure UI concern -- stays here.
   const modalPanelRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  const isAnimatingRef = useRef(false);
-  const pendingNavRef = useRef<number | null>(null);
-  // Tracks the post-transition selectedWorkflowId so the 240ms pending-nav
-  // callback reads the correct value even after setSelectedWorkflowId fires.
-  const selectedWorkflowIdRef = useRef<string | null>(null);
-  const [scanlineKey, setScanlineKey] = useState(0);
-  const [crtOffset, setCrtOffset] = useState(0);
-  const [glitchY, setGlitchY] = useState(38);
-  const [glitchY2, setGlitchY2] = useState(62);
-  const [glitchW, setGlitchW] = useState(3);
-  const [glitchW2, setGlitchW2] = useState(2);
-  const [contentAnimClass, setContentAnimClass] = useState('');
-  const [borderFlashing, setBorderFlashing] = useState(false);
-  const [hintVisible, setHintVisible] = useState(false);
-  const { data, isLoading, isError, error, refetch } = useWorkflowList();
 
-  // Focus management: move focus into the modal on open, restore to trigger on close.
+  // useModalTransition owns pure CRT/glitch animation state.
+  // It stays in the view because it is purely visual and has no data concerns.
+  const modalTransition = useModalTransition();
+
+  // Focus management: move focus into the modal panel when it opens.
+  // The ViewModel handles restore-to-trigger on close.
+  // rAF defers until after the opacity transition starts so the panel is visible.
+  const selectedWorkflowId = state.kind === 'ready' ? state.selectedWorkflowId : null;
+
   useEffect(() => {
     if (selectedWorkflowId) {
-      // rAF defers until after the opacity transition starts so the panel is visible
       const id = requestAnimationFrame(() => modalPanelRef.current?.focus());
       return () => cancelAnimationFrame(id);
-    } else if (triggerRef.current) {
-      triggerRef.current.focus();
-      triggerRef.current = null;
     }
   }, [selectedWorkflowId]);
 
-  // Issue #4: Lock body scroll when modal is open, preserving scroll position.
-  // Setting overflow:hidden alone resets scroll to top -- position:fixed preserves it.
-  useEffect(() => {
-    if (!selectedWorkflowId) return;
+  if (state.kind === 'loading') {
+    return <WorkflowListSkeleton />;
+  }
 
-    const scrollY = window.scrollY;
-    document.body.style.overflow = 'hidden';
-    document.body.style.position = 'fixed';
-    document.body.style.top = `-${scrollY}px`;
-    document.body.style.width = '100%';
+  if (state.kind === 'error') {
+    return (
+      <WorkflowListError
+        message={state.message}
+        onRetry={state.onRetry}
+      />
+    );
+  }
 
-    return () => {
-      document.body.style.overflow = '';
-      document.body.style.position = '';
-      document.body.style.top = '';
-      document.body.style.width = '';
-      window.scrollTo(0, scrollY);
-    };
-  }, [selectedWorkflowId]);
+  // state.kind === 'ready'
+  const {
+    selectedTag,
+    selectedSource,
+    hintVisible,
+    filteredWorkflows,
+    flatWorkflows,
+    availableSources,
+  } = state;
 
-  // Issue #5: Close modal on Escape key.
-  useEffect(() => {
-    if (!selectedWorkflowId) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setSelectedWorkflowId(null);
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [selectedWorkflowId]);
-
-  // Filter: exclude routines tag; apply selected tag + source filters
-  const allWorkflows = useMemo(
-    () => data?.workflows.filter((w) => !w.tags.includes('routines')) ?? [],
-    [data],
-  );
-
-  const availableSources = useMemo(() => {
-    const sources = new Set(allWorkflows.map((w) => w.source.displayName));
-    return [...sources].sort();
-  }, [allWorkflows]);
-
-  const visibleWorkflows = useMemo(() => {
-    const knownIds = new Set(CATALOG_TAGS.map((t) => t.id));
-    let filtered = selectedTag
-      ? selectedTag === '__other__'
-        ? allWorkflows.filter((w) => !w.tags.some((t) => t !== 'routines' && knownIds.has(t)))
-        : allWorkflows.filter((w) => w.tags.includes(selectedTag))
-      : allWorkflows;
-    if (selectedSource) {
-      filtered = filtered.filter((w) => w.source.displayName === selectedSource);
-    }
-    return filtered;
-  }, [allWorkflows, selectedTag, selectedSource]);
-
-  // Flatten into a single ordered array matching the visual card order.
-  // When selectedTag is set the list is already flat. When showing all tags,
-  // the order must match the grouped rendering below.
-  const flatWorkflows = useMemo((): readonly ConsoleWorkflowSummary[] => {
-    if (selectedTag) return visibleWorkflows;
-    return groupWorkflowsByTag(visibleWorkflows).flatMap((g) => g.workflows);
-  }, [visibleWorkflows, selectedTag]);
+  const knownTagIds = new Set(CATALOG_TAGS.map((t) => t.id));
+  const tagsWithWorkflows = new Set(filteredWorkflows.flatMap((w) => w.tags));
+  const countByTag = new Map(CATALOG_TAGS.map((t) => [t.id, filteredWorkflows.filter((w) => w.tags.includes(t.id)).length]));
+  const otherCount = filteredWorkflows.filter((w) => !w.tags.some((t) => t !== 'routines' && knownTagIds.has(t))).length;
 
   const currentIndex = flatWorkflows.findIndex((w) => w.id === selectedWorkflowId);
 
-  // Issue #6: Store the trigger element before opening the modal.
-  const handleCardSelect = useCallback((id: string, triggerEl: HTMLButtonElement) => {
-    triggerRef.current = triggerEl;
-    setSelectedWorkflowId(id);
-    selectedWorkflowIdRef.current = id;
-    triggerEl.blur();
-  }, []);
+  return (
+    <WorkflowsReadyView
+      selectedWorkflowId={selectedWorkflowId}
+      selectedTag={selectedTag}
+      selectedSource={selectedSource}
+      hintVisible={hintVisible}
+      filteredWorkflows={filteredWorkflows}
+      flatWorkflows={flatWorkflows}
+      availableSources={availableSources}
+      tagsWithWorkflows={tagsWithWorkflows}
+      countByTag={countByTag}
+      otherCount={otherCount}
+      currentIndex={currentIndex}
+      dispatch={dispatch}
+      onCardSelect={onCardSelect}
+      triggerRef={triggerRef}
+      modalPanelRef={modalPanelRef}
+      scrollRef={scrollRef}
+      modalTransition={modalTransition}
+    />
+  );
+}
 
-  const navigateModal = useCallback((direction: 'prev' | 'next', axis: 'horizontal' | 'vertical') => {
-    if (flatWorkflows.length <= 1) return;
-    const current = flatWorkflows.findIndex((w) => w.id === selectedWorkflowId);
-    if (current === -1) return;
+// ---------------------------------------------------------------------------
+// WorkflowsReadyView -- rendered when state.kind === 'ready'
+// ---------------------------------------------------------------------------
 
-    const nextIndex = direction === 'next'
-      ? (current + 1) % flatWorkflows.length
-      : (current - 1 + flatWorkflows.length) % flatWorkflows.length;
+interface ReadyViewProps {
+  readonly selectedWorkflowId: string | null;
+  readonly selectedTag: string | null;
+  readonly selectedSource: string | null;
+  readonly hintVisible: boolean;
+  readonly filteredWorkflows: readonly ConsoleWorkflowSummary[];
+  readonly flatWorkflows: readonly ConsoleWorkflowSummary[];
+  readonly availableSources: readonly { readonly id: string; readonly displayName: string }[];
+  readonly tagsWithWorkflows: Set<string>;
+  readonly countByTag: Map<string, number>;
+  readonly otherCount: number;
+  readonly currentIndex: number;
+  readonly dispatch: UseWorkflowsViewModelResult['dispatch'];
+  readonly onCardSelect: UseWorkflowsViewModelResult['onCardSelect'];
+  readonly triggerRef: UseWorkflowsViewModelResult['triggerRef'];
+  readonly modalPanelRef: React.RefObject<HTMLDivElement | null>;
+  readonly scrollRef: React.RefObject<HTMLDivElement | null>;
+  readonly modalTransition: ReturnType<typeof useModalTransition>;
+}
 
-    if (isAnimatingRef.current) {
-      pendingNavRef.current = nextIndex;
-      return;
-    }
+function WorkflowsReadyView({
+  selectedWorkflowId,
+  selectedTag,
+  selectedSource,
+  hintVisible,
+  filteredWorkflows,
+  flatWorkflows,
+  availableSources,
+  tagsWithWorkflows,
+  countByTag,
+  otherCount,
+  currentIndex,
+  dispatch,
+  onCardSelect,
+  modalPanelRef,
+  scrollRef,
+  modalTransition,
+}: ReadyViewProps) {
+  // ViewModel for the workflow detail modal. The modal's onBack closes the modal
+  // and onNavigateToWorkflow dispatches workflow_selected to switch to another
+  // workflow without leaving the modal. The keyboard handler in the ViewModel is
+  // effectively suppressed by WorkflowsView's capture-phase handler above it.
+  const workflowDetailViewModel = useWorkflowDetailViewModel({
+    workflowId: selectedWorkflowId,
+    activeTag: selectedTag,
+    onBack: () => dispatch({ type: 'modal_closed' }),
+    onNavigateToWorkflow: (id) => dispatch({ type: 'workflow_selected', id }),
+  });
 
-    startModalTransition(nextIndex, direction, axis);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [flatWorkflows, selectedWorkflowId]);
-
-  function startModalTransition(nextIndex: number, direction: 'prev' | 'next', axis: 'horizontal' | 'vertical') {
-    isAnimatingRef.current = true;
-    setBorderFlashing(true);
-    setScanlineKey((k) => k + 1);
-    setCrtOffset(Math.floor(Math.random() * 4));
-    setGlitchY(5 + Math.floor(Math.random() * 80));
-    setGlitchY2(5 + Math.floor(Math.random() * 80));
-    setGlitchW(2 + Math.floor(Math.random() * 40));  // 2–42px
-    setGlitchW2(2 + Math.floor(Math.random() * 25)); // 2–27px
-    const exitClass = axis === 'horizontal'
-      ? (direction === 'next' ? 'modal-content--exit-h-next' : 'modal-content--exit-h-prev')
-      : (direction === 'next' ? 'modal-content--exit-v-next' : 'modal-content--exit-v-prev');
-    setContentAnimClass(exitClass);
-
-    // Reset scroll position immediately
-    if (scrollRef.current) scrollRef.current.scrollTop = 0;
-
-    // At midpoint (80ms), swap the workflow ID and start enter animation
-    const nextId = flatWorkflows[nextIndex]!.id;
-    setTimeout(() => {
-      setSelectedWorkflowId(nextId);
-      selectedWorkflowIdRef.current = nextId;
-      const enterClass = axis === 'horizontal'
-        ? (direction === 'next' ? 'modal-content--enter-h-next' : 'modal-content--enter-h-prev')
-        : (direction === 'next' ? 'modal-content--enter-v-next' : 'modal-content--enter-v-prev');
-      setContentAnimClass(enterClass);
-      setBorderFlashing(false);
-    }, 80);
-
-    // After full animation, clear. Use selectedWorkflowIdRef (not the closed-over
-    // selectedWorkflowId state) to get the post-transition value for pending-nav direction.
-    setTimeout(() => {
-      setContentAnimClass('');
-      isAnimatingRef.current = false;
-      if (pendingNavRef.current !== null) {
-        const pending = pendingNavRef.current;
-        pendingNavRef.current = null;
-        const cur = flatWorkflows.findIndex((w) => w.id === selectedWorkflowIdRef.current);
-        const dir = pending > cur ? 'next' : 'prev';
-        startModalTransition(pending, dir, 'horizontal');
-      }
-    }, 240);
-  }
+  const navigateModal = useCallback(
+    (direction: 'prev' | 'next', axis: 'horizontal' | 'vertical') => {
+      modalTransition.navigate(
+        selectedWorkflowId,
+        flatWorkflows,
+        direction,
+        axis,
+        (nextId) => {
+          dispatch({ type: 'workflow_selected', id: nextId });
+          modalTransition.selectedWorkflowIdRef.current = nextId;
+        },
+        scrollRef,
+      );
+    },
+    [flatWorkflows, selectedWorkflowId, modalTransition, dispatch, scrollRef],
+  );
 
   // Keyboard navigation between workflows while modal is open.
   useEffect(() => {
     if (!selectedWorkflowId) return;
-
-    // Show keyboard hint briefly -- only when navigation is actually possible
-    if (flatWorkflows.length > 1) setHintVisible(true);
-    const hintTimer = setTimeout(() => setHintVisible(false), 3000);
 
     const activeKeys = ['ArrowLeft', 'ArrowRight', 'a', 'A', 'd', 'D'];
     const suppressedKeys = ['ArrowUp', 'ArrowDown', 'w', 'W', 's', 'S'];
 
     const handler = (e: KeyboardEvent) => {
       if (suppressedKeys.includes(e.key)) {
-        // Block grid keyboard nav from firing while modal is open
         e.preventDefault();
         e.stopPropagation();
         return;
@@ -260,30 +236,23 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
     document.addEventListener('keydown', handler, { capture: true });
     return () => {
       document.removeEventListener('keydown', handler, { capture: true });
-      clearTimeout(hintTimer);
     };
   }, [selectedWorkflowId, navigateModal]);
 
-  // Issue #7: Keyboard navigation -- roving tabindex + arrow keys + WASD + Enter/Space.
   const { getItemProps, containerProps } = useGridKeyNav({
     count: flatWorkflows.length,
     cols: 'auto',
     onActivate: useCallback((i: number) => {
-      // When Enter/Space fires, document.activeElement is the focused button.
-      // We use it as the trigger element for focus-restoration on modal close.
-      const triggerEl = document.activeElement as HTMLButtonElement;
-      handleCardSelect(flatWorkflows[i].id, triggerEl);
-    }, [flatWorkflows, handleCardSelect]),
+      const workflow = flatWorkflows[i];
+      if (!workflow) return;
+      const active = document.activeElement;
+      if (!(active instanceof HTMLButtonElement)) return;
+      onCardSelect(workflow.id, active);
+    }, [flatWorkflows, onCardSelect]),
   });
 
-  // Derive which tag pills have at least one workflow and count per tag.
-  const knownTagIds = new Set(CATALOG_TAGS.map((t) => t.id));
-  const tagsWithWorkflows = new Set(allWorkflows.flatMap((w) => w.tags));
-  const countByTag = new Map(CATALOG_TAGS.map((t) => [t.id, allWorkflows.filter((w) => w.tags.includes(t.id)).length]));
-  const otherCount = allWorkflows.filter((w) => !w.tags.some((t) => t !== 'routines' && knownTagIds.has(t))).length;
-
   return (
-    <div className="space-y-4" aria-busy={isLoading}>
+    <div className="space-y-4">
       {/* Page title */}
       <div>
         <h1
@@ -293,7 +262,7 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
           Workflows
         </h1>
         <p className="font-mono text-[10px] tracking-[0.25em] text-[var(--text-muted)] mt-1.5">
-          // {allWorkflows.length} available
+          // {filteredWorkflows.length} available
         </p>
       </div>
 
@@ -305,19 +274,19 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
       >
         <TagPill
           label="All"
-          count={allWorkflows.length}
+          count={filteredWorkflows.length}
           isActive={selectedTag === null}
-          disabled={isLoading}
-          onClick={() => onSelectTag(null)}
+          disabled={false}
+          onClick={() => dispatch({ type: 'tag_changed', tag: null })}
         />
-        {CATALOG_TAGS.filter((t) => tagsWithWorkflows.has(t.id) || !data).map((tag) => (
+        {CATALOG_TAGS.filter((t) => tagsWithWorkflows.has(t.id)).map((tag) => (
           <TagPill
             key={tag.id}
             label={tag.label}
             count={countByTag.get(tag.id) ?? 0}
             isActive={selectedTag === tag.id}
-            disabled={isLoading}
-            onClick={() => onSelectTag(selectedTag === tag.id ? null : tag.id)}
+            disabled={false}
+            onClick={() => dispatch({ type: 'tag_changed', tag: selectedTag === tag.id ? null : tag.id })}
           />
         ))}
         {otherCount > 0 && (
@@ -325,8 +294,8 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
             label="Other"
             count={otherCount}
             isActive={selectedTag === '__other__'}
-            disabled={isLoading}
-            onClick={() => onSelectTag(selectedTag === '__other__' ? null : '__other__')}
+            disabled={false}
+            onClick={() => dispatch({ type: 'tag_changed', tag: selectedTag === '__other__' ? null : '__other__' })}
           />
         )}
       </div>
@@ -340,33 +309,26 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
         >
           <TagPill
             label="All Sources"
-            count={allWorkflows.length}
+            count={filteredWorkflows.length}
             isActive={selectedSource === null}
-            disabled={isLoading}
-            onClick={() => setSelectedSource(null)}
+            disabled={false}
+            onClick={() => dispatch({ type: 'source_changed', source: null })}
           />
           {availableSources.map((source) => (
             <TagPill
-              key={source}
-              label={source}
-              count={allWorkflows.filter((w) => w.source.displayName === source).length}
-              isActive={selectedSource === source}
-              disabled={isLoading}
-              onClick={() => setSelectedSource(selectedSource === source ? null : source)}
+              key={source.id}
+              label={source.displayName}
+              count={filteredWorkflows.filter((w) => w.source.displayName === source.displayName).length}
+              isActive={selectedSource === source.displayName}
+              disabled={false}
+              onClick={() => dispatch({ type: 'source_changed', source: selectedSource === source.displayName ? null : source.displayName })}
             />
           ))}
         </div>
       )}
 
       {/* Content area */}
-      {isLoading ? (
-        <WorkflowListSkeleton />
-      ) : isError ? (
-        <WorkflowListError
-          message={error instanceof Error ? error.message : 'Could not load workflows.'}
-          onRetry={() => void refetch()}
-        />
-      ) : visibleWorkflows.length === 0 ? (
+      {filteredWorkflows.length === 0 ? (
         <div className="py-8 text-center space-y-3">
           <p className="text-sm text-[var(--text-muted)]">
             No workflows in this category.
@@ -374,7 +336,7 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
           {selectedTag !== null && (
             <button
               type="button"
-              onClick={() => onSelectTag(null)}
+              onClick={() => dispatch({ type: 'tag_changed', tag: null })}
               className="text-sm text-[var(--accent)] hover:text-[var(--accent-hover)] transition-colors"
             >
               Clear filter
@@ -386,15 +348,15 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
         <div className="space-y-2">
           <SectionHeader
             label={selectedTag === '__other__' ? 'Other' : (TAG_DISPLAY[selectedTag] ?? selectedTag)}
-            count={visibleWorkflows.length}
+            count={filteredWorkflows.length}
             showRule={true}
           />
           <div {...containerProps} className="grid grid-cols-2 lg:grid-cols-3 gap-3">
-            {visibleWorkflows.map((workflow, i) => (
+            {filteredWorkflows.map((workflow, i) => (
               <WorkflowCard
                 key={workflow.id}
                 workflow={workflow}
-                onSelect={(triggerEl) => handleCardSelect(workflow.id, triggerEl)}
+                onSelect={(triggerEl) => onCardSelect(workflow.id, triggerEl)}
                 navProps={getItemProps(i)}
                 isActive={workflow.id === selectedWorkflowId}
               />
@@ -403,11 +365,10 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
         </div>
       ) : (
         // All: grouped by tag with section headers.
-        // Cards are indexed sequentially across all groups to match flatWorkflows.
         <div className="space-y-6">
           {(() => {
             let flatIndex = 0;
-            return groupWorkflowsByTag(visibleWorkflows).map((group) => (
+            return groupWorkflowsByTag(filteredWorkflows).map((group) => (
               <div key={group.tagId ?? '__other__'} className="space-y-2">
                 <SectionHeader label={group.label} count={group.workflows.length} showRule />
                 <div {...containerProps} className="grid grid-cols-2 lg:grid-cols-3 gap-3">
@@ -417,7 +378,7 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
                       <WorkflowCard
                         key={workflow.id}
                         workflow={workflow}
-                        onSelect={(triggerEl) => handleCardSelect(workflow.id, triggerEl)}
+                        onSelect={(triggerEl) => onCardSelect(workflow.id, triggerEl)}
                         navProps={getItemProps(i)}
                         isActive={workflow.id === selectedWorkflowId}
                       />
@@ -429,6 +390,7 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
           })()}
         </div>
       )}
+
       {/* Workflow detail modal */}
       <div
         className="fixed inset-0 z-50 flex items-end justify-center p-4 pointer-events-none"
@@ -439,7 +401,7 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
           <div
             className="absolute inset-0 pointer-events-auto"
             style={{ background: 'rgba(0,0,0,0.22)', backdropFilter: 'blur(2px)' }}
-            onClick={() => setSelectedWorkflowId(null)}
+            onClick={() => dispatch({ type: 'modal_closed' })}
           />
         )}
 
@@ -450,7 +412,7 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
           role="dialog"
           aria-modal="true"
           aria-label={`Workflow detail${selectedWorkflowId ? `: ${flatWorkflows.find((w) => w.id === selectedWorkflowId)?.name ?? ''}` : ''}`}
-          className={`relative w-full max-w-3xl ${selectedWorkflowId ? "pointer-events-auto" : "pointer-events-none"}${borderFlashing ? ' modal-border-flashing' : ''}`}
+          className={`relative w-full max-w-3xl ${selectedWorkflowId ? "pointer-events-auto" : "pointer-events-none"}${modalTransition.state.borderFlashing ? ' modal-border-flashing' : ''}`}
           style={{
             height: '85vh',
             transform: selectedWorkflowId ? 'translateY(0) scale(1)' : 'translateY(24px) scale(0.97)',
@@ -458,7 +420,6 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
             transition: window.matchMedia('(prefers-reduced-motion: reduce)').matches
               ? 'opacity 150ms ease-out'
               : 'transform 250ms ease-out, opacity 250ms ease-out',
-            /* backdrop-filter here, not inside CutCornerBox -- clip-path breaks backdrop-filter */
             backdropFilter: 'blur(2px)',
             WebkitBackdropFilter: 'blur(2px)',
           }}
@@ -470,13 +431,20 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
             dropShadow="drop-shadow(0 4px 24px rgba(244,196,48,0.15))"
             className="h-full flex flex-col"
           >
-            {/* CRT scanline overlay -- clip-path applied directly to guarantee cut corner is respected */}
-            {scanlineKey > 0 && (
+            {/* CRT scanline overlay */}
+            {modalTransition.state.scanline !== null && (
               <div
-                key={scanlineKey}
+                key={modalTransition.state.scanline.key}
                 className="modal-scanline"
                 aria-hidden="true"
-                style={{ '--crt-offset': `${crtOffset}px`, '--glitch-y': `${glitchY}%`, '--glitch-y2': `${glitchY2}%`, '--glitch-w': `${glitchW}px`, '--glitch-w2': `${glitchW2}px`, clipPath: cutCornerPath(20) } as React.CSSProperties}
+                style={{
+                  '--crt-offset': `${modalTransition.state.scanline.crtOffset}px`,
+                  '--glitch-y': `${modalTransition.state.scanline.glitchY}%`,
+                  '--glitch-y2': `${modalTransition.state.scanline.glitchY2}%`,
+                  '--glitch-w': `${modalTransition.state.scanline.glitchW}px`,
+                  '--glitch-w2': `${modalTransition.state.scanline.glitchW2}px`,
+                  clipPath: cutCornerPath(20),
+                } as React.CSSProperties}
               />
             )}
 
@@ -504,7 +472,7 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
               </div>
               <button
                 type="button"
-                onClick={() => setSelectedWorkflowId(null)}
+                onClick={() => dispatch({ type: 'modal_closed' })}
                 className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors text-xl leading-none"
                 aria-label="Close"
               >
@@ -515,7 +483,7 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
             {/* Scrollable content */}
             <div
               ref={scrollRef}
-              className={`flex-1 overflow-auto overscroll-contain px-6 py-5 ${contentAnimClass}`}
+              className={`flex-1 overflow-auto overscroll-contain px-6 py-5 ${modalTransition.state.contentAnimClass}`}
               style={{ '--text-muted': 'var(--text-secondary)' } as React.CSSProperties}
             >
               {/* Screen reader announcement */}
@@ -524,11 +492,7 @@ export function WorkflowsView({ selectedTag, onSelectTag, onSelectWorkflow: _onS
               </div>
 
               {selectedWorkflowId && (
-                <WorkflowDetail
-                  workflowId={selectedWorkflowId}
-                  activeTag={selectedTag}
-                  onBack={() => setSelectedWorkflowId(null)}
-                />
+                <WorkflowDetail viewModel={workflowDetailViewModel} />
               )}
             </div>
           </CutCornerBox>

--- a/console/src/views/WorkspaceView.tsx
+++ b/console/src/views/WorkspaceView.tsx
@@ -1,22 +1,16 @@
 import {
   useState,
-  useMemo,
   useEffect,
   useRef,
   useCallback,
   type RefObject,
 } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
-import { useNavigate } from '@tanstack/react-router';
-import { useSessionList, useWorktreeList, useWorkspaceEvents } from '../api/hooks';
 import { SessionList } from './SessionList';
 import type { FileChangeStatus, ChangedFile, ConsoleSessionSummary } from '../api/types';
-import {
-  type WorkspaceItem,
-  type Scope,
-  joinSessionsAndWorktrees,
-  sortItemsForRepo,
-} from './workspace-types';
+import { type WorkspaceItem, type Scope, type RepoGroup } from './workspace-types';
+import type { UseWorkspaceViewModelResult } from '../hooks/useWorkspaceViewModel';
+import type { UseSessionListViewModelResult } from '../hooks/useSessionListViewModel';
 import { formatRelativeTime } from '../utils/time';
 import { CutCornerBox } from '../components/CutCornerBox';
 import { BracketBadge } from '../components/BracketBadge';
@@ -60,14 +54,6 @@ function pickRandom<T>(pool: readonly T[]): T {
   return pool[Math.floor(Math.random() * pool.length)];
 }
 
-// ---------------------------------------------------------------------------
-// Archive state
-// ---------------------------------------------------------------------------
-
-interface ArchiveState {
-  readonly repoName: string | undefined;
-}
-
 /**
  * Expand state for a single branch's collapsible panels.
  * Stored in a ref map keyed by `branch + '\0' + repoRoot` so panels survive
@@ -81,22 +67,21 @@ interface BranchExpandState {
 type ExpandStateMap = Map<string, BranchExpandState>;
 
 // ---------------------------------------------------------------------------
-// RepoGroup
-// ---------------------------------------------------------------------------
-
-interface RepoGroup {
-  readonly repoRoot: string;
-  readonly repoName: string;
-  readonly sortedItems: readonly WorkspaceItem[];
-}
-
-// ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
 
 interface Props {
-  /** When true, the view is hidden (parent navigated to SessionDetail). Kept
-   * mounted so state is preserved for scroll restoration on back-nav. */
+  /**
+   * ViewModel result from useWorkspaceViewModel().
+   * WorkspaceView is a pure presentational component -- it does not fetch data.
+   */
+  readonly viewModel: UseWorkspaceViewModelResult;
+  /** ViewModel for the inline archive (SessionList) sub-panel. */
+  readonly sessionListViewModel: UseSessionListViewModelResult;
+  /**
+   * When true, the view is hidden (parent navigated to SessionDetail). Kept
+   * mounted so expandStateRef survives SSE-driven remounts of child components.
+   */
   hidden?: boolean;
 }
 
@@ -104,38 +89,21 @@ interface Props {
 // WorkspaceView
 // ---------------------------------------------------------------------------
 
-export function WorkspaceView({ hidden = false }: Props) {
-  const navigate = useNavigate();
-  const { data: sessionData, isLoading: sessionsLoading, error: sessionsError, refetch } = useSessionList();
-  const { data: worktreeData, isLoading: worktreesFetching } = useWorktreeList();
-  // Subscribe to server-sent events -- triggers immediate refetch when sessions change
-  useWorkspaceEvents();
-
-  const [scope, setScope] = useState<Scope>('active');
-  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
-  const [archive, setArchive] = useState<ArchiveState | null>(null);
-
-  // Scroll restoration: capture scroll position before navigating to SessionDetail,
-  // restore on return. Sessions are always visible so no accordion key to restore.
-  const scrollYRef = useRef<number>(0);
-  const isFirstRender = useRef(true);
+export function WorkspaceView({ viewModel, sessionListViewModel, hidden = false }: Props) {
+  const { state, dispatch, scrollYRef, onSelectSession } = viewModel;
 
   // Expand state for branch panels (changed files, unpushed commits).
-  // Hoisted here so SSE-driven re-renders that unmount/remount BranchGroup and
-  // WorktreeOnlyRow do not reset the user's open panels. Keyed by
-  // `branch + '\0' + repoRoot` -- same composite key used by the join.
+  // Kept as a local ref (not in reducer state) so SSE-driven re-renders that
+  // unmount/remount BranchGroup and WorktreeOnlyRow do not reset the user's
+  // open panels. Keyed by `branch + '\0' + repoRoot`.
+  //
+  // Invariant: WorkspaceView stays permanently mounted (AppShell renders it
+  // with CSS hidden only). If this invariant breaks, expand state is lost.
   const expandStateRef = useRef<ExpandStateMap>(new Map());
 
-  const wrappedSelectSession = useCallback(
-    (sessionId: string) => {
-      scrollYRef.current = window.scrollY;
-      navigate({ to: '/session/$sessionId', params: { sessionId } });
-    },
-    [navigate],
-  );
-
-  // Restore scroll position when returning from SessionDetail.
-  // Skip on first mount -- page is already at 0 and there is nothing to restore.
+  // Scroll restoration: restore captured position when returning from SessionDetail.
+  // Skip on first render -- page is already at 0 and there is nothing to restore.
+  const isFirstRender = useRef(true);
   useEffect(() => {
     if (isFirstRender.current) {
       isFirstRender.current = false;
@@ -147,86 +115,10 @@ export function WorkspaceView({ hidden = false }: Props) {
       });
       return () => cancelAnimationFrame(id);
     }
-  }, [hidden]);
+  }, [hidden, scrollYRef]);
 
-  const { repoGroups, orderedItems, archiveRepos, dormantHiddenCount } = useMemo(() => {
-    const nowMs = Date.now();
-    const empty = { repoGroups: [] as RepoGroup[], orderedItems: [] as WorkspaceItem[], archiveRepos: [] as Array<[string, string]>, dormantHiddenCount: 0 };
-    if (!sessionData) return empty;
-
-    const worktreeRepos = worktreeData?.repos ?? [];
-    const joined = joinSessionsAndWorktrees(sessionData.sessions, worktreeRepos);
-
-    const reposSeen = new Map<string, string>();
-    for (const item of joined) {
-      if (!reposSeen.has(item.repoRoot)) reposSeen.set(item.repoRoot, item.repoName);
-    }
-
-    // Group by repo
-    const byRepo = new Map<string, WorkspaceItem[]>();
-    for (const item of joined) {
-      const existing = byRepo.get(item.repoRoot) ?? [];
-      existing.push(item);
-      byRepo.set(item.repoRoot, existing);
-    }
-
-    // Sort repos: repos with active sessions first, then alphabetical
-    const groups: RepoGroup[] = [...byRepo.entries()]
-      .map(([repoRoot, items]) => ({
-        repoRoot,
-        repoName: items[0]!.repoName,
-        sortedItems: sortItemsForRepo(items, scope, nowMs),
-      }))
-      .filter(g => g.sortedItems.length > 0)
-      .sort((a, b) => {
-        const aActive = a.sortedItems.some(i => i.primarySession?.status === 'in_progress' || i.primarySession?.status === 'blocked') ? 0 : 1;
-        const bActive = b.sortedItems.some(i => i.primarySession?.status === 'in_progress' || i.primarySession?.status === 'blocked') ? 0 : 1;
-        if (aActive !== bActive) return aActive - bActive;
-        return a.repoName.localeCompare(b.repoName);
-      });
-
-    const flat = groups.flatMap(g => g.sortedItems);
-
-    // Count items hidden from Active scope because they're dormant (no git changes)
-    const dormantHiddenCount = scope === 'active'
-      ? joined.filter(item =>
-          item.primarySession?.status === 'dormant' &&
-          (item.worktree?.changedCount ?? 0) === 0 &&
-          (item.worktree?.aheadCount ?? 0) === 0
-        ).length
-      : 0;
-
-    return {
-      repoGroups: groups,
-      orderedItems: flat,
-      archiveRepos: [...reposSeen.entries()] as Array<[string, string]>,
-      dormantHiddenCount,
-    };
-  }, [sessionData, worktreeData, scope]);
-
-  // Reset keyboard focus when the item list changes length (e.g. after scope toggle).
-  // Prevents focusedIndex pointing to a different item than the user expects.
-  useEffect(() => {
-    setFocusedIndex(-1);
-  }, [orderedItems.length]);
-
-  // Keyboard navigation -- disabled while hidden (e.g. SessionDetail overlaid on top)
-  useWorkspaceKeyboard({
-    items: orderedItems,
-    focusedIndex,
-    setFocusedIndex,
-    onSelectSession: wrappedSelectSession,
-    scope,
-    setScope,
-    refetch,
-    archive,
-    setArchive,
-    disabled: hidden,
-  });
-
-  const hasAnySessions = (sessionData?.totalCount ?? 0) > 0;
-
-  if (sessionsLoading) {
+  // Render based on view state discriminant
+  if (state.kind === 'loading') {
     return (
       <div className={`flex items-center justify-center py-32 ${hidden ? 'hidden' : ''}`}>
         <span className="font-mono text-[11px] text-[var(--text-muted)] uppercase tracking-[0.25em] motion-safe:animate-pulse">
@@ -236,7 +128,7 @@ export function WorkspaceView({ hidden = false }: Props) {
     );
   }
 
-  if (sessionsError) {
+  if (state.kind === 'error') {
     return (
       <div
         className={`p-4 ${hidden ? 'hidden' : ''}`}
@@ -246,11 +138,24 @@ export function WorkspaceView({ hidden = false }: Props) {
           // ERROR
         </span>
         <span className="text-sm text-[var(--text-secondary)]">
-          Failed to load workspace: {sessionsError.message}
+          Failed to load workspace: {state.message}
         </span>
       </div>
     );
   }
+
+  // state.kind === 'ready'
+  const {
+    scope,
+    focusedIndex,
+    archive,
+    repoGroups,
+    orderedItems,
+    archiveRepos,
+    dormantHiddenCount,
+    worktreesFetching,
+    hasAnySessions,
+  } = state;
 
   // Archive view (inline SessionList)
   if (archive !== null) {
@@ -258,7 +163,7 @@ export function WorkspaceView({ hidden = false }: Props) {
       <div className={`space-y-4 ${hidden ? 'hidden' : ''}`}>
         <div className="flex items-center gap-3">
           <button
-            onClick={() => setArchive(null)}
+            onClick={() => dispatch({ type: 'archive_closed' })}
             className="font-mono text-[10px] uppercase tracking-[0.20em] text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors"
           >
             // WORKSPACE &larr;
@@ -270,7 +175,7 @@ export function WorkspaceView({ hidden = false }: Props) {
           )}
         </div>
         <SessionList
-          onSelectSession={wrappedSelectSession}
+          viewModel={sessionListViewModel}
         />
       </div>
     );
@@ -297,7 +202,7 @@ export function WorkspaceView({ hidden = false }: Props) {
                 // {orderedItems.length} session{orderedItems.length !== 1 ? 's' : ''}
               </p>
             </div>
-            <ScopeToggle scope={scope} onChange={setScope} />
+            <ScopeToggle scope={scope} onChange={(s) => dispatch({ type: 'scope_changed', scope: s })} />
           </div>
 
           {orderedItems.length === 0 ? (
@@ -313,10 +218,11 @@ export function WorkspaceView({ hidden = false }: Props) {
                     key={group.repoRoot}
                     group={group}
                     showHeader={true}
+                    scope={scope}
                     focusedIndex={focusedIndex}
                     groupOffset={groupOffset}
                     worktreesFetching={worktreesFetching}
-                    onSelectSession={wrappedSelectSession}
+                    onSelectSession={onSelectSession}
                     expandStateRef={expandStateRef}
                   />
                 );
@@ -327,14 +233,17 @@ export function WorkspaceView({ hidden = false }: Props) {
           {dormantHiddenCount > 0 && (
           <button
             type="button"
-            onClick={() => setScope('all')}
+            onClick={() => dispatch({ type: 'scope_changed', scope: 'all' })}
             className="font-mono text-[10px] uppercase tracking-[0.20em] text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors text-left"
           >
             // {dormantHiddenCount} dormant session{dormantHiddenCount !== 1 ? 's' : ''} hidden — show all
           </button>
         )}
 
-        <ArchiveLinks repos={archiveRepos} onOpen={(repoName) => setArchive({ repoName })} />
+        <ArchiveLinks
+          repos={archiveRepos}
+          onOpen={(repoName) => dispatch({ type: 'archive_opened', repoName })}
+        />
         </>
       )}
       <TipCard />
@@ -351,6 +260,7 @@ const SECTION_COLLAPSE_THRESHOLD = 12;
 function RepoSection({
   group,
   showHeader,
+  scope,
   focusedIndex,
   groupOffset,
   worktreesFetching,
@@ -359,6 +269,7 @@ function RepoSection({
 }: {
   readonly group: RepoGroup;
   readonly showHeader: boolean;
+  readonly scope: Scope;
   readonly focusedIndex: number;
   readonly groupOffset: number;
   readonly worktreesFetching: boolean;
@@ -425,6 +336,7 @@ function RepoSection({
                 key={`${item.branch}\0${item.repoRoot}`}
                 item={item}
                 isFocused={isFocused}
+                scope={scope}
                 worktreesFetching={worktreesFetching}
                 onSelectSession={onSelectSession}
                 expandStateRef={expandStateRef}
@@ -474,12 +386,14 @@ const SESSION_SORT = (a: ConsoleSessionSummary, b: ConsoleSessionSummary) => {
 function BranchGroup({
   item,
   isFocused,
+  scope,
   worktreesFetching,
   onSelectSession,
   expandStateRef,
 }: {
   readonly item: WorkspaceItem;
   readonly isFocused: boolean;
+  readonly scope: Scope;
   readonly worktreesFetching: boolean;
   readonly onSelectSession: (id: string) => void;
   readonly expandStateRef: RefObject<ExpandStateMap>;
@@ -510,8 +424,18 @@ function BranchGroup({
     });
   }, [expandKey, expandStateRef]);
 
-  const activeSessions = sorted.filter(s => s.status === 'in_progress' || s.status === 'blocked' || s.status === 'dormant');
-  const historySessions = sorted.filter(s => s.status !== 'in_progress' && s.status !== 'blocked' && s.status !== 'dormant');
+  // In Active scope, dormant sessions are demoted to history -- they appear
+  // behind the "expand history" toggle rather than cluttering the active list.
+  // In All scope, dormant sessions stay visible in the active section so the
+  // user can see all running/stalled work at once.
+  const isDormantVisible = (s: ConsoleSessionSummary) =>
+    s.status === 'dormant' && scope === 'all';
+  const activeSessions = sorted.filter(s =>
+    s.status === 'in_progress' || s.status === 'blocked' || isDormantVisible(s)
+  );
+  const historySessions = sorted.filter(s =>
+    s.status !== 'in_progress' && s.status !== 'blocked' && !isDormantVisible(s)
+  );
 
   return (
     <TreeLine style={isFocused ? { outline: '2px solid var(--accent)', outlineOffset: '2px' } : undefined}>
@@ -1127,134 +1051,4 @@ function TipCard() {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Keyboard navigation hook
-// ---------------------------------------------------------------------------
-
-interface KeyboardOptions {
-  readonly items: readonly WorkspaceItem[];
-  readonly focusedIndex: number;
-  readonly setFocusedIndex: (i: number) => void;
-  /** Called when Enter/Space is pressed on a focused item -- navigates to session detail */
-  readonly onSelectSession: (sessionId: string) => void;
-  readonly scope: Scope;
-  readonly setScope: (scope: Scope) => void;
-  readonly refetch: () => void;
-  readonly archive: ArchiveState | null;
-  readonly setArchive: (state: ArchiveState | null) => void;
-  readonly disabled: boolean;
-}
-
-function useWorkspaceKeyboard({
-  items,
-  focusedIndex,
-  setFocusedIndex,
-  onSelectSession,
-  scope,
-  setScope,
-  refetch,
-  archive,
-  setArchive,
-  disabled,
-}: KeyboardOptions) {
-  const itemsRef = useRef(items);
-  itemsRef.current = items;
-
-  const onSelectSessionRef = useRef(onSelectSession);
-  onSelectSessionRef.current = onSelectSession;
-
-  const scopeRef = useRef(scope);
-  scopeRef.current = scope;
-
-  const focusedIndexRef = useRef(focusedIndex);
-  focusedIndexRef.current = focusedIndex;
-
-  const archiveRef = useRef(archive);
-  archiveRef.current = archive;
-
-  const disabledRef = useRef(disabled);
-  disabledRef.current = disabled;
-
-  // (no expandedKeyRef -- sessions are always visible, no accordion state)
-
-  useEffect(() => {
-    function handler(e: KeyboardEvent) {
-      // Skip when the workspace view is hidden behind SessionDetail
-      if (disabledRef.current) return;
-
-      // Skip when modifier keys are held -- let browser shortcuts like Cmd+R pass through
-      if (e.metaKey || e.ctrlKey || e.altKey) return;
-
-      // Skip if focus is inside an input or textarea (avoid interfering with typing)
-      const active = document.activeElement;
-      if (
-        active instanceof HTMLInputElement ||
-        active instanceof HTMLTextAreaElement ||
-        active instanceof HTMLSelectElement
-      ) {
-        return;
-      }
-
-      // Close archive on Escape
-      if (e.key === 'Escape' && archiveRef.current !== null) {
-        setArchive(null);
-        return;
-      }
-
-      const items = itemsRef.current;
-      const focusedIndex = focusedIndexRef.current;
-
-      switch (e.key) {
-        case 'j':
-        case 'ArrowDown': {
-          e.preventDefault();
-          const next = Math.min(focusedIndex + 1, items.length - 1);
-          setFocusedIndex(next);
-          break;
-        }
-        case 'k':
-        case 'ArrowUp': {
-          e.preventDefault();
-          const prev = Math.max(focusedIndex - 1, 0);
-          setFocusedIndex(prev);
-          break;
-        }
-        case 'Enter':
-        case ' ': {
-          e.preventDefault();
-          if (focusedIndex >= 0 && focusedIndex < items.length) {
-            const item = items[focusedIndex];
-            const sessionId = item.primarySession?.sessionId;
-            if (sessionId) {
-              onSelectSessionRef.current(sessionId);
-            }
-          }
-          break;
-        }
-        case 'Escape': {
-          // Escape with archive open closes it; otherwise no-op (no accordion to collapse)
-          break;
-        }
-        case '/': {
-          e.preventDefault();
-          setArchive({ repoName: undefined });
-          break;
-        }
-        case 'r': {
-          e.preventDefault();
-          refetch();
-          break;
-        }
-        case 'a': {
-          e.preventDefault();
-          setScope(scopeRef.current === 'active' ? 'all' : 'active');
-          break;
-        }
-      }
-    }
-
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [setFocusedIndex, setScope, refetch, setArchive]);
-}
 // build-1775224304

--- a/console/src/views/performance-use-cases.ts
+++ b/console/src/views/performance-use-cases.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure use-case functions for PerformanceView derived display data.
+ *
+ * No React imports. Same inputs always produce the same outputs.
+ * Extracted from PerformanceView's useMemo chains.
+ */
+import type { ToolCallTiming } from '../api/types';
+
+// ---------------------------------------------------------------------------
+// Sort configuration
+// ---------------------------------------------------------------------------
+
+export type SortOrder = 'recent' | 'slowest';
+
+export interface SortOption {
+  readonly value: SortOrder;
+  readonly label: string;
+  readonly compareFn: (a: ToolCallTiming, b: ToolCallTiming) => number;
+}
+
+export const SORT_OPTIONS: readonly SortOption[] = [
+  { value: 'recent', label: 'Recent first', compareFn: (a, b) => b.startedAtMs - a.startedAtMs },
+  { value: 'slowest', label: 'Slowest first', compareFn: (a, b) => b.durationMs - a.durationMs },
+];
+
+// ---------------------------------------------------------------------------
+// Outcome configuration (single source of truth)
+// ---------------------------------------------------------------------------
+
+export type Outcome = 'success' | 'error' | 'unknown_tool';
+
+export const OUTCOME_CONFIG: Record<
+  Outcome,
+  { readonly color: string; readonly label: string; readonly isError: boolean }
+> = {
+  success: { color: 'var(--success)', label: 'OK', isError: false },
+  error: { color: 'var(--error)', label: 'Error', isError: true },
+  unknown_tool: { color: 'var(--warning)', label: 'Unknown', isError: true },
+};
+
+// ---------------------------------------------------------------------------
+// Derived display data
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns observations sorted by the given sort order.
+ *
+ * Uses the compareFn from SORT_OPTIONS. Creates a shallow copy before sorting
+ * so the input array is never mutated.
+ */
+export function sortObservations(
+  observations: readonly ToolCallTiming[],
+  sortOrder: SortOrder,
+): readonly ToolCallTiming[] {
+  const option = SORT_OPTIONS.find((o) => o.value === sortOrder)!;
+  return [...observations].sort(option.compareFn);
+}
+
+/**
+ * Returns the maximum durationMs across all observations.
+ *
+ * Uses reduce to avoid Math.max(...spread) which crashes on large arrays.
+ * Returns 0 for an empty array.
+ */
+export function computeMaxDuration(observations: readonly ToolCallTiming[]): number {
+  return observations.reduce((max, o) => Math.max(max, o.durationMs), 0);
+}
+
+/**
+ * Returns the count of observations whose outcome is classified as an error.
+ */
+export function computeErrorCount(observations: readonly ToolCallTiming[]): number {
+  return observations.filter((o) => OUTCOME_CONFIG[o.outcome].isError).length;
+}
+
+/**
+ * Returns the average durationMs rounded to the nearest integer, or null
+ * if the observations array is empty.
+ */
+export function computeAvgMs(observations: readonly ToolCallTiming[]): number | null {
+  if (observations.length === 0) return null;
+  return Math.round(
+    observations.reduce((sum, o) => sum + o.durationMs, 0) / observations.length,
+  );
+}
+
+/**
+ * Returns the most recent startedAtMs across all observations, or null if
+ * the array is empty.
+ *
+ * Uses reduce to avoid Math.max(...spread) which crashes on large arrays.
+ */
+export function computeLastCallMs(observations: readonly ToolCallTiming[]): number | null {
+  if (observations.length === 0) return null;
+  return observations.reduce((max, o) => Math.max(max, o.startedAtMs), 0);
+}
+
+/**
+ * Returns the bar width in pixels for a timing row, capped at 120px.
+ *
+ * Returns 0 when maxDuration is 0 to avoid division by zero.
+ */
+export function computeBarWidth(durationMs: number, maxDuration: number): number {
+  return maxDuration > 0 ? Math.round((durationMs / maxDuration) * 120) : 0;
+}
+
+/**
+ * Returns a human-readable count label for the observations ring buffer.
+ */
+export function computeCountLabel(count: number): string {
+  return `${count} recorded`;
+}

--- a/console/src/views/session-list-reducer.ts
+++ b/console/src/views/session-list-reducer.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure reducer for SessionList UI interaction state.
+ *
+ * Manages only user-driven interaction state: search input, sort axis,
+ * group axis, status filter, and pagination cursor. Loading and error state
+ * come from the repository layer (React Query) and are composed into
+ * SessionListViewState by the ViewModel hook -- they do not live here.
+ *
+ * No React imports. Pure function: same inputs always produce the same output.
+ *
+ * Invariant: `page` is always reset to 0 when any filter, sort, or group
+ * changes. Only `page_changed` events may set page to a non-zero value.
+ * This prevents stale pagination state after a filter narrows the result set.
+ */
+import type { SortField, GroupBy, StatusFilter } from './session-list-use-cases';
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+export interface SessionListInteractionState {
+  /**
+   * Raw (undebounced) search value. Drives the input field display.
+   * The ViewModel applies debouncing before using this in the data pipeline.
+   */
+  readonly rawSearch: string;
+  readonly sort: SortField;
+  readonly groupBy: GroupBy;
+  readonly statusFilter: StatusFilter;
+  readonly page: number;
+}
+
+// ---------------------------------------------------------------------------
+// Initial state factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the initial interaction state.
+ *
+ * @param initialSearch - Optional search string to pre-seed the search field
+ *   (e.g. branch name from worktree click-through).
+ */
+export function createInitialSessionListState(
+  initialSearch = '',
+): SessionListInteractionState {
+  return {
+    rawSearch: initialSearch,
+    sort: 'recent',
+    groupBy: 'none',
+    statusFilter: 'all',
+    page: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+export type SessionListEvent =
+  | { readonly type: 'search_changed'; readonly value: string }
+  | { readonly type: 'sort_changed'; readonly sort: SortField }
+  | { readonly type: 'group_changed'; readonly groupBy: GroupBy }
+  | { readonly type: 'status_changed'; readonly statusFilter: StatusFilter }
+  | { readonly type: 'page_changed'; readonly page: number };
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled SessionListEvent type: ${String((value as { type: string }).type)}`);
+}
+
+/**
+ * Pure session list reducer. Handles UI interaction events only.
+ *
+ * Invariant: page is reset to 0 on all non-page_changed events. This ensures
+ * the user does not see a blank list after a filter narrows the result set
+ * to fewer pages than the current page index.
+ */
+export function sessionListReducer(
+  state: SessionListInteractionState,
+  event: SessionListEvent,
+): SessionListInteractionState {
+  switch (event.type) {
+    case 'search_changed':
+      return { ...state, rawSearch: event.value, page: 0 };
+
+    case 'sort_changed':
+      return { ...state, sort: event.sort, page: 0 };
+
+    case 'group_changed':
+      return { ...state, groupBy: event.groupBy, page: 0 };
+
+    case 'status_changed':
+      return { ...state, statusFilter: event.statusFilter, page: 0 };
+
+    case 'page_changed':
+      // page_changed is the only event that does NOT reset page to 0.
+      return { ...state, page: event.page };
+
+    default:
+      return assertNever(event);
+  }
+}

--- a/console/src/views/session-list-use-cases.ts
+++ b/console/src/views/session-list-use-cases.ts
@@ -1,0 +1,198 @@
+/**
+ * Pure use-case functions and constants for the SessionList view.
+ *
+ * No React imports. All functions are deterministic: same inputs always
+ * produce the same output. These are the only place business logic lives
+ * for the session list -- keep them here, not in hooks or components.
+ *
+ * Sort / group axis definitions:
+ * Adding a new sort or group axis requires a single entry in SORT_AXES or
+ * GROUP_AXES -- no edits to switch statements or separate type unions.
+ */
+import type { ConsoleSessionSummary, ConsoleSessionStatus } from '../api/types';
+
+// ---------------------------------------------------------------------------
+// Types (exported so reducer and ViewModel can import without duplication)
+// ---------------------------------------------------------------------------
+
+export type StatusFilter = 'all' | ConsoleSessionStatus;
+
+// Parameterised so that `value` is inferred as a literal type rather than
+// widened to `string`. This lets TypeScript catch typos in SortField/GroupBy
+// assignments at compile time.
+interface SortAxisDef<V extends string> {
+  readonly value: V;
+  readonly label: string;
+  readonly compareFn: (a: ConsoleSessionSummary, b: ConsoleSessionSummary) => number;
+}
+
+interface GroupAxisDef<V extends string> {
+  readonly value: V;
+  readonly label: string;
+  // Returns the group key for a session, or null for the "ungrouped" sentinel.
+  readonly keyFn: ((s: ConsoleSessionSummary) => string) | null;
+  // Optional comparator for group labels. Defaults to localeCompare.
+  readonly groupCompareFn?: (a: string, b: string) => number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const STATUS_SORT_ORDER: Record<ConsoleSessionStatus, number> = {
+  in_progress: 0,
+  blocked: 1,
+  dormant: 2,
+  complete_with_gaps: 3,
+  complete: 4,
+};
+
+export const SORT_AXES = [
+  {
+    value: 'recent' as const,
+    label: 'Recent',
+    compareFn: (a: ConsoleSessionSummary, b: ConsoleSessionSummary) => b.lastModifiedMs - a.lastModifiedMs,
+  },
+  {
+    value: 'status' as const,
+    label: 'Status',
+    compareFn: (a: ConsoleSessionSummary, b: ConsoleSessionSummary) =>
+      STATUS_SORT_ORDER[a.status] - STATUS_SORT_ORDER[b.status] || b.lastModifiedMs - a.lastModifiedMs,
+  },
+  {
+    value: 'workflow' as const,
+    label: 'Workflow',
+    compareFn: (a: ConsoleSessionSummary, b: ConsoleSessionSummary) =>
+      (a.workflowName ?? a.workflowId ?? '').localeCompare(b.workflowName ?? b.workflowId ?? '') ||
+      b.lastModifiedMs - a.lastModifiedMs,
+  },
+  {
+    value: 'nodes' as const,
+    label: 'Node count',
+    compareFn: (a: ConsoleSessionSummary, b: ConsoleSessionSummary) =>
+      b.nodeCount - a.nodeCount || b.lastModifiedMs - a.lastModifiedMs,
+  },
+] as const satisfies readonly SortAxisDef<string>[];
+
+export const GROUP_AXES = [
+  { value: 'none' as const, label: 'No grouping', keyFn: null },
+  { value: 'workflow' as const, label: 'Workflow', keyFn: (s: ConsoleSessionSummary) => s.workflowName ?? s.workflowId ?? 'Unknown workflow' },
+  {
+    value: 'status' as const,
+    label: 'Status',
+    keyFn: (s: ConsoleSessionSummary) => s.status,
+    // Sort status groups by severity order rather than alphabetically.
+    groupCompareFn: (a: string, b: string) =>
+      (STATUS_SORT_ORDER[a as ConsoleSessionStatus] ?? 99) - (STATUS_SORT_ORDER[b as ConsoleSessionStatus] ?? 99),
+  },
+  { value: 'branch' as const, label: 'Branch', keyFn: (s: ConsoleSessionSummary) => s.gitBranch ?? 'No branch' },
+] as const satisfies readonly GroupAxisDef<string>[];
+
+export type SortField = (typeof SORT_AXES)[number]['value'];
+export type GroupBy = (typeof GROUP_AXES)[number]['value'];
+
+export const STATUS_FILTER_OPTIONS: readonly { readonly value: StatusFilter; readonly label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'dormant', label: 'Dormant' },
+  { value: 'complete', label: 'Complete' },
+  { value: 'complete_with_gaps', label: 'Gaps' },
+  { value: 'blocked', label: 'Blocked' },
+];
+
+export const PAGE_SIZE = 25;
+
+// ---------------------------------------------------------------------------
+// Pure use-case functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Filters sessions by status and search query.
+ *
+ * Search matches against: sessionTitle, workflowName, workflowId, sessionId, gitBranch.
+ * Returns a new array; does not mutate the input.
+ */
+export function filterSessions(
+  sessions: readonly ConsoleSessionSummary[],
+  search: string,
+  statusFilter: StatusFilter,
+): readonly ConsoleSessionSummary[] {
+  let filtered: readonly ConsoleSessionSummary[] = sessions;
+
+  if (statusFilter !== 'all') {
+    filtered = filtered.filter((s) => s.status === statusFilter);
+  }
+
+  if (search.trim()) {
+    const q = search.toLowerCase();
+    filtered = filtered.filter((s) =>
+      (s.sessionTitle ?? '').toLowerCase().includes(q) ||
+      (s.workflowName ?? '').toLowerCase().includes(q) ||
+      (s.workflowId ?? '').toLowerCase().includes(q) ||
+      s.sessionId.toLowerCase().includes(q) ||
+      (s.gitBranch ?? '').toLowerCase().includes(q)
+    );
+  }
+
+  return filtered;
+}
+
+/**
+ * Sorts sessions by the given sort axis.
+ * Returns a new array; does not mutate the input.
+ */
+export function sortSessions(
+  sessions: readonly ConsoleSessionSummary[],
+  sort: SortField,
+): readonly ConsoleSessionSummary[] {
+  const axis = SORT_AXES.find((a) => a.value === sort) ?? SORT_AXES[0];
+  return [...sessions].sort(axis.compareFn);
+}
+
+/**
+ * Groups sessions by the given group axis.
+ * Returns an array of { label, sessions } groups.
+ * Does not mutate the input.
+ */
+export function groupSessions(
+  sessions: readonly ConsoleSessionSummary[],
+  groupBy: GroupBy,
+): readonly { readonly label: string; readonly sessions: readonly ConsoleSessionSummary[] }[] {
+  const axis = GROUP_AXES.find((a) => a.value === groupBy) ?? GROUP_AXES[0];
+  if (!axis.keyFn) return [{ label: '', sessions }];
+
+  const groups = new Map<string, ConsoleSessionSummary[]>();
+
+  for (const s of sessions) {
+    const key = (axis.keyFn as (s: ConsoleSessionSummary) => string)(s);
+    const list = groups.get(key) ?? [];
+    list.push(s);
+    groups.set(key, list);
+  }
+
+  // Cast to the base interface to access the optional groupCompareFn field.
+  const compareFn = (axis as GroupAxisDef<string>).groupCompareFn ?? ((a: string, b: string) => a.localeCompare(b));
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => compareFn(a, b))
+    .map(([label, groupedSessions]) => ({ label, sessions: groupedSessions }));
+}
+
+/**
+ * Computes per-status session counts from the FULL unfiltered session list.
+ *
+ * Invariant: this must always receive the complete session list, not the
+ * post-filter subset. Status filter pills show counts for ALL sessions
+ * regardless of the active filter.
+ *
+ * Returns a record mapping each StatusFilter value to its count.
+ * 'all' is always the total session count.
+ */
+export function computeStatusCounts(
+  sessions: readonly ConsoleSessionSummary[],
+): Record<StatusFilter, number> {
+  const counts: Record<string, number> = { all: sessions.length };
+  for (const s of sessions) {
+    counts[s.status] = (counts[s.status] ?? 0) + 1;
+  }
+  return counts as Record<StatusFilter, number>;
+}

--- a/console/src/views/workflow-detail-use-cases.ts
+++ b/console/src/views/workflow-detail-use-cases.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure use cases for WorkflowDetail.
+ *
+ * No React imports. All functions are deterministic and side-effect-free.
+ */
+import type { ConsoleWorkflowSummary } from '../api/types';
+
+// ---------------------------------------------------------------------------
+// getAdjacentWorkflows
+// ---------------------------------------------------------------------------
+
+export interface AdjacentWorkflows {
+  readonly prevWorkflow: ConsoleWorkflowSummary | null;
+  readonly nextWorkflow: ConsoleWorkflowSummary | null;
+}
+
+/**
+ * Returns the immediately adjacent workflows (prev and next) in a flat list.
+ *
+ * Returns null for both when workflowId is null/empty or not found in the list.
+ * Returns null for prevWorkflow when at the start of the list.
+ * Returns null for nextWorkflow when at the end of the list.
+ *
+ * Pure function: same inputs always produce the same output.
+ */
+export function getAdjacentWorkflows(
+  workflowId: string | null | undefined,
+  workflows: readonly ConsoleWorkflowSummary[],
+): AdjacentWorkflows {
+  if (!workflowId) return { prevWorkflow: null, nextWorkflow: null };
+
+  const idx = workflows.findIndex((w) => w.id === workflowId);
+  if (idx === -1) return { prevWorkflow: null, nextWorkflow: null };
+
+  return {
+    prevWorkflow: idx > 0 ? (workflows[idx - 1] ?? null) : null,
+    nextWorkflow: idx < workflows.length - 1 ? (workflows[idx + 1] ?? null) : null,
+  };
+}

--- a/console/src/views/workflows-reducer.ts
+++ b/console/src/views/workflows-reducer.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure reducer for workflows UI interaction state.
+ *
+ * Manages only user-driven interaction state: selected workflow (inline modal),
+ * tag filter, source filter, and keyboard hint visibility. Loading and error
+ * state come from the repository layer and are composed into WorkflowsViewState
+ * by the ViewModel hook -- they do not live here.
+ *
+ * No React imports. Pure function: same inputs always produce the same output.
+ */
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+export interface WorkflowsInteractionState {
+  readonly selectedWorkflowId: string | null;
+  readonly selectedTag: string | null;
+  readonly selectedSource: string | null;
+  /**
+   * True briefly when the modal opens with multiple workflows available,
+   * to show the keyboard navigation hint. Dismissed after 3s via ViewModel.
+   */
+  readonly hintVisible: boolean;
+}
+
+export const INITIAL_WORKFLOWS_STATE: WorkflowsInteractionState = {
+  selectedWorkflowId: null,
+  selectedTag: null,
+  selectedSource: null,
+  hintVisible: false,
+};
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+export type WorkflowsEvent =
+  | { readonly type: 'workflow_selected'; readonly id: string | null }
+  | { readonly type: 'tag_changed'; readonly tag: string | null }
+  | { readonly type: 'source_changed'; readonly source: string | null }
+  | { readonly type: 'modal_closed' }
+  | { readonly type: 'hint_dismissed' };
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled WorkflowsEvent type: ${String((value as { type: string }).type)}`);
+}
+
+/**
+ * Pure workflows reducer. Handles UI interaction events only.
+ *
+ * Invariants:
+ * - selectedWorkflowId === null means the inline modal is closed.
+ * - hintVisible is set to true when a workflow is selected (non-null id) and
+ *   reset to false on modal close. The 3s auto-dismiss is handled in the
+ *   ViewModel via a useEffect, not here.
+ * - tag_changed and source_changed clear selectedWorkflowId because navigating
+ *   away from the current filter invalidates the current modal context.
+ */
+export function workflowsReducer(
+  state: WorkflowsInteractionState,
+  event: WorkflowsEvent,
+): WorkflowsInteractionState {
+  switch (event.type) {
+    case 'workflow_selected':
+      return {
+        ...state,
+        selectedWorkflowId: event.id,
+        // Show the nav hint when a workflow opens; hide it when the modal closes.
+        hintVisible: event.id !== null,
+      };
+
+    case 'tag_changed':
+      // Clear selected workflow -- the current modal is no longer valid after
+      // the filter changes.
+      return { ...state, selectedTag: event.tag, selectedWorkflowId: null, hintVisible: false };
+
+    case 'source_changed':
+      return { ...state, selectedSource: event.source, selectedWorkflowId: null, hintVisible: false };
+
+    case 'modal_closed':
+      return { ...state, selectedWorkflowId: null, hintVisible: false };
+
+    case 'hint_dismissed':
+      return { ...state, hintVisible: false };
+
+    default:
+      return assertNever(event);
+  }
+}

--- a/console/src/views/workflows-use-cases.ts
+++ b/console/src/views/workflows-use-cases.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure use-case functions for the Workflows catalog view.
+ *
+ * No React imports. All functions are deterministic: same inputs always
+ * produce the same output. These are the only place business logic lives
+ * for the Workflows catalog -- keep them here, not in hooks or components.
+ *
+ * The caller is responsible for filtering out 'routines' workflows before
+ * passing data to these functions. The repository layer handles that filter.
+ */
+import type { ConsoleWorkflowSummary } from '../api/types';
+import { CATALOG_TAGS } from '../config/tags';
+
+// ---------------------------------------------------------------------------
+// Source info
+// ---------------------------------------------------------------------------
+
+export interface WorkflowSourceOption {
+  readonly id: string;
+  readonly displayName: string;
+}
+
+// ---------------------------------------------------------------------------
+// Use cases
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the sorted, unique list of non-routines tags present in the workflow list.
+ *
+ * Follows CATALOG_TAGS order for known tags; unknown tags appear sorted alphabetically
+ * after the known ones.
+ */
+export function getAvailableTags(workflows: readonly ConsoleWorkflowSummary[]): readonly string[] {
+  const present = new Set<string>();
+  for (const w of workflows) {
+    for (const t of w.tags) {
+      if (t !== 'routines') present.add(t);
+    }
+  }
+  const knownOrdered = CATALOG_TAGS.map((t) => t.id).filter((id) => present.has(id));
+  const unknown = [...present].filter((id) => !CATALOG_TAGS.some((t) => t.id === id)).sort();
+  return [...knownOrdered, ...unknown];
+}
+
+/**
+ * Returns the unique source options derived from the workflow list.
+ * Each source is identified by its kind (id) and displayName.
+ * Order is stable: first-seen order from the list.
+ */
+export function getAvailableSources(
+  workflows: readonly ConsoleWorkflowSummary[],
+): readonly WorkflowSourceOption[] {
+  const seen = new Map<string, WorkflowSourceOption>();
+  for (const w of workflows) {
+    if (!seen.has(w.source.kind)) {
+      seen.set(w.source.kind, { id: w.source.kind, displayName: w.source.displayName });
+    }
+  }
+  return [...seen.values()];
+}
+
+/**
+ * Filters workflows by tag and source.
+ *
+ * - tag === null: no tag filter applied
+ * - tag === '__other__': include workflows with no recognized non-routines catalog tag
+ * - tag === someId: include workflows with that tag
+ * - source === null: no source filter applied
+ * - source === displayName: include workflows from that source
+ */
+export function filterWorkflows(
+  workflows: readonly ConsoleWorkflowSummary[],
+  tag: string | null,
+  source: string | null,
+): readonly ConsoleWorkflowSummary[] {
+  const knownTagIds = new Set(CATALOG_TAGS.map((t) => t.id));
+
+  let filtered = workflows;
+
+  if (tag !== null) {
+    if (tag === '__other__') {
+      filtered = filtered.filter((w) => !w.tags.some((t) => t !== 'routines' && knownTagIds.has(t)));
+    } else {
+      filtered = filtered.filter((w) => w.tags.includes(tag));
+    }
+  }
+
+  if (source !== null) {
+    filtered = filtered.filter((w) => w.source.displayName === source);
+  }
+
+  return filtered;
+}
+
+/**
+ * Flattens the filtered workflow list into a single ordered array matching
+ * the visual card order for keyboard navigation.
+ *
+ * When a tag is selected, the list is already flat.
+ * When showing all tags, workflows are ordered by CATALOG_TAGS group order to
+ * match the grouped rendering in the view.
+ */
+export function flattenWorkflows(
+  filtered: readonly ConsoleWorkflowSummary[],
+  selectedTag: string | null,
+): readonly ConsoleWorkflowSummary[] {
+  if (selectedTag !== null) return filtered;
+
+  const knownTagIds = new Set(CATALOG_TAGS.map((t) => t.id));
+  const buckets = new Map<string, ConsoleWorkflowSummary[]>();
+  const other: ConsoleWorkflowSummary[] = [];
+
+  for (const w of filtered) {
+    const firstKnownTag = w.tags.find((t) => t !== 'routines' && knownTagIds.has(t));
+    if (firstKnownTag) {
+      const bucket = buckets.get(firstKnownTag) ?? [];
+      bucket.push(w);
+      buckets.set(firstKnownTag, bucket);
+    } else {
+      other.push(w);
+    }
+  }
+
+  const result: ConsoleWorkflowSummary[] = [];
+  for (const { id } of CATALOG_TAGS) {
+    const bucket = buckets.get(id);
+    if (bucket) result.push(...bucket);
+  }
+  result.push(...other);
+
+  return result;
+}

--- a/console/src/views/workspace-reducer.ts
+++ b/console/src/views/workspace-reducer.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure reducer for workspace UI interaction state.
+ *
+ * Manages only user-driven interaction state: scope toggle, keyboard focus,
+ * and archive panel open/close. Loading and error state come from the
+ * repository layer (React Query) and are composed into WorkspaceViewState
+ * by the ViewModel hook -- they do not live here.
+ *
+ * No React imports. Pure function: same inputs always produce the same output.
+ */
+import type { Scope } from './workspace-types';
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+export interface ArchiveState {
+  readonly repoName: string | undefined;
+}
+
+export interface WorkspaceInteractionState {
+  readonly scope: Scope;
+  readonly focusedIndex: number;
+  readonly archive: ArchiveState | null;
+}
+
+export const INITIAL_WORKSPACE_STATE: WorkspaceInteractionState = {
+  scope: 'active',
+  focusedIndex: -1,
+  archive: null,
+};
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+export type WorkspaceEvent =
+  | { readonly type: 'scope_changed'; readonly scope: Scope }
+  | { readonly type: 'focus_moved'; readonly index: number }
+  | { readonly type: 'archive_opened'; readonly repoName: string | undefined }
+  | { readonly type: 'archive_closed' };
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled WorkspaceEvent type: ${String((value as { type: string }).type)}`);
+}
+
+/**
+ * Pure workspace reducer. Handles UI interaction events only.
+ *
+ * Invariant: focusedIndex of -1 means no item is focused.
+ * Resetting focusedIndex to -1 when the item list changes is handled
+ * by the ViewModel hook via a useEffect, not here.
+ */
+export function workspaceReducer(
+  state: WorkspaceInteractionState,
+  event: WorkspaceEvent,
+): WorkspaceInteractionState {
+  switch (event.type) {
+    case 'scope_changed':
+      // Reset keyboard focus when scope changes -- the item list reorders,
+      // so the current index no longer points to the same item.
+      return { ...state, scope: event.scope, focusedIndex: -1 };
+
+    case 'focus_moved':
+      return { ...state, focusedIndex: event.index };
+
+    case 'archive_opened':
+      return { ...state, archive: { repoName: event.repoName } };
+
+    case 'archive_closed':
+      return { ...state, archive: null };
+
+    default:
+      return assertNever(event);
+  }
+}

--- a/console/src/views/workspace-types.ts
+++ b/console/src/views/workspace-types.ts
@@ -307,11 +307,119 @@ export function countNeedsAttention(items: readonly WorkspaceItem[]): number {
 }
 
 /**
- * Returns the count of sessions that have unresolved gaps across all items.
+ * Returns the count of items that have at least one session with unresolved gaps.
+ *
+ * Not currently consumed by the console UI -- reserved for a future
+ * gaps-attention badge or filter. Kept here alongside countNeedsAttention
+ * as the canonical aggregation layer for workspace-level attention signals.
  */
 export function countHasGaps(items: readonly WorkspaceItem[]): number {
   return items.reduce((count, item) => {
     const hasGap = item.allSessions.some((s) => s.hasUnresolvedGaps);
     return hasGap ? count + 1 : count;
   }, 0);
+}
+
+// ---------------------------------------------------------------------------
+// RepoGroup -- the display unit for a group of branches under one repo
+// ---------------------------------------------------------------------------
+
+export interface RepoGroup {
+  readonly repoRoot: string;
+  readonly repoName: string;
+  readonly sortedItems: readonly WorkspaceItem[];
+}
+
+// ---------------------------------------------------------------------------
+// buildRepoGroups -- pure use case: join + group + sort for workspace display
+// ---------------------------------------------------------------------------
+
+export interface RepoGroupsResult {
+  readonly repoGroups: readonly RepoGroup[];
+  readonly orderedItems: readonly WorkspaceItem[];
+  /**
+   * All repos seen in the unfiltered join, used for archive links.
+   * Always shows all repos regardless of scope so archive links are stable.
+   */
+  readonly archiveRepos: ReadonlyArray<readonly [string, string]>;
+  /** Count of dormant items hidden from the active scope (no git changes). */
+  readonly dormantHiddenCount: number;
+}
+
+/**
+ * Joins sessions and worktrees, groups by repo, sorts within each group,
+ * and returns all derived display data for the workspace view.
+ *
+ * This is the primary use case that drives WorkspaceView rendering.
+ * It calls joinSessionsAndWorktrees and sortItemsForRepo internally.
+ *
+ * Pure function: same inputs always produce the same outputs.
+ */
+export function buildRepoGroups(
+  sessions: readonly ConsoleSessionSummary[],
+  worktreeRepos: readonly ConsoleRepoWorktrees[],
+  scope: Scope,
+  nowMs: number,
+): RepoGroupsResult {
+  const joined = joinSessionsAndWorktrees(sessions, worktreeRepos);
+
+  const reposSeen = new Map<string, string>();
+  for (const item of joined) {
+    if (!reposSeen.has(item.repoRoot)) reposSeen.set(item.repoRoot, item.repoName);
+  }
+
+  // Group by repo
+  const byRepo = new Map<string, WorkspaceItem[]>();
+  for (const item of joined) {
+    const existing = byRepo.get(item.repoRoot) ?? [];
+    existing.push(item);
+    byRepo.set(item.repoRoot, existing);
+  }
+
+  // Sort repos: repos with active sessions first, then alphabetical
+  const groups: RepoGroup[] = [...byRepo.entries()]
+    .map(([repoRoot, items]) => ({
+      repoRoot,
+      repoName: items[0]!.repoName,
+      sortedItems: sortItemsForRepo(items, scope, nowMs),
+    }))
+    .filter((g) => g.sortedItems.length > 0)
+    .sort((a, b) => {
+      const aActive = a.sortedItems.some(
+        (i) =>
+          i.primarySession?.status === 'in_progress' ||
+          i.primarySession?.status === 'blocked',
+      )
+        ? 0
+        : 1;
+      const bActive = b.sortedItems.some(
+        (i) =>
+          i.primarySession?.status === 'in_progress' ||
+          i.primarySession?.status === 'blocked',
+      )
+        ? 0
+        : 1;
+      if (aActive !== bActive) return aActive - bActive;
+      return a.repoName.localeCompare(b.repoName);
+    });
+
+  const orderedItems = groups.flatMap((g) => g.sortedItems);
+
+  // Count items hidden from Active scope because they're dormant (no git changes)
+  const dormantHiddenCount =
+    scope === 'active'
+      ? joined.filter(
+          (item) =>
+            item.primarySession?.status === 'dormant' &&
+            (item.worktree?.changedCount ?? 0) === 0 &&
+            (item.worktree?.aheadCount ?? 0) === 0,
+        ).length
+      : 0;
+
+  return {
+    repoGroups: groups,
+    orderedItems,
+    archiveRepos: [...reposSeen.entries()].map(([root, name]) => [root, name] as const),
+    dormantHiddenCount,
+  };
 }

--- a/console/vitest.config.ts
+++ b/console/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  plugins: [react()],
   test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
+    // Hook integration tests need jsdom for React rendering (renderHook).
+    // Pure function tests (use cases, reducers) would work in node but
+    // jsdom is a superset -- one environment covers both.
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    globals: true,
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,8 @@
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^12.0.2",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/node": "^20.19.9",
@@ -170,6 +172,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
@@ -282,6 +294,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -330,6 +343,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -909,6 +923,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2156,6 +2171,69 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
@@ -2183,6 +2261,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -2461,6 +2546,7 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -2627,6 +2713,16 @@
       "integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-ify": {
       "version": "1.0.0",
@@ -3445,6 +3541,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -3457,6 +3563,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -3472,9 +3585,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -3927,6 +4040,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4479,6 +4593,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5207,6 +5322,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5241,6 +5366,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7419,6 +7545,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8002,6 +8129,44 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -8126,6 +8291,38 @@
       "bin": {
         "rc": "cli.js"
       }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/read-package-up": {
       "version": "11.0.0",
@@ -8343,12 +8540,20 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/semantic-release": {
       "version": "25.0.3",
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -9445,6 +9650,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9665,6 +9871,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9812,6 +10019,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9928,6 +10136,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9941,6 +10150,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -10311,6 +10521,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -113,6 +113,8 @@
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.2",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/node": "^20.19.9",

--- a/src/mcp/transports/shutdown-hooks.ts
+++ b/src/mcp/transports/shutdown-hooks.ts
@@ -55,6 +55,49 @@ export function wireShutdownHooks(opts: ShutdownHookOptions): void {
   });
 }
 
+export interface StdoutShutdownOptions {
+  /**
+   * Writable stream to watch for errors.
+   *
+   * Defaults to `process.stdout`. Inject a fake stream in tests to avoid
+   * touching the real stdout descriptor.
+   */
+  readonly stdout?: NodeJS.WritableStream;
+}
+
+/**
+ * Wire stdout-error shutdown for stdio transport.
+ *
+ * The MCP SDK's StdioServerTransport registers error listeners on stdin but
+ * NOT on stdout. When the MCP client (Claude Code) closes the connection
+ * mid-write, Node.js emits an 'error' event with code EPIPE on stdout. With
+ * no listener, Node.js converts this to an uncaught exception and the process
+ * crashes silently with exit code 1.
+ *
+ * This function registers an error listener that routes the failure through
+ * the same clean shutdown path as SIGINT/SIGTERM instead of crashing.
+ *
+ * Must be called BEFORE server.connect(transport) so the handler is in place
+ * before any writes can occur.
+ */
+export function wireStdoutShutdown(opts?: StdoutShutdownOptions): void {
+  const shutdownEvents = container.resolve<ShutdownEvents>(DI.Runtime.ShutdownEvents);
+  const stdout = opts?.stdout ?? process.stdout;
+
+  stdout.on('error', (err) => {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED') {
+      // Pipe broken: MCP client disconnected. Initiate clean shutdown rather
+      // than crashing -- this ensures the HTTP server and lock files are
+      // cleaned up gracefully.
+      console.error('[MCP] stdout pipe broken (client disconnected), initiating shutdown');
+    } else {
+      console.error('[MCP] stdout error:', err);
+    }
+    shutdownEvents.emit({ kind: 'shutdown_requested', signal: 'SIGHUP' });
+  });
+}
+
 export interface StdinShutdownOptions {
   /**
    * Readable stream to watch for EOF.

--- a/src/mcp/transports/stdio-entry.ts
+++ b/src/mcp/transports/stdio-entry.ts
@@ -6,7 +6,7 @@
  */
 
 import { composeServer } from '../server.js';
-import { wireShutdownHooks, wireStdinShutdown } from './shutdown-hooks.js';
+import { wireShutdownHooks, wireStdinShutdown, wireStdoutShutdown } from './shutdown-hooks.js';
 
 const INITIAL_ROOTS_TIMEOUT_MS = 1000;
 
@@ -22,6 +22,23 @@ async function fetchInitialRootsWithTimeout(server: {
 }
 
 export async function startStdioServer(): Promise<void> {
+  // Last-resort logging: surface unhandled errors to stderr before Node.js
+  // terminates. Without these, crashes are silent (exit code 1, no message).
+  // Note: wireStdoutShutdown() handles the primary EPIPE crash path;
+  // these handlers catch anything else that slips through.
+  process.on('uncaughtException', (err) => {
+    console.error('[MCP] Uncaught exception -- process will exit:', err);
+    // Do not call process.exit() here: let the default Node.js behavior
+    // handle termination so the exit code is correct.
+  });
+  process.on('unhandledRejection', (reason) => {
+    console.error('[MCP] Unhandled promise rejection:', reason);
+    // Node.js v15+: registering this handler suppresses the runtime's default
+    // exit-on-unhandled-rejection behavior. Explicitly exit so the process
+    // does not silently continue in an undefined state.
+    process.exit(1);
+  });
+
   const { server, ctx, rootsManager } = await composeServer();
 
   const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
@@ -41,6 +58,17 @@ export async function startStdioServer(): Promise<void> {
       console.error('[Roots] Failed to fetch updated roots after change notification');
     }
   });
+
+  // -------------------------------------------------------------------------
+  // stdio-specific: Guard stdout against EPIPE before connecting transport.
+  //
+  // The MCP SDK's StdioServerTransport only registers error listeners on
+  // stdin. If the client disconnects while a write is in-flight, stdout emits
+  // EPIPE with no listener -- Node.js converts this to an uncaught exception
+  // and the process crashes. wireStdoutShutdown() registers the listener
+  // *before* server.connect() so no write can occur without the guard in place.
+  // -------------------------------------------------------------------------
+  wireStdoutShutdown();
 
   // -------------------------------------------------------------------------
   // stdio-specific: Connect transport

--- a/src/v2/infra/local/session-lock/index.ts
+++ b/src/v2/infra/local/session-lock/index.ts
@@ -1,4 +1,5 @@
 import type { ResultAsync } from 'neverthrow';
+import { okAsync } from 'neverthrow';
 import type { DataDirPortV2 } from '../../../ports/data-dir.port.js';
 import type { FileSystemPortV2 } from '../../../ports/fs.port.js';
 import type { TimeClockPortV2 } from '../../../ports/time-clock.port.js';
@@ -9,8 +10,8 @@ import type { SessionLockHandleV2, SessionLockError, SessionLockPortV2 } from '.
  * Local, per-session single-writer lock.
  *
  * Locked behavior:
- * - fail fast if the lock file already exists
- * - no stale detection / no auto-breaking
+ * - clear stale lock files left by crashed processes before acquiring
+ * - fail fast if a live process holds the lock
  */
 export class LocalSessionLockV2 implements SessionLockPortV2 {
   constructor(
@@ -18,6 +19,45 @@ export class LocalSessionLockV2 implements SessionLockPortV2 {
     private readonly fs: FileSystemPortV2,
     private readonly clock: TimeClockPortV2
   ) {}
+
+  /**
+   * Remove the lock file if it was written by a process that is no longer
+   * alive. This handles the case where the MCP server crashed (e.g. EPIPE)
+   * without releasing the lock, which would otherwise block all future
+   * sessions for the same sessionId.
+   *
+   * Uses `process.kill(pid, 0)` -- signal 0 checks process existence without
+   * sending a signal. Throws ESRCH when the PID does not exist.
+   *
+   * Never fails: if the lock file can't be read or the PID check is
+   * ambiguous, the method returns ok(undefined) and acquisition proceeds
+   * normally (will fail with SESSION_LOCK_BUSY if lock is genuinely held).
+   */
+  private clearIfStaleLock(lockPath: string): ResultAsync<void, never> {
+    return this.fs
+      .readFileUtf8(lockPath)
+      .map((content) => {
+        try {
+          const data = JSON.parse(content) as { pid?: unknown };
+          const pid = typeof data.pid === 'number' ? data.pid : null;
+          if (pid === null) return false;
+          try {
+            process.kill(pid, 0); // throws ESRCH if dead, EPERM if alive but no permission
+            return false; // process is alive -- lock is valid
+          } catch (e) {
+            return (e as NodeJS.ErrnoException).code === 'ESRCH'; // dead → stale
+          }
+        } catch {
+          return false; // parse error → can't determine staleness
+        }
+      })
+      .andThen((isStale) => {
+        if (!isStale) return okAsync(undefined);
+        console.error(`[SessionLock] Removing stale lock at ${lockPath} (process no longer alive)`);
+        return this.fs.unlink(lockPath);
+      })
+      .orElse(() => okAsync(undefined)); // lock file missing → nothing to clear
+  }
 
   acquire(sessionId: SessionId): ResultAsync<SessionLockHandleV2, SessionLockError> {
     const sessionDir = this.dataDir.sessionDir(sessionId);
@@ -37,6 +77,7 @@ export class LocalSessionLockV2 implements SessionLockPortV2 {
 
     return this.fs
       .mkdirp(sessionDir)
+      .andThen(() => this.clearIfStaleLock(lockPath))
       .andThen(() =>
         this.fs.openExclusive(
           lockPath,

--- a/tests/unit/console-performance-use-cases.test.ts
+++ b/tests/unit/console-performance-use-cases.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for performance-use-cases.ts pure functions.
+ *
+ * Pure function tests -- no DOM, no React, no mocks.
+ * Pattern follows console-workflows-use-cases.test.ts.
+ *
+ * Covers:
+ *   - sortObservations: recent-first and slowest-first ordering
+ *   - computeMaxDuration: safe max via reduce
+ *   - computeErrorCount: counts error and unknown_tool outcomes
+ *   - computeAvgMs: average, rounding, null on empty
+ *   - computeLastCallMs: most recent startedAtMs, null on empty
+ *   - computeBarWidth: proportion capped at 120px, zero-guard
+ *   - computeCountLabel: string formatting
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  sortObservations,
+  computeMaxDuration,
+  computeErrorCount,
+  computeAvgMs,
+  computeLastCallMs,
+  computeBarWidth,
+  computeCountLabel,
+} from '../../console/src/views/performance-use-cases';
+import type { ToolCallTiming } from '../../console/src/api/types';
+
+// ---------------------------------------------------------------------------
+// Fixture builder
+// ---------------------------------------------------------------------------
+
+function makeObs(overrides: Partial<ToolCallTiming> = {}): ToolCallTiming {
+  return {
+    toolName: 'test_tool',
+    startedAtMs: 1000,
+    durationMs: 100,
+    outcome: 'success',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// sortObservations
+// ---------------------------------------------------------------------------
+
+describe('sortObservations', () => {
+  it('returns empty array for empty input', () => {
+    expect(sortObservations([], 'recent')).toEqual([]);
+    expect(sortObservations([], 'slowest')).toEqual([]);
+  });
+
+  it('sorts recent-first by startedAtMs descending', () => {
+    const obs = [
+      makeObs({ startedAtMs: 1000 }),
+      makeObs({ startedAtMs: 3000 }),
+      makeObs({ startedAtMs: 2000 }),
+    ];
+    const result = sortObservations(obs, 'recent');
+    expect(result[0]!.startedAtMs).toBe(3000);
+    expect(result[1]!.startedAtMs).toBe(2000);
+    expect(result[2]!.startedAtMs).toBe(1000);
+  });
+
+  it('sorts slowest-first by durationMs descending', () => {
+    const obs = [
+      makeObs({ durationMs: 50 }),
+      makeObs({ durationMs: 200 }),
+      makeObs({ durationMs: 100 }),
+    ];
+    const result = sortObservations(obs, 'slowest');
+    expect(result[0]!.durationMs).toBe(200);
+    expect(result[1]!.durationMs).toBe(100);
+    expect(result[2]!.durationMs).toBe(50);
+  });
+
+  it('does not mutate the input array', () => {
+    const obs = [
+      makeObs({ startedAtMs: 1000 }),
+      makeObs({ startedAtMs: 3000 }),
+    ];
+    const originalFirst = obs[0]!.startedAtMs;
+    sortObservations(obs, 'recent');
+    expect(obs[0]!.startedAtMs).toBe(originalFirst);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeMaxDuration
+// ---------------------------------------------------------------------------
+
+describe('computeMaxDuration', () => {
+  it('returns 0 for empty array', () => {
+    expect(computeMaxDuration([])).toBe(0);
+  });
+
+  it('returns the single value for a one-element array', () => {
+    expect(computeMaxDuration([makeObs({ durationMs: 42 })])).toBe(42);
+  });
+
+  it('returns the maximum durationMs across multiple observations', () => {
+    const obs = [
+      makeObs({ durationMs: 100 }),
+      makeObs({ durationMs: 500 }),
+      makeObs({ durationMs: 250 }),
+    ];
+    expect(computeMaxDuration(obs)).toBe(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeErrorCount
+// ---------------------------------------------------------------------------
+
+describe('computeErrorCount', () => {
+  it('returns 0 for empty array', () => {
+    expect(computeErrorCount([])).toBe(0);
+  });
+
+  it('returns 0 when all observations are success', () => {
+    const obs = [makeObs({ outcome: 'success' }), makeObs({ outcome: 'success' })];
+    expect(computeErrorCount(obs)).toBe(0);
+  });
+
+  it('counts error outcomes', () => {
+    const obs = [
+      makeObs({ outcome: 'success' }),
+      makeObs({ outcome: 'error' }),
+      makeObs({ outcome: 'error' }),
+    ];
+    expect(computeErrorCount(obs)).toBe(2);
+  });
+
+  it('counts unknown_tool as an error', () => {
+    const obs = [
+      makeObs({ outcome: 'success' }),
+      makeObs({ outcome: 'unknown_tool' }),
+    ];
+    expect(computeErrorCount(obs)).toBe(1);
+  });
+
+  it('counts mixed error and unknown_tool together', () => {
+    const obs = [
+      makeObs({ outcome: 'error' }),
+      makeObs({ outcome: 'unknown_tool' }),
+      makeObs({ outcome: 'success' }),
+    ];
+    expect(computeErrorCount(obs)).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeAvgMs
+// ---------------------------------------------------------------------------
+
+describe('computeAvgMs', () => {
+  it('returns null for empty array', () => {
+    expect(computeAvgMs([])).toBeNull();
+  });
+
+  it('returns the single value for one element', () => {
+    expect(computeAvgMs([makeObs({ durationMs: 100 })])).toBe(100);
+  });
+
+  it('returns the arithmetic mean rounded to nearest integer', () => {
+    const obs = [
+      makeObs({ durationMs: 100 }),
+      makeObs({ durationMs: 200 }),
+    ];
+    expect(computeAvgMs(obs)).toBe(150);
+  });
+
+  it('rounds fractional result to nearest integer', () => {
+    const obs = [
+      makeObs({ durationMs: 100 }),
+      makeObs({ durationMs: 101 }),
+      makeObs({ durationMs: 102 }),
+    ];
+    // (100 + 101 + 102) / 3 = 101
+    expect(computeAvgMs(obs)).toBe(101);
+  });
+
+  it('rounds 0.5 up', () => {
+    const obs = [makeObs({ durationMs: 1 }), makeObs({ durationMs: 2 })];
+    // (1 + 2) / 2 = 1.5 -> rounds to 2
+    expect(computeAvgMs(obs)).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeLastCallMs
+// ---------------------------------------------------------------------------
+
+describe('computeLastCallMs', () => {
+  it('returns null for empty array', () => {
+    expect(computeLastCallMs([])).toBeNull();
+  });
+
+  it('returns the single startedAtMs for one element', () => {
+    expect(computeLastCallMs([makeObs({ startedAtMs: 5000 })])).toBe(5000);
+  });
+
+  it('returns the maximum startedAtMs', () => {
+    const obs = [
+      makeObs({ startedAtMs: 1000 }),
+      makeObs({ startedAtMs: 9000 }),
+      makeObs({ startedAtMs: 3000 }),
+    ];
+    expect(computeLastCallMs(obs)).toBe(9000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeBarWidth
+// ---------------------------------------------------------------------------
+
+describe('computeBarWidth', () => {
+  it('returns 0 when maxDuration is 0 (zero-guard)', () => {
+    expect(computeBarWidth(100, 0)).toBe(0);
+  });
+
+  it('returns 120 when duration equals maxDuration (full bar)', () => {
+    expect(computeBarWidth(500, 500)).toBe(120);
+  });
+
+  it('returns 60 when duration is half of maxDuration', () => {
+    expect(computeBarWidth(250, 500)).toBe(60);
+  });
+
+  it('rounds to nearest integer', () => {
+    // 1/3 of 120 = 40
+    expect(computeBarWidth(1, 3)).toBe(40);
+  });
+
+  it('returns 0 for a 0ms duration', () => {
+    expect(computeBarWidth(0, 500)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCountLabel
+// ---------------------------------------------------------------------------
+
+describe('computeCountLabel', () => {
+  it('formats zero as "0 recorded"', () => {
+    expect(computeCountLabel(0)).toBe('0 recorded');
+  });
+
+  it('formats a positive count', () => {
+    expect(computeCountLabel(42)).toBe('42 recorded');
+  });
+
+  it('formats 1 correctly (no special singular/plural)', () => {
+    expect(computeCountLabel(1)).toBe('1 recorded');
+  });
+});

--- a/tests/unit/console-session-list-reducer.test.ts
+++ b/tests/unit/console-session-list-reducer.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for sessionListReducer.
+ *
+ * Pure function tests -- no DOM, no React, no mocks.
+ * Pattern follows console-workspace-reducer.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  sessionListReducer,
+  createInitialSessionListState,
+  type SessionListInteractionState,
+  type SessionListEvent,
+} from '../../console/src/views/session-list-reducer';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function reduce(
+  state: SessionListInteractionState,
+  event: SessionListEvent,
+): SessionListInteractionState {
+  return sessionListReducer(state, event);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('sessionListReducer', () => {
+  describe('createInitialSessionListState', () => {
+    it('has correct default values with no args', () => {
+      expect(createInitialSessionListState()).toEqual({
+        rawSearch: '',
+        sort: 'recent',
+        groupBy: 'none',
+        statusFilter: 'all',
+        page: 0,
+      });
+    });
+
+    it('seeds rawSearch from initialSearch arg', () => {
+      const state = createInitialSessionListState('feature/my-branch');
+      expect(state.rawSearch).toBe('feature/my-branch');
+    });
+
+    it('other fields are defaults when initialSearch is provided', () => {
+      const state = createInitialSessionListState('foo');
+      expect(state.sort).toBe('recent');
+      expect(state.groupBy).toBe('none');
+      expect(state.statusFilter).toBe('all');
+      expect(state.page).toBe(0);
+    });
+  });
+
+  describe('search_changed', () => {
+    it('sets rawSearch', () => {
+      const state = createInitialSessionListState();
+      const next = reduce(state, { type: 'search_changed', value: 'hello' });
+      expect(next.rawSearch).toBe('hello');
+    });
+
+    it('resets page to 0', () => {
+      const state: SessionListInteractionState = { ...createInitialSessionListState(), page: 3 };
+      const next = reduce(state, { type: 'search_changed', value: 'hello' });
+      expect(next.page).toBe(0);
+    });
+
+    it('does not mutate other fields', () => {
+      const state: SessionListInteractionState = {
+        ...createInitialSessionListState(),
+        sort: 'status',
+        groupBy: 'workflow',
+        statusFilter: 'in_progress',
+        page: 2,
+      };
+      const next = reduce(state, { type: 'search_changed', value: 'test' });
+      expect(next.sort).toBe('status');
+      expect(next.groupBy).toBe('workflow');
+      expect(next.statusFilter).toBe('in_progress');
+    });
+
+    it('can clear search by setting empty string', () => {
+      const state: SessionListInteractionState = { ...createInitialSessionListState(), rawSearch: 'foo' };
+      const next = reduce(state, { type: 'search_changed', value: '' });
+      expect(next.rawSearch).toBe('');
+    });
+  });
+
+  describe('sort_changed', () => {
+    it('sets sort', () => {
+      const state = createInitialSessionListState();
+      const next = reduce(state, { type: 'sort_changed', sort: 'status' });
+      expect(next.sort).toBe('status');
+    });
+
+    it('resets page to 0', () => {
+      const state: SessionListInteractionState = { ...createInitialSessionListState(), page: 2 };
+      const next = reduce(state, { type: 'sort_changed', sort: 'workflow' });
+      expect(next.page).toBe(0);
+    });
+
+    it('does not mutate rawSearch or groupBy or statusFilter', () => {
+      const state: SessionListInteractionState = {
+        ...createInitialSessionListState(),
+        rawSearch: 'foo',
+        groupBy: 'status',
+        statusFilter: 'blocked',
+      };
+      const next = reduce(state, { type: 'sort_changed', sort: 'nodes' });
+      expect(next.rawSearch).toBe('foo');
+      expect(next.groupBy).toBe('status');
+      expect(next.statusFilter).toBe('blocked');
+    });
+  });
+
+  describe('group_changed', () => {
+    it('sets groupBy', () => {
+      const state = createInitialSessionListState();
+      const next = reduce(state, { type: 'group_changed', groupBy: 'workflow' });
+      expect(next.groupBy).toBe('workflow');
+    });
+
+    it('resets page to 0', () => {
+      const state: SessionListInteractionState = { ...createInitialSessionListState(), page: 5 };
+      const next = reduce(state, { type: 'group_changed', groupBy: 'branch' });
+      expect(next.page).toBe(0);
+    });
+
+    it('does not mutate rawSearch or sort or statusFilter', () => {
+      const state: SessionListInteractionState = {
+        ...createInitialSessionListState(),
+        rawSearch: 'bar',
+        sort: 'workflow',
+        statusFilter: 'complete',
+      };
+      const next = reduce(state, { type: 'group_changed', groupBy: 'status' });
+      expect(next.rawSearch).toBe('bar');
+      expect(next.sort).toBe('workflow');
+      expect(next.statusFilter).toBe('complete');
+    });
+  });
+
+  describe('status_changed', () => {
+    it('sets statusFilter', () => {
+      const state = createInitialSessionListState();
+      const next = reduce(state, { type: 'status_changed', statusFilter: 'in_progress' });
+      expect(next.statusFilter).toBe('in_progress');
+    });
+
+    it('resets page to 0', () => {
+      const state: SessionListInteractionState = { ...createInitialSessionListState(), page: 4 };
+      const next = reduce(state, { type: 'status_changed', statusFilter: 'blocked' });
+      expect(next.page).toBe(0);
+    });
+
+    it('can set statusFilter back to all', () => {
+      const state: SessionListInteractionState = {
+        ...createInitialSessionListState(),
+        statusFilter: 'complete',
+      };
+      const next = reduce(state, { type: 'status_changed', statusFilter: 'all' });
+      expect(next.statusFilter).toBe('all');
+    });
+
+    it('does not mutate rawSearch or sort or groupBy', () => {
+      const state: SessionListInteractionState = {
+        ...createInitialSessionListState(),
+        rawSearch: 'baz',
+        sort: 'nodes',
+        groupBy: 'branch',
+      };
+      const next = reduce(state, { type: 'status_changed', statusFilter: 'dormant' });
+      expect(next.rawSearch).toBe('baz');
+      expect(next.sort).toBe('nodes');
+      expect(next.groupBy).toBe('branch');
+    });
+  });
+
+  describe('page_changed', () => {
+    it('sets page', () => {
+      const state = createInitialSessionListState();
+      const next = reduce(state, { type: 'page_changed', page: 3 });
+      expect(next.page).toBe(3);
+    });
+
+    it('does NOT reset rawSearch, sort, groupBy, or statusFilter', () => {
+      const state: SessionListInteractionState = {
+        rawSearch: 'foo',
+        sort: 'status',
+        groupBy: 'workflow',
+        statusFilter: 'in_progress',
+        page: 0,
+      };
+      const next = reduce(state, { type: 'page_changed', page: 5 });
+      expect(next.rawSearch).toBe('foo');
+      expect(next.sort).toBe('status');
+      expect(next.groupBy).toBe('workflow');
+      expect(next.statusFilter).toBe('in_progress');
+    });
+
+    it('can page back to 0', () => {
+      const state: SessionListInteractionState = { ...createInitialSessionListState(), page: 3 };
+      const next = reduce(state, { type: 'page_changed', page: 0 });
+      expect(next.page).toBe(0);
+    });
+  });
+
+  describe('page reset invariant', () => {
+    it('search_changed resets page even when page is already 0', () => {
+      const state = createInitialSessionListState();
+      const next = reduce(state, { type: 'search_changed', value: 'x' });
+      expect(next.page).toBe(0);
+    });
+
+    it('sort_changed resets page', () => {
+      const state: SessionListInteractionState = { ...createInitialSessionListState(), page: 10 };
+      const next = reduce(state, { type: 'sort_changed', sort: 'workflow' });
+      expect(next.page).toBe(0);
+    });
+
+    it('group_changed resets page', () => {
+      const state: SessionListInteractionState = { ...createInitialSessionListState(), page: 10 };
+      const next = reduce(state, { type: 'group_changed', groupBy: 'status' });
+      expect(next.page).toBe(0);
+    });
+
+    it('status_changed resets page', () => {
+      const state: SessionListInteractionState = { ...createInitialSessionListState(), page: 10 };
+      const next = reduce(state, { type: 'status_changed', statusFilter: 'complete' });
+      expect(next.page).toBe(0);
+    });
+
+    it('page_changed is the ONLY event that does not reset page to 0', () => {
+      const state: SessionListInteractionState = { ...createInitialSessionListState(), page: 3 };
+      const next = reduce(state, { type: 'page_changed', page: 7 });
+      expect(next.page).toBe(7);
+    });
+  });
+
+  describe('immutability', () => {
+    it('does not mutate the input state on search_changed', () => {
+      const state = Object.freeze(createInitialSessionListState());
+      expect(() => reduce(state, { type: 'search_changed', value: 'test' })).not.toThrow();
+    });
+
+    it('does not mutate the input state on sort_changed', () => {
+      const state = Object.freeze(createInitialSessionListState());
+      expect(() => reduce(state, { type: 'sort_changed', sort: 'status' })).not.toThrow();
+    });
+
+    it('does not mutate the input state on group_changed', () => {
+      const state = Object.freeze(createInitialSessionListState());
+      expect(() => reduce(state, { type: 'group_changed', groupBy: 'workflow' })).not.toThrow();
+    });
+
+    it('does not mutate the input state on status_changed', () => {
+      const state = Object.freeze(createInitialSessionListState());
+      expect(() => reduce(state, { type: 'status_changed', statusFilter: 'blocked' })).not.toThrow();
+    });
+
+    it('does not mutate the input state on page_changed', () => {
+      const state = Object.freeze(createInitialSessionListState());
+      expect(() => reduce(state, { type: 'page_changed', page: 2 })).not.toThrow();
+    });
+  });
+
+  describe('assertNever exhaustiveness', () => {
+    it('throws on unknown event type', () => {
+      const state = createInitialSessionListState();
+      const unknownEvent = { type: 'unknown_event_type' } as unknown as SessionListEvent;
+      expect(() => reduce(state, unknownEvent)).toThrow('Unhandled SessionListEvent type: unknown_event_type');
+    });
+  });
+});

--- a/tests/unit/console-session-list-use-cases.test.ts
+++ b/tests/unit/console-session-list-use-cases.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Unit tests for session-list-use-cases.ts pure functions.
+ *
+ * Pure function tests -- no DOM, no React, no mocks.
+ * Pattern follows console-workflows-use-cases.test.ts.
+ *
+ * Covers:
+ *   - filterSessions: status + search filtering
+ *   - sortSessions: all 4 sort axes
+ *   - groupSessions: all 4 group axes
+ *   - computeStatusCounts: full list invariant
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  filterSessions,
+  sortSessions,
+  groupSessions,
+  computeStatusCounts,
+} from '../../console/src/views/session-list-use-cases';
+import type { ConsoleSessionSummary } from '../../console/src/api/types';
+
+// ---------------------------------------------------------------------------
+// Fixture builder
+// ---------------------------------------------------------------------------
+
+let idCounter = 0;
+
+beforeEach(() => { idCounter = 0; });
+
+function makeSession(overrides: Partial<ConsoleSessionSummary> = {}): ConsoleSessionSummary {
+  idCounter += 1;
+  return {
+    sessionId: `sess-${idCounter}`,
+    sessionTitle: `Session ${idCounter}`,
+    workflowId: `wf-${idCounter}`,
+    workflowName: `Workflow ${idCounter}`,
+    workflowHash: null,
+    runId: null,
+    status: 'complete',
+    health: 'healthy',
+    nodeCount: idCounter,
+    edgeCount: idCounter,
+    tipCount: 1,
+    hasUnresolvedGaps: false,
+    recapSnippet: null,
+    gitBranch: `feature/branch-${idCounter}`,
+    repoRoot: '/repo',
+    lastModifiedMs: idCounter * 1000,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// filterSessions
+// ---------------------------------------------------------------------------
+
+describe('filterSessions', () => {
+  it('returns all sessions when statusFilter is all and search is empty', () => {
+    const sessions = [makeSession(), makeSession(), makeSession()];
+    expect(filterSessions(sessions, '', 'all')).toHaveLength(3);
+  });
+
+  it('filters by status', () => {
+    const sessions = [
+      makeSession({ status: 'in_progress' }),
+      makeSession({ status: 'complete' }),
+      makeSession({ status: 'blocked' }),
+    ];
+    const result = filterSessions(sessions, '', 'in_progress');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.status).toBe('in_progress');
+  });
+
+  it('filters by dormant status', () => {
+    const sessions = [
+      makeSession({ status: 'dormant' }),
+      makeSession({ status: 'complete' }),
+    ];
+    const result = filterSessions(sessions, '', 'dormant');
+    expect(result).toHaveLength(1);
+  });
+
+  it('matches search against sessionTitle', () => {
+    const sessions = [
+      makeSession({ sessionTitle: 'Fix the login bug' }),
+      makeSession({ sessionTitle: 'Add dark mode' }),
+    ];
+    const result = filterSessions(sessions, 'login', 'all');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessionTitle).toBe('Fix the login bug');
+  });
+
+  it('matches search against workflowName', () => {
+    const sessions = [
+      makeSession({ workflowName: 'coding-task-workflow' }),
+      makeSession({ workflowName: 'mr-review-workflow' }),
+    ];
+    const result = filterSessions(sessions, 'mr-review', 'all');
+    expect(result).toHaveLength(1);
+  });
+
+  it('matches search against workflowId', () => {
+    const sessions = [
+      makeSession({ workflowId: 'wf-abc-123', workflowName: null }),
+      makeSession({ workflowId: 'wf-def-456', workflowName: null }),
+    ];
+    const result = filterSessions(sessions, 'abc-123', 'all');
+    expect(result).toHaveLength(1);
+  });
+
+  it('matches search against sessionId', () => {
+    const sessions = [
+      makeSession({ sessionId: 'unique-id-xyz' }),
+      makeSession({ sessionId: 'other-session' }),
+    ];
+    const result = filterSessions(sessions, 'unique-id', 'all');
+    expect(result).toHaveLength(1);
+  });
+
+  it('matches search against gitBranch', () => {
+    const sessions = [
+      makeSession({ gitBranch: 'feature/acei-1234' }),
+      makeSession({ gitBranch: 'main' }),
+    ];
+    const result = filterSessions(sessions, 'acei-1234', 'all');
+    expect(result).toHaveLength(1);
+  });
+
+  it('search is case-insensitive', () => {
+    const sessions = [makeSession({ sessionTitle: 'Fix Login Bug' })];
+    expect(filterSessions(sessions, 'fix login', 'all')).toHaveLength(1);
+    expect(filterSessions(sessions, 'FIX LOGIN', 'all')).toHaveLength(1);
+  });
+
+  it('combines status and search (AND logic)', () => {
+    const sessions = [
+      makeSession({ status: 'in_progress', sessionTitle: 'Feature work', gitBranch: 'main', workflowName: 'coding', workflowId: 'wf-1' }),
+      makeSession({ status: 'complete', sessionTitle: 'Feature done', gitBranch: 'main', workflowName: 'coding', workflowId: 'wf-2' }),
+      makeSession({ status: 'in_progress', sessionTitle: 'Other task', gitBranch: 'main', workflowName: 'coding', workflowId: 'wf-3' }),
+    ];
+    const result = filterSessions(sessions, 'feature', 'in_progress');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessionTitle).toBe('Feature work');
+  });
+
+  it('returns empty array when no sessions match', () => {
+    const sessions = [makeSession({ status: 'complete' })];
+    expect(filterSessions(sessions, '', 'in_progress')).toHaveLength(0);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(filterSessions([], 'foo', 'all')).toHaveLength(0);
+  });
+
+  it('does not mutate the input array', () => {
+    const sessions = [makeSession(), makeSession()];
+    const originalLength = sessions.length;
+    filterSessions(sessions, 'foo', 'complete');
+    expect(sessions).toHaveLength(originalLength);
+  });
+
+  it('ignores whitespace-only search', () => {
+    const sessions = [makeSession(), makeSession()];
+    expect(filterSessions(sessions, '   ', 'all')).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sortSessions
+// ---------------------------------------------------------------------------
+
+describe('sortSessions', () => {
+  it("sorts by recent (lastModifiedMs descending)", () => {
+    const s1 = makeSession({ lastModifiedMs: 1000 });
+    const s2 = makeSession({ lastModifiedMs: 3000 });
+    const s3 = makeSession({ lastModifiedMs: 2000 });
+    const result = sortSessions([s1, s2, s3], 'recent');
+    expect(result[0]!.lastModifiedMs).toBe(3000);
+    expect(result[1]!.lastModifiedMs).toBe(2000);
+    expect(result[2]!.lastModifiedMs).toBe(1000);
+  });
+
+  it('sorts by status (in_progress first, complete last)', () => {
+    const s1 = makeSession({ status: 'complete', lastModifiedMs: 100 });
+    const s2 = makeSession({ status: 'in_progress', lastModifiedMs: 100 });
+    const s3 = makeSession({ status: 'blocked', lastModifiedMs: 100 });
+    const result = sortSessions([s1, s2, s3], 'status');
+    expect(result[0]!.status).toBe('in_progress');
+    expect(result[1]!.status).toBe('blocked');
+    expect(result[2]!.status).toBe('complete');
+  });
+
+  it('sorts by status with tiebreak by lastModifiedMs descending', () => {
+    const s1 = makeSession({ status: 'complete', lastModifiedMs: 1000 });
+    const s2 = makeSession({ status: 'complete', lastModifiedMs: 3000 });
+    const result = sortSessions([s1, s2], 'status');
+    expect(result[0]!.lastModifiedMs).toBe(3000);
+  });
+
+  it('sorts by workflow name alphabetically', () => {
+    const s1 = makeSession({ workflowName: 'zebra-workflow', workflowId: null });
+    const s2 = makeSession({ workflowName: 'apple-workflow', workflowId: null });
+    const result = sortSessions([s1, s2], 'workflow');
+    expect(result[0]!.workflowName).toBe('apple-workflow');
+  });
+
+  it('uses workflowId when workflowName is null for workflow sort', () => {
+    const s1 = makeSession({ workflowName: null, workflowId: 'zzz-workflow' });
+    const s2 = makeSession({ workflowName: null, workflowId: 'aaa-workflow' });
+    const result = sortSessions([s1, s2], 'workflow');
+    expect(result[0]!.workflowId).toBe('aaa-workflow');
+  });
+
+  it('sorts by nodeCount descending', () => {
+    const s1 = makeSession({ nodeCount: 5 });
+    const s2 = makeSession({ nodeCount: 20 });
+    const s3 = makeSession({ nodeCount: 1 });
+    const result = sortSessions([s1, s2, s3], 'nodes');
+    expect(result[0]!.nodeCount).toBe(20);
+    expect(result[1]!.nodeCount).toBe(5);
+    expect(result[2]!.nodeCount).toBe(1);
+  });
+
+  it('does not mutate the input array', () => {
+    const sessions = [makeSession({ lastModifiedMs: 1000 }), makeSession({ lastModifiedMs: 3000 })];
+    const originalFirst = sessions[0]!.sessionId;
+    sortSessions(sessions, 'recent');
+    expect(sessions[0]!.sessionId).toBe(originalFirst);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(sortSessions([], 'recent')).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupSessions
+// ---------------------------------------------------------------------------
+
+describe('groupSessions', () => {
+  it("returns single group with empty label when groupBy is 'none'", () => {
+    const sessions = [makeSession(), makeSession()];
+    const result = groupSessions(sessions, 'none');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.label).toBe('');
+    expect(result[0]!.sessions).toHaveLength(2);
+  });
+
+  it("groups by workflow name", () => {
+    const sessions = [
+      makeSession({ workflowName: 'workflow-a' }),
+      makeSession({ workflowName: 'workflow-b' }),
+      makeSession({ workflowName: 'workflow-a' }),
+    ];
+    const result = groupSessions(sessions, 'workflow');
+    expect(result).toHaveLength(2);
+    const groupA = result.find((g) => g.label === 'workflow-a');
+    expect(groupA?.sessions).toHaveLength(2);
+  });
+
+  it("uses workflowId as fallback when workflowName is null for workflow grouping", () => {
+    const sessions = [
+      makeSession({ workflowName: null, workflowId: 'wf-123' }),
+    ];
+    const result = groupSessions(sessions, 'workflow');
+    expect(result[0]!.label).toBe('wf-123');
+  });
+
+  it("uses 'Unknown workflow' when both workflowName and workflowId are null", () => {
+    const sessions = [
+      makeSession({ workflowName: null, workflowId: null }),
+    ];
+    const result = groupSessions(sessions, 'workflow');
+    expect(result[0]!.label).toBe('Unknown workflow');
+  });
+
+  it("groups by status and sorts by STATUS_SORT_ORDER (in_progress first)", () => {
+    const sessions = [
+      makeSession({ status: 'complete' }),
+      makeSession({ status: 'in_progress' }),
+      makeSession({ status: 'blocked' }),
+    ];
+    const result = groupSessions(sessions, 'status');
+    expect(result[0]!.label).toBe('in_progress');
+    expect(result[1]!.label).toBe('blocked');
+    expect(result[2]!.label).toBe('complete');
+  });
+
+  it("groups by branch", () => {
+    const sessions = [
+      makeSession({ gitBranch: 'main' }),
+      makeSession({ gitBranch: 'feature/foo' }),
+      makeSession({ gitBranch: 'main' }),
+    ];
+    const result = groupSessions(sessions, 'branch');
+    expect(result).toHaveLength(2);
+    const mainGroup = result.find((g) => g.label === 'main');
+    expect(mainGroup?.sessions).toHaveLength(2);
+  });
+
+  it("uses 'No branch' when gitBranch is null", () => {
+    const sessions = [makeSession({ gitBranch: null })];
+    const result = groupSessions(sessions, 'branch');
+    expect(result[0]!.label).toBe('No branch');
+  });
+
+  it('groups are sorted alphabetically for workflow grouping', () => {
+    const sessions = [
+      makeSession({ workflowName: 'zzz' }),
+      makeSession({ workflowName: 'aaa' }),
+    ];
+    const result = groupSessions(sessions, 'workflow');
+    expect(result[0]!.label).toBe('aaa');
+    expect(result[1]!.label).toBe('zzz');
+  });
+
+  it('does not mutate the input array', () => {
+    const sessions = [makeSession(), makeSession()];
+    const originalIds = sessions.map((s) => s.sessionId);
+    groupSessions(sessions, 'status');
+    expect(sessions.map((s) => s.sessionId)).toEqual(originalIds);
+  });
+
+  it('returns single group for empty input with groupBy none', () => {
+    const result = groupSessions([], 'none');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessions).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeStatusCounts
+// ---------------------------------------------------------------------------
+
+describe('computeStatusCounts', () => {
+  it("'all' count equals the total session count", () => {
+    const sessions = [makeSession(), makeSession(), makeSession()];
+    const counts = computeStatusCounts(sessions);
+    expect(counts['all']).toBe(3);
+  });
+
+  it('counts each status correctly', () => {
+    const sessions = [
+      makeSession({ status: 'in_progress' }),
+      makeSession({ status: 'in_progress' }),
+      makeSession({ status: 'complete' }),
+      makeSession({ status: 'blocked' }),
+    ];
+    const counts = computeStatusCounts(sessions);
+    expect(counts['in_progress']).toBe(2);
+    expect(counts['complete']).toBe(1);
+    expect(counts['blocked']).toBe(1);
+  });
+
+  it("statuses not present are 0 via ?? fallback", () => {
+    const sessions = [makeSession({ status: 'complete' })];
+    const counts = computeStatusCounts(sessions);
+    // in_progress not present -- should be undefined (falsy), not explicitly 0
+    expect(counts['in_progress'] ?? 0).toBe(0);
+  });
+
+  it('returns { all: 0 } for empty list', () => {
+    const counts = computeStatusCounts([]);
+    expect(counts['all']).toBe(0);
+  });
+
+  it('includes dormant status', () => {
+    const sessions = [makeSession({ status: 'dormant' })];
+    const counts = computeStatusCounts(sessions);
+    expect(counts['dormant']).toBe(1);
+    expect(counts['all']).toBe(1);
+  });
+
+  it('includes complete_with_gaps status', () => {
+    const sessions = [makeSession({ status: 'complete_with_gaps' })];
+    const counts = computeStatusCounts(sessions);
+    expect(counts['complete_with_gaps']).toBe(1);
+  });
+
+  it('does not mutate the input array', () => {
+    const sessions = [makeSession(), makeSession()];
+    const originalIds = sessions.map((s) => s.sessionId);
+    computeStatusCounts(sessions);
+    expect(sessions.map((s) => s.sessionId)).toEqual(originalIds);
+  });
+});

--- a/tests/unit/console-workflow-detail-use-cases.test.ts
+++ b/tests/unit/console-workflow-detail-use-cases.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for workflow-detail-use-cases.ts pure functions.
+ *
+ * Pure function tests -- no DOM, no React, no mocks.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getAdjacentWorkflows,
+} from '../../console/src/views/workflow-detail-use-cases';
+import type { ConsoleWorkflowSummary } from '../../console/src/api/types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeWorkflow(id: string): ConsoleWorkflowSummary {
+  return {
+    id,
+    name: `Workflow ${id}`,
+    description: null,
+    version: '1.0.0',
+    tags: [],
+    source: { kind: 'bundled', displayName: 'WorkRail' },
+    stepCount: 1,
+  };
+}
+
+const WF_A = makeWorkflow('wf-a');
+const WF_B = makeWorkflow('wf-b');
+const WF_C = makeWorkflow('wf-c');
+const LIST = [WF_A, WF_B, WF_C] as const;
+
+// ---------------------------------------------------------------------------
+// getAdjacentWorkflows
+// ---------------------------------------------------------------------------
+
+describe('getAdjacentWorkflows', () => {
+  it('returns both null for null workflowId', () => {
+    const result = getAdjacentWorkflows(null, LIST);
+    expect(result.prevWorkflow).toBeNull();
+    expect(result.nextWorkflow).toBeNull();
+  });
+
+  it('returns both null for empty string workflowId', () => {
+    const result = getAdjacentWorkflows('', LIST);
+    expect(result.prevWorkflow).toBeNull();
+    expect(result.nextWorkflow).toBeNull();
+  });
+
+  it('returns both null for workflowId not in list', () => {
+    const result = getAdjacentWorkflows('wf-unknown', LIST);
+    expect(result.prevWorkflow).toBeNull();
+    expect(result.nextWorkflow).toBeNull();
+  });
+
+  it('returns both null for empty workflow list', () => {
+    const result = getAdjacentWorkflows('wf-a', []);
+    expect(result.prevWorkflow).toBeNull();
+    expect(result.nextWorkflow).toBeNull();
+  });
+
+  it('first item has null prev and correct next', () => {
+    const result = getAdjacentWorkflows('wf-a', LIST);
+    expect(result.prevWorkflow).toBeNull();
+    expect(result.nextWorkflow).toEqual(WF_B);
+  });
+
+  it('middle item has correct prev and next', () => {
+    const result = getAdjacentWorkflows('wf-b', LIST);
+    expect(result.prevWorkflow).toEqual(WF_A);
+    expect(result.nextWorkflow).toEqual(WF_C);
+  });
+
+  it('last item has correct prev and null next', () => {
+    const result = getAdjacentWorkflows('wf-c', LIST);
+    expect(result.prevWorkflow).toEqual(WF_B);
+    expect(result.nextWorkflow).toBeNull();
+  });
+
+  it('single-item list returns both null', () => {
+    const result = getAdjacentWorkflows('wf-a', [WF_A]);
+    expect(result.prevWorkflow).toBeNull();
+    expect(result.nextWorkflow).toBeNull();
+  });
+
+  it('is pure -- does not mutate the input list', () => {
+    const input = [WF_A, WF_B, WF_C];
+    const frozen = Object.freeze([...input]);
+    expect(() => getAdjacentWorkflows('wf-b', frozen)).not.toThrow();
+  });
+});

--- a/tests/unit/console-workflows-reducer.test.ts
+++ b/tests/unit/console-workflows-reducer.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Unit tests for workflowsReducer.
+ *
+ * Pure function tests -- no DOM, no React, no mocks.
+ * Pattern follows console-workspace-reducer.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  workflowsReducer,
+  INITIAL_WORKFLOWS_STATE,
+  type WorkflowsInteractionState,
+  type WorkflowsEvent,
+} from '../../console/src/views/workflows-reducer';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function reduce(
+  state: WorkflowsInteractionState,
+  event: WorkflowsEvent,
+): WorkflowsInteractionState {
+  return workflowsReducer(state, event);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('workflowsReducer', () => {
+  describe('initial state', () => {
+    it('has all fields null/false', () => {
+      expect(INITIAL_WORKFLOWS_STATE).toEqual({
+        selectedWorkflowId: null,
+        selectedTag: null,
+        selectedSource: null,
+        hintVisible: false,
+      });
+    });
+  });
+
+  describe('workflow_selected', () => {
+    it('sets selectedWorkflowId to the given id', () => {
+      const next = reduce(INITIAL_WORKFLOWS_STATE, {
+        type: 'workflow_selected',
+        id: 'workflow-abc',
+      });
+      expect(next.selectedWorkflowId).toBe('workflow-abc');
+    });
+
+    it('sets hintVisible to true when a non-null id is selected', () => {
+      const next = reduce(INITIAL_WORKFLOWS_STATE, {
+        type: 'workflow_selected',
+        id: 'workflow-abc',
+      });
+      expect(next.hintVisible).toBe(true);
+    });
+
+    it('sets selectedWorkflowId to null when id is null', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        selectedWorkflowId: 'workflow-abc',
+        hintVisible: true,
+      };
+      const next = reduce(state, { type: 'workflow_selected', id: null });
+      expect(next.selectedWorkflowId).toBeNull();
+    });
+
+    it('sets hintVisible to false when id is null', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        selectedWorkflowId: 'workflow-abc',
+        hintVisible: true,
+      };
+      const next = reduce(state, { type: 'workflow_selected', id: null });
+      expect(next.hintVisible).toBe(false);
+    });
+
+    it('does not mutate other fields', () => {
+      const state: WorkflowsInteractionState = {
+        selectedWorkflowId: null,
+        selectedTag: 'coding',
+        selectedSource: 'bundled',
+        hintVisible: false,
+      };
+      const next = reduce(state, { type: 'workflow_selected', id: 'wf-1' });
+      expect(next.selectedTag).toBe('coding');
+      expect(next.selectedSource).toBe('bundled');
+    });
+  });
+
+  describe('tag_changed', () => {
+    it('sets selectedTag', () => {
+      const next = reduce(INITIAL_WORKFLOWS_STATE, {
+        type: 'tag_changed',
+        tag: 'coding',
+      });
+      expect(next.selectedTag).toBe('coding');
+    });
+
+    it('clears selectedWorkflowId on tag change', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        selectedWorkflowId: 'wf-1',
+      };
+      const next = reduce(state, { type: 'tag_changed', tag: 'design' });
+      expect(next.selectedWorkflowId).toBeNull();
+    });
+
+    it('clears hintVisible on tag change', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        hintVisible: true,
+      };
+      const next = reduce(state, { type: 'tag_changed', tag: 'design' });
+      expect(next.hintVisible).toBe(false);
+    });
+
+    it('can set tag back to null (clear filter)', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        selectedTag: 'coding',
+      };
+      const next = reduce(state, { type: 'tag_changed', tag: null });
+      expect(next.selectedTag).toBeNull();
+    });
+
+    it('does not mutate selectedSource', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        selectedSource: 'bundled',
+      };
+      const next = reduce(state, { type: 'tag_changed', tag: 'coding' });
+      expect(next.selectedSource).toBe('bundled');
+    });
+  });
+
+  describe('source_changed', () => {
+    it('sets selectedSource', () => {
+      const next = reduce(INITIAL_WORKFLOWS_STATE, {
+        type: 'source_changed',
+        source: 'bundled',
+      });
+      expect(next.selectedSource).toBe('bundled');
+    });
+
+    it('clears selectedWorkflowId on source change', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        selectedWorkflowId: 'wf-1',
+      };
+      const next = reduce(state, { type: 'source_changed', source: 'user' });
+      expect(next.selectedWorkflowId).toBeNull();
+    });
+
+    it('clears hintVisible on source change', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        hintVisible: true,
+      };
+      const next = reduce(state, { type: 'source_changed', source: 'user' });
+      expect(next.hintVisible).toBe(false);
+    });
+
+    it('can clear source filter by setting null', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        selectedSource: 'bundled',
+      };
+      const next = reduce(state, { type: 'source_changed', source: null });
+      expect(next.selectedSource).toBeNull();
+    });
+
+    it('does not mutate selectedTag', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        selectedTag: 'coding',
+      };
+      const next = reduce(state, { type: 'source_changed', source: 'bundled' });
+      expect(next.selectedTag).toBe('coding');
+    });
+  });
+
+  describe('modal_closed', () => {
+    it('clears selectedWorkflowId', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        selectedWorkflowId: 'wf-1',
+      };
+      const next = reduce(state, { type: 'modal_closed' });
+      expect(next.selectedWorkflowId).toBeNull();
+    });
+
+    it('sets hintVisible to false', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        hintVisible: true,
+        selectedWorkflowId: 'wf-1',
+      };
+      const next = reduce(state, { type: 'modal_closed' });
+      expect(next.hintVisible).toBe(false);
+    });
+
+    it('is a no-op when modal is already closed', () => {
+      const next = reduce(INITIAL_WORKFLOWS_STATE, { type: 'modal_closed' });
+      expect(next.selectedWorkflowId).toBeNull();
+      expect(next.hintVisible).toBe(false);
+    });
+
+    it('does not mutate selectedTag or selectedSource', () => {
+      const state: WorkflowsInteractionState = {
+        selectedWorkflowId: 'wf-1',
+        selectedTag: 'coding',
+        selectedSource: 'bundled',
+        hintVisible: true,
+      };
+      const next = reduce(state, { type: 'modal_closed' });
+      expect(next.selectedTag).toBe('coding');
+      expect(next.selectedSource).toBe('bundled');
+    });
+  });
+
+  describe('hint_dismissed', () => {
+    it('sets hintVisible to false', () => {
+      const state: WorkflowsInteractionState = {
+        ...INITIAL_WORKFLOWS_STATE,
+        hintVisible: true,
+      };
+      const next = reduce(state, { type: 'hint_dismissed' });
+      expect(next.hintVisible).toBe(false);
+    });
+
+    it('is a no-op when hint is already hidden', () => {
+      const next = reduce(INITIAL_WORKFLOWS_STATE, { type: 'hint_dismissed' });
+      expect(next.hintVisible).toBe(false);
+    });
+
+    it('does not mutate other fields', () => {
+      const state: WorkflowsInteractionState = {
+        selectedWorkflowId: 'wf-1',
+        selectedTag: 'coding',
+        selectedSource: 'bundled',
+        hintVisible: true,
+      };
+      const next = reduce(state, { type: 'hint_dismissed' });
+      expect(next.selectedWorkflowId).toBe('wf-1');
+      expect(next.selectedTag).toBe('coding');
+      expect(next.selectedSource).toBe('bundled');
+    });
+  });
+
+  describe('immutability', () => {
+    it('does not mutate the input state on workflow_selected', () => {
+      const state = Object.freeze({ ...INITIAL_WORKFLOWS_STATE });
+      expect(() => reduce(state, { type: 'workflow_selected', id: 'wf-1' })).not.toThrow();
+    });
+
+    it('does not mutate the input state on tag_changed', () => {
+      const state = Object.freeze({ ...INITIAL_WORKFLOWS_STATE });
+      expect(() => reduce(state, { type: 'tag_changed', tag: 'coding' })).not.toThrow();
+    });
+
+    it('does not mutate the input state on modal_closed', () => {
+      const state = Object.freeze({ ...INITIAL_WORKFLOWS_STATE, selectedWorkflowId: 'wf-1' });
+      expect(() => reduce(state, { type: 'modal_closed' })).not.toThrow();
+    });
+  });
+
+  describe('assertNever exhaustiveness', () => {
+    it('throws on unknown event type', () => {
+      const state = INITIAL_WORKFLOWS_STATE;
+      const unknownEvent = { type: 'unknown_event_type' } as unknown as WorkflowsEvent;
+      expect(() => reduce(state, unknownEvent)).toThrow('Unhandled WorkflowsEvent type: unknown_event_type');
+    });
+  });
+});

--- a/tests/unit/console-workflows-use-cases.test.ts
+++ b/tests/unit/console-workflows-use-cases.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for workflows-use-cases.ts pure functions.
+ *
+ * Pure function tests -- no DOM, no React, no mocks.
+ * Pattern follows console-workspace-types.test.ts.
+ *
+ * Covers:
+ *   - getAvailableTags: sorted unique non-routines tags
+ *   - getAvailableSources: unique source options
+ *   - filterWorkflows: tag + source filtering
+ *   - flattenWorkflows: flat list for keyboard navigation
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getAvailableTags,
+  getAvailableSources,
+  filterWorkflows,
+  flattenWorkflows,
+} from '../../console/src/views/workflows-use-cases';
+import type { ConsoleWorkflowSummary } from '../../console/src/api/types';
+
+// ---------------------------------------------------------------------------
+// Fixture builder
+// ---------------------------------------------------------------------------
+
+let idCounter = 0;
+
+// Reset before each test so IDs are deterministic regardless of test order.
+beforeEach(() => { idCounter = 0; });
+
+function makeWorkflow(overrides: Partial<ConsoleWorkflowSummary> = {}): ConsoleWorkflowSummary {
+  idCounter += 1;
+  return {
+    id: `wf-${idCounter}`,
+    name: `Workflow ${idCounter}`,
+    description: `Description ${idCounter}`,
+    version: '1.0.0',
+    tags: [],
+    source: { kind: 'bundled', displayName: 'Bundled' },
+    stepCount: 3,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getAvailableTags
+// ---------------------------------------------------------------------------
+
+describe('getAvailableTags', () => {
+  it('returns empty array for empty workflow list', () => {
+    expect(getAvailableTags([])).toEqual([]);
+  });
+
+  it('excludes the routines tag', () => {
+    const workflows = [makeWorkflow({ tags: ['routines', 'coding'] })];
+    const tags = getAvailableTags(workflows);
+    expect(tags).not.toContain('routines');
+    expect(tags).toContain('coding');
+  });
+
+  it('returns unique tags (deduplication)', () => {
+    const workflows = [
+      makeWorkflow({ tags: ['coding'] }),
+      makeWorkflow({ tags: ['coding', 'design'] }),
+    ];
+    const tags = getAvailableTags(workflows);
+    expect(tags.filter((t) => t === 'coding')).toHaveLength(1);
+    expect(tags).toContain('design');
+  });
+
+  it('follows CATALOG_TAGS order for known tags', () => {
+    // coding comes before design in CATALOG_TAGS
+    const workflows = [
+      makeWorkflow({ tags: ['design'] }),
+      makeWorkflow({ tags: ['coding'] }),
+    ];
+    const tags = getAvailableTags(workflows);
+    const codingIndex = tags.indexOf('coding');
+    const designIndex = tags.indexOf('design');
+    expect(codingIndex).toBeLessThan(designIndex);
+  });
+
+  it('places unknown tags alphabetically after known tags', () => {
+    const workflows = [
+      makeWorkflow({ tags: ['coding'] }),
+      makeWorkflow({ tags: ['zzz-unknown'] }),
+    ];
+    const tags = getAvailableTags(workflows);
+    const codingIndex = tags.indexOf('coding');
+    const unknownIndex = tags.indexOf('zzz-unknown');
+    expect(codingIndex).toBeLessThan(unknownIndex);
+  });
+
+  it('returns only tags present in the workflow list', () => {
+    const workflows = [makeWorkflow({ tags: ['coding'] })];
+    const tags = getAvailableTags(workflows);
+    expect(tags).not.toContain('design');
+    expect(tags).not.toContain('investigation');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAvailableSources
+// ---------------------------------------------------------------------------
+
+describe('getAvailableSources', () => {
+  it('returns empty array for empty workflow list', () => {
+    expect(getAvailableSources([])).toEqual([]);
+  });
+
+  it('returns unique sources by kind', () => {
+    const workflows = [
+      makeWorkflow({ source: { kind: 'bundled', displayName: 'Bundled' } }),
+      makeWorkflow({ source: { kind: 'bundled', displayName: 'Bundled' } }),
+      makeWorkflow({ source: { kind: 'user', displayName: 'User' } }),
+    ];
+    const sources = getAvailableSources(workflows);
+    expect(sources).toHaveLength(2);
+  });
+
+  it('uses kind as id and displayName from the workflow', () => {
+    const workflows = [
+      makeWorkflow({ source: { kind: 'user', displayName: 'My Custom Workflows' } }),
+    ];
+    const sources = getAvailableSources(workflows);
+    expect(sources[0]).toEqual({ id: 'user', displayName: 'My Custom Workflows' });
+  });
+
+  it('preserves first-seen order', () => {
+    const workflows = [
+      makeWorkflow({ source: { kind: 'user', displayName: 'User' } }),
+      makeWorkflow({ source: { kind: 'bundled', displayName: 'Bundled' } }),
+    ];
+    const sources = getAvailableSources(workflows);
+    expect(sources[0]!.id).toBe('user');
+    expect(sources[1]!.id).toBe('bundled');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterWorkflows
+// ---------------------------------------------------------------------------
+
+describe('filterWorkflows', () => {
+  const bundledWorkflow = makeWorkflow({
+    tags: ['coding'],
+    source: { kind: 'bundled', displayName: 'Bundled' },
+  });
+  const userWorkflow = makeWorkflow({
+    tags: ['design'],
+    source: { kind: 'user', displayName: 'Custom' },
+  });
+  const untaggedWorkflow = makeWorkflow({
+    tags: [],
+    source: { kind: 'bundled', displayName: 'Bundled' },
+  });
+
+  const allWorkflows = [bundledWorkflow, userWorkflow, untaggedWorkflow];
+
+  it('returns all workflows when tag and source are null', () => {
+    const result = filterWorkflows(allWorkflows, null, null);
+    expect(result).toHaveLength(3);
+  });
+
+  it('filters by tag', () => {
+    const result = filterWorkflows(allWorkflows, 'coding', null);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe(bundledWorkflow.id);
+  });
+
+  it('filters by __other__ (no known catalog tag)', () => {
+    // untaggedWorkflow has no known tags, bundledWorkflow has 'coding' (known), userWorkflow has 'design' (known)
+    const result = filterWorkflows(allWorkflows, '__other__', null);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe(untaggedWorkflow.id);
+  });
+
+  it('filters by source displayName', () => {
+    const result = filterWorkflows(allWorkflows, null, 'Custom');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe(userWorkflow.id);
+  });
+
+  it('combines tag and source filters (AND logic)', () => {
+    // coding + Bundled -> bundledWorkflow only
+    const result = filterWorkflows(allWorkflows, 'coding', 'Bundled');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe(bundledWorkflow.id);
+  });
+
+  it('returns empty array when no workflows match', () => {
+    const result = filterWorkflows(allWorkflows, 'coding', 'Custom');
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(filterWorkflows([], 'coding', null)).toHaveLength(0);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [...allWorkflows];
+    const originalLength = input.length;
+    filterWorkflows(input, 'coding', null);
+    expect(input).toHaveLength(originalLength);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// flattenWorkflows
+// ---------------------------------------------------------------------------
+
+describe('flattenWorkflows', () => {
+  it('returns filtered list as-is when selectedTag is non-null', () => {
+    const wf1 = makeWorkflow({ tags: ['coding'] });
+    const wf2 = makeWorkflow({ tags: ['coding'] });
+    const result = flattenWorkflows([wf1, wf2], 'coding');
+    expect(result).toHaveLength(2);
+    expect(result[0]!.id).toBe(wf1.id);
+    expect(result[1]!.id).toBe(wf2.id);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(flattenWorkflows([], null)).toHaveLength(0);
+    expect(flattenWorkflows([], 'coding')).toHaveLength(0);
+  });
+
+  it('when selectedTag is null, orders by CATALOG_TAGS group order', () => {
+    // coding comes before design in CATALOG_TAGS
+    const designWorkflow = makeWorkflow({ tags: ['design'] });
+    const codingWorkflow = makeWorkflow({ tags: ['coding'] });
+    // Pass in design first, expect coding first in output
+    const result = flattenWorkflows([designWorkflow, codingWorkflow], null);
+    expect(result[0]!.id).toBe(codingWorkflow.id);
+    expect(result[1]!.id).toBe(designWorkflow.id);
+  });
+
+  it('when selectedTag is null, places untagged workflows at the end', () => {
+    const codingWorkflow = makeWorkflow({ tags: ['coding'] });
+    const untaggedWorkflow = makeWorkflow({ tags: [] });
+    const result = flattenWorkflows([untaggedWorkflow, codingWorkflow], null);
+    expect(result[0]!.id).toBe(codingWorkflow.id);
+    expect(result[1]!.id).toBe(untaggedWorkflow.id);
+  });
+
+  it('when selectedTag is null, preserves order within each group', () => {
+    const coding1 = makeWorkflow({ tags: ['coding'] });
+    const coding2 = makeWorkflow({ tags: ['coding'] });
+    const result = flattenWorkflows([coding1, coding2], null);
+    expect(result[0]!.id).toBe(coding1.id);
+    expect(result[1]!.id).toBe(coding2.id);
+  });
+
+  it('when selectedTag is null with __other__ tag, places in other group at end', () => {
+    // __other__ as selectedTag is handled by filterWorkflows, not flattenWorkflows.
+    // flattenWorkflows only groups by CATALOG_TAGS -- unknown-tag workflows go at end.
+    const codingWorkflow = makeWorkflow({ tags: ['coding'] });
+    const unknownTagWorkflow = makeWorkflow({ tags: ['some-unknown-tag'] });
+    const result = flattenWorkflows([unknownTagWorkflow, codingWorkflow], null);
+    expect(result[0]!.id).toBe(codingWorkflow.id);
+    expect(result[1]!.id).toBe(unknownTagWorkflow.id);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      makeWorkflow({ tags: ['design'] }),
+      makeWorkflow({ tags: ['coding'] }),
+    ];
+    const originalOrder = input.map((w) => w.id);
+    flattenWorkflows(input, null);
+    expect(input.map((w) => w.id)).toEqual(originalOrder);
+  });
+});

--- a/tests/unit/console-workspace-reducer.test.ts
+++ b/tests/unit/console-workspace-reducer.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for workspaceReducer.
+ *
+ * Pure function tests -- no DOM, no React, no mocks.
+ * Pattern follows perf-state.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  workspaceReducer,
+  INITIAL_WORKSPACE_STATE,
+  type WorkspaceInteractionState,
+  type WorkspaceEvent,
+} from '../../console/src/views/workspace-reducer';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function reduce(
+  state: WorkspaceInteractionState,
+  event: WorkspaceEvent,
+): WorkspaceInteractionState {
+  return workspaceReducer(state, event);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('workspaceReducer', () => {
+  describe('initial state', () => {
+    it('has scope active, focusedIndex -1, archive null', () => {
+      expect(INITIAL_WORKSPACE_STATE).toEqual({
+        scope: 'active',
+        focusedIndex: -1,
+        archive: null,
+      });
+    });
+  });
+
+  describe('scope_changed', () => {
+    it('updates scope to all', () => {
+      const next = reduce(INITIAL_WORKSPACE_STATE, {
+        type: 'scope_changed',
+        scope: 'all',
+      });
+      expect(next.scope).toBe('all');
+    });
+
+    it('updates scope back to active', () => {
+      const state: WorkspaceInteractionState = { ...INITIAL_WORKSPACE_STATE, scope: 'all' };
+      const next = reduce(state, { type: 'scope_changed', scope: 'active' });
+      expect(next.scope).toBe('active');
+    });
+
+    it('resets focusedIndex to -1 (item list reorders on scope change)', () => {
+      const state: WorkspaceInteractionState = {
+        scope: 'active',
+        focusedIndex: 3,
+        archive: { repoName: 'myrepo' },
+      };
+      const next = reduce(state, { type: 'scope_changed', scope: 'all' });
+      expect(next.focusedIndex).toBe(-1);
+    });
+
+    it('preserves archive state on scope change', () => {
+      const state: WorkspaceInteractionState = {
+        scope: 'active',
+        focusedIndex: 3,
+        archive: { repoName: 'myrepo' },
+      };
+      const next = reduce(state, { type: 'scope_changed', scope: 'all' });
+      expect(next.archive).toEqual({ repoName: 'myrepo' });
+    });
+  });
+
+  describe('focus_moved', () => {
+    it('updates focusedIndex', () => {
+      const next = reduce(INITIAL_WORKSPACE_STATE, { type: 'focus_moved', index: 5 });
+      expect(next.focusedIndex).toBe(5);
+    });
+
+    it('can reset focusedIndex to -1', () => {
+      const state: WorkspaceInteractionState = { ...INITIAL_WORKSPACE_STATE, focusedIndex: 3 };
+      const next = reduce(state, { type: 'focus_moved', index: -1 });
+      expect(next.focusedIndex).toBe(-1);
+    });
+
+    it('does not mutate other fields', () => {
+      const state: WorkspaceInteractionState = {
+        scope: 'all',
+        focusedIndex: 0,
+        archive: null,
+      };
+      const next = reduce(state, { type: 'focus_moved', index: 2 });
+      expect(next.scope).toBe('all');
+      expect(next.archive).toBeNull();
+    });
+  });
+
+  describe('archive_opened', () => {
+    it('sets archive with a repoName', () => {
+      const next = reduce(INITIAL_WORKSPACE_STATE, {
+        type: 'archive_opened',
+        repoName: 'zillow-android',
+      });
+      expect(next.archive).toEqual({ repoName: 'zillow-android' });
+    });
+
+    it('sets archive with undefined repoName (global archive)', () => {
+      const next = reduce(INITIAL_WORKSPACE_STATE, {
+        type: 'archive_opened',
+        repoName: undefined,
+      });
+      expect(next.archive).toEqual({ repoName: undefined });
+    });
+
+    it('does not mutate other fields', () => {
+      const state: WorkspaceInteractionState = {
+        scope: 'all',
+        focusedIndex: 2,
+        archive: null,
+      };
+      const next = reduce(state, { type: 'archive_opened', repoName: 'repo' });
+      expect(next.scope).toBe('all');
+      expect(next.focusedIndex).toBe(2);
+    });
+  });
+
+  describe('archive_closed', () => {
+    it('sets archive to null', () => {
+      const state: WorkspaceInteractionState = {
+        ...INITIAL_WORKSPACE_STATE,
+        archive: { repoName: 'myrepo' },
+      };
+      const next = reduce(state, { type: 'archive_closed' });
+      expect(next.archive).toBeNull();
+    });
+
+    it('is a no-op when archive is already null', () => {
+      const next = reduce(INITIAL_WORKSPACE_STATE, { type: 'archive_closed' });
+      expect(next.archive).toBeNull();
+    });
+
+    it('does not mutate other fields', () => {
+      const state: WorkspaceInteractionState = {
+        scope: 'all',
+        focusedIndex: 4,
+        archive: { repoName: 'repo' },
+      };
+      const next = reduce(state, { type: 'archive_closed' });
+      expect(next.scope).toBe('all');
+      expect(next.focusedIndex).toBe(4);
+    });
+  });
+
+  describe('immutability', () => {
+    it('does not mutate the input state', () => {
+      const state: WorkspaceInteractionState = {
+        scope: 'active',
+        focusedIndex: 0,
+        archive: null,
+      };
+      const frozen = Object.freeze(state);
+      // Should not throw even though input is frozen
+      expect(() =>
+        reduce(frozen, { type: 'scope_changed', scope: 'all' }),
+      ).not.toThrow();
+    });
+  });
+});

--- a/tests/unit/console-workspace-types.test.ts
+++ b/tests/unit/console-workspace-types.test.ts
@@ -14,7 +14,10 @@ import {
   sortItemsForRepo,
   itemVisibility,
   countNeedsAttention,
+  countHasGaps,
   selectPrimarySession,
+  buildRepoGroups,
+  type RepoGroupsResult,
 } from '../../console/src/views/workspace-types.js';
 import type { WorkspaceItem } from '../../console/src/views/workspace-types.js';
 import type {
@@ -399,6 +402,55 @@ describe('countNeedsAttention', () => {
 });
 
 // ---------------------------------------------------------------------------
+// countHasGaps
+// ---------------------------------------------------------------------------
+
+describe('countHasGaps', () => {
+  function makeItem(hasGaps: boolean): WorkspaceItem {
+    return {
+      branch: 'feature/x',
+      repoRoot: '/repo',
+      repoName: 'repo',
+      worktree: undefined,
+      primarySession: undefined,
+      allSessions: hasGaps
+        ? [makeSession({ hasUnresolvedGaps: true }), makeSession({ hasUnresolvedGaps: false })]
+        : [makeSession({ hasUnresolvedGaps: false })],
+      activityMs: NOW_MS,
+    };
+  }
+
+  it('counts items with at least one gap session', () => {
+    expect(countHasGaps([makeItem(true), makeItem(false)])).toBe(1);
+  });
+
+  it('returns 0 when no sessions have gaps', () => {
+    expect(countHasGaps([makeItem(false), makeItem(false)])).toBe(0);
+  });
+
+  it('counts each item at most once regardless of gap session count', () => {
+    // item with two gap sessions should still count as 1
+    const item: WorkspaceItem = {
+      branch: 'feature/y',
+      repoRoot: '/repo',
+      repoName: 'repo',
+      worktree: undefined,
+      primarySession: undefined,
+      allSessions: [
+        makeSession({ hasUnresolvedGaps: true }),
+        makeSession({ hasUnresolvedGaps: true }),
+      ],
+      activityMs: NOW_MS,
+    };
+    expect(countHasGaps([item])).toBe(1);
+  });
+
+  it('returns 0 for empty list', () => {
+    expect(countHasGaps([])).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // selectPrimarySession
 // ---------------------------------------------------------------------------
 
@@ -423,5 +475,105 @@ describe('selectPrimarySession', () => {
     const older = makeSession({ sessionId: 'sess_0000000000000000000000001', status: 'complete', lastModifiedMs: NOW_MS - 2 * DAY_MS });
     const newer = makeSession({ sessionId: 'sess_0000000000000000000000002', status: 'complete', lastModifiedMs: NOW_MS - DAY_MS });
     expect(selectPrimarySession([older, newer])!.sessionId).toBe('sess_0000000000000000000000002');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRepoGroups
+// ---------------------------------------------------------------------------
+
+function makeSimpleRepo(repoRoot = '/repos/myrepo', branch = 'main'): ConsoleRepoWorktrees {
+  return makeRepo(repoRoot, [makeWorktree({ path: repoRoot, branch, headTimestampMs: NOW_MS - DAY_MS })]);
+}
+
+describe('buildRepoGroups', () => {
+  it('returns empty results when sessions and repos are empty', () => {
+    const result: RepoGroupsResult = buildRepoGroups([], [], 'active', NOW_MS);
+    expect(result.repoGroups).toHaveLength(0);
+    expect(result.orderedItems).toHaveLength(0);
+    expect(result.archiveRepos).toHaveLength(0);
+    expect(result.dormantHiddenCount).toBe(0);
+  });
+
+  it('returns a single repo group for sessions in one repo', () => {
+    const sessions = [makeSession({ sessionId: 'sess_test_000000000000000000000002', gitBranch: 'main', repoRoot: '/repos/myrepo' })];
+    const repos = [makeSimpleRepo()];
+    const result = buildRepoGroups(sessions, repos, 'active', NOW_MS);
+    expect(result.repoGroups).toHaveLength(1);
+    expect(result.repoGroups[0]!.repoName).toBe('myrepo');
+    expect(result.orderedItems).toHaveLength(1);
+    expect(result.archiveRepos).toHaveLength(1);
+  });
+
+  it('groups sessions from two repos into two groups', () => {
+    const sessions = [
+      makeSession({ sessionId: 'sess_test_000000000000000000000003', gitBranch: 'main', repoRoot: '/repos/repo-a' }),
+      makeSession({ sessionId: 'sess_test_000000000000000000000004', gitBranch: 'feature', repoRoot: '/repos/repo-b' }),
+    ];
+    const repos: ConsoleRepoWorktrees[] = [
+      {
+        repoName: 'repo-a', repoRoot: '/repos/repo-a',
+        worktrees: [makeWorktree({ path: '/repos/repo-a', branch: 'main', headTimestampMs: NOW_MS - DAY_MS })],
+      },
+      {
+        repoName: 'repo-b', repoRoot: '/repos/repo-b',
+        worktrees: [makeWorktree({ path: '/repos/repo-b', branch: 'feature', headTimestampMs: NOW_MS - DAY_MS })],
+      },
+    ];
+    const result = buildRepoGroups(sessions, repos, 'active', NOW_MS);
+    expect(result.repoGroups).toHaveLength(2);
+    expect(result.orderedItems).toHaveLength(2);
+  });
+
+  it('sorts repos with active sessions before inactive repos', () => {
+    const sessions = [
+      makeSession({ sessionId: 'sess_test_000000000000000000000005', gitBranch: 'main', repoRoot: '/repos/a-repo', status: 'complete', lastModifiedMs: NOW_MS - DAY_MS }),
+      makeSession({ sessionId: 'sess_test_000000000000000000000006', gitBranch: 'feature', repoRoot: '/repos/b-repo', status: 'in_progress', lastModifiedMs: NOW_MS }),
+    ];
+    const repos: ConsoleRepoWorktrees[] = [
+      {
+        repoName: 'a-repo', repoRoot: '/repos/a-repo',
+        worktrees: [makeWorktree({ path: '/repos/a-repo', branch: 'main', headTimestampMs: NOW_MS - DAY_MS })],
+      },
+      {
+        repoName: 'b-repo', repoRoot: '/repos/b-repo',
+        worktrees: [makeWorktree({ path: '/repos/b-repo', branch: 'feature', headTimestampMs: NOW_MS, activeSessionCount: 1 })],
+      },
+    ];
+    const result = buildRepoGroups(sessions, repos, 'active', NOW_MS);
+    // b-repo (active) should come first even though a-repo is alphabetically first
+    expect(result.repoGroups[0]!.repoName).toBe('b-repo');
+    expect(result.repoGroups[1]!.repoName).toBe('a-repo');
+  });
+
+  it('counts dormant hidden items when scope is active', () => {
+    const sessions = [
+      makeSession({ sessionId: 'sess_test_000000000000000000000007', gitBranch: 'stale-branch', repoRoot: '/repos/myrepo', status: 'dormant', lastModifiedMs: NOW_MS - DAY_MS }),
+    ];
+    const repos: ConsoleRepoWorktrees[] = [
+      {
+        repoName: 'myrepo', repoRoot: '/repos/myrepo',
+        worktrees: [makeWorktree({ path: '/repos/myrepo', branch: 'stale-branch', headTimestampMs: NOW_MS - DAY_MS, changedCount: 0, aheadCount: 0 })],
+      },
+    ];
+    const result = buildRepoGroups(sessions, repos, 'active', NOW_MS);
+    expect(result.dormantHiddenCount).toBe(1);
+    // Dormant item is hidden so the repo group is filtered out
+    expect(result.repoGroups).toHaveLength(0);
+  });
+
+  it('dormantHiddenCount is 0 when scope is all', () => {
+    const sessions = [
+      makeSession({ sessionId: 'sess_test_000000000000000000000008', gitBranch: 'stale-branch', repoRoot: '/repos/myrepo', status: 'dormant', lastModifiedMs: NOW_MS - DAY_MS }),
+    ];
+    const repos: ConsoleRepoWorktrees[] = [
+      {
+        repoName: 'myrepo', repoRoot: '/repos/myrepo',
+        worktrees: [makeWorktree({ path: '/repos/myrepo', branch: 'stale-branch', headTimestampMs: NOW_MS - DAY_MS, changedCount: 0, aheadCount: 0 })],
+      },
+    ];
+    const result = buildRepoGroups(sessions, repos, 'all', NOW_MS);
+    expect(result.dormantHiddenCount).toBe(0);
+    expect(result.repoGroups).toHaveLength(1);
   });
 });

--- a/tests/unit/transports/shutdown-hooks.test.ts
+++ b/tests/unit/transports/shutdown-hooks.test.ts
@@ -86,7 +86,7 @@ vi.mock('../../../src/di/tokens.js', () => ({
 }));
 
 // Import after mocks are set up
-const { wireShutdownHooks, wireStdinShutdown } = await import(
+const { wireShutdownHooks, wireStdinShutdown, wireStdoutShutdown } = await import(
   '../../../src/mcp/transports/shutdown-hooks.js'
 );
 
@@ -224,5 +224,84 @@ describe('wireStdinShutdown', () => {
 
     expect(emittedEvents).toHaveLength(1);
     expect(emittedEvents[0]).toEqual({ kind: 'shutdown_requested', signal: 'SIGHUP' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fake writable stream for wireStdoutShutdown tests
+// ---------------------------------------------------------------------------
+
+function createFakeStdout(): NodeJS.WritableStream & {
+  simulateError(code: string): void;
+} {
+  const emitter = new EventEmitter() as NodeJS.WritableStream & {
+    simulateError(code: string): void;
+  };
+  emitter.simulateError = (code: string) => {
+    const err = Object.assign(new Error(`write ${code}`), { code });
+    emitter.emit('error', err);
+  };
+  return emitter;
+}
+
+describe('wireStdoutShutdown', () => {
+  beforeEach(() => {
+    fakeShutdownEvents._listeners.length = 0;
+    fakeProcessSignals._handlers.clear();
+    fakeProcessSignals._onceHandlers.clear();
+    fakeTerminator._calls.length = 0;
+  });
+
+  it('emits shutdown_requested with SIGHUP on EPIPE', () => {
+    const fakeStdout = createFakeStdout();
+    const emittedEvents: Array<{ kind: string; signal: string }> = [];
+
+    fakeShutdownEvents._listeners.push((event) => emittedEvents.push(event));
+
+    wireStdoutShutdown({ stdout: fakeStdout });
+    fakeStdout.simulateError('EPIPE');
+
+    expect(emittedEvents).toHaveLength(1);
+    expect(emittedEvents[0]).toEqual({ kind: 'shutdown_requested', signal: 'SIGHUP' });
+  });
+
+  it('emits shutdown_requested with SIGHUP on ERR_STREAM_DESTROYED', () => {
+    const fakeStdout = createFakeStdout();
+    const emittedEvents: Array<{ kind: string; signal: string }> = [];
+
+    fakeShutdownEvents._listeners.push((event) => emittedEvents.push(event));
+
+    wireStdoutShutdown({ stdout: fakeStdout });
+    fakeStdout.simulateError('ERR_STREAM_DESTROYED');
+
+    expect(emittedEvents).toHaveLength(1);
+    expect(emittedEvents[0]).toEqual({ kind: 'shutdown_requested', signal: 'SIGHUP' });
+  });
+
+  it('emits shutdown_requested for other stdout errors too', () => {
+    const fakeStdout = createFakeStdout();
+    const emittedEvents: Array<{ kind: string; signal: string }> = [];
+
+    fakeShutdownEvents._listeners.push((event) => emittedEvents.push(event));
+
+    wireStdoutShutdown({ stdout: fakeStdout });
+    fakeStdout.simulateError('EIO');
+
+    expect(emittedEvents).toHaveLength(1);
+    expect(emittedEvents[0]).toEqual({ kind: 'shutdown_requested', signal: 'SIGHUP' });
+  });
+
+  it('handles multiple errors (does not throw after first)', () => {
+    const fakeStdout = createFakeStdout();
+    const emittedEvents: Array<{ kind: string; signal: string }> = [];
+
+    fakeShutdownEvents._listeners.push((event) => emittedEvents.push(event));
+
+    wireStdoutShutdown({ stdout: fakeStdout });
+    fakeStdout.simulateError('EPIPE');
+    fakeStdout.simulateError('EPIPE');
+
+    // Both fire since we register with .on() not .once()
+    expect(emittedEvents).toHaveLength(2);
   });
 });

--- a/tests/unit/v2/session-lock-stale.test.ts
+++ b/tests/unit/v2/session-lock-stale.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for LocalSessionLockV2.clearIfStaleLock() behavior.
+ *
+ * Tests the stale lock detection path introduced to handle crash recovery.
+ * A "stale" lock is one whose owning process (by PID) is no longer alive.
+ *
+ * Tests exercise clearIfStaleLock indirectly through acquire(), which
+ * calls it as pre-flight cleanup before attempting openExclusive.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { InMemoryFileSystem } from '../../fakes/v2/file-system.fake.js';
+import { FakeTimeClockV2 } from '../../fakes/v2/time-clock.fake.js';
+import { LocalSessionLockV2 } from '../../../src/v2/infra/local/session-lock/index.js';
+import type { DataDirPortV2 } from '../../../src/v2/ports/data-dir.port.js';
+import type { SessionId } from '../../../src/v2/durable-core/ids/index.js';
+
+// ---------------------------------------------------------------------------
+// Fake DataDir
+// ---------------------------------------------------------------------------
+
+const SESSION_DIR = '/data/sessions/sess-001';
+const LOCK_PATH = '/data/sessions/sess-001/.lock';
+const SESSION_ID = 'sess-001' as SessionId;
+
+const fakeDataDir: DataDirPortV2 = {
+  root: () => '/data',
+  sessionDir: () => SESSION_DIR,
+  sessionLockPath: () => LOCK_PATH,
+  perfDir: () => '/data/perf',
+  snapshotDir: () => '/data/snapshots',
+  snapshotPath: () => '/data/snapshots/snap.json',
+  snapshotTmpPath: () => '/data/snapshots/snap.json.tmp',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeLock(pid: number) {
+  return JSON.stringify({ v: 1, sessionId: SESSION_ID, pid, startedAtMs: Date.now() });
+}
+
+async function acquireExpectSuccess(lock: LocalSessionLockV2) {
+  const result = await lock.acquire(SESSION_ID);
+  expect(result.isOk()).toBe(true);
+}
+
+async function acquireExpectBusy(lock: LocalSessionLockV2) {
+  const result = await lock.acquire(SESSION_ID);
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.code).toBe('SESSION_LOCK_BUSY');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('LocalSessionLockV2 stale lock detection', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('clears a stale lock (dead PID) and acquires successfully', async () => {
+    const fs = new InMemoryFileSystem();
+    const clock = new FakeTimeClockV2();
+    const lock = new LocalSessionLockV2(fakeDataDir, fs, clock);
+
+    // Plant a stale lock with a dead PID
+    const deadPid = 99999;
+    vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+      if (pid === deadPid && signal === 0) {
+        const err = Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' });
+        throw err;
+      }
+      return true;
+    });
+
+    // Pre-create the lock file with the dead PID
+    await fs.mkdirp(SESSION_DIR);
+    await fs.writeFileBytes(LOCK_PATH, new TextEncoder().encode(makeLock(deadPid)));
+
+    // Acquire should clear the stale lock and succeed
+    await acquireExpectSuccess(lock);
+  });
+
+  it('does NOT clear a live lock (process still alive)', async () => {
+    const fs = new InMemoryFileSystem();
+    const clock = new FakeTimeClockV2();
+    const lock = new LocalSessionLockV2(fakeDataDir, fs, clock);
+
+    const livePid = 12345;
+    // process.kill(pid, 0) does NOT throw for live processes
+    vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    await fs.mkdirp(SESSION_DIR);
+    await fs.writeFileBytes(LOCK_PATH, new TextEncoder().encode(makeLock(livePid)));
+
+    // Acquire should fail -- live lock, not stale
+    await acquireExpectBusy(lock);
+  });
+
+  it('does NOT clear a lock when EPERM is returned (alive, no permission)', async () => {
+    const fs = new InMemoryFileSystem();
+    const clock = new FakeTimeClockV2();
+    const lock = new LocalSessionLockV2(fakeDataDir, fs, clock);
+
+    const pidNoPermission = 1; // init/systemd -- alive but EPERM
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      const err = Object.assign(new Error('kill EPERM'), { code: 'EPERM' });
+      throw err;
+    });
+
+    await fs.mkdirp(SESSION_DIR);
+    await fs.writeFileBytes(LOCK_PATH, new TextEncoder().encode(makeLock(pidNoPermission)));
+
+    // Should be treated as live (not stale) -- lock is preserved
+    await acquireExpectBusy(lock);
+  });
+
+  it('proceeds normally when no lock file exists (no stale to clear)', async () => {
+    const fs = new InMemoryFileSystem();
+    const clock = new FakeTimeClockV2();
+    const lock = new LocalSessionLockV2(fakeDataDir, fs, clock);
+
+    // No pre-existing lock file -- clearIfStaleLock returns ok() gracefully
+    await acquireExpectSuccess(lock);
+  });
+
+  it('does not clear lock when lock file has invalid JSON', async () => {
+    const fs = new InMemoryFileSystem();
+    const clock = new FakeTimeClockV2();
+    const lock = new LocalSessionLockV2(fakeDataDir, fs, clock);
+
+    vi.spyOn(process, 'kill'); // Should not be called
+
+    await fs.mkdirp(SESSION_DIR);
+    await fs.writeFileBytes(LOCK_PATH, new TextEncoder().encode('not-json'));
+
+    // Can't determine staleness -- treated as live, acquire fails
+    await acquireExpectBusy(lock);
+
+    expect(process.kill).not.toHaveBeenCalled();
+  });
+
+  it('does not clear lock when PID field is missing from lock file', async () => {
+    const fs = new InMemoryFileSystem();
+    const clock = new FakeTimeClockV2();
+    const lock = new LocalSessionLockV2(fakeDataDir, fs, clock);
+
+    vi.spyOn(process, 'kill'); // Should not be called
+
+    await fs.mkdirp(SESSION_DIR);
+    await fs.writeFileBytes(LOCK_PATH, new TextEncoder().encode(JSON.stringify({ v: 1 })));
+
+    await acquireExpectBusy(lock);
+    expect(process.kill).not.toHaveBeenCalled();
+  });
+
+  it('release removes the lock file', async () => {
+    const fs = new InMemoryFileSystem();
+    const clock = new FakeTimeClockV2();
+    const lock = new LocalSessionLockV2(fakeDataDir, fs, clock);
+
+    const handle = await lock.acquire(SESSION_ID);
+    expect(handle.isOk()).toBe(true);
+
+    const release = await lock.release(handle._unsafeUnwrap());
+    expect(release.isOk()).toBe(true);
+
+    // Lock file should be gone -- next acquire should succeed
+    await acquireExpectSuccess(lock);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -58,6 +58,9 @@ export default defineConfig({
           ...shared,
         },
       },
+      // Console ViewModel hook tests live in console/src/hooks/__tests__/ and
+      // run via the console's own vitest config (console/vitest.config.ts).
+      // Use: cd console && npx vitest run   OR   npm test --prefix console
     ],
     
     // Coverage configuration


### PR DESCRIPTION
## Summary

Two independent improvements in one PR:

**Console MVI refactor** -- Every view now follows a strict layered architecture: Repository -> Use Cases -> Reducer -> ViewModel -> pure presenter. Previously, views owned their own data fetching, business logic, and rendering all in one file.

- All 6 views refactored: WorkspaceView, WorkflowsView, WorkflowDetail, SessionDetail, SessionList, PerformanceView
- AppShell is the single orchestration point -- instantiates all ViewModels, passes results as props
- 14 new hooks (repositories + ViewModels), 7 reducer/use-case files
- `console/CLAUDE.md` documents the pattern, decision criteria, naming conventions, and common mistakes so future contributors don't have to guess
- Fix: dormant sessions in multi-session branches now correctly demote to the history section in Active scope instead of cluttering the active list

**MCP server stability** -- Addresses the root cause of the workrail MCP server crashing silently during Claude Code sessions.

- Root cause: `StdioServerTransport` from the MCP SDK only registers error listeners on stdin, not stdout. When the client closes the connection mid-write, stdout emits EPIPE with no handler → Node.js uncaught exception → silent crash
- Fix: `wireStdoutShutdown()` registers a stdout error handler before `server.connect()`, routing EPIPE into the clean shutdown path
- Fix: `clearIfStaleLock()` detects and removes lock files left by crashed processes via `process.kill(pid, 0)` PID liveness check (confirmed stale lock on disk from a previous crash)
- Added `uncaughtException`/`unhandledRejection` handlers so crashes are visible in stderr instead of silent

## Test plan

- [ ] `npm run test:unit` -- 2867 passing (root: reducers, use cases, wireStdoutShutdown x4, clearIfStaleLock x6)
- [ ] `cd console && npx vitest run` -- 128 passing (ViewModel hook tests via renderHook + vi.mock)
- [ ] `cd console && npx vite build` -- clean build, no new errors
- [ ] Verify workrail no longer crashes silently when Claude Code disconnects during parallel agent runs
- [ ] Verify Active scope in console no longer shows dormant sessions from multi-session branches

🤖 Generated with [Claude Code](https://claude.ai/claude-code)