### PR TITLE
chore: fix trailing comma in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,6 @@
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"
-    },
+    }
   }
 }


### PR DESCRIPTION
Invalid JSON from trailing comma causes Claude Code /doctor to always flag this file.