### PR TITLE
chore: add pre-push hook to block direct pushes to protected branches

### DIFF
--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Block direct pushes to main/master.
+# This hook runs even when using refspec forms like HEAD:main or mybranch:main
+# because git always resolves remote_ref to refs/heads/main before calling this hook.
+while read local_ref local_sha remote_ref remote_sha; do
+  if [[ "$remote_ref" == "refs/heads/main" || "$remote_ref" == "refs/heads/master" ]]; then
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════╗"
+    echo "║  BLOCKED: Direct push to main/master is not allowed.    ║"
+    echo "║  Create a feature branch and open a PR instead.         ║"
+    echo "╚══════════════════════════════════════════════════════════╝"
+    echo ""
+    exit 1
+  fi
+done
+exit 0


### PR DESCRIPTION
Adds missing pre-push hook to .git-hooks/. The repo uses core.hooksPath=.git-hooks but the directory only had commit-msg and pre-commit -- the global pre-push hook was never called. Also updates the Claude settings hook to catch refspec syntax like HEAD:branch-name patterns.