### PR TITLE
chore(docs): sync roadmap and tickets to current state

### DIFF
--- a/docs/roadmap/now-next-later.md
+++ b/docs/roadmap/now-next-later.md
@@ -16,15 +16,11 @@ Lightweight cross-cutting roadmap. **This is the single entry point** -- check h
 
 *(groomed, roughly ordered by value -- ready to execute)*
 
-1. **Console execution-trace explainability** -- The DAG shows only `node_created`/`edge_created`. Engine decisions (fast paths, skipped phases, condition evaluation, loop entry/exit) are invisible, making legitimate runs look broken. This needs a **design phase first** before any implementation -- see `docs/tickets/next-up.md` Ticket 5 and `docs/ideas/backlog.md`.
+1. **Execution trace Layer 3** -- edge cause diamonds on DAG edges, loop bracket in gutter, `[ CAUSE ]` expandable footer on `blocked_attempt` nodes. No backend changes needed. One data dependency for ghost nodes (skipped steps) -- needs backend confirmation before that sub-feature. See `docs/design/console-execution-trace-discovery.md`.
 
-3. **Legacy workflow modernization** -- `exploration-workflow.json` is the highest-priority candidate. `mr-review-workflow.json` and `bug-investigation.json` are next. See `docs/roadmap/open-work-inventory.md` for the full prioritized list and what "modernization" means. -- `workflow-for-workflows.v2.json` and `production-readiness-audit.json` have been tuned through authoring reasoning, not evidence from varied real runs. Run both on multiple tasks spanning different archetypes. Tune `STANDARD` vs `THOROUGH` depth from what is observed. See `docs/tickets/next-up.md` Ticket 6.
+2. **`fix-multi-instance-gaps` PR** -- branch `fix/etienneb/multi-instance-gaps` has 1 committed, pushed, unpushed-to-PR change: `fix(mcp): resolve three multi-instance safety gaps` (HttpServer.ts, http-entry.ts, tests). Needs a PR opened and merged.
 
-3. **Progress notifications** -- Long workflows block with no agent visibility. Design is mostly done; three open issues remain before implementation: (a) `progressToken` threading through `ToolContext`, (b) `NotificationSender` port to give `advance.ts` access to `sendNotification`, (c) step-node counting (filter `step` nodes only, exclude `blocked_attempt`/`checkpoint`). See `docs/plans/v2-followup-enhancements.md` P2.
-
-4. **Console execution-trace explainability** -- The DAG shows only `node_created`/`edge_created`. Engine decisions (fast paths, skipped phases, condition evaluation, loop entry/exit) are invisible, making legitimate runs look broken. This needs a **design phase first** before any implementation -- see `docs/tickets/next-up.md` Ticket 5 and `docs/ideas/backlog.md`.
-
-5. **Legacy workflow modernization** -- `exploration-workflow.json` is the highest-priority candidate. `mr-review-workflow.json` and `bug-investigation.json` are next. See `docs/roadmap/open-work-inventory.md` for the full prioritized list and what "modernization" means.
+3. **Legacy workflow modernization** -- `exploration-workflow.json` is the highest-priority candidate. `mr-review-workflow.json` and `bug-investigation.json` are next. See `docs/roadmap/open-work-inventory.md` for the full prioritized list and what "modernization" means.
 
 ---
 
@@ -32,11 +28,10 @@ Lightweight cross-cutting roadmap. **This is the single entry point** -- check h
 
 *(not yet groomed; rough priority order)*
 
-- **Console engine-trace UX** -- after the design from #4 above is complete and agreed
-- **Dashboard artifacts** -- replace file-based docs with session-scoped structured outputs rendered in the console; design exists in `workflow-execution-contract.md`, blocked on a richer console UI substrate
-- **Evict stale repo roots** -- `remembered-roots-store` accumulates forever; stale repos inflate worktree counts and slow scanning. Add TTL eviction. See #241.
-- **Typed SSE events + server-side `.git/` watchers** -- true live worktree updates without polling; replaces the interval-based worktrees refetch. See #242.
-- **Progress notifications** -- not worth the ceremony for current workflow lengths
+- **Console engine-trace UX -- Layer 3b (ghost nodes)** -- skipped steps shown at 0.25 opacity with `[ SKIPPED ]` badge; requires backend to emit skipped step IDs in trace refs
+- **Dashboard artifacts** -- replace file-based docs with session-scoped structured outputs rendered in the console; design exists in `workflow-execution-contract.md`
+- **Evict stale repo roots** -- `remembered-roots-store` accumulates forever; stale repos inflate worktree counts. Add TTL eviction. See #241.
+- **Typed SSE events + server-side `.git/` watchers** -- true live worktree updates without polling. See #242.
 - **Authorable response supplements** -- workflow schema surface, validation rules, authoring guidance; design needed first
 - **Declarative composition engine** -- spec-driven workflow assembly from pre-validated routines
 - **Parallel `forEach` execution** -- concurrent loop iterations with result collection
@@ -50,7 +45,8 @@ Lightweight cross-cutting roadmap. **This is the single entry point** -- check h
 - **Multi-tenancy and running-workflow upgrades**
 - **Console cyberpunk polish** -- scanlines, bracket notation for status badges, letter-spacing 0.30em, `//` separators (see `docs/design/console-cyberpunk-ui-discovery.md` for ranked list)
 - **Workflows inventory screen redesign** -- split-pane layout, keyboard-nav item list + persistent detail panel; design-first (see `docs/design/console-ui-backlog.md`)
-- **Equip / unequip workflows from the console** -- `[ EQUIPPED ]` badge, equipped/unequipped visual state, backend toggle endpoint
+- **Equip / unequip workflows from the console** -- `[ EQUIPPED ]` badge, backend toggle endpoint
+- **Forever backward compatibility** -- `workrailVersion` field in workflows, engine version adapters; see `docs/ideas/backlog.md` (high importance, not yet properly designed)
 
 ---
 
@@ -58,15 +54,19 @@ Lightweight cross-cutting roadmap. **This is the single entry point** -- check h
 
 *(moved here to keep Now/Next clean)*
 
-- ~~**Trial the quality gate and readiness audit**~~ -- `workflow-for-workflows.v2.json` and `production-readiness-audit.json` exercised extensively on the MVI refactor and MCP stability work across this session; STANDARD/THOROUGH depth validated
+- ~~**GitHub branch protection + pre-push hook**~~ -- server-side rule blocks direct pushes; `.git-hooks/pre-push` added (was missing despite `core.hooksPath` local override); Claude hook updated to catch `:main` refspec syntax (#344)
+- ~~**Console execution trace explainability -- Layers 1 + 2**~~ -- `[ TRACE ]` tab on each RunCard renders chronological decision log; NodeDetailSection routing sections show `[ WHY SELECTED ]`, `[ CONDITIONS EVALUATED ]` with `[ PASS ]`/`[ SKIP ]` badges; contextFacts chip strip in DAG header (#340)
+- ~~**Top-level runCondition tracing**~~ -- `nextTopLevel()` now emits `evaluated_condition` trace entries for each step, explaining why sparse DAGs jump from phase 0 to phase 6; `formatConditionTrace()` produces `SKIP: taskComplexity (equals)` / `PASS: taskComplexity=Medium (not_equals: Small)`
+- ~~**Filter chips cross-contamination fix**~~ -- selecting a source no longer hides/changes tag pill counts; `sourceFilteredWorkflows` / `tagFilteredWorkflows` added to ViewModel state
+- ~~**Windows CI fix**~~ -- duplicate `createFakeStdout` declaration in shutdown-hooks.test.ts resolved; unblocked release pipeline
+- ~~**Trial the quality gate and readiness audit**~~ -- `workflow-for-workflows.v2.json` and `production-readiness-audit.json` exercised extensively on the MVI refactor and MCP stability work; STANDARD/THOROUGH depth validated
 - ~~**Assessment-gate adoption in mr-review-workflow**~~ -- `mr-review-workflow.agentic.v2.json` already has assessmentRefs/assessmentConsequences alongside `bug-investigation`, `coding-task-workflow-agentic.lean.v2`, and `workflow-for-workflows.v2`
-- ~~**Console CPU spiral**~~ -- all three fixes shipped: `change` SSE events no longer invalidate worktrees (governed by refetchInterval only), enrichWorktree semaphore at MAX=8, fs.watch filtered to `.jsonl` writes
+- ~~**Console CPU spiral**~~ -- all three fixes shipped: `change` SSE events no longer invalidate worktrees, enrichWorktree semaphore MAX=8, fs.watch filtered to `.jsonl` writes
 - ~~**Console MVI architecture**~~ -- all 6 views refactored to Repository → UseCases → Reducer → ViewModel → pure presenter; 290+ new tests; `console/CLAUDE.md` documents the pattern (#332)
-- ~~**MCP server stability**~~ -- `wireStdoutShutdown` (EPIPE crash), `clearIfStaleLock` (stale lock after crash), `HttpServer.stop()` idempotency (double SIGTERM), port exhaustion graceful degradation, `openDashboard` degraded-mode guard (#332, #335)
+- ~~**MCP server stability**~~ -- `wireStdoutShutdown` (EPIPE crash), `clearIfStaleLock` (stale lock after crash), `HttpServer.stop()` idempotency, port exhaustion graceful degradation (#332, #335)
 - ~~**HTTP MCP dev environment**~~ -- nodemon + HTTP transport for local dev; `npm run dev:mcp:watch` (#334)
 - ~~**Worktree scan parallelization**~~ -- parallel filter, lazy workspace dir, reduced subprocess timeout (#325)
 - ~~**Workflow-source setup phase 1**~~ -- rooted team sharing, remembered roots, grouped source visibility (#160–#164)
 - ~~**MCP Roots Protocol**~~ -- per-request workspace anchor resolution, `RootsReader`/`RootsWriter` capability split (#75/#78/#147)
-- ~~**Content coherence and linked references**~~ -- `StepContentEnvelope`, `WorkflowReference`, parallel resolution, discriminated union types
 - ~~**v2 production readiness**~~ -- v2 default-on, feature flag gate removed
 - ~~**Retrieval budget and recovery surface**~~ -- 24 KB recovery budget, 2 KB resume preview, deterministic tiering

--- a/docs/tickets/next-up.md
+++ b/docs/tickets/next-up.md
@@ -4,94 +4,80 @@ Groomed near-term tickets. Check `docs/roadmap/now-next-later.md` first for the 
 
 ---
 
-## Ticket 1: Assessment-gate adoption in mr-review-workflow
+## Ticket 1: Open PR for fix-multi-instance-gaps
 
-### Problem
-
-The assessment-gate engine feature exists and is piloted in `bug-investigation.agentic.v2.json`, but adoption is intentionally narrow. The next highest-value workflow to adopt it is `mr-review-workflow.agentic.v2.json`.
-
-### Goal
-
-Add workflow-level assessment declarations and step-level assessment refs + consequence declarations to `mr-review-workflow.agentic.v2.json`. Calibrate follow-up wording and consequence visibility from observed behavior.
-
-### Acceptance criteria
-
-- `workflows/mr-review-workflow.agentic.v2.json` uses assessment refs on at least its core review steps
-- Follow-up consequence behavior matches the pattern piloted in `bug-investigation.agentic.v2.json`
-- `npm run validate:registry` passes
-- Planning docs updated to reflect the expanded rollout
-
-### Files
-
-- `workflows/mr-review-workflow.agentic.v2.json`
-- `docs/plans/mr-review-workflow-redesign.md`
-- `docs/roadmap/open-work-inventory.md`
+Branch `fix/etienneb/multi-instance-gaps` has a committed + pushed fix: `fix(mcp): resolve three multi-instance safety gaps` (HttpServer.ts, http-entry.ts, tests). Needs a PR opened and merged.
 
 ---
 
-## Ticket 3: Trial quality gate and readiness audit on real tasks
+## Ticket 2: Execution trace Layer 3a (no backend)
 
-### Problem
+### What to build
 
-`workflow-for-workflows.v2.json` and `production-readiness-audit.json` have been tuned through authoring reasoning, not evidence from varied real use. The remaining risk is ceremony vs usefulness at `STANDARD` vs `THOROUGH` depth.
+Three independent DAG annotations, all using existing trace data:
 
-### Goal
-
-Run both workflows on multiple distinct tasks spanning at least two archetypes each. Tune from what is observed. Record findings in planning docs.
-
-### Acceptance criteria
-
-- `workflow-for-workflows.v2.json` exercised on 2+ distinct authoring tasks spanning different archetypes
-- `production-readiness-audit.json` exercised on 2+ realistic audit targets with different scope/risk shapes
-- Observed weaknesses classified into authoring-integrity, outcome-effectiveness, or ceremony/depth tuning buckets
-- Any resulting workflow edits revalidated with `npm run validate:registry`
-- Planning docs capture the tuned follow-up state
+- **Edge cause diamonds** -- 10×10px rotated square at each edge midpoint, character code (C/F/D/>) + color indicating trace item kind. Hover shows the trace item summary.
+- **Loop bracket in gutter** -- amber vertical line spanning looped nodes, `[ LOOP ]` top cap + `[ // Nx ]` bottom cap. Suppressed for single-iteration loops.
+- **`[ CAUSE ]` footer on blocked_attempt nodes** -- expandable footer showing the blocker summary from the trace.
 
 ### Files
 
-- `workflows/workflow-for-workflows.v2.json`
-- `workflows/production-readiness-audit.json`
+- `console/src/components/RunLineageDag.tsx`
+- `console/src/components/NodeDetailSection.tsx` (CAUSE footer section)
+
+### Notes
+
+- `run.executionTraceSummary` is already available in `RunLineageDag` (used for contextFacts chips). No new props needed.
+- Layer 3b (ghost nodes for skipped steps) requires backend confirmation that skipped step IDs are emitted in trace refs -- keep separate.
+- See `docs/design/console-execution-trace-discovery.md` for the full design.
 
 ---
 
-## Ticket 4: Design console execution-trace explainability
-
-### Problem
-
-The console DAG shows only `node_created`/`edge_created`. Engine decisions -- fast paths, skipped phases, condition evaluation, loop entry/exit, `taskComplexity` -- are invisible. Legitimate runs look broken when the DAG is sparse.
+## Ticket 3: Legacy workflow modernization -- exploration-workflow.json
 
 ### Goal
 
-Produce a concrete design (DTO shape + UX direction) so the console can explain *why* the engine took a path, not just *which* nodes were created. This is a design ticket -- no implementation.
+Modernize `workflows/exploration-workflow.json` to current v2/lean authoring patterns. This is the highest-priority candidate among the unmodernized workflows.
 
-### Acceptance criteria
+### What modernization means
 
-- Concrete console design exists for showing engine decisions alongside the DAG
-- Design distinguishes authoring phases from actual execution nodes
-- Proposed DTO shape identifies which engine events and run-context fields must be projected
-- Design includes at least one clear UX treatment for fast paths / skipped phases that currently look like broken graphs
+- Current v2/lean structure where appropriate
+- `metaGuidance` and `recommendedPreferences`
+- `references` for authoritative companion material
+- `templateCall` / routine injection instead of repeating large prompt blocks
+- Tighter loop-control wording and evidence-oriented review structure
 
-### Non-goals
+### Related
 
-- Implementing the full console redesign
-- Exposing every raw engine event directly in the UI
+- `docs/roadmap/open-work-inventory.md` (full prioritized modernization list)
+- `docs/authoring.md` (modern baseline)
 
-### Files / related
+---
 
-- `docs/reference/workflow-execution-contract.md`
-- `src/v2/usecases/console-service.ts`
-- `console/src/api/types.ts`
-- `docs/ideas/backlog.md` (Console engine-trace visibility)
+## Ticket 4: Design console execution-trace explainability (Layer 3b -- ghost nodes)
+
+### Status
+
+Blocked on backend confirmation. `ConsoleDagNode` has no `stepId` field. The backend needs to either emit a step_id-to-position mapping or emit synthetic `skipped_step` DAG nodes before this can be built.
+
+### What needs backend work
+
+- Confirm whether `selected_next_step` trace refs include skipped step IDs
+- Add `stepId` field to `ConsoleDagNode` DTO or a new `skipped_step` event kind
 
 ---
 
 ## Recently completed
 
-- ~~**Ticket: v2 sign-off and cleanup**~~ (done -- v2 is default-on, stale docs cleaned up)
-- ~~**Ticket: Retrieval budget strengthening**~~ (done -- 24 KB recovery budget, deterministic tiering, #144161e)
-- ~~**Ticket: Expand lifecycle validation coverage**~~ (done -- auto-walk smoke test covers all bundled workflows)
-- ~~**Ticket: Workflow-source setup phase 1**~~ (done -- rooted team sharing, remembered roots, grouped source visibility, #160–#164)
-- ~~**Ticket: Finish prompt/supplement boundary alignment**~~ (done -- documented in authoring.md, workflow-execution-contract.md)
-- ~~**Ticket: Console CPU spiral**~~ (done -- change events no longer invalidate worktrees, enrichWorktree semaphore MAX=8, fs.watch filtered to .jsonl)
-- ~~**Ticket: Console MVI architecture**~~ (done -- all 6 views refactored, 290+ tests, console/CLAUDE.md, #332)
-- ~~**Ticket: MCP server stability**~~ (done -- EPIPE crash, stale lock, double SIGTERM, port exhaustion, #332 #335)
+- ~~**Ticket: Console execution trace Layer 1 + 2**~~ (done -- `[ TRACE ]` tab, NodeDetailSection routing sections, condition tracing, #340)
+- ~~**Ticket: Top-level runCondition tracing**~~ (done -- `formatConditionTrace`, `traceStepRunConditionSkipped/Passed`, `nextTopLevel` emits evaluated_condition entries)
+- ~~**Ticket: Filter chips cross-contamination**~~ (done -- `sourceFilteredWorkflows`/`tagFilteredWorkflows` in ViewModel)
+- ~~**Ticket: Windows CI fix**~~ (done -- duplicate createFakeStdout resolved)
+- ~~**Ticket: GitHub branch protection + pre-push hook**~~ (done -- server-side rule + .git-hooks/pre-push, #344)
+- ~~**Ticket: Assessment-gate mr-review adoption**~~ (done -- already had assessmentRefs)
+- ~~**Ticket: Console CPU spiral**~~ (done -- all three fixes shipped)
+- ~~**Ticket: Console MVI architecture**~~ (done -- all 6 views, #332)
+- ~~**Ticket: MCP server stability**~~ (done -- EPIPE, stale lock, double SIGTERM, #332 #335)
+- ~~**Ticket: v2 sign-off and cleanup**~~ (done)
+- ~~**Ticket: Retrieval budget strengthening**~~ (done)
+- ~~**Ticket: Workflow-source setup phase 1**~~ (done, #160–#164)


### PR DESCRIPTION
Cleans up duplicates in now-next-later.md, marks completed work as shipped, adds Layer 3 execution trace and fix-multi-instance-gaps as the immediate next items.