### PR TITLE
feat(daemon): add KeyedAsyncQueue for per-session execution serialization

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,6 @@
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"
-    },
+    }
   }
 }

--- a/src/v2/infra/in-memory/keyed-async-queue/index.ts
+++ b/src/v2/infra/in-memory/keyed-async-queue/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-key async serialization queue.
+ *
+ * Ensures that concurrent calls to `enqueue()` with the same key are executed
+ * serially (FIFO). Calls with different keys run concurrently.
+ *
+ * Used by the WorkRail autonomous daemon to prevent token corruption when
+ * multiple triggers fire concurrently for the same session.
+ *
+ * Design: dual-promise pattern.
+ * - The void chain (`Map<string, Promise<void>>`) serializes execution.
+ * - A separate result promise returns `T` to the caller.
+ * - A `.catch(() => {})` on the void chain prevents a failing `fn()` from
+ *   breaking the chain for subsequent enqueues on the same key.
+ * - The `.finally()` identity check avoids premature cleanup when a new
+ *   enqueue arrives while the current one is finishing.
+ */
+export class KeyedAsyncQueue {
+  private readonly queues = new Map<string, Promise<void>>();
+
+  enqueue<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const result = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    const tail: Promise<void> = (this.queues.get(key) ?? Promise.resolve())
+      .then(() => fn())
+      .then(resolve, reject)
+      .catch(() => {
+        // Swallow on the void chain so subsequent enqueues are not blocked.
+        // The error already propagated to the caller via `result`.
+      })
+      .finally(() => {
+        // Only clean up if no newer enqueue has replaced this tail.
+        if (this.queues.get(key) === tail) {
+          this.queues.delete(key);
+        }
+      });
+
+    this.queues.set(key, tail);
+    return result;
+  }
+
+  /** Number of keys with active or pending work. Useful for testing. */
+  get activeKeyCount(): number {
+    return this.queues.size;
+  }
+}

--- a/tests/unit/v2/keyed-async-queue.test.ts
+++ b/tests/unit/v2/keyed-async-queue.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { KeyedAsyncQueue } from '../../../src/v2/infra/in-memory/keyed-async-queue/index.js';
+
+describe('KeyedAsyncQueue', () => {
+  it('resolves the result of fn()', async () => {
+    const queue = new KeyedAsyncQueue();
+    const result = await queue.enqueue('a', () => Promise.resolve(42));
+    expect(result).toBe(42);
+  });
+
+  it('rejects when fn() rejects, propagating the error to caller', async () => {
+    const queue = new KeyedAsyncQueue();
+    const err = new Error('test error');
+    await expect(queue.enqueue('a', () => Promise.reject(err))).rejects.toBe(err);
+  });
+
+  it('serializes concurrent enqueues for the same key (FIFO order)', async () => {
+    const queue = new KeyedAsyncQueue();
+    const order: number[] = [];
+
+    let resolveFirst!: () => void;
+    const first = queue.enqueue('key', () => new Promise<void>((res) => {
+      resolveFirst = res;
+    }).then(() => { order.push(1); }));
+
+    const second = queue.enqueue('key', async () => { order.push(2); });
+
+    // Second should not run until first resolves.
+    await Promise.resolve(); // yield to microtask queue
+    expect(order).toEqual([]);
+
+    resolveFirst();
+    await first;
+    await second;
+
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('runs enqueues for different keys concurrently', async () => {
+    const queue = new KeyedAsyncQueue();
+    const order: string[] = [];
+
+    let resolveA!: () => void;
+    const a = queue.enqueue('a', () => new Promise<void>((res) => {
+      resolveA = res;
+    }).then(() => { order.push('a'); }));
+
+    const b = queue.enqueue('b', async () => { order.push('b'); });
+
+    // b should complete before a (different key, no serialization)
+    await b;
+    expect(order).toEqual(['b']);
+
+    resolveA();
+    await a;
+    expect(order).toEqual(['b', 'a']);
+  });
+
+  it('continues processing subsequent enqueues after fn() failure', async () => {
+    const queue = new KeyedAsyncQueue();
+    const order: number[] = [];
+
+    // First enqueue fails
+    await expect(
+      queue.enqueue('key', () => Promise.reject(new Error('fail')))
+    ).rejects.toThrow('fail');
+
+    // Second enqueue should still run
+    await queue.enqueue('key', async () => { order.push(1); });
+
+    expect(order).toEqual([1]);
+  });
+
+  it('cleans up Map entry after completion', async () => {
+    const queue = new KeyedAsyncQueue();
+    await queue.enqueue('key', () => Promise.resolve());
+    // Allow microtask queue to flush
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(queue.activeKeyCount).toBe(0);
+  });
+
+  it('handles multiple keys independently', async () => {
+    const queue = new KeyedAsyncQueue();
+    const results = await Promise.all([
+      queue.enqueue('x', () => Promise.resolve(1)),
+      queue.enqueue('y', () => Promise.resolve(2)),
+      queue.enqueue('z', () => Promise.resolve(3)),
+    ]);
+    expect(results).toEqual([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `KeyedAsyncQueue` -- a per-key async serialization primitive for the WorkRail autonomous daemon
- Prevents token corruption when multiple triggers fire concurrently for the same session
- Uses dual-promise pattern: void chain for serialization, result promise for caller
- fn() failures are isolated and never break the chain for subsequent enqueues

## Design

`Map<string, Promise<void>>` with three invariants:
1. Only one `fn()` runs per key at a time
2. fn() error propagates to caller, never swallowed on the void chain
3. Map entries clean up automatically via identity-checked `.finally()`

This is a prerequisite for `src/daemon/workflow-runner.ts` (step 3 of the WorkRail Auto MVP).

## Test plan

- [ ] CI passes (7 new tests)
- Serializes concurrent same-key enqueues (FIFO)
- Runs different-key enqueues concurrently
- Isolates fn() failures without breaking subsequent enqueues
- Cleans up Map entries after completion

🤖 Generated with [Claude Code](https://claude.ai/claude-code)