### PR TITLE
chore(docs): update roadmap -- Layer 3a and fix-multi-instance-gaps shipped

### DIFF
--- a/docs/roadmap/now-next-later.md
+++ b/docs/roadmap/now-next-later.md
@@ -2,7 +2,7 @@
 
 Lightweight cross-cutting roadmap. **This is the single entry point** -- check here first before digging into tickets or plan docs.
 
-*Last updated: 2026-04-14*
+*Last updated: 2026-04-15*
 
 ---
 
@@ -16,11 +16,7 @@ Lightweight cross-cutting roadmap. **This is the single entry point** -- check h
 
 *(groomed, roughly ordered by value -- ready to execute)*
 
-1. **Execution trace Layer 3** -- edge cause diamonds on DAG edges, loop bracket in gutter, `[ CAUSE ]` expandable footer on `blocked_attempt` nodes. No backend changes needed. One data dependency for ghost nodes (skipped steps) -- needs backend confirmation before that sub-feature. See `docs/design/console-execution-trace-discovery.md`.
-
-2. **`fix-multi-instance-gaps` PR** -- branch `fix/etienneb/multi-instance-gaps` has 1 committed, pushed, unpushed-to-PR change: `fix(mcp): resolve three multi-instance safety gaps` (HttpServer.ts, http-entry.ts, tests). Needs a PR opened and merged.
-
-3. **Legacy workflow modernization** -- `exploration-workflow.json` is the highest-priority candidate. `mr-review-workflow.json` and `bug-investigation.json` are next. See `docs/roadmap/open-work-inventory.md` for the full prioritized list and what "modernization" means.
+1. **Legacy workflow modernization** -- `exploration-workflow.json` is the highest-priority candidate. `mr-review-workflow.json` and `bug-investigation.json` are next. See `docs/roadmap/open-work-inventory.md` for the full prioritized list and what "modernization" means.
 
 ---
 
@@ -28,7 +24,7 @@ Lightweight cross-cutting roadmap. **This is the single entry point** -- check h
 
 *(not yet groomed; rough priority order)*
 
-- **Console engine-trace UX -- Layer 3b (ghost nodes)** -- skipped steps shown at 0.25 opacity with `[ SKIPPED ]` badge; requires backend to emit skipped step IDs in trace refs
+- **Execution trace Layer 3b (ghost nodes)** -- skipped steps shown at 0.25 opacity with `[ SKIPPED ]` badge; requires backend to emit skipped step IDs in trace refs -- needs design + backend confirmation first
 - **Dashboard artifacts** -- replace file-based docs with session-scoped structured outputs rendered in the console; design exists in `workflow-execution-contract.md`
 - **Evict stale repo roots** -- `remembered-roots-store` accumulates forever; stale repos inflate worktree counts. Add TTL eviction. See #241.
 - **Typed SSE events + server-side `.git/` watchers** -- true live worktree updates without polling. See #242.
@@ -54,6 +50,8 @@ Lightweight cross-cutting roadmap. **This is the single entry point** -- check h
 
 *(moved here to keep Now/Next clean)*
 
+- ~~**Execution trace Layer 3a**~~ -- edge cause diamonds on DAG edges, loop bracket in gutter, `[ CAUSE ]` expandable footer on blocked_attempt nodes (#347)
+- ~~**`fix-multi-instance-gaps`**~~ -- three multi-instance HttpServer safety gaps resolved (#346)
 - ~~**GitHub branch protection + pre-push hook**~~ -- server-side rule blocks direct pushes; `.git-hooks/pre-push` added (was missing despite `core.hooksPath` local override); Claude hook updated to catch `:main` refspec syntax (#344)
 - ~~**Console execution trace explainability -- Layers 1 + 2**~~ -- `[ TRACE ]` tab on each RunCard renders chronological decision log; NodeDetailSection routing sections show `[ WHY SELECTED ]`, `[ CONDITIONS EVALUATED ]` with `[ PASS ]`/`[ SKIP ]` badges; contextFacts chip strip in DAG header (#340)
 - ~~**Top-level runCondition tracing**~~ -- `nextTopLevel()` now emits `evaluated_condition` trace entries for each step, explaining why sparse DAGs jump from phase 0 to phase 6; `formatConditionTrace()` produces `SKIP: taskComplexity (equals)` / `PASS: taskComplexity=Medium (not_equals: Small)`

--- a/docs/tickets/next-up.md
+++ b/docs/tickets/next-up.md
@@ -4,36 +4,27 @@ Groomed near-term tickets. Check `docs/roadmap/now-next-later.md` first for the 
 
 ---
 
-## Ticket 1: Open PR for fix-multi-instance-gaps
+## Ticket 1: Execution trace Layer 3b -- ghost nodes (backend required)
 
-Branch `fix/etienneb/multi-instance-gaps` has a committed + pushed fix: `fix(mcp): resolve three multi-instance safety gaps` (HttpServer.ts, http-entry.ts, tests). Needs a PR opened and merged.
+### What it is
 
----
+Skipped steps shown in the DAG at 0.25 opacity with a `[ SKIPPED ]` badge and dashed border, so users immediately see the scale of what was bypassed without any interaction.
 
-## Ticket 2: Execution trace Layer 3a (no backend)
+### Blocked on
 
-### What to build
+`ConsoleDagNode` has no `stepId` field. The backend needs to either:
+- Emit a step_id-to-position mapping in `executionTraceSummary`
+- Or emit synthetic `skipped_step` entries as DAG nodes
 
-Three independent DAG annotations, all using existing trace data:
+Confirm whether `selected_next_step` trace refs already include skipped step IDs (check `src/v2/durable-core/domain/decision-trace-builder.ts`).
 
-- **Edge cause diamonds** -- 10×10px rotated square at each edge midpoint, character code (C/F/D/>) + color indicating trace item kind. Hover shows the trace item summary.
-- **Loop bracket in gutter** -- amber vertical line spanning looped nodes, `[ LOOP ]` top cap + `[ // Nx ]` bottom cap. Suppressed for single-iteration loops.
-- **`[ CAUSE ]` footer on blocked_attempt nodes** -- expandable footer showing the blocker summary from the trace.
+### Design reference
 
-### Files
-
-- `console/src/components/RunLineageDag.tsx`
-- `console/src/components/NodeDetailSection.tsx` (CAUSE footer section)
-
-### Notes
-
-- `run.executionTraceSummary` is already available in `RunLineageDag` (used for contextFacts chips). No new props needed.
-- Layer 3b (ghost nodes for skipped steps) requires backend confirmation that skipped step IDs are emitted in trace refs -- keep separate.
-- See `docs/design/console-execution-trace-discovery.md` for the full design.
+`docs/design/console-execution-trace-discovery.md` -- section on ghost nodes
 
 ---
 
-## Ticket 3: Legacy workflow modernization -- exploration-workflow.json
+## Ticket 2: Legacy workflow modernization -- exploration-workflow.json
 
 ### Goal
 
@@ -54,7 +45,7 @@ Modernize `workflows/exploration-workflow.json` to current v2/lean authoring pat
 
 ---
 
-## Ticket 4: Design console execution-trace explainability (Layer 3b -- ghost nodes)
+## Ticket 3: Design console execution-trace explainability (Layer 3b -- ghost nodes)
 
 ### Status
 
@@ -69,6 +60,8 @@ Blocked on backend confirmation. `ConsoleDagNode` has no `stepId` field. The bac
 
 ## Recently completed
 
+- ~~**Ticket: Execution trace Layer 3a**~~ (done -- edge cause diamonds, loop bracket, CAUSE footer on blocked_attempt nodes, #347)
+- ~~**Ticket: fix-multi-instance-gaps**~~ (done -- three multi-instance HttpServer safety gaps, #346)
 - ~~**Ticket: Console execution trace Layer 1 + 2**~~ (done -- `[ TRACE ]` tab, NodeDetailSection routing sections, condition tracing, #340)
 - ~~**Ticket: Top-level runCondition tracing**~~ (done -- `formatConditionTrace`, `traceStepRunConditionSkipped/Passed`, `nextTopLevel` emits evaluated_condition entries)
 - ~~**Ticket: Filter chips cross-contamination**~~ (done -- `sourceFilteredWorkflows`/`tagFilteredWorkflows` in ViewModel)


### PR DESCRIPTION
Marks Layer 3a (#347) and fix-multi-instance-gaps (#346) as done. Next is legacy workflow modernization and Layer 3b (blocked on backend).