### PR TITLE
feat(console): execution trace Layer 3a -- DAG annotations

### DIFF
--- a/console/src/components/RunLineageDag.tsx
+++ b/console/src/components/RunLineageDag.tsx
@@ -60,6 +60,8 @@ export function RunLineageDag({ run, selectedNodeId = null, onNodeClick }: Props
   const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null);
   // Delay timer stored in a ref to avoid causing extra renders on set/clear.
   const tooltipTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Clear any pending tooltip timer on unmount to prevent setState-after-unmount warnings.
+  useEffect(() => () => { if (tooltipTimerRef.current !== null) clearTimeout(tooltipTimerRef.current); }, []);
 
   const model = useMemo(() => buildLineageDagModel(run), [run]);
   const nodeById = useMemo(
@@ -442,7 +444,11 @@ export function RunLineageDag({ run, selectedNodeId = null, onNodeClick }: Props
         <div
           style={{
             width: Math.max(model.graphWidth, 960),
-            height: Math.max(model.graphHeight, 360),
+            // Add CAUSE footer extension if any blocked_attempt nodes have cause items,
+            // otherwise the footer is clipped on bottommost nodes.
+            // Add CAUSE footer extension if any blocked_attempt nodes have cause items,
+            // otherwise the footer is clipped on bottommost nodes.
+            height: Math.max(model.graphHeight + (blockedCauseMap && blockedCauseMap.size > 0 ? 40 : 0), 360),
           }}
         >
           <ReactFlow
@@ -989,9 +995,11 @@ const EDGE_CAUSE_CONFIG: Record<EdgeCauseKind, { readonly char: string; readonly
 // EdgeCauseDiamond component
 //
 // Renders a 10x10 rotated square at (x, y) within the canvas-sized div.
-// The diamond visual has pointerEvents:none to avoid blocking node clicks.
-// A separate 20x20 transparent hover-target div sits on top with pointerEvents:auto.
-// Both are at z-index 1-2, below ReactFlow's node layer (z-index 3+).
+// IMPORTANT: diamonds are siblings of the ReactFlow canvas in the same parent div.
+// A separate hover-target at z-index > 0 would sit above the entire ReactFlow
+// layer and silently swallow node clicks. Instead, mouse handlers are applied
+// directly to the diamond visual with pointerEvents:auto. Hit area is small
+// (10x10) but only covers edge midpoints, not node centers.
 // ---------------------------------------------------------------------------
 
 function EdgeCauseDiamond({
@@ -1010,57 +1018,42 @@ function EdgeCauseDiamond({
   const cfg = EDGE_CAUSE_CONFIG[cause.kind];
 
   return (
-    <>
-      {/* Diamond visual -- pointerEvents:none so node clicks pass through */}
-      <div
+    <div
+      style={{
+        position: 'absolute',
+        left: x - 5,
+        top: y - 5,
+        width: 10,
+        height: 10,
+        transform: 'rotate(45deg)',
+        background: cfg.color,
+        zIndex: 1,
+        pointerEvents: 'auto',
+        cursor: 'default',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      onMouseEnter={(e) => onMouseEnter(e, cause.summary)}
+      onMouseLeave={onMouseLeave}
+    >
+      {/* Character label (de-rotated to appear upright) */}
+      <span
         style={{
-          position: 'absolute',
-          left: x - 5,
-          top: y - 5,
-          width: 10,
-          height: 10,
-          transform: 'rotate(45deg)',
-          background: cfg.color,
-          zIndex: 1,
+          display: 'block',
+          transform: 'rotate(-45deg)',
+          fontSize: 7,
+          lineHeight: 1,
+          fontFamily: 'monospace',
+          fontWeight: 700,
+          color: 'rgba(0,0,0,0.75)',
+          userSelect: 'none',
           pointerEvents: 'none',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
         }}
       >
-        {/* Character label (de-rotated to appear upright) */}
-        <span
-          style={{
-            display: 'block',
-            transform: 'rotate(-45deg)',
-            fontSize: 7,
-            lineHeight: 1,
-            fontFamily: 'monospace',
-            fontWeight: 700,
-            color: 'rgba(0,0,0,0.75)',
-            userSelect: 'none',
-          }}
-        >
-          {cfg.char}
-        </span>
-      </div>
-
-      {/* Transparent hover target -- pointerEvents:auto, larger hit area */}
-      <div
-        style={{
-          position: 'absolute',
-          left: x - 10,
-          top: y - 10,
-          width: 20,
-          height: 20,
-          zIndex: 2,
-          pointerEvents: 'auto',
-          cursor: 'default',
-        }}
-        onMouseEnter={(e) => onMouseEnter(e, cause.summary)}
-        onMouseLeave={onMouseLeave}
-      />
-    </>
+        {cfg.char}
+      </span>
+    </div>
   );
 }
 

--- a/console/src/components/RunLineageDag.tsx
+++ b/console/src/components/RunLineageDag.tsx
@@ -140,8 +140,9 @@ export function RunLineageDag({ run, selectedNodeId = null, onNodeClick }: Props
   }, [run.executionTraceSummary, run.nodes]);
 
   // Height extension for blocked_attempt nodes with cause items (sub-feature C).
-  // 40px = 32px footer collapsed + 8px border gap.
-  const CAUSE_FOOTER_HEIGHT_EXTENSION = 40;
+  // Must budget for the expanded state (72px) not just collapsed (32px),
+  // because ReactFlow clips to the node height. Use 72 + 8px gap.
+  const CAUSE_FOOTER_HEIGHT_EXTENSION = 80;
 
   const { nodes, edges } = useMemo(() => {
     const currentIncomingEdgeId = model.currentNodeId
@@ -261,10 +262,11 @@ export function RunLineageDag({ run, selectedNodeId = null, onNodeClick }: Props
         const cause = findEdgeCauseItem(edge, items);
         if (!cause) return null;
 
-        const sourceWidth = sourceNode.isActiveLineage ? ACTIVE_NODE_WIDTH : SIDE_NODE_WIDTH;
-        const sourceHeight = sourceNode.isActiveLineage ? ACTIVE_NODE_HEIGHT : SIDE_NODE_HEIGHT;
-        const targetWidth = targetNode.isActiveLineage ? ACTIVE_NODE_WIDTH : SIDE_NODE_WIDTH;
-        const targetHeight = targetNode.isActiveLineage ? ACTIVE_NODE_HEIGHT : SIDE_NODE_HEIGHT;
+        // Both nodes are guaranteed active-lineage by the guard above.
+        const sourceWidth = ACTIVE_NODE_WIDTH;
+        const sourceHeight = ACTIVE_NODE_HEIGHT;
+        const targetWidth = ACTIVE_NODE_WIDTH;
+        const targetHeight = ACTIVE_NODE_HEIGHT;
 
         // Geometric midpoint between the two node centers (approximate -- smoothstep curves
         // don't pass through this exact point, but it's close enough for a 10px annotation).
@@ -309,7 +311,9 @@ export function RunLineageDag({ run, selectedNodeId = null, onNodeClick }: Props
 
         const ys = positionedNodes.map((n) => n.y);
         const topY = Math.min(...ys);
-        const bottomY = Math.max(...ys) + (positionedNodes[0]!.isActiveLineage ? ACTIVE_NODE_HEIGHT : SIDE_NODE_HEIGHT);
+        // Use the highest-Y node's type for the correct height constant.
+        const bottomNode = positionedNodes.reduce((a, b) => a.y > b.y ? a : b);
+        const bottomY = Math.max(...ys) + (bottomNode!.isActiveLineage ? ACTIVE_NODE_HEIGHT : SIDE_NODE_HEIGHT);
 
         // X position: left gutter, just inside the scroll overhang area
         // LINEAGE_SCROLL_OVERHANG (600) + LINEAGE_PADDING (56) is where the first node starts.
@@ -640,7 +644,8 @@ function NodeLabel({
           <div className="flex items-center px-3" style={{ height: 32 }}>
             <button
               type="button"
-              onClick={() => setCauseExpanded((e) => !e)}
+              aria-expanded={causeExpanded}
+              onClick={(e) => { e.stopPropagation(); setCauseExpanded((v) => !v); }}
               className="font-mono text-[9px] uppercase tracking-[0.22em] px-2 py-0.5 transition-colors"
               style={{
                 color: causeExpanded ? 'var(--text-muted)' : 'var(--accent)',

--- a/console/src/components/RunLineageDag.tsx
+++ b/console/src/components/RunLineageDag.tsx
@@ -13,10 +13,19 @@ import {
   ACTIVE_NODE_HEIGHT,
   ACTIVE_NODE_WIDTH,
   buildLineageDagModel,
+  LINEAGE_SCROLL_OVERHANG,
   shortNodeId,
   SIDE_NODE_HEIGHT,
   SIDE_NODE_WIDTH,
 } from '../lib/lineage-dag-layout';
+import {
+  findEdgeCauseItem,
+  getLoopBracketsFromGroups,
+  getNodeRoutingItems,
+  groupTraceEntries,
+  type EdgeCauseKind,
+} from '../views/session-detail-use-cases';
+import type { ConsoleExecutionTraceItem } from '../api/types';
 
 interface Props {
   run: ConsoleDagRun;
@@ -95,6 +104,43 @@ export function RunLineageDag({ run, selectedNodeId = null, onNodeClick }: Props
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // ---------------------------------------------------------------------------
+  // Overlay data: blocked_attempt cause items (sub-feature C)
+  //
+  // Maps nodeId -> cause items for blocked_attempt nodes that have trace data.
+  // null means trace not available (executionTraceSummary is null).
+  // An empty array means trace is available but this node has no cause items.
+  //
+  // NOTE: causeItems are passed to NodeLabel which uses them to decide whether
+  // to render the CAUSE footer band. The node height in flowNodes is also
+  // adjusted based on whether cause items exist.
+  // ---------------------------------------------------------------------------
+
+  const blockedCauseMap = useMemo(() => {
+    if (!run.executionTraceSummary) return null;
+    const summary = run.executionTraceSummary;
+    const result = new Map<string, readonly ConsoleExecutionTraceItem[]>();
+
+    for (const node of run.nodes) {
+      if (node.nodeKind !== 'blocked_attempt') continue;
+      const routing = getNodeRoutingItems(summary, node.nodeId);
+      // Combine all relevant cause item categories
+      const causeItems = [
+        ...routing.divergences,
+        ...routing.forks,
+        ...routing.conditions,
+        ...routing.whySelected,
+      ];
+      result.set(node.nodeId, causeItems);
+    }
+
+    return result;
+  }, [run.executionTraceSummary, run.nodes]);
+
+  // Height extension for blocked_attempt nodes with cause items (sub-feature C).
+  // 40px = 32px footer collapsed + 8px border gap.
+  const CAUSE_FOOTER_HEIGHT_EXTENSION = 40;
+
   const { nodes, edges } = useMemo(() => {
     const currentIncomingEdgeId = model.currentNodeId
       ? model.edges.find((edge) => edge.toNodeId === model.currentNodeId)?.fromNodeId ?? null
@@ -104,10 +150,15 @@ export function RunLineageDag({ run, selectedNodeId = null, onNodeClick }: Props
       const { node, isActiveLineage, isCurrent } = positionedNode;
       const isSelected = node.nodeId === selectedNodeId;
       const width = isActiveLineage ? ACTIVE_NODE_WIDTH : SIDE_NODE_WIDTH;
-      const height = isActiveLineage ? ACTIVE_NODE_HEIGHT : SIDE_NODE_HEIGHT;
       const borderColor = getNodeBorderColor(node, isActiveLineage, isCurrent, isSelected);
       const background = getNodeBackgroundColor(node, isActiveLineage);
       const displayLabel = getDisplayLabel(node, positionedNode.branchKind, positionedNode.branchIndex);
+
+      // Cause items for this node (undefined = trace not available)
+      const causeItems = blockedCauseMap?.get(node.nodeId);
+      const hasCauseFooter = node.nodeKind === 'blocked_attempt' && causeItems !== undefined && causeItems.length > 0;
+      const baseHeight = isActiveLineage ? ACTIVE_NODE_HEIGHT : SIDE_NODE_HEIGHT;
+      const height = hasCauseFooter ? baseHeight + CAUSE_FOOTER_HEIGHT_EXTENSION : baseHeight;
 
       return {
         id: node.nodeId,
@@ -125,6 +176,7 @@ export function RunLineageDag({ run, selectedNodeId = null, onNodeClick }: Props
               displayLabel={displayLabel}
               stepNumber={isActiveLineage ? positionedNode.depth + 1 : null}
               totalSteps={isActiveLineage ? model.summary.lineageNodeCount : null}
+              causeItems={causeItems}
             />
           ),
         },
@@ -184,7 +236,94 @@ export function RunLineageDag({ run, selectedNodeId = null, onNodeClick }: Props
     });
 
     return { nodes: flowNodes, edges: flowEdges };
-  }, [isLiveRun, model.currentNodeId, model.edges, model.nodes, nodeById, selectedNodeId]);
+  }, [blockedCauseMap, isLiveRun, model.currentNodeId, model.edges, model.nodes, nodeById, selectedNodeId]);
+
+  // ---------------------------------------------------------------------------
+  // Overlay data: edge cause diamonds (sub-feature A)
+  //
+  // Computed in a separate useMemo from flowNodes/flowEdges so that changes to
+  // executionTraceSummary don't trigger a full ReactFlow node rebuild.
+  // ---------------------------------------------------------------------------
+
+  const edgeCauses = useMemo(() => {
+    if (!run.executionTraceSummary) return null;
+    const items = run.executionTraceSummary.items;
+
+    return model.edges
+      .map((edge) => {
+        const sourceNode = nodeById.get(edge.fromNodeId);
+        const targetNode = nodeById.get(edge.toNodeId);
+        if (!sourceNode || !targetNode) return null;
+        if (!sourceNode.isActiveLineage || !targetNode.isActiveLineage) return null;
+
+        const cause = findEdgeCauseItem(edge, items);
+        if (!cause) return null;
+
+        const sourceWidth = sourceNode.isActiveLineage ? ACTIVE_NODE_WIDTH : SIDE_NODE_WIDTH;
+        const sourceHeight = sourceNode.isActiveLineage ? ACTIVE_NODE_HEIGHT : SIDE_NODE_HEIGHT;
+        const targetWidth = targetNode.isActiveLineage ? ACTIVE_NODE_WIDTH : SIDE_NODE_WIDTH;
+        const targetHeight = targetNode.isActiveLineage ? ACTIVE_NODE_HEIGHT : SIDE_NODE_HEIGHT;
+
+        // Geometric midpoint between the two node centers (approximate -- smoothstep curves
+        // don't pass through this exact point, but it's close enough for a 10px annotation).
+        const x = (sourceNode.x + sourceWidth / 2 + targetNode.x + targetWidth / 2) / 2;
+        const y = (sourceNode.y + sourceHeight / 2 + targetNode.y + targetHeight / 2) / 2;
+
+        return {
+          edgeKey: `${edge.fromNodeId}->${edge.toNodeId}`,
+          x,
+          y,
+          cause,
+        };
+      })
+      .filter((d): d is NonNullable<typeof d> => d !== null);
+  }, [model.edges, nodeById, run.executionTraceSummary]);
+
+  // ---------------------------------------------------------------------------
+  // Overlay data: loop brackets (sub-feature B)
+  //
+  // Derives positioned loop brackets from the execution trace.
+  // Each bracket has a top Y and bottom Y derived from the Y positions of all
+  // DAG nodes referenced by the loop's trace items.
+  // Brackets with iterationCount === 1 are suppressed (single-iteration loops
+  // don't need a bracket).
+  // ---------------------------------------------------------------------------
+
+  const loopBrackets = useMemo(() => {
+    if (!run.executionTraceSummary) return null;
+    const entries = groupTraceEntries(run.executionTraceSummary.items);
+    const rawBrackets = getLoopBracketsFromGroups(entries);
+
+    return rawBrackets
+      .filter((bracket) => bracket.iterationCount > 1)
+      .map((bracket) => {
+        // Find Y positions of all referenced nodes. Skip brackets where any
+        // node is not in the positioned set (graceful degradation).
+        const positionedNodes = bracket.nodeIds
+          .map((id) => nodeById.get(id))
+          .filter((n): n is NonNullable<typeof n> => n !== undefined);
+
+        if (positionedNodes.length === 0) return null;
+
+        const ys = positionedNodes.map((n) => n.y);
+        const topY = Math.min(...ys);
+        const bottomY = Math.max(...ys) + (positionedNodes[0]!.isActiveLineage ? ACTIVE_NODE_HEIGHT : SIDE_NODE_HEIGHT);
+
+        // X position: left gutter, just inside the scroll overhang area
+        // LINEAGE_SCROLL_OVERHANG (600) + LINEAGE_PADDING (56) is where the first node starts.
+        // We place the bracket at x=LINEAGE_SCROLL_OVERHANG - 36 so it's visible in the gutter.
+        const gutterX = LINEAGE_SCROLL_OVERHANG - 36;
+
+        return {
+          key: bracket.loopId,
+          iterationCount: bracket.iterationCount,
+          topY,
+          bottomY,
+          gutterX,
+        };
+      })
+      .filter((b): b is NonNullable<typeof b> => b !== null);
+  }, [model.nodes, nodeById, run.executionTraceSummary]);
 
   const handleNodeClick: NodeMouseHandler = useCallback(
     (_event, node) => {
@@ -215,6 +354,35 @@ export function RunLineageDag({ run, selectedNodeId = null, onNodeClick }: Props
   }, [nodeById]);
 
   const handleNodeMouseLeave: NodeMouseHandler = useCallback(() => {
+    if (tooltipTimerRef.current !== null) {
+      clearTimeout(tooltipTimerRef.current);
+      tooltipTimerRef.current = null;
+    }
+    setHoveredLabel(null);
+    setTooltipPos(null);
+  }, []);
+
+  // Diamond hover: reuse the same hoveredLabel/tooltipPos state as node label tooltips.
+  // The transparent hover-target div calls these handlers (not the diamond visual itself).
+  const handleDiamondMouseEnter = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>, summary: string) => {
+      const containerRect = scrollContainerRef.current?.getBoundingClientRect();
+      if (!containerRect) return;
+
+      const x = event.clientX - containerRect.left + 12;
+      const y = event.clientY - containerRect.top + 16;
+      const clampedX = Math.min(x, (scrollContainerRef.current?.clientWidth ?? 9999) - 272);
+
+      if (tooltipTimerRef.current !== null) clearTimeout(tooltipTimerRef.current);
+      tooltipTimerRef.current = setTimeout(() => {
+        setHoveredLabel(summary);
+        setTooltipPos({ x: clampedX, y });
+      }, 300);
+    },
+    [],
+  );
+
+  const handleDiamondMouseLeave = useCallback(() => {
     if (tooltipTimerRef.current !== null) {
       clearTimeout(tooltipTimerRef.current);
       tooltipTimerRef.current = null;
@@ -297,6 +465,29 @@ export function RunLineageDag({ run, selectedNodeId = null, onNodeClick }: Props
             onNodeMouseLeave={handleNodeMouseLeave}
             style={{ background: 'transparent' }}
           />
+
+          {/* Sub-feature A: Edge cause diamonds */}
+          {edgeCauses && edgeCauses.map((diamond) => (
+            <EdgeCauseDiamond
+              key={diamond.edgeKey}
+              x={diamond.x}
+              y={diamond.y}
+              cause={diamond.cause}
+              onMouseEnter={handleDiamondMouseEnter}
+              onMouseLeave={handleDiamondMouseLeave}
+            />
+          ))}
+
+          {/* Sub-feature B: Loop bracket SVG overlays */}
+          {loopBrackets && loopBrackets.map((bracket) => (
+            <LoopBracketOverlay
+              key={bracket.key}
+              topY={bracket.topY}
+              bottomY={bracket.bottomY}
+              gutterX={bracket.gutterX}
+              iterationCount={bracket.iterationCount}
+            />
+          ))}
         </div>
         {hoveredLabel && tooltipPos && (
           <div
@@ -336,6 +527,7 @@ function NodeLabel({
   displayLabel,
   stepNumber,
   totalSteps,
+  causeItems,
 }: {
   node: ConsoleDagNode;
   isActiveLineage: boolean;
@@ -347,8 +539,19 @@ function NodeLabel({
   displayLabel: string;
   stepNumber: number | null;
   totalSteps: number | null;
+  /**
+   * Cause items for this node from the execution trace.
+   * undefined = executionTraceSummary not available (legacy session).
+   * empty array = trace available but no cause items for this node.
+   * Non-empty = render CAUSE footer band.
+   */
+  causeItems?: readonly ConsoleExecutionTraceItem[];
 }) {
   const stripeColor = getRichnessStripeColor(node);
+  // Footer is only shown for blocked_attempt nodes with actual cause items
+  const showCauseFooter = node.nodeKind === 'blocked_attempt' && causeItems !== undefined && causeItems.length > 0;
+  // Transient UI state: whether the CAUSE footer is expanded (local only, not feature state)
+  const [causeExpanded, setCauseExpanded] = useState(false);
 
   return (
     <div
@@ -415,6 +618,43 @@ function NodeLabel({
           <MonoLabel className="shrink-0" color="transparent">spacer</MonoLabel>
         )}
       </div>
+
+      {/* Sub-feature C: CAUSE footer band for blocked_attempt nodes */}
+      {showCauseFooter && (
+        <div
+          style={{
+            borderTop: '1px solid rgba(239, 68, 68, 0.25)',
+            background: 'rgba(80, 24, 31, 0.80)',
+            overflow: 'hidden',
+            transition: 'height 120ms ease',
+            height: causeExpanded ? 72 : 32,
+            flexShrink: 0,
+          }}
+        >
+          <div className="flex items-center px-3" style={{ height: 32 }}>
+            <button
+              type="button"
+              onClick={() => setCauseExpanded((e) => !e)}
+              className="font-mono text-[9px] uppercase tracking-[0.22em] px-2 py-0.5 transition-colors"
+              style={{
+                color: causeExpanded ? 'var(--text-muted)' : 'var(--accent)',
+                border: `1px solid ${causeExpanded ? 'rgba(123,141,167,0.25)' : 'rgba(244,196,48,0.40)'}`,
+                background: causeExpanded ? 'rgba(123,141,167,0.06)' : 'rgba(244,196,48,0.08)',
+              }}
+            >
+              {causeExpanded ? '[ CLOSE ]' : '[ CAUSE ]'}
+            </button>
+          </div>
+          {causeExpanded && causeItems && causeItems[0] && (
+            <div
+              className="px-3 pb-2 font-mono text-[9px] leading-relaxed"
+              style={{ color: 'var(--text-secondary)' }}
+            >
+              {causeItems[0].summary}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -656,5 +896,171 @@ function getDisplayLabel(
 
 function truncateLabel(label: string): string {
   return label.length > 18 ? `${label.slice(0, 18)}…` : label;
+}
+
+// ---------------------------------------------------------------------------
+// LoopBracketOverlay
+//
+// Renders a vertical amber line with [ LOOP ] and [ // Nx ] MonoLabels
+// in the left gutter of the DAG canvas. Positioned absolutely within the
+// canvas-sized div so it scrolls with the content.
+// ---------------------------------------------------------------------------
+
+function LoopBracketOverlay({
+  topY,
+  bottomY,
+  gutterX,
+  iterationCount,
+}: {
+  topY: number;
+  bottomY: number;
+  gutterX: number;
+  iterationCount: number;
+}) {
+  const height = bottomY - topY;
+  if (height <= 0) return null;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: gutterX,
+        top: topY,
+        width: 32,
+        height,
+        pointerEvents: 'none',
+        zIndex: 1,
+      }}
+    >
+      {/* Vertical amber line -- 3px wide, full height */}
+      <div
+        style={{
+          position: 'absolute',
+          left: 14,
+          top: 0,
+          bottom: 0,
+          width: 3,
+          background: 'var(--accent)',
+          opacity: 0.70,
+        }}
+      />
+
+      {/* [ LOOP ] label at top */}
+      <div
+        style={{
+          position: 'absolute',
+          left: 0,
+          top: -2,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        <MonoLabel color="var(--accent)" style={{ fontSize: 9 }}>[ LOOP ]</MonoLabel>
+      </div>
+
+      {/* [ // Nx ] label at bottom */}
+      <div
+        style={{
+          position: 'absolute',
+          left: 0,
+          bottom: -2,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        <MonoLabel color="var(--accent)" style={{ fontSize: 9 }}>{`[ // ${iterationCount}x ]`}</MonoLabel>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Edge cause diamond config
+//
+// Maps EdgeCauseKind to the display character and color used on the diamond.
+// ---------------------------------------------------------------------------
+
+const EDGE_CAUSE_CONFIG: Record<EdgeCauseKind, { readonly char: string; readonly color: string }> = {
+  condition: { char: 'C', color: '#f4c430' },
+  fork:      { char: 'F', color: 'var(--warning)' },
+  divergence:{ char: 'D', color: 'var(--error)' },
+  advance:   { char: '>', color: 'rgba(0,175,192,0.60)' },
+};
+
+// ---------------------------------------------------------------------------
+// EdgeCauseDiamond component
+//
+// Renders a 10x10 rotated square at (x, y) within the canvas-sized div.
+// The diamond visual has pointerEvents:none to avoid blocking node clicks.
+// A separate 20x20 transparent hover-target div sits on top with pointerEvents:auto.
+// Both are at z-index 1-2, below ReactFlow's node layer (z-index 3+).
+// ---------------------------------------------------------------------------
+
+function EdgeCauseDiamond({
+  x,
+  y,
+  cause,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  x: number;
+  y: number;
+  cause: { kind: EdgeCauseKind; summary: string };
+  onMouseEnter: (event: React.MouseEvent<HTMLDivElement>, summary: string) => void;
+  onMouseLeave: () => void;
+}) {
+  const cfg = EDGE_CAUSE_CONFIG[cause.kind];
+
+  return (
+    <>
+      {/* Diamond visual -- pointerEvents:none so node clicks pass through */}
+      <div
+        style={{
+          position: 'absolute',
+          left: x - 5,
+          top: y - 5,
+          width: 10,
+          height: 10,
+          transform: 'rotate(45deg)',
+          background: cfg.color,
+          zIndex: 1,
+          pointerEvents: 'none',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {/* Character label (de-rotated to appear upright) */}
+        <span
+          style={{
+            display: 'block',
+            transform: 'rotate(-45deg)',
+            fontSize: 7,
+            lineHeight: 1,
+            fontFamily: 'monospace',
+            fontWeight: 700,
+            color: 'rgba(0,0,0,0.75)',
+            userSelect: 'none',
+          }}
+        >
+          {cfg.char}
+        </span>
+      </div>
+
+      {/* Transparent hover target -- pointerEvents:auto, larger hit area */}
+      <div
+        style={{
+          position: 'absolute',
+          left: x - 10,
+          top: y - 10,
+          width: 20,
+          height: 20,
+          zIndex: 2,
+          pointerEvents: 'auto',
+          cursor: 'default',
+        }}
+        onMouseEnter={(e) => onMouseEnter(e, cause.summary)}
+        onMouseLeave={onMouseLeave}
+      />
+    </>
+  );
 }
 

--- a/console/src/views/session-detail-use-cases.test.ts
+++ b/console/src/views/session-detail-use-cases.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for the pure helper functions in session-detail-use-cases.ts.
+ *
+ * These tests cover the Layer 3a DAG annotation helpers:
+ *   - findEdgeCauseItem: correlates an edge to its preceding trace item
+ *   - getLoopBracketsFromGroups: extracts loop bracket descriptors from grouped entries
+ */
+import { describe, it, expect } from 'vitest';
+import type { ConsoleDagEdge, ConsoleExecutionTraceItem } from '../api/types';
+import {
+  findEdgeCauseItem,
+  getLoopBracketsFromGroups,
+  groupTraceEntries,
+} from './session-detail-use-cases';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEdge(createdAtEventIndex: number): ConsoleDagEdge {
+  return {
+    edgeKind: 'acked_step',
+    fromNodeId: 'node-a',
+    toNodeId: 'node-b',
+    createdAtEventIndex,
+  };
+}
+
+function makeItem(
+  kind: ConsoleExecutionTraceItem['kind'],
+  recordedAtEventIndex: number,
+  summary = `summary for ${kind} at ${recordedAtEventIndex}`,
+  refs: ConsoleExecutionTraceItem['refs'] = [],
+): ConsoleExecutionTraceItem {
+  return { kind, recordedAtEventIndex, summary, refs };
+}
+
+// ---------------------------------------------------------------------------
+// findEdgeCauseItem
+// ---------------------------------------------------------------------------
+
+describe('findEdgeCauseItem', () => {
+  it('returns null when items is empty', () => {
+    const edge = makeEdge(10);
+    expect(findEdgeCauseItem(edge, [])).toBeNull();
+  });
+
+  it('returns null when all items are after the edge', () => {
+    const edge = makeEdge(5);
+    const items = [makeItem('selected_next_step', 6), makeItem('evaluated_condition', 7)];
+    expect(findEdgeCauseItem(edge, items)).toBeNull();
+  });
+
+  it('returns null when items only have non-cause kinds (context_fact, entered_loop)', () => {
+    const edge = makeEdge(10);
+    const items = [makeItem('context_fact', 3), makeItem('entered_loop', 5)];
+    expect(findEdgeCauseItem(edge, items)).toBeNull();
+  });
+
+  it('returns the immediately preceding selected_next_step item as advance', () => {
+    const edge = makeEdge(10);
+    const items = [makeItem('selected_next_step', 8)];
+    const result = findEdgeCauseItem(edge, items);
+    expect(result).not.toBeNull();
+    expect(result!.kind).toBe('advance');
+    expect(result!.summary).toBe('summary for selected_next_step at 8');
+  });
+
+  it('returns evaluated_condition as condition kind', () => {
+    const edge = makeEdge(10);
+    const items = [makeItem('evaluated_condition', 9)];
+    const result = findEdgeCauseItem(edge, items);
+    expect(result!.kind).toBe('condition');
+  });
+
+  it('returns detected_non_tip_advance as fork kind', () => {
+    const edge = makeEdge(10);
+    const items = [makeItem('detected_non_tip_advance', 7)];
+    const result = findEdgeCauseItem(edge, items);
+    expect(result!.kind).toBe('fork');
+  });
+
+  it('returns divergence as divergence kind', () => {
+    const edge = makeEdge(10);
+    const items = [makeItem('divergence', 6)];
+    const result = findEdgeCauseItem(edge, items);
+    expect(result!.kind).toBe('divergence');
+  });
+
+  it('picks the highest qualifying recordedAtEventIndex <= edge index', () => {
+    const edge = makeEdge(10);
+    const items = [
+      makeItem('selected_next_step', 3, 'old advance'),
+      makeItem('selected_next_step', 8, 'recent advance'),
+      makeItem('selected_next_step', 11, 'future advance'),
+    ];
+    const result = findEdgeCauseItem(edge, items);
+    expect(result!.summary).toBe('recent advance');
+  });
+
+  it('includes items at exactly edge.createdAtEventIndex', () => {
+    const edge = makeEdge(10);
+    const items = [makeItem('selected_next_step', 10, 'exact match')];
+    const result = findEdgeCauseItem(edge, items);
+    expect(result!.summary).toBe('exact match');
+  });
+
+  it('skips context_fact and entered_loop/exited_loop items even if they are closest', () => {
+    const edge = makeEdge(10);
+    const items = [
+      makeItem('selected_next_step', 5, 'earlier advance'),
+      makeItem('context_fact', 9, 'close but wrong kind'),
+      makeItem('entered_loop', 8, 'loop entry'),
+      makeItem('exited_loop', 9, 'loop exit'),
+    ];
+    const result = findEdgeCauseItem(edge, items);
+    expect(result!.kind).toBe('advance');
+    expect(result!.summary).toBe('earlier advance');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLoopBracketsFromGroups
+// ---------------------------------------------------------------------------
+
+describe('getLoopBracketsFromGroups', () => {
+  it('returns empty array when entries contains no loop groups', () => {
+    const items = [makeItem('selected_next_step', 1), makeItem('evaluated_condition', 2)];
+    const entries = groupTraceEntries(items);
+    expect(getLoopBracketsFromGroups(entries)).toHaveLength(0);
+  });
+
+  it('returns one bracket for a single loop group', () => {
+    const items = [
+      makeItem('entered_loop', 1, 'enter loop', [{ kind: 'loop_id', value: 'loop-1' }, { kind: 'node_id', value: 'node-a' }]),
+      makeItem('selected_next_step', 2, 'inner step', [{ kind: 'node_id', value: 'node-b' }]),
+      makeItem('exited_loop', 3, 'exit loop', [{ kind: 'loop_id', value: 'loop-1' }, { kind: 'node_id', value: 'node-c' }]),
+    ];
+    const entries = groupTraceEntries(items);
+    const brackets = getLoopBracketsFromGroups(entries);
+
+    expect(brackets).toHaveLength(1);
+    expect(brackets[0]!.loopId).toBe('loop-1');
+    // iterationCount = count of selected_next_step inner items = 1
+    expect(brackets[0]!.iterationCount).toBe(1);
+  });
+
+  it('collects node_id refs from entered, exited, and inner items', () => {
+    const items = [
+      makeItem('entered_loop', 1, 'enter', [{ kind: 'loop_id', value: 'loop-1' }, { kind: 'node_id', value: 'node-a' }]),
+      makeItem('selected_next_step', 2, 'inner 1', [{ kind: 'node_id', value: 'node-b' }]),
+      makeItem('selected_next_step', 3, 'inner 2', [{ kind: 'node_id', value: 'node-c' }]),
+      makeItem('exited_loop', 4, 'exit', [{ kind: 'loop_id', value: 'loop-1' }, { kind: 'node_id', value: 'node-d' }]),
+    ];
+    const entries = groupTraceEntries(items);
+    const brackets = getLoopBracketsFromGroups(entries);
+
+    expect(brackets).toHaveLength(1);
+    const nodeIds = brackets[0]!.nodeIds;
+    expect(nodeIds).toContain('node-a');
+    expect(nodeIds).toContain('node-b');
+    expect(nodeIds).toContain('node-c');
+    expect(nodeIds).toContain('node-d');
+    expect(nodeIds).toHaveLength(4);
+  });
+
+  it('deduplicates node_id refs that appear in multiple inner items', () => {
+    const items = [
+      makeItem('entered_loop', 1, 'enter', [{ kind: 'loop_id', value: 'loop-1' }, { kind: 'node_id', value: 'node-a' }]),
+      makeItem('selected_next_step', 2, 'inner 1', [{ kind: 'node_id', value: 'node-a' }]),
+      makeItem('exited_loop', 3, 'exit', [{ kind: 'loop_id', value: 'loop-1' }]),
+    ];
+    const entries = groupTraceEntries(items);
+    const brackets = getLoopBracketsFromGroups(entries);
+
+    // node-a appears in entered_loop AND inner selected_next_step -- must be deduped
+    const nodeIds = brackets[0]!.nodeIds;
+    expect(nodeIds.filter((id) => id === 'node-a')).toHaveLength(1);
+  });
+
+  it('records correct iterationCount from inner selected_next_step items', () => {
+    const items = [
+      makeItem('entered_loop', 1, 'enter', [{ kind: 'loop_id', value: 'loop-1' }]),
+      makeItem('selected_next_step', 2, 'iter 1', []),
+      makeItem('selected_next_step', 3, 'iter 2', []),
+      makeItem('selected_next_step', 4, 'iter 3', []),
+      makeItem('exited_loop', 5, 'exit', [{ kind: 'loop_id', value: 'loop-1' }]),
+    ];
+    const entries = groupTraceEntries(items);
+    const brackets = getLoopBracketsFromGroups(entries);
+
+    expect(brackets[0]!.iterationCount).toBe(3);
+  });
+
+  it('returns brackets for all loop groups in entries', () => {
+    const items = [
+      makeItem('entered_loop', 1, 'enter loop1', [{ kind: 'loop_id', value: 'loop-1' }]),
+      makeItem('selected_next_step', 2, 'inner', []),
+      makeItem('exited_loop', 3, 'exit loop1', [{ kind: 'loop_id', value: 'loop-1' }]),
+      makeItem('entered_loop', 4, 'enter loop2', [{ kind: 'loop_id', value: 'loop-2' }]),
+      makeItem('selected_next_step', 5, 'inner', []),
+      makeItem('exited_loop', 6, 'exit loop2', [{ kind: 'loop_id', value: 'loop-2' }]),
+    ];
+    const entries = groupTraceEntries(items);
+    const brackets = getLoopBracketsFromGroups(entries);
+
+    expect(brackets).toHaveLength(2);
+    const loopIds = brackets.map((b) => b.loopId);
+    expect(loopIds).toContain('loop-1');
+    expect(loopIds).toContain('loop-2');
+  });
+
+  it('ignores standalone entries', () => {
+    const items = [
+      makeItem('selected_next_step', 1, 'standalone'),
+      makeItem('evaluated_condition', 2, 'standalone condition'),
+    ];
+    const entries = groupTraceEntries(items);
+    const brackets = getLoopBracketsFromGroups(entries);
+    expect(brackets).toHaveLength(0);
+  });
+});

--- a/console/src/views/session-detail-use-cases.ts
+++ b/console/src/views/session-detail-use-cases.ts
@@ -3,7 +3,7 @@
  *
  * No React, no side effects. All functions are deterministic.
  */
-import type { ConsoleExecutionTraceItem, ConsoleExecutionTraceSummary } from '../api/types';
+import type { ConsoleDagEdge, ConsoleExecutionTraceItem, ConsoleExecutionTraceSummary } from '../api/types';
 
 // ---------------------------------------------------------------------------
 // Condition evaluation helpers
@@ -130,6 +130,135 @@ export function groupTraceEntries(items: readonly ConsoleExecutionTraceItem[]): 
   }
 
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// Edge cause correlation
+// ---------------------------------------------------------------------------
+
+/**
+ * The kind of execution event that preceded (caused) an edge transition.
+ *
+ * Maps to trace item kinds, normalized to a smaller vocabulary for rendering:
+ * - 'condition'  <- evaluated_condition
+ * - 'fork'       <- detected_non_tip_advance
+ * - 'divergence' <- divergence
+ * - 'advance'    <- selected_next_step (normal step advance)
+ */
+export type EdgeCauseKind = 'condition' | 'fork' | 'divergence' | 'advance';
+
+export interface EdgeCause {
+  readonly kind: EdgeCauseKind;
+  readonly summary: string;
+}
+
+/** Returns the EdgeCauseKind for a trace item kind, or null if the item kind
+ *  is not one that causes an edge (e.g., context_fact, entered_loop). */
+function edgeCauseKindFromItem(item: ConsoleExecutionTraceItem): EdgeCauseKind | null {
+  switch (item.kind) {
+    case 'evaluated_condition': return 'condition';
+    case 'detected_non_tip_advance': return 'fork';
+    case 'divergence': return 'divergence';
+    case 'selected_next_step': return 'advance';
+    default: return null;
+  }
+}
+
+/**
+ * Finds the trace item that most likely caused (preceded) this edge.
+ *
+ * Algorithm: linear scan over all items, find the one whose recordedAtEventIndex
+ * is the largest value still <= the edge's createdAtEventIndex and whose kind
+ * maps to an EdgeCauseKind.
+ *
+ * Returns null when no qualifying item exists (e.g., no trace for this edge yet,
+ * or the edge was created before any relevant trace items).
+ *
+ * NOTE: Edge midpoints for cause diamonds are geometric approximations (midpoint
+ * of the two node centers). Smoothstep curves don't pass through this exact point,
+ * but the visual approximation is sufficient for a 10px annotation.
+ */
+export function findEdgeCauseItem(
+  edge: ConsoleDagEdge,
+  items: readonly ConsoleExecutionTraceItem[],
+): EdgeCause | null {
+  let best: EdgeCause | null = null;
+  let bestIndex = -1;
+
+  for (const item of items) {
+    const kind = edgeCauseKindFromItem(item);
+    if (kind === null) continue;
+    if (item.recordedAtEventIndex > edge.createdAtEventIndex) continue;
+    if (item.recordedAtEventIndex > bestIndex) {
+      bestIndex = item.recordedAtEventIndex;
+      best = { kind, summary: item.summary };
+    }
+  }
+
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// Loop bracket extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Represents a single loop bracket to render in the DAG gutter.
+ *
+ * nodeIds: all DAG node IDs referenced by the entered_loop or exited_loop
+ * items in this group (via node_id refs). Used to determine the Y range
+ * for the bracket line.
+ */
+export interface LoopBracket {
+  readonly loopId: string;
+  readonly iterationCount: number;
+  readonly nodeIds: readonly string[];
+}
+
+/**
+ * Extracts LoopBracket descriptors from a list of grouped trace entries.
+ *
+ * Only `loop_group` entries (paired entered_loop/exited_loop) produce brackets.
+ * Standalone entries are ignored.
+ *
+ * NOTE: Suppression for iterationCount === 1 is intentionally left to the
+ * render layer (RunLineageDag.tsx) so this function remains generic and testable
+ * without render-layer assumptions.
+ */
+export function getLoopBracketsFromGroups(
+  entries: readonly TraceEntry[],
+): readonly LoopBracket[] {
+  const brackets: LoopBracket[] = [];
+
+  for (const entry of entries) {
+    if (entry.kind !== 'loop_group') continue;
+
+    // Collect all node_id refs from the entered_loop item
+    const enteredNodeIds = entry.enteredItem.refs
+      .filter((r) => r.kind === 'node_id')
+      .map((r) => r.value);
+
+    // Collect all node_id refs from the exited_loop item
+    const exitedNodeIds = entry.exitedItem.refs
+      .filter((r) => r.kind === 'node_id')
+      .map((r) => r.value);
+
+    // Collect node_id refs from all inner items too, to span the full loop range
+    const innerNodeIds = entry.innerItems.flatMap((item) =>
+      item.refs.filter((r) => r.kind === 'node_id').map((r) => r.value),
+    );
+
+    // Deduplicate -- a node may be referenced by multiple inner items
+    const allNodeIds = [...new Set([...enteredNodeIds, ...exitedNodeIds, ...innerNodeIds])];
+
+    brackets.push({
+      loopId: entry.loopId,
+      iterationCount: entry.iterationCount,
+      nodeIds: allNodeIds,
+    });
+  }
+
+  return brackets;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three visual overlays on the DAG that make execution decisions visible at a glance -- no user interaction required. Uses existing `executionTraceSummary` data already in the DTO. Zero backend changes.

**Edge cause diamonds:** 10×10px rotated square at each active-lineage edge midpoint. Character + color indicates why the engine advanced: `>` (normal, cyan), `C` (condition, amber), `F` (fork, orange), `D` (divergence, red). Hover shows trace item summary.

**Loop brackets:** Vertical amber line in the left gutter spanning multi-iteration loops. `[ LOOP ]` top cap, `[ // Nx ]` bottom cap. Single-iteration loops suppressed. SVG overlay outside ReactFlow.

**CAUSE footer on blocked_attempt nodes:** Expandable 32→72px footer band with `[ CAUSE ]` / `[ CLOSE ]` button showing the cause trace item summary.

## Test plan
- `cd console && npx vitest run` -- 145 passing (17 new pure-function tests)
- `cd console && npx tsc -b --noEmit` -- clean
- `npm run test:unit` -- all passing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)