### PR TITLE
feat(mcp): surface managed-source workflows as virtual tags in list_workflows

### DIFF
--- a/src/mcp/handlers/v2-workflow.ts
+++ b/src/mcp/handlers/v2-workflow.ts
@@ -80,7 +80,62 @@ function readWorkflowTags(): WorkflowTagsFile | null {
 const WORKFLOW_TAGS: WorkflowTagsFile | null = readWorkflowTags();
 
 /**
+ * Convert a kebab-case namespace like "mercury-android" to a display name like "Mercury Android".
+ * Recognises common acronyms so "mercury-ios" becomes "Mercury iOS".
+ */
+function namespaceToDisplayName(namespace: string): string {
+  const ACRONYMS: Readonly<Record<string, string>> = {
+    ios: 'iOS',
+    api: 'API',
+    ui: 'UI',
+    ux: 'UX',
+    mcp: 'MCP',
+  };
+  return namespace
+    .split('-')
+    .map((word) => ACRONYMS[word] ?? word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * Build virtual source tags for namespaced workflow IDs that are not registered in the
+ * bundled tags file (e.g. "mercury-android.clickstream-implementation" → tag "mercury-android").
+ * Exported for unit testing.
+ */
+export function buildVirtualSourceTags(
+  tagsFile: WorkflowTagsFile,
+  compiledWorkflowIds: readonly string[],
+): Array<{ id: string; displayName: string; count: number; when: string[]; examples: string[] }> {
+  const registeredIds = new Set(Object.keys(tagsFile.workflows));
+  const namespaceMap = new Map<string, string[]>();
+  for (const id of compiledWorkflowIds) {
+    if (registeredIds.has(id)) continue;
+    const dotIndex = id.indexOf('.');
+    if (dotIndex === -1) continue;
+    const namespace = id.slice(0, dotIndex);
+    const bucket = namespaceMap.get(namespace);
+    if (bucket) {
+      bucket.push(id);
+    } else {
+      namespaceMap.set(namespace, [id]);
+    }
+  }
+  return Array.from(namespaceMap.entries()).map(([namespace, ids]) => {
+    const displayName = namespaceToDisplayName(namespace);
+    return {
+      id: namespace,
+      displayName,
+      count: ids.length,
+      when: [`running ${displayName} workflows`],
+      examples: ids.slice(0, 3),
+    };
+  });
+}
+
+/**
  * Build a tag summary from the tag definitions and the compiled workflow list.
+ * Bundled functional tags come first; virtual source tags for unregistered namespaced
+ * workflows are appended after.
  * Exported for unit testing.
  */
 export function buildTagSummary(
@@ -88,7 +143,7 @@ export function buildTagSummary(
   compiledWorkflowIds: readonly string[],
 ): Array<{ id: string; displayName: string; count: number; when: string[]; examples: string[] }> {
   const idSet = new Set(compiledWorkflowIds);
-  return tagsFile.tags.map((tag) => {
+  const bundledTags = tagsFile.tags.map((tag) => {
     const count = Object.entries(tagsFile.workflows)
       .filter(([wid, meta]) => !meta.hidden && idSet.has(wid) && meta.tags.includes(tag.id))
       .length;
@@ -100,10 +155,14 @@ export function buildTagSummary(
       examples: [...tag.examples],
     };
   });
+  return [...bundledTags, ...buildVirtualSourceTags(tagsFile, compiledWorkflowIds)];
 }
 
 /**
  * Filter compiled workflow IDs to those matching any of the requested tags.
+ * Handles both bundled functional tags (from tagsFile.workflows) and virtual source
+ * tags derived from namespace prefixes (e.g. tag "mercury-android" matches all IDs of
+ * the form "mercury-android.*" that are not in the bundled registry).
  */
 function filterByTags(
   tagsFile: WorkflowTagsFile,
@@ -111,11 +170,22 @@ function filterByTags(
   requestedTags: readonly string[],
 ): readonly string[] {
   const tagSet = new Set(requestedTags);
+  // Registered workflow matching (bundled functional tags).
   const matching = new Set(
     Object.entries(tagsFile.workflows)
       .filter(([, meta]) => !meta.hidden && meta.tags.some((t) => tagSet.has(t)))
-      .map(([wid]) => wid)
+      .map(([wid]) => wid),
   );
+  // Virtual namespace tag matching: tag "mercury-android" matches all unregistered IDs
+  // whose namespace prefix equals the requested tag.
+  const registeredIds = new Set(Object.keys(tagsFile.workflows));
+  for (const id of compiledWorkflowIds) {
+    if (registeredIds.has(id)) continue;
+    const dotIndex = id.indexOf('.');
+    if (dotIndex === -1) continue;
+    const namespace = id.slice(0, dotIndex);
+    if (tagSet.has(namespace)) matching.add(id);
+  }
   return compiledWorkflowIds.filter((id) => matching.has(id));
 }
 

--- a/src/mcp/handlers/v2-workflow.ts
+++ b/src/mcp/handlers/v2-workflow.ts
@@ -79,21 +79,23 @@ function readWorkflowTags(): WorkflowTagsFile | null {
 
 const WORKFLOW_TAGS: WorkflowTagsFile | null = readWorkflowTags();
 
+/** Well-known acronyms that should not be title-cased like ordinary words. */
+const NAMESPACE_ACRONYMS: Readonly<Record<string, string>> = {
+  ios: 'iOS',
+  api: 'API',
+  ui: 'UI',
+  ux: 'UX',
+  mcp: 'MCP',
+};
+
 /**
  * Convert a kebab-case namespace like "mercury-android" to a display name like "Mercury Android".
  * Recognises common acronyms so "mercury-ios" becomes "Mercury iOS".
  */
 function namespaceToDisplayName(namespace: string): string {
-  const ACRONYMS: Readonly<Record<string, string>> = {
-    ios: 'iOS',
-    api: 'API',
-    ui: 'UI',
-    ux: 'UX',
-    mcp: 'MCP',
-  };
   return namespace
     .split('-')
-    .map((word) => ACRONYMS[word] ?? word.charAt(0).toUpperCase() + word.slice(1))
+    .map((word) => NAMESPACE_ACRONYMS[word] ?? word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');
 }
 
@@ -155,6 +157,11 @@ export function buildTagSummary(
       examples: [...tag.examples],
     };
   });
+  // Invariant: bundled tag IDs are functional slugs (e.g. "coding", "review_audit") while
+  // virtual source tag IDs are namespace prefixes (e.g. "mercury-android"). These
+  // namespaces are categorically distinct, so collision is not expected. If workflow-tags.json
+  // ever gains a bundled tag whose id matches a team namespace, two entries with the same id
+  // would appear in the summary — update the bundled tag id to avoid the overlap.
   return [...bundledTags, ...buildVirtualSourceTags(tagsFile, compiledWorkflowIds)];
 }
 
@@ -164,7 +171,7 @@ export function buildTagSummary(
  * tags derived from namespace prefixes (e.g. tag "mercury-android" matches all IDs of
  * the form "mercury-android.*" that are not in the bundled registry).
  */
-function filterByTags(
+export function filterByTags(
   tagsFile: WorkflowTagsFile,
   compiledWorkflowIds: readonly string[],
   requestedTags: readonly string[],

--- a/tests/unit/mcp/workflow-tags.test.ts
+++ b/tests/unit/mcp/workflow-tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildTagSummary, buildVirtualSourceTags } from '../../../src/mcp/handlers/v2-workflow.js';
+import { buildTagSummary, buildVirtualSourceTags, filterByTags } from '../../../src/mcp/handlers/v2-workflow.js';
 
 const SAMPLE_TAGS_FILE = {
   tags: [
@@ -106,5 +106,39 @@ describe('buildVirtualSourceTags', () => {
   it('applies acronym-aware title casing', () => {
     const tags = buildVirtualSourceTags(SAMPLE_TAGS_FILE, ['mercury-ios.some-workflow']);
     expect(tags[0]!.displayName).toBe('Mercury iOS');
+  });
+});
+
+describe('filterByTags', () => {
+  it('returns registered workflows matching a bundled functional tag', () => {
+    const ids = ['coding-task', 'mr-review', 'mercury-android.workflow-a'];
+    const result = filterByTags(SAMPLE_TAGS_FILE, ids, ['coding']);
+    expect(result).toEqual(['coding-task']);
+  });
+
+  it('returns unregistered namespaced workflows when their namespace is requested', () => {
+    const ids = ['coding-task', 'mercury-android.workflow-a', 'mercury-android.workflow-b', 'mercury-ios.workflow-c'];
+    const result = filterByTags(SAMPLE_TAGS_FILE, ids, ['mercury-android']);
+    expect(result).toContain('mercury-android.workflow-a');
+    expect(result).toContain('mercury-android.workflow-b');
+    expect(result).not.toContain('mercury-ios.workflow-c');
+    expect(result).not.toContain('coding-task');
+  });
+
+  it('handles a mix of bundled and virtual tag filters', () => {
+    const ids = ['coding-task', 'mercury-android.workflow-a'];
+    const result = filterByTags(SAMPLE_TAGS_FILE, ids, ['coding', 'mercury-android']);
+    expect(result).toContain('coding-task');
+    expect(result).toContain('mercury-android.workflow-a');
+  });
+
+  it('does not include registered namespaced IDs as virtual tag matches', () => {
+    const tagsFileWithNs = {
+      ...SAMPLE_TAGS_FILE,
+      workflows: { ...SAMPLE_TAGS_FILE.workflows, 'acme.registered': { tags: ['coding'] as const } },
+    };
+    // 'acme.registered' is registered under 'coding', not as a virtual tag
+    const result = filterByTags(tagsFileWithNs, ['acme.registered'], ['acme']);
+    expect(result).toHaveLength(0); // registered IDs are skipped in virtual matching
   });
 });

--- a/tests/unit/mcp/workflow-tags.test.ts
+++ b/tests/unit/mcp/workflow-tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildTagSummary } from '../../../src/mcp/handlers/v2-workflow.js';
+import { buildTagSummary, buildVirtualSourceTags } from '../../../src/mcp/handlers/v2-workflow.js';
 
 const SAMPLE_TAGS_FILE = {
   tags: [
@@ -45,5 +45,66 @@ describe('buildTagSummary', () => {
     const coding = summary.find((t) => t.id === 'coding')!;
     expect(coding.when).toEqual(['implementing a feature']);
     expect(coding.examples).toEqual(['coding-task']);
+  });
+
+  it('appends virtual source tags for unregistered namespaced workflow IDs', () => {
+    const ids = ['coding-task', 'mercury-android.clickstream-impl', 'mercury-android.telemetry-impl', 'mercury-ios.clickstream-impl'];
+    const summary = buildTagSummary(SAMPLE_TAGS_FILE, ids);
+    const androidTag = summary.find((t) => t.id === 'mercury-android');
+    const iosTag = summary.find((t) => t.id === 'mercury-ios');
+    expect(androidTag).toBeDefined();
+    expect(androidTag!.count).toBe(2);
+    expect(androidTag!.displayName).toBe('Mercury Android');
+    expect(androidTag!.examples).toEqual(['mercury-android.clickstream-impl', 'mercury-android.telemetry-impl']);
+    expect(iosTag).toBeDefined();
+    expect(iosTag!.count).toBe(1);
+    expect(iosTag!.displayName).toBe('Mercury iOS');
+  });
+
+  it('does not create virtual tags for already-registered namespaced IDs', () => {
+    // wr.discovery is registered in SAMPLE_TAGS_FILE if we add it, but here we verify
+    // that an ID present in tagsFile.workflows is not double-counted as a virtual tag.
+    const tagsFileWithNs = {
+      ...SAMPLE_TAGS_FILE,
+      workflows: { ...SAMPLE_TAGS_FILE.workflows, 'acme.my-workflow': { tags: ['coding'] as const } },
+    };
+    const summary = buildTagSummary(tagsFileWithNs, ['acme.my-workflow']);
+    expect(summary.find((t) => t.id === 'acme')).toBeUndefined();
+  });
+
+  it('virtual source tags come after bundled functional tags', () => {
+    const ids = ['coding-task', 'acme.workflow-one'];
+    const summary = buildTagSummary(SAMPLE_TAGS_FILE, ids);
+    const bundledIdx = summary.findIndex((t) => t.id === 'coding');
+    const virtualIdx = summary.findIndex((t) => t.id === 'acme');
+    expect(bundledIdx).toBeGreaterThanOrEqual(0);
+    expect(virtualIdx).toBeGreaterThan(bundledIdx);
+  });
+});
+
+describe('buildVirtualSourceTags', () => {
+  it('groups unregistered namespaced IDs by namespace prefix', () => {
+    const ids = ['mercury-android.workflow-a', 'mercury-android.workflow-b', 'mercury-ios.workflow-c', 'non-namespaced'];
+    const tags = buildVirtualSourceTags(SAMPLE_TAGS_FILE, ids);
+    expect(tags).toHaveLength(2);
+    const android = tags.find((t) => t.id === 'mercury-android')!;
+    expect(android.count).toBe(2);
+    expect(android.examples).toEqual(['mercury-android.workflow-a', 'mercury-android.workflow-b']);
+  });
+
+  it('caps examples at 3', () => {
+    const ids = ['acme.a', 'acme.b', 'acme.c', 'acme.d'];
+    const tags = buildVirtualSourceTags(SAMPLE_TAGS_FILE, ids);
+    expect(tags[0]!.examples).toHaveLength(3);
+  });
+
+  it('skips IDs without a dot', () => {
+    const tags = buildVirtualSourceTags(SAMPLE_TAGS_FILE, ['no-dot-here']);
+    expect(tags).toHaveLength(0);
+  });
+
+  it('applies acronym-aware title casing', () => {
+    const tags = buildVirtualSourceTags(SAMPLE_TAGS_FILE, ['mercury-ios.some-workflow']);
+    expect(tags[0]!.displayName).toBe('Mercury iOS');
   });
 });


### PR DESCRIPTION
## Summary

- Workflows distributed via managed sources (common-ground, `WORKFLOW_STORAGE_PATH`) were loadable by ID but invisible to tag-based browsing — no way to discover them without prior knowledge of their IDs
- `buildTagSummary` now appends virtual source tags derived from the namespace prefix of unregistered namespaced workflow IDs (e.g. `mercury-android.clickstream-implementation` → tag `mercury-android` / display `Mercury Android`)
- `filterByTags` updated to match those virtual tags on follow-up `list_workflows(tags=["mercury-android"])` calls — without this fix a discoverable tag that returns nothing on filter would be broken UX

No schema changes, no sidecar files, no new config. Self-maintaining from the namespaced ID format already enforced by the schema. Any team distributing workflows with namespaced IDs gets discovery for free.

## Implementation

- `namespaceToDisplayName` — kebab-to-title-case with acronym map (`ios→iOS`, `api→API`, `ui→UI`, `ux→UX`, `mcp→MCP`)
- `buildVirtualSourceTags` — new exported pure function; groups unregistered namespaced IDs by prefix; emits one virtual tag per namespace with count, displayName, when, examples (capped at 3)
- `buildTagSummary` — appends virtual source tags after bundled functional tags
- `filterByTags` — adds namespace prefix matching for unregistered IDs

## Test plan

- [ ] `tests/unit/mcp/workflow-tags.test.ts` — 11 tests pass (4 pre-existing + 7 new)
- [ ] `npm run build` — clean
- [ ] `npm run validate:registry` — all 5 variants pass
- [ ] New tests cover: virtual tag generated, count/displayName/examples correct, registered IDs not double-counted, ordering (bundled before virtual), examples capped at 3, no-dot IDs skipped, acronym casing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)