### PR TITLE
fix(mcp): zombie-bridge guard — probe stdin before bridging

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -49,28 +49,35 @@ const DEFAULT_MCP_PORT = 3100;
 const STDIO_CLIENT_PROBE_MS = 150;
 
 /**
- * Wait up to `timeoutMs` for stdin to become readable without consuming data.
+ * Wait up to `timeoutMs` for `stdin` to become readable without consuming data.
  *
  * Uses the `readable` event so the stream stays paused — bytes remain in the
  * buffer for the MCP transport to read once it starts. Returns true if data
  * arrives within the window, false on timeout.
+ *
+ * `timeoutMs` and `stdin` are explicit parameters (not hardcoded globals) so
+ * tests can pass 0ms and a fake stream without real-time delays or process
+ * coupling. Production callers use STDIO_CLIENT_PROBE_MS and process.stdin.
  */
-function waitForStdinReadable(timeoutMs: number): Promise<boolean> {
+export function waitForStdinReadable(
+  timeoutMs: number,
+  stdin: NodeJS.ReadableStream = process.stdin,
+): Promise<boolean> {
   return new Promise((resolve) => {
-    process.stdin.pause(); // prevent accidental drain while probing
+    stdin.pause(); // prevent accidental drain while probing
 
     const timer = setTimeout(() => {
-      process.stdin.removeListener('readable', onReadable);
+      stdin.removeListener('readable', onReadable);
       resolve(false);
     }, timeoutMs);
 
     const onReadable = () => {
       clearTimeout(timer);
-      process.stdin.removeListener('readable', onReadable);
+      stdin.removeListener('readable', onReadable);
       resolve(true);
     };
 
-    process.stdin.once('readable', onReadable);
+    stdin.once('readable', onReadable);
   });
 }
 
@@ -87,7 +94,7 @@ async function main(): Promise<void> {
       // immediately. An HTTP-type `command` helper never writes to stdin.
       // Without this check, N command helpers become N idle bridges and
       // overload the primary.
-      const hasClient = await waitForStdinReadable(STDIO_CLIENT_PROBE_MS);
+      const hasClient = await waitForStdinReadable(STDIO_CLIENT_PROBE_MS, process.stdin);
       if (!hasClient) {
         console.error(
           `[Startup] Primary on :${primaryPort}, no stdio client within ${STDIO_CLIENT_PROBE_MS}ms — exiting`,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -13,6 +13,14 @@
  * bridge mode instead of spinning up a full second server. The bridge forwards
  * JSON-RPC between the IDE's stdio connection and the primary's HTTP endpoint,
  * giving true single-instance semantics across all clients and integrations.
+ *
+ * Zombie-bridge guard: when an MCP client uses `type: http` with a `command`
+ * field, Claude Code spawns the command to auto-start the server but then
+ * communicates via HTTP — stdin of the command process stays empty. Without
+ * the guard, those processes would start in bridge mode and hold idle HTTP
+ * sessions against the primary, overloading it with N concurrent sessions.
+ * The guard probes stdin briefly before committing to bridge mode: processes
+ * that receive no MCP data exit cleanly instead of becoming zombie bridges.
  */
 
 import { resolveTransportMode } from './mcp/transports/transport-mode.js';
@@ -33,6 +41,39 @@ export { composeServer } from './mcp/server.js';
 /** Default MCP HTTP transport port. */
 const DEFAULT_MCP_PORT = 3100;
 
+/**
+ * How long to wait for stdin data before concluding there is no real MCP
+ * client connected to this process (ms). A real stdio MCP client sends its
+ * `initialize` request within ~50ms; 150ms gives comfortable margin.
+ */
+const STDIO_CLIENT_PROBE_MS = 150;
+
+/**
+ * Wait up to `timeoutMs` for stdin to become readable without consuming data.
+ *
+ * Uses the `readable` event so the stream stays paused — bytes remain in the
+ * buffer for the MCP transport to read once it starts. Returns true if data
+ * arrives within the window, false on timeout.
+ */
+function waitForStdinReadable(timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    process.stdin.pause(); // prevent accidental drain while probing
+
+    const timer = setTimeout(() => {
+      process.stdin.removeListener('readable', onReadable);
+      resolve(false);
+    }, timeoutMs);
+
+    const onReadable = () => {
+      clearTimeout(timer);
+      process.stdin.removeListener('readable', onReadable);
+      resolve(true);
+    };
+
+    process.stdin.once('readable', onReadable);
+  });
+}
+
 async function main(): Promise<void> {
   const mode = resolveTransportMode(process.env);
 
@@ -41,6 +82,19 @@ async function main(): Promise<void> {
   if (mode.kind === 'stdio') {
     const primaryPort = await detectHealthyPrimary(DEFAULT_MCP_PORT);
     if (primaryPort != null) {
+      // Zombie-bridge guard: probe stdin before starting the bridge.
+      // A real stdio client (Claude Code stdio, firebender) sends MCP data
+      // immediately. An HTTP-type `command` helper never writes to stdin.
+      // Without this check, N command helpers become N idle bridges and
+      // overload the primary.
+      const hasClient = await waitForStdinReadable(STDIO_CLIENT_PROBE_MS);
+      if (!hasClient) {
+        console.error(
+          `[Startup] Primary on :${primaryPort}, no stdio client within ${STDIO_CLIENT_PROBE_MS}ms — exiting`,
+        );
+        process.exit(0);
+      }
+
       console.error(`[Startup] Primary detected on :${primaryPort} — starting in bridge mode`);
       try {
         await startBridgeServer(primaryPort);

--- a/tests/unit/mcp/stdin-probe.test.ts
+++ b/tests/unit/mcp/stdin-probe.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { EventEmitter } from 'events';
+import { waitForStdinReadable } from '../../../src/mcp-server.js';
+
+/**
+ * Tests for waitForStdinReadable — the zombie-bridge guard.
+ *
+ * Uses a fake readable stream so tests are deterministic and zero-delay.
+ * No real process.stdin touched; no timing dependencies.
+ */
+
+function makeFakeStdin(): NodeJS.ReadableStream & { triggerReadable: () => void } {
+  const emitter = new EventEmitter() as NodeJS.ReadableStream & { triggerReadable: () => void };
+  // NodeJS.ReadableStream needs pause() — implement as no-op (stream is already "paused")
+  (emitter as unknown as { pause: () => void }).pause = () => {};
+  emitter.triggerReadable = () => emitter.emit('readable');
+  return emitter;
+}
+
+describe('waitForStdinReadable', () => {
+  it('returns true when stdin becomes readable before the timeout', async () => {
+    const stdin = makeFakeStdin();
+    const probePromise = waitForStdinReadable(1000, stdin);
+    stdin.triggerReadable();
+    expect(await probePromise).toBe(true);
+  });
+
+  it('returns false when stdin produces no data within the timeout', async () => {
+    const stdin = makeFakeStdin();
+    expect(await waitForStdinReadable(0, stdin)).toBe(false);
+  });
+
+  it('resolves with true if readable fires before timeout expires', async () => {
+    const stdin = makeFakeStdin();
+    // Schedule readable to fire after a short delay, before a long timeout
+    setTimeout(() => stdin.triggerReadable(), 5);
+    expect(await waitForStdinReadable(500, stdin)).toBe(true);
+  });
+
+  it('does not leave a dangling readable listener after resolving true', async () => {
+    const stdin = makeFakeStdin();
+    const probePromise = waitForStdinReadable(1000, stdin);
+    stdin.triggerReadable();
+    await probePromise;
+    expect((stdin as EventEmitter).listenerCount('readable')).toBe(0);
+  });
+
+  it('does not leave a dangling readable listener after timing out', async () => {
+    const stdin = makeFakeStdin();
+    await waitForStdinReadable(0, stdin);
+    expect((stdin as EventEmitter).listenerCount('readable')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

When a project uses \`type: http\` with a \`command\` field, Claude Code spawns the command to auto-start the server but communicates via HTTP — stdin of the command process stays empty. With bridge mode, every such project spawns an idle bridge process that holds an HTTP MCP session against the primary. With 7-9 projects open simultaneously, the primary is overloaded and tool calls hang.

## Fix

\`waitForStdinReadable(150ms)\` pauses stdin and waits for the \`readable\` event before committing to bridge mode. No bytes are consumed — the MCP transport reads the buffered data once it starts.

- **Real stdio client** (Claude Code stdio transport, firebender): sends \`initialize\` within ~50ms → probe passes → bridge starts
- **HTTP \`command\` helper**: never writes to stdin → probe times out → process exits cleanly

This makes the \`command\` field safe for both \`type: http\` and \`type: stdio\` configs without any configuration change.

## Test plan

- [ ] `npm run build` — clean
- [ ] Manual: open 7+ Claude Code projects with stdio config, confirm only one workrail process per primary (others exit or bridge with real stdio traffic)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)