### PR TITLE
feat(console): execution trace explainability -- Layers 1 + 2

### DIFF
--- a/console/src/components/NodeDetailSection.tsx
+++ b/console/src/components/NodeDetailSection.tsx
@@ -3,7 +3,7 @@ import { useNodeDetail } from '../api/hooks';
 import { MarkdownView } from './MarkdownView';
 import { MonoLabel } from './MonoLabel';
 import { TraceBadge } from './TraceBadge';
-import { getNodeRoutingItems } from '../views/session-detail-use-cases';
+import { getNodeRoutingItems, isConditionPassed } from '../views/session-detail-use-cases';
 import type {
   ConsoleNodeDetail,
   ConsoleRunStatus,
@@ -126,10 +126,11 @@ function RoutingSection({
     nodeId,
   );
 
-  // Mirror the original check: any item that references this node_id counts,
-  // even kinds not rendered explicitly (e.g. context_fact with a node_id ref).
+  // Only count items that are actually rendered -- context_fact items are shown
+  // as chips in the DAG header, not in this section. If only context_fact items
+  // ref this node, show the "no routing trace" fallback rather than an empty body.
   const hasAnyItems = executionTraceSummary.items.some(
-    (item) => item.refs.some((r) => r.kind === 'node_id' && r.value === nodeId),
+    (item) => item.kind !== 'context_fact' && item.refs.some((r) => r.kind === 'node_id' && r.value === nodeId),
   );
 
   // When no items match but trace is non-null: show "no routing trace" message
@@ -138,7 +139,7 @@ function RoutingSection({
       <Section title="Routing context">
         {nodeKind === 'blocked_attempt' && whySelected.length === 0 ? (
           <div className="flex items-start gap-2 py-1">
-            <TraceBadge label="WHY SELECTED" color="var(--text-muted)" />
+            <TraceBadge label="WHY SELECTED" color="var(--text-muted)" bgColor="rgba(123,141,167,0.08)" />
             <span className="text-xs text-[var(--text-muted)] leading-relaxed">
               This step was attempted but not selected as the preferred path.
             </span>
@@ -159,7 +160,7 @@ function RoutingSection({
         {(whySelected.length > 0 || nodeKind === 'blocked_attempt') && (
           <div>
             <div className="mb-1.5 flex items-center gap-2">
-              <TraceBadge label="WHY SELECTED" color="var(--accent)" />
+              <TraceBadge label="WHY SELECTED" color="var(--accent)" bgColor="rgba(244,196,48,0.10)" />
             </div>
             {whySelected.length > 0 ? (
               <div className="space-y-1 pl-2 border-l border-[var(--border)]">
@@ -182,20 +183,21 @@ function RoutingSection({
         {conditions.length > 0 && (
           <div>
             <div className="mb-1.5">
-              <TraceBadge label="CONDITIONS EVALUATED" color="var(--text-secondary)" />
+              <TraceBadge label="CONDITIONS EVALUATED" color="var(--text-secondary)" bgColor="rgba(168,159,140,0.10)" />
             </div>
             <div className="space-y-1 pl-2 border-l border-[var(--border)]">
               {/* SKIP conditions first -- surfaces why this path was not taken before confirming what passed */}
               {[
-                ...conditions.filter((c) => !/\btrue\b|\bpass/i.test(c.summary)),
-                ...conditions.filter((c) => /\btrue\b|\bpass/i.test(c.summary)),
+                ...conditions.filter((c) => !isConditionPassed(c)),
+                ...conditions.filter((c) => isConditionPassed(c)),
               ].map((item, idx) => {
-                const passed = /\btrue\b|\bpass/i.test(item.summary);
+                const passed = isConditionPassed(item);
                 return (
                   <div key={idx} className="flex items-start gap-2 text-xs py-0.5">
                     <TraceBadge
                       label={passed ? 'PASS' : 'SKIP'}
                       color={passed ? 'var(--success)' : 'var(--warning)'}
+                      bgColor={passed ? 'rgba(34,197,94,0.10)' : 'rgba(251,191,36,0.10)'}
                     />
                     <span className="flex-1 text-[var(--text-secondary)] leading-relaxed">{item.summary}</span>
                   </div>
@@ -209,7 +211,7 @@ function RoutingSection({
         {loops.length > 0 && (
           <div>
             <div className="mb-1.5">
-              <TraceBadge label="LOOP" color="var(--accent-strong)" />
+              <TraceBadge label="LOOP" color="var(--accent-strong)" bgColor="rgba(0,240,255,0.10)" />
             </div>
             <div className="space-y-1 pl-2 border-l border-[var(--border)]">
               {loops.map((item, idx) => (
@@ -223,7 +225,7 @@ function RoutingSection({
         {divergences.length > 0 && (
           <div>
             <div className="mb-1.5">
-              <TraceBadge label="DIVERGENCE" color="var(--error)" />
+              <TraceBadge label="DIVERGENCE" color="var(--error)" bgColor="rgba(255,107,107,0.10)" />
             </div>
             <div className="space-y-1 pl-2 border-l border-[var(--border)]">
               {divergences.map((item, idx) => (
@@ -237,7 +239,7 @@ function RoutingSection({
         {forks.length > 0 && (
           <div>
             <div className="mb-1.5">
-              <TraceBadge label="FORK" color="var(--warning)" />
+              <TraceBadge label="FORK" color="var(--warning)" bgColor="rgba(251,191,36,0.10)" />
             </div>
             <div className="space-y-1 pl-2 border-l border-[var(--border)]">
               {forks.map((item, idx) => (
@@ -259,10 +261,11 @@ function RunRoutingSection({ items }: { items: readonly ConsoleExecutionTraceIte
       <div>
         <button
           type="button"
+          aria-expanded={expanded}
           onClick={() => setExpanded((e) => !e)}
           className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.20em] text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
         >
-          <TraceBadge label="RUN ROUTING" color="var(--text-muted)" />
+          <TraceBadge label="RUN ROUTING" color="var(--text-muted)" bgColor="rgba(123,141,167,0.08)" />
           <span className="text-[var(--text-muted)]">// {items.length} ambient items</span>
           <span>{expanded ? '[-]' : '[+]'}</span>
         </button>

--- a/console/src/components/NodeDetailSection.tsx
+++ b/console/src/components/NodeDetailSection.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { useNodeDetail } from '../api/hooks';
 import { MarkdownView } from './MarkdownView';
 import { MonoLabel } from './MonoLabel';
+import { TraceBadge } from './TraceBadge';
+import { getNodeRoutingItems } from '../views/session-detail-use-cases';
 import type {
   ConsoleNodeDetail,
   ConsoleRunStatus,
@@ -101,23 +103,6 @@ interface SectionDef {
 // Routing section components (used in SECTION_REGISTRY entries below)
 // ---------------------------------------------------------------------------
 
-function RoutingTraceBadge({
-  label,
-  color,
-}: {
-  label: string;
-  color: string;
-}) {
-  return (
-    <span
-      className="shrink-0 inline-flex items-center px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.20em]"
-      style={{ color, backgroundColor: `${color}18`, border: `1px solid ${color}40` }}
-    >
-      {label}
-    </span>
-  );
-}
-
 function RoutingItemRow({ item }: { item: ConsoleExecutionTraceItem }) {
   return (
     <div className="flex items-start gap-2 text-xs py-1">
@@ -136,19 +121,16 @@ function RoutingSection({
   nodeKind: ConsoleNodeDetail['nodeKind'];
   executionTraceSummary: ConsoleExecutionTraceSummary;
 }) {
-  const nodeItems = executionTraceSummary.items.filter(
-    (item) => item.refs.some((r) => r.kind === 'node_id' && r.value === nodeId),
+  const { whySelected, conditions, loops, divergences, forks } = getNodeRoutingItems(
+    executionTraceSummary,
+    nodeId,
   );
 
-  const whySelected = nodeItems.filter((i) => i.kind === 'selected_next_step');
-  const conditions = nodeItems.filter((i) => i.kind === 'evaluated_condition');
-  const loops = nodeItems.filter((i) => i.kind === 'entered_loop' || i.kind === 'exited_loop');
-  const divergences = nodeItems.filter((i) => i.kind === 'divergence');
-  // detected_non_tip_advance always has a node_id ref (run-execution-trace.ts prepends one)
-  // -- must render explicitly or these items make hasAnyItems=true but show nothing.
-  const forks = nodeItems.filter((i) => i.kind === 'detected_non_tip_advance');
-
-  const hasAnyItems = nodeItems.length > 0;
+  // Mirror the original check: any item that references this node_id counts,
+  // even kinds not rendered explicitly (e.g. context_fact with a node_id ref).
+  const hasAnyItems = executionTraceSummary.items.some(
+    (item) => item.refs.some((r) => r.kind === 'node_id' && r.value === nodeId),
+  );
 
   // When no items match but trace is non-null: show "no routing trace" message
   if (!hasAnyItems) {
@@ -156,7 +138,7 @@ function RoutingSection({
       <Section title="Routing context">
         {nodeKind === 'blocked_attempt' && whySelected.length === 0 ? (
           <div className="flex items-start gap-2 py-1">
-            <RoutingTraceBadge label="WHY SELECTED" color="var(--text-muted)" />
+            <TraceBadge label="WHY SELECTED" color="var(--text-muted)" />
             <span className="text-xs text-[var(--text-muted)] leading-relaxed">
               This step was attempted but not selected as the preferred path.
             </span>
@@ -177,7 +159,7 @@ function RoutingSection({
         {(whySelected.length > 0 || nodeKind === 'blocked_attempt') && (
           <div>
             <div className="mb-1.5 flex items-center gap-2">
-              <RoutingTraceBadge label="WHY SELECTED" color="var(--accent)" />
+              <TraceBadge label="WHY SELECTED" color="var(--accent)" />
             </div>
             {whySelected.length > 0 ? (
               <div className="space-y-1 pl-2 border-l border-[var(--border)]">
@@ -200,7 +182,7 @@ function RoutingSection({
         {conditions.length > 0 && (
           <div>
             <div className="mb-1.5">
-              <RoutingTraceBadge label="CONDITIONS EVALUATED" color="var(--text-secondary)" />
+              <TraceBadge label="CONDITIONS EVALUATED" color="var(--text-secondary)" />
             </div>
             <div className="space-y-1 pl-2 border-l border-[var(--border)]">
               {/* SKIP conditions first -- surfaces why this path was not taken before confirming what passed */}
@@ -211,7 +193,7 @@ function RoutingSection({
                 const passed = /\btrue\b|\bpass/i.test(item.summary);
                 return (
                   <div key={idx} className="flex items-start gap-2 text-xs py-0.5">
-                    <RoutingTraceBadge
+                    <TraceBadge
                       label={passed ? 'PASS' : 'SKIP'}
                       color={passed ? 'var(--success)' : 'var(--warning)'}
                     />
@@ -227,7 +209,7 @@ function RoutingSection({
         {loops.length > 0 && (
           <div>
             <div className="mb-1.5">
-              <RoutingTraceBadge label="LOOP" color="var(--accent-strong)" />
+              <TraceBadge label="LOOP" color="var(--accent-strong)" />
             </div>
             <div className="space-y-1 pl-2 border-l border-[var(--border)]">
               {loops.map((item, idx) => (
@@ -241,7 +223,7 @@ function RoutingSection({
         {divergences.length > 0 && (
           <div>
             <div className="mb-1.5">
-              <RoutingTraceBadge label="DIVERGENCE" color="var(--error)" />
+              <TraceBadge label="DIVERGENCE" color="var(--error)" />
             </div>
             <div className="space-y-1 pl-2 border-l border-[var(--border)]">
               {divergences.map((item, idx) => (
@@ -255,7 +237,7 @@ function RoutingSection({
         {forks.length > 0 && (
           <div>
             <div className="mb-1.5">
-              <RoutingTraceBadge label="FORK" color="var(--warning)" />
+              <TraceBadge label="FORK" color="var(--warning)" />
             </div>
             <div className="space-y-1 pl-2 border-l border-[var(--border)]">
               {forks.map((item, idx) => (
@@ -280,7 +262,7 @@ function RunRoutingSection({ items }: { items: readonly ConsoleExecutionTraceIte
           onClick={() => setExpanded((e) => !e)}
           className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.20em] text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
         >
-          <RoutingTraceBadge label="RUN ROUTING" color="var(--text-muted)" />
+          <TraceBadge label="RUN ROUTING" color="var(--text-muted)" />
           <span className="text-[var(--text-muted)]">// {items.length} ambient items</span>
           <span>{expanded ? '[-]' : '[+]'}</span>
         </button>

--- a/console/src/components/RunLineageDag.tsx
+++ b/console/src/components/RunLineageDag.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { MonoLabel } from './MonoLabel';
+import { camelToSpacedUpper } from '../utils/format';
 import {
   ReactFlow,
   type Edge,
@@ -257,7 +258,7 @@ export function RunLineageDag({ run, selectedNodeId = null, onNodeClick }: Props
                   border: '1px solid rgba(123, 141, 167, 0.20)',
                 }}
               >
-                <span style={{ color: 'var(--text-secondary)' }}>{dagCamelToSpacedUpper(fact.key)}</span>
+                <span style={{ color: 'var(--text-secondary)' }}>{camelToSpacedUpper(fact.key)}</span>
                 <span style={{ color: 'var(--text-muted)' }}>//</span>
                 <span style={{ color: 'var(--text-primary)' }}>{fact.value}</span>
               </div>
@@ -657,10 +658,3 @@ function truncateLabel(label: string): string {
   return label.length > 18 ? `${label.slice(0, 18)}…` : label;
 }
 
-/** Converts a camelCase key to spaced uppercase (e.g. taskComplexity -> TASK COMPLEXITY). */
-function dagCamelToSpacedUpper(key: string): string {
-  return key
-    .replace(/([A-Z])/g, ' $1')
-    .toUpperCase()
-    .trim();
-}

--- a/console/src/components/RunNarrativeView.tsx
+++ b/console/src/components/RunNarrativeView.tsx
@@ -19,6 +19,12 @@ import type {
   ConsoleExecutionTraceItem,
   ConsoleRunStatus,
 } from '../api/types';
+import {
+  groupTraceEntries,
+  type LoopGroup,
+} from '../views/session-detail-use-cases';
+import { TraceBadge } from './TraceBadge';
+import { camelToSpacedUpper } from '../utils/format';
 
 // ---------------------------------------------------------------------------
 // Public props
@@ -27,114 +33,6 @@ import type {
 interface Props {
   readonly summary: ConsoleExecutionTraceSummary;
   readonly runStatus: ConsoleRunStatus;
-}
-
-// ---------------------------------------------------------------------------
-// Loop grouping logic
-//
-// INVARIANT: entered_loop and exited_loop items are matched by loop_id ref value.
-// An orphaned entered_loop (no matching exited_loop) is rendered as a standalone
-// [ LOOP ] entry rather than dropped silently.
-//
-// Algorithm:
-// 1. Linear scan over items sorted by recordedAtEventIndex.
-// 2. When an entered_loop is seen, start accumulating a pending group keyed by loop_id.
-// 3. When an exited_loop is seen with a matching loop_id, close the group.
-// 4. All other items are rendered as standalone entries.
-// 5. Any pending (unclosed) groups at end-of-list become standalone entries.
-// ---------------------------------------------------------------------------
-
-type StandaloneEntry = {
-  readonly kind: 'standalone';
-  readonly item: ConsoleExecutionTraceItem;
-};
-
-type LoopGroup = {
-  readonly kind: 'loop_group';
-  readonly loopId: string;
-  readonly enteredItem: ConsoleExecutionTraceItem;
-  readonly innerItems: readonly ConsoleExecutionTraceItem[];
-  readonly exitedItem: ConsoleExecutionTraceItem;
-  readonly iterationCount: number;
-};
-
-type TraceEntry = StandaloneEntry | LoopGroup;
-
-function getLoopId(item: ConsoleExecutionTraceItem): string | null {
-  return item.refs.find((r) => r.kind === 'loop_id')?.value ?? null;
-}
-
-/**
- * Groups entered_loop/exited_loop pairs by loop_id.
- * context_fact items are excluded (shown via contextFacts chips instead).
- */
-function groupTraceEntries(items: readonly ConsoleExecutionTraceItem[]): readonly TraceEntry[] {
-  // Filter out context_fact items -- they are shown as chips, not list entries.
-  const filtered = items.filter((item) => item.kind !== 'context_fact');
-  const sorted = [...filtered].sort((a, b) => a.recordedAtEventIndex - b.recordedAtEventIndex);
-
-  const result: TraceEntry[] = [];
-  // Map of loopId -> { enteredItem, innerItems } for open (unclosed) loops.
-  // loopStack tracks the insertion order so inner items always go to the
-  // most-recently-opened (innermost) loop rather than the oldest open loop.
-  const pendingLoops = new Map<string, { enteredItem: ConsoleExecutionTraceItem; innerItems: ConsoleExecutionTraceItem[] }>();
-  const loopStack: string[] = []; // loopIds in open order, most recent at end
-
-  for (const item of sorted) {
-    if (item.kind === 'entered_loop') {
-      const loopId = getLoopId(item);
-      if (loopId) {
-        pendingLoops.set(loopId, { enteredItem: item, innerItems: [] });
-        loopStack.push(loopId);
-      } else {
-        // No loop_id ref -- treat as standalone
-        result.push({ kind: 'standalone', item });
-      }
-    } else if (item.kind === 'exited_loop') {
-      const loopId = getLoopId(item);
-      const pending = loopId ? pendingLoops.get(loopId) : undefined;
-      if (pending && loopId) {
-        pendingLoops.delete(loopId);
-        const stackIdx = loopStack.lastIndexOf(loopId);
-        if (stackIdx !== -1) loopStack.splice(stackIdx, 1);
-        // Count iterations: number of selected_next_step items inside the loop
-        const iterationCount = Math.max(
-          1,
-          pending.innerItems.filter((i) => i.kind === 'selected_next_step').length,
-        );
-        result.push({
-          kind: 'loop_group',
-          loopId,
-          enteredItem: pending.enteredItem,
-          innerItems: pending.innerItems,
-          exitedItem: item,
-          iterationCount,
-        });
-      } else {
-        // Orphaned exited_loop -- treat as standalone
-        result.push({ kind: 'standalone', item });
-      }
-    } else {
-      // Non-loop item: add to the innermost open loop (last in stack), or standalone
-      const innermostLoopId = loopStack.at(-1);
-      const activePending = innermostLoopId ? pendingLoops.get(innermostLoopId) : undefined;
-      if (activePending) {
-        activePending.innerItems.push(item);
-      } else {
-        result.push({ kind: 'standalone', item });
-      }
-    }
-  }
-
-  // Flush any unclosed (orphaned) loops as standalone entries
-  for (const [, pending] of pendingLoops) {
-    result.push({ kind: 'standalone', item: pending.enteredItem });
-    for (const inner of pending.innerItems) {
-      result.push({ kind: 'standalone', item: inner });
-    }
-  }
-
-  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -170,17 +68,6 @@ function getBadgeConfig(item: ConsoleExecutionTraceItem): BadgeConfig {
     default:
       return { label: 'INFO', color: 'var(--text-secondary)', bgColor: 'rgba(123, 141, 167, 0.08)' };
   }
-}
-
-function TraceBadge({ label, color, bgColor }: { label: string; color: string; bgColor: string }) {
-  return (
-    <span
-      className="shrink-0 inline-flex items-center px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.20em]"
-      style={{ color, backgroundColor: bgColor, border: `1px solid ${color}40` }}
-    >
-      {label}
-    </span>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -273,14 +160,6 @@ function EndMarker({ runStatus }: { runStatus: ConsoleRunStatus }) {
 // ---------------------------------------------------------------------------
 // Context facts chip strip
 // ---------------------------------------------------------------------------
-
-function camelToSpacedUpper(key: string): string {
-  return key
-    .replace(/_/g, ' ')       // snake_case -> spaces
-    .replace(/([A-Z])/g, ' $1') // camelCase -> spaces
-    .toUpperCase()
-    .trim();
-}
 
 function ContextFactsRow({ facts }: { facts: ConsoleExecutionTraceSummary['contextFacts'] }) {
   if (facts.length === 0) return null;

--- a/console/src/components/RunNarrativeView.tsx
+++ b/console/src/components/RunNarrativeView.tsx
@@ -21,6 +21,7 @@ import type {
 } from '../api/types';
 import {
   groupTraceEntries,
+  isConditionPassed,
   type LoopGroup,
 } from '../views/session-detail-use-cases';
 import { TraceBadge } from './TraceBadge';
@@ -50,8 +51,7 @@ function getBadgeConfig(item: ConsoleExecutionTraceItem): BadgeConfig {
     case 'selected_next_step':
       return { label: 'STEP', color: 'var(--accent)', bgColor: 'rgba(244, 196, 48, 0.12)' };
     case 'evaluated_condition': {
-      // Heuristic: if the summary contains "true" or "passed" it's a positive evaluation
-      const isTrue = /\btrue\b|\bpass/i.test(item.summary);
+      const isTrue = isConditionPassed(item);
       return isTrue
         ? { label: 'CONDITION', color: 'var(--success)', bgColor: 'rgba(34, 197, 94, 0.12)' }
         : { label: 'CONDITION', color: 'var(--text-muted)', bgColor: 'rgba(123, 141, 167, 0.10)' };

--- a/console/src/components/TraceBadge.tsx
+++ b/console/src/components/TraceBadge.tsx
@@ -1,0 +1,28 @@
+/**
+ * TraceBadge -- shared badge chip used in execution trace views.
+ *
+ * Used by RunNarrativeView and NodeDetailSection to display
+ * trace item kind labels (STEP, CONDITION, LOOP, FORK, etc.).
+ *
+ * bgColor is optional; when absent it defaults to `${color}18`
+ * (18 hex = ~10% opacity), matching the RoutingTraceBadge convention
+ * used in NodeDetailSection.
+ */
+
+interface TraceBadgeProps {
+  readonly label: string;
+  readonly color: string;
+  readonly bgColor?: string;
+}
+
+export function TraceBadge({ label, color, bgColor }: TraceBadgeProps) {
+  const bg = bgColor ?? `${color}18`;
+  return (
+    <span
+      className="shrink-0 inline-flex items-center px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.20em]"
+      style={{ color, backgroundColor: bg, border: `1px solid ${color}40` }}
+    >
+      {label}
+    </span>
+  );
+}

--- a/console/src/components/TraceBadge.tsx
+++ b/console/src/components/TraceBadge.tsx
@@ -4,23 +4,23 @@
  * Used by RunNarrativeView and NodeDetailSection to display
  * trace item kind labels (STEP, CONDITION, LOOP, FORK, etc.).
  *
- * bgColor is optional; when absent it defaults to `${color}18`
- * (18 hex = ~10% opacity), matching the RoutingTraceBadge convention
- * used in NodeDetailSection.
+ * bgColor must be a complete, valid CSS color value. There is no
+ * default -- callers must always pass bgColor explicitly to avoid
+ * invalid CSS when `color` is a CSS custom property (var(--x)18 is
+ * not valid CSS and renders transparent).
  */
 
 interface TraceBadgeProps {
   readonly label: string;
   readonly color: string;
-  readonly bgColor?: string;
+  readonly bgColor: string;
 }
 
 export function TraceBadge({ label, color, bgColor }: TraceBadgeProps) {
-  const bg = bgColor ?? `${color}18`;
   return (
     <span
       className="shrink-0 inline-flex items-center px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.20em]"
-      style={{ color, backgroundColor: bg, border: `1px solid ${color}40` }}
+      style={{ color, backgroundColor: bgColor, border: `1px solid ${color}40` }}
     >
       {label}
     </span>

--- a/console/src/utils/format.ts
+++ b/console/src/utils/format.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared string formatting utilities for the WorkRail Console.
+ */
+
+/**
+ * Converts a camelCase or snake_case key to spaced uppercase.
+ *
+ * Examples:
+ *   taskComplexity  -> TASK COMPLEXITY
+ *   my_key          -> MY KEY
+ *   someKey_name    -> SOME KEY NAME
+ */
+export function camelToSpacedUpper(key: string): string {
+  return key
+    .replace(/_/g, ' ')        // snake_case -> spaces
+    .replace(/([A-Z])/g, ' $1') // camelCase -> spaces
+    .toUpperCase()
+    .trim();
+}

--- a/console/src/utils/format.ts
+++ b/console/src/utils/format.ts
@@ -12,8 +12,9 @@
  */
 export function camelToSpacedUpper(key: string): string {
   return key
-    .replace(/_/g, ' ')        // snake_case -> spaces
-    .replace(/([A-Z])/g, ' $1') // camelCase -> spaces
+    .replace(/_/g, ' ')          // snake_case -> spaces
+    .replace(/([A-Z])/g, ' $1')  // camelCase -> spaces
+    .replace(/\s+/g, ' ')        // collapse consecutive spaces (mixed camelCase+snake_case)
     .toUpperCase()
     .trim();
 }

--- a/console/src/views/SessionDetail.tsx
+++ b/console/src/views/SessionDetail.tsx
@@ -246,10 +246,21 @@ function RunCard({
 
       {/* Tab strip -- only shown when execution trace data is available */}
       {hasTrace && (
-        <div role="tablist" aria-label="Run view mode" className="flex items-center border-b border-[var(--border)] shrink-0 h-9 px-2 gap-0.5">
+        <div
+          role="tablist"
+          aria-label="Run view mode"
+          className="flex items-center border-b border-[var(--border)] shrink-0 h-9 px-2 gap-0.5"
+          onKeyDown={(e) => {
+            // ARIA tabs pattern: arrow keys move between tabs
+            if (e.key === 'ArrowRight') { e.preventDefault(); setActiveTab('trace'); }
+            if (e.key === 'ArrowLeft')  { e.preventDefault(); setActiveTab('dag'); }
+          }}
+        >
           <button
             type="button"
+            id="tab-dag"
             role="tab"
+            tabIndex={activeTab === 'dag' ? 0 : -1}
             aria-selected={activeTab === 'dag'}
             onClick={() => setActiveTab('dag')}
             className={[
@@ -268,7 +279,9 @@ function RunCard({
           </button>
           <button
             type="button"
+            id="tab-trace"
             role="tab"
+            tabIndex={activeTab === 'trace' ? 0 : -1}
             aria-selected={activeTab === 'trace'}
             onClick={() => setActiveTab('trace')}
             className={[
@@ -288,7 +301,11 @@ function RunCard({
         </div>
       )}
 
-      <div className="flex-1">
+      <div
+        role="tabpanel"
+        aria-labelledby={activeTab === 'dag' ? 'tab-dag' : 'tab-trace'}
+        className="flex-1"
+      >
         {activeTab === 'trace' && run.executionTraceSummary !== null ? (
           <RunNarrativeView
             summary={run.executionTraceSummary}

--- a/console/src/views/session-detail-use-cases.ts
+++ b/console/src/views/session-detail-use-cases.ts
@@ -6,6 +6,21 @@
 import type { ConsoleExecutionTraceItem, ConsoleExecutionTraceSummary } from '../api/types';
 
 // ---------------------------------------------------------------------------
+// Condition evaluation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Heuristic: determines whether an evaluated_condition trace item represents
+ * a condition that passed (true) or was skipped/false.
+ *
+ * The engine summary strings currently use natural language -- this will be
+ * replaced by a structured `passed: boolean` field when the backend adds it.
+ */
+export function isConditionPassed(item: ConsoleExecutionTraceItem): boolean {
+  return /\btrue\b|\bpass/i.test(item.summary);
+}
+
+// ---------------------------------------------------------------------------
 // Execution trace grouping types
 // ---------------------------------------------------------------------------
 

--- a/console/src/views/session-detail-use-cases.ts
+++ b/console/src/views/session-detail-use-cases.ts
@@ -1,0 +1,154 @@
+/**
+ * Pure use-case functions and types for the Session Detail view.
+ *
+ * No React, no side effects. All functions are deterministic.
+ */
+import type { ConsoleExecutionTraceItem, ConsoleExecutionTraceSummary } from '../api/types';
+
+// ---------------------------------------------------------------------------
+// Execution trace grouping types
+// ---------------------------------------------------------------------------
+
+export type StandaloneEntry = {
+  readonly kind: 'standalone';
+  readonly item: ConsoleExecutionTraceItem;
+};
+
+export type LoopGroup = {
+  readonly kind: 'loop_group';
+  readonly loopId: string;
+  readonly enteredItem: ConsoleExecutionTraceItem;
+  readonly innerItems: readonly ConsoleExecutionTraceItem[];
+  readonly exitedItem: ConsoleExecutionTraceItem;
+  readonly iterationCount: number;
+};
+
+export type TraceEntry = StandaloneEntry | LoopGroup;
+
+// ---------------------------------------------------------------------------
+// Loop grouping logic
+//
+// INVARIANT: entered_loop and exited_loop items are matched by loop_id ref value.
+// An orphaned entered_loop (no matching exited_loop) is rendered as a standalone
+// [ LOOP ] entry rather than dropped silently.
+//
+// Algorithm:
+// 1. Linear scan over items sorted by recordedAtEventIndex.
+// 2. When an entered_loop is seen, start accumulating a pending group keyed by loop_id.
+// 3. When an exited_loop is seen with a matching loop_id, close the group.
+// 4. All other items are rendered as standalone entries.
+// 5. Any pending (unclosed) groups at end-of-list become standalone entries.
+// ---------------------------------------------------------------------------
+
+function getLoopId(item: ConsoleExecutionTraceItem): string | null {
+  return item.refs.find((r) => r.kind === 'loop_id')?.value ?? null;
+}
+
+/**
+ * Groups entered_loop/exited_loop pairs by loop_id.
+ * context_fact items are excluded (shown via contextFacts chips instead).
+ */
+export function groupTraceEntries(items: readonly ConsoleExecutionTraceItem[]): readonly TraceEntry[] {
+  // Filter out context_fact items -- they are shown as chips, not list entries.
+  const filtered = items.filter((item) => item.kind !== 'context_fact');
+  const sorted = [...filtered].sort((a, b) => a.recordedAtEventIndex - b.recordedAtEventIndex);
+
+  const result: TraceEntry[] = [];
+  // Map of loopId -> { enteredItem, innerItems } for open (unclosed) loops.
+  // loopStack tracks the insertion order so inner items always go to the
+  // most-recently-opened (innermost) loop rather than the oldest open loop.
+  const pendingLoops = new Map<string, { enteredItem: ConsoleExecutionTraceItem; innerItems: ConsoleExecutionTraceItem[] }>();
+  const loopStack: string[] = []; // loopIds in open order, most recent at end
+
+  for (const item of sorted) {
+    if (item.kind === 'entered_loop') {
+      const loopId = getLoopId(item);
+      if (loopId) {
+        pendingLoops.set(loopId, { enteredItem: item, innerItems: [] });
+        loopStack.push(loopId);
+      } else {
+        // No loop_id ref -- treat as standalone
+        result.push({ kind: 'standalone', item });
+      }
+    } else if (item.kind === 'exited_loop') {
+      const loopId = getLoopId(item);
+      const pending = loopId ? pendingLoops.get(loopId) : undefined;
+      if (pending && loopId) {
+        pendingLoops.delete(loopId);
+        const stackIdx = loopStack.lastIndexOf(loopId);
+        if (stackIdx !== -1) loopStack.splice(stackIdx, 1);
+        // Count iterations: number of selected_next_step items inside the loop
+        const iterationCount = Math.max(
+          1,
+          pending.innerItems.filter((i) => i.kind === 'selected_next_step').length,
+        );
+        result.push({
+          kind: 'loop_group',
+          loopId,
+          enteredItem: pending.enteredItem,
+          innerItems: pending.innerItems,
+          exitedItem: item,
+          iterationCount,
+        });
+      } else {
+        // Orphaned exited_loop -- treat as standalone
+        result.push({ kind: 'standalone', item });
+      }
+    } else {
+      // Non-loop item: add to the innermost open loop (last in stack), or standalone
+      const innermostLoopId = loopStack.at(-1);
+      const activePending = innermostLoopId ? pendingLoops.get(innermostLoopId) : undefined;
+      if (activePending) {
+        activePending.innerItems.push(item);
+      } else {
+        result.push({ kind: 'standalone', item });
+      }
+    }
+  }
+
+  // Flush any unclosed (orphaned) loops as standalone entries
+  for (const [, pending] of pendingLoops) {
+    result.push({ kind: 'standalone', item: pending.enteredItem });
+    for (const inner of pending.innerItems) {
+      result.push({ kind: 'standalone', item: inner });
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Node routing items
+// ---------------------------------------------------------------------------
+
+export interface NodeRoutingItems {
+  readonly whySelected: readonly ConsoleExecutionTraceItem[];
+  readonly conditions: readonly ConsoleExecutionTraceItem[];
+  readonly loops: readonly ConsoleExecutionTraceItem[];
+  readonly divergences: readonly ConsoleExecutionTraceItem[];
+  readonly forks: readonly ConsoleExecutionTraceItem[];
+}
+
+/**
+ * Extracts and categorizes execution trace items relevant to a specific node.
+ *
+ * Items are included when they reference the given nodeId via a node_id ref.
+ * Results are split by item kind to drive the RoutingSection UI.
+ */
+export function getNodeRoutingItems(
+  summary: ConsoleExecutionTraceSummary,
+  nodeId: string,
+): NodeRoutingItems {
+  const nodeItems = summary.items.filter(
+    (item) => item.refs.some((r) => r.kind === 'node_id' && r.value === nodeId),
+  );
+
+  return {
+    whySelected: nodeItems.filter((i) => i.kind === 'selected_next_step'),
+    conditions: nodeItems.filter((i) => i.kind === 'evaluated_condition'),
+    loops: nodeItems.filter((i) => i.kind === 'entered_loop' || i.kind === 'exited_loop'),
+    divergences: nodeItems.filter((i) => i.kind === 'divergence'),
+    // detected_non_tip_advance always has a node_id ref (run-execution-trace.ts prepends one)
+    forks: nodeItems.filter((i) => i.kind === 'detected_non_tip_advance'),
+  };
+}

--- a/tests/unit/console-session-detail-use-cases.test.ts
+++ b/tests/unit/console-session-detail-use-cases.test.ts
@@ -226,3 +226,75 @@ describe('getNodeRoutingItems', () => {
     expect(result.whySelected).toHaveLength(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// groupTraceEntries -- nested loop invariant
+// ---------------------------------------------------------------------------
+
+describe('groupTraceEntries -- nested loops (loopStack innermost-wins)', () => {
+  beforeEach(() => { nextIndex = 0; });
+
+  it('routes non-loop items to the innermost open loop via loopStack', () => {
+    // Scenario: enter-A, enter-B, step (-> B), exit-B, step (-> A), exit-A
+    // loopStack at each point: [A] -> [A,B] -> [A,B] -> [A] -> [A] -> []
+    const enterA = makeItem('entered_loop', [{ kind: 'loop_id', value: 'loop-A' }]);
+    const enterB = makeItem('entered_loop', [{ kind: 'loop_id', value: 'loop-B' }]);
+    const stepInsideB = makeItem('selected_next_step');
+    const exitB = makeItem('exited_loop', [{ kind: 'loop_id', value: 'loop-B' }]);
+    const stepInsideA = makeItem('selected_next_step');
+    const exitA = makeItem('exited_loop', [{ kind: 'loop_id', value: 'loop-A' }]);
+
+    const result = groupTraceEntries([enterA, enterB, stepInsideB, exitB, stepInsideA, exitA]);
+
+    // Known limitation: innerItems holds raw ConsoleExecutionTraceItem, not TraceEntry.
+    // A closed nested loop (loop-B) becomes a top-level LoopGroup rather than being
+    // nested inside loop-A's innerItems. Both loops appear as top-level entries.
+    expect(result).toHaveLength(2);
+
+    // loop-B closes first and becomes the first top-level LoopGroup
+    const groupB = result[0] as LoopGroup;
+    expect(groupB.kind).toBe('loop_group');
+    expect(groupB.loopId).toBe('loop-B');
+    // stepInsideB went to loop-B (innermost at the time) via loopStack.at(-1)
+    expect(groupB.innerItems).toHaveLength(1);
+    expect(groupB.innerItems[0]).toBe(stepInsideB);
+
+    // loop-A closes second and becomes the second top-level LoopGroup
+    const groupA = result[1] as LoopGroup;
+    expect(groupA.kind).toBe('loop_group');
+    expect(groupA.loopId).toBe('loop-A');
+    // stepInsideA went to loop-A (only remaining open loop after B closed)
+    expect(groupA.innerItems).toHaveLength(1);
+    expect(groupA.innerItems[0]).toBe(stepInsideA);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// camelToSpacedUpper
+// ---------------------------------------------------------------------------
+
+import { camelToSpacedUpper } from '../../console/src/utils/format.js';
+
+describe('camelToSpacedUpper', () => {
+  it('converts camelCase to SPACED UPPER', () => {
+    expect(camelToSpacedUpper('taskComplexity')).toBe('TASK COMPLEXITY');
+  });
+
+  it('converts snake_case to SPACED UPPER', () => {
+    expect(camelToSpacedUpper('my_key')).toBe('MY KEY');
+  });
+
+  it('handles mixed camelCase and snake_case without double spaces', () => {
+    expect(camelToSpacedUpper('someKey_name')).toBe('SOME KEY NAME');
+  });
+
+  it('handles consecutive capitals (LLM -> L L M) -- known limitation', () => {
+    // Consecutive capitals each get a space prefix; this is a known limitation
+    // acceptable for current engine key names (all simple camelCase)
+    expect(camelToSpacedUpper('myLLMKey')).toBe('MY L L M KEY');
+  });
+
+  it('trims leading/trailing whitespace', () => {
+    expect(camelToSpacedUpper('simpleKey')).toBe('SIMPLE KEY');
+  });
+});

--- a/tests/unit/console-session-detail-use-cases.test.ts
+++ b/tests/unit/console-session-detail-use-cases.test.ts
@@ -1,107 +1,55 @@
 /**
- * Unit tests for groupTraceEntries -- the pure function that pairs
- * entered_loop/exited_loop items into LoopGroup entries.
+ * Unit tests for session-detail-use-cases.ts pure functions.
  *
- * Tests all 6 code paths in the grouping algorithm:
- * 1. Normal paired loop (entered + exited, same loop_id)
- * 2. Orphaned entered_loop (no matching exited)
- * 3. Orphaned exited_loop (no matching entered)
- * 4. entered_loop with no loop_id ref (treated as standalone)
- * 5. context_fact items filtered out before grouping
- * 6. Nested / overlapping loops sharing different loop_ids
+ * Pure function tests -- no DOM, no React, no mocks.
+ *
+ * Covers:
+ *   - groupTraceEntries: loop grouping algorithm (all 8 code paths)
+ *   - getNodeRoutingItems: node-scoped trace item categorization
  */
-import { describe, it, expect } from 'vitest';
-import type { ConsoleExecutionTraceItem, ConsoleExecutionTraceItemRef } from '../../api/types';
-
-// ---------------------------------------------------------------------------
-// Re-export the private function for testing by importing from the module.
-// groupTraceEntries is not exported -- we test it via a thin re-export shim
-// defined here to avoid coupling tests to internal module structure.
-// ---------------------------------------------------------------------------
-
-// We access the function by re-importing the module in test scope.
-// Since it is not exported, we inline a copy for testing purposes.
-// This is intentional: the test is for the algorithm, not the module boundary.
-
-type StandaloneEntry = { kind: 'standalone'; item: ConsoleExecutionTraceItem };
-type LoopGroup = {
-  kind: 'loop_group';
-  loopId: string;
-  enteredItem: ConsoleExecutionTraceItem;
-  innerItems: readonly ConsoleExecutionTraceItem[];
-  exitedItem: ConsoleExecutionTraceItem;
-  iterationCount: number;
-};
-type TraceEntry = StandaloneEntry | LoopGroup;
-
-function getLoopId(item: ConsoleExecutionTraceItem): string | null {
-  return item.refs.find((r: ConsoleExecutionTraceItemRef) => r.kind === 'loop_id')?.value ?? null;
-}
-
-function groupTraceEntries(items: readonly ConsoleExecutionTraceItem[]): readonly TraceEntry[] {
-  const filtered = items.filter((item) => item.kind !== 'context_fact');
-  const sorted = [...filtered].sort((a, b) => a.recordedAtEventIndex - b.recordedAtEventIndex);
-  const result: TraceEntry[] = [];
-  const pendingLoops = new Map<string, { enteredItem: ConsoleExecutionTraceItem; innerItems: ConsoleExecutionTraceItem[] }>();
-
-  for (const item of sorted) {
-    if (item.kind === 'entered_loop') {
-      const loopId = getLoopId(item);
-      if (loopId) {
-        pendingLoops.set(loopId, { enteredItem: item, innerItems: [] });
-      } else {
-        result.push({ kind: 'standalone', item });
-      }
-    } else if (item.kind === 'exited_loop') {
-      const loopId = getLoopId(item);
-      const pending = loopId ? pendingLoops.get(loopId) : undefined;
-      if (pending && loopId) {
-        pendingLoops.delete(loopId);
-        const iterationCount = Math.max(1, pending.innerItems.filter((i) => i.kind === 'selected_next_step').length);
-        result.push({ kind: 'loop_group', loopId, enteredItem: pending.enteredItem, innerItems: pending.innerItems, exitedItem: item, iterationCount });
-      } else {
-        result.push({ kind: 'standalone', item });
-      }
-    } else {
-      let addedToLoop = false;
-      for (const [, pending] of pendingLoops) {
-        pending.innerItems.push(item);
-        addedToLoop = true;
-        break;
-      }
-      if (!addedToLoop) result.push({ kind: 'standalone', item });
-    }
-  }
-
-  for (const [, pending] of pendingLoops) {
-    result.push({ kind: 'standalone', item: pending.enteredItem });
-    for (const inner of pending.innerItems) result.push({ kind: 'standalone', item: inner });
-  }
-
-  return result;
-}
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  groupTraceEntries,
+  getNodeRoutingItems,
+  type StandaloneEntry,
+  type LoopGroup,
+} from '../../console/src/views/session-detail-use-cases';
+import type {
+  ConsoleExecutionTraceItem,
+  ConsoleExecutionTraceRef,
+  ConsoleExecutionTraceSummary,
+} from '../../console/src/api/types';
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
 let nextIndex = 0;
+
+beforeEach(() => { nextIndex = 0; });
+
 function makeItem(
   kind: ConsoleExecutionTraceItem['kind'],
-  refs: ConsoleExecutionTraceItemRef[] = [],
+  refs: ConsoleExecutionTraceRef[] = [],
   summary = `summary for ${kind}`,
 ): ConsoleExecutionTraceItem {
   return { kind, summary, refs, recordedAtEventIndex: nextIndex++ };
 }
 
-function loopRef(loopId: string): ConsoleExecutionTraceItemRef {
+function loopRef(loopId: string): ConsoleExecutionTraceRef {
   return { kind: 'loop_id', value: loopId };
 }
 
-beforeEach(() => { nextIndex = 0; });
+function nodeRef(nodeId: string): ConsoleExecutionTraceRef {
+  return { kind: 'node_id', value: nodeId };
+}
+
+function makeSummary(items: ConsoleExecutionTraceItem[]): ConsoleExecutionTraceSummary {
+  return { items, contextFacts: [] };
+}
 
 // ---------------------------------------------------------------------------
-// Tests
+// groupTraceEntries tests
 // ---------------------------------------------------------------------------
 
 describe('groupTraceEntries', () => {
@@ -205,5 +153,76 @@ describe('groupTraceEntries', () => {
     expect((result[0] as LoopGroup).loopId).toBe('loop-a');
     expect(result[1]!.kind).toBe('loop_group');
     expect((result[1] as LoopGroup).loopId).toBe('loop-b');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getNodeRoutingItems tests
+// ---------------------------------------------------------------------------
+
+describe('getNodeRoutingItems', () => {
+  it('returns empty arrays when summary has no items', () => {
+    const result = getNodeRoutingItems(makeSummary([]), 'node-1');
+    expect(result.whySelected).toHaveLength(0);
+    expect(result.conditions).toHaveLength(0);
+    expect(result.loops).toHaveLength(0);
+    expect(result.divergences).toHaveLength(0);
+    expect(result.forks).toHaveLength(0);
+  });
+
+  it('returns empty arrays when no items reference the given nodeId', () => {
+    const item = makeItem('selected_next_step', [nodeRef('node-other')]);
+    const result = getNodeRoutingItems(makeSummary([item]), 'node-1');
+    expect(result.whySelected).toHaveLength(0);
+  });
+
+  it('categorizes selected_next_step into whySelected', () => {
+    const item = makeItem('selected_next_step', [nodeRef('node-1')]);
+    const result = getNodeRoutingItems(makeSummary([item]), 'node-1');
+    expect(result.whySelected).toHaveLength(1);
+    expect(result.whySelected[0]).toBe(item);
+  });
+
+  it('categorizes evaluated_condition into conditions', () => {
+    const item = makeItem('evaluated_condition', [nodeRef('node-1')]);
+    const result = getNodeRoutingItems(makeSummary([item]), 'node-1');
+    expect(result.conditions).toHaveLength(1);
+    expect(result.conditions[0]).toBe(item);
+  });
+
+  it('categorizes entered_loop and exited_loop into loops', () => {
+    const enter = makeItem('entered_loop', [nodeRef('node-1')]);
+    const exit = makeItem('exited_loop', [nodeRef('node-1')]);
+    const result = getNodeRoutingItems(makeSummary([enter, exit]), 'node-1');
+    expect(result.loops).toHaveLength(2);
+  });
+
+  it('categorizes divergence into divergences', () => {
+    const item = makeItem('divergence', [nodeRef('node-1')]);
+    const result = getNodeRoutingItems(makeSummary([item]), 'node-1');
+    expect(result.divergences).toHaveLength(1);
+    expect(result.divergences[0]).toBe(item);
+  });
+
+  it('categorizes detected_non_tip_advance into forks', () => {
+    const item = makeItem('detected_non_tip_advance', [nodeRef('node-1')]);
+    const result = getNodeRoutingItems(makeSummary([item]), 'node-1');
+    expect(result.forks).toHaveLength(1);
+    expect(result.forks[0]).toBe(item);
+  });
+
+  it('does not include items referencing a different node', () => {
+    const item = makeItem('selected_next_step', [nodeRef('node-2')]);
+    const result = getNodeRoutingItems(makeSummary([item]), 'node-1');
+    expect(result.whySelected).toHaveLength(0);
+  });
+
+  it('includes items that reference the node among multiple refs', () => {
+    const item = makeItem('selected_next_step', [
+      { kind: 'step_id', value: 'step-abc' },
+      nodeRef('node-1'),
+    ]);
+    const result = getNodeRoutingItems(makeSummary([item]), 'node-1');
+    expect(result.whySelected).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Surfaces the engine's execution trace data in the console so users can understand *why* a workflow ran the way it did -- not just *what* nodes were created.

**The problem:** The console DAG shows only `node_created`/`edge_created` events. Users are confused when:
- A 10-step workflow shows only 2 nodes (fast-path skips are invisible)
- Loop iterations have no explanation
- `blocked_attempt` nodes appear with no context

**The solution:** The engine already computes `executionTraceSummary` on every run -- it was never rendered. This PR renders it.

## What's in this PR

**Layer 1 -- TRACE tab inside RunCard (zero backend changes)**
- `[ DAG ] [ TRACE ]` tab strip on each RunCard; hidden for legacy sessions (`executionTraceSummary === null`)
- `RunNarrativeView`: chronological trace log with `[ KIND ]` badges, loop grouping (collapsed >3 iterations), contextFacts row, auto-scroll + `[ N NEW ]` for live runs
- `HintBanner` conditional hint when trace data is present
- Badge vocabulary: `[ STEP ]` `[ CONDITION ]` `[ FORK ]` `[ DIVERGE ]` `[ LOOP ]`

**Layer 2 -- NodeDetailSection routing sections**
- `routing` section (FIRST in SECTION_REGISTRY, always expanded): `[ WHY SELECTED ]`, `[ CONDITIONS EVALUATED ]` with `[ PASS ]`/`[ SKIP ]` badges (SKIP first), `[ LOOP ]`, `[ DIVERGENCE ]`, `[ FORK ]`
- `run_routing` section (collapsed by default): ambient trace items with no node_id ref
- contextFacts chip row in DAG header (`[ TASK COMPLEXITY ] // simple`)

**Also fixed:** Workflow filter chips cross-contamination bug -- selecting a source filter was changing tag pill counts/visibility and vice versa.

**Shared infrastructure extracted:** `session-detail-use-cases.ts`, `TraceBadge.tsx`, `utils/format.ts`

## Layer 3 (not in this PR)
Edge cause diamonds, loop bracket in gutter, CAUSE footer on blocked_attempt nodes -- tracked separately, no backend changes needed.

## Test plan
- [ ] `npm run test:unit` -- 2886 passing (18 new tests: `groupTraceEntries` + `getNodeRoutingItems`)
- [ ] `cd console && npx vitest run` -- 128 passing
- [ ] `cd console && npx tsc -b --noEmit` -- clean
- [ ] Verify `[ TRACE ]` tab appears on runs with execution trace data, hidden on legacy sessions
- [ ] Verify tag/source filter pills are now independent (selecting a source does not hide tag pills)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)