### PR TITLE
feat(daemon): add DaemonRegistry and console [ LIVE ] badge for autonomous sessions

### DIFF
--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -94,6 +94,12 @@ export interface ConsoleSessionSummary {
   /** Repo root path from the session record. Used as fallback when worktree data is unavailable. */
   readonly repoRoot: string | null;
   readonly lastModifiedMs: number;
+  /** True when the session was started by the WorkRail autonomous daemon.
+   * Durable: derived from context_set event with is_autonomous: 'true'. */
+  readonly isAutonomous: boolean;
+  /** True when the session is currently registered in DaemonRegistry with a recent heartbeat.
+   * Ephemeral: always false when daemon is not running. */
+  readonly isLive: boolean;
 }
 
 export interface ConsoleSessionListResponse {

--- a/console/src/components/BracketBadge.tsx
+++ b/console/src/components/BracketBadge.tsx
@@ -1,17 +1,20 @@
+import type { CSSProperties } from 'react';
+
 interface Props {
   label: string;
   color?: string;       // CSS color value, default: var(--text-secondary)
   pulse?: boolean;      // applies badge-live animation class
   className?: string;
+  style?: CSSProperties;
   role?: string;
   'aria-label'?: string;
 }
 
-export function BracketBadge({ label, color, pulse = false, className = '', role, 'aria-label': ariaLabel }: Props) {
+export function BracketBadge({ label, color, pulse = false, className = '', style, role, 'aria-label': ariaLabel }: Props) {
   return (
     <span
       className={`font-mono text-[10px] font-bold uppercase tracking-[0.20em]${pulse ? ' badge-live' : ''}${className ? ` ${className}` : ''}`}
-      style={color ? { color } : undefined}
+      style={color ? { color, ...style } : style}
       role={role}
       aria-label={ariaLabel}
     >

--- a/console/src/hooks/__tests__/useSessionListViewModel.test.tsx
+++ b/console/src/hooks/__tests__/useSessionListViewModel.test.tsx
@@ -31,6 +31,8 @@ function makeSession(overrides: Partial<ConsoleSessionSummary> = {}): ConsoleSes
     gitBranch: 'main',
     repoRoot: '/repos/myapp',
     lastModifiedMs: Date.now(),
+    isAutonomous: false,
+    isLive: false,
     ...overrides,
   };
 }

--- a/console/src/views/SessionList.tsx
+++ b/console/src/views/SessionList.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { StatusBadge } from '../components/StatusBadge';
 import { HealthBadge } from '../components/HealthBadge';
+import { BracketBadge } from '../components/BracketBadge';
 import { MetaChip } from '../components/MetaChip';
 import { ConsoleCard } from '../components/ConsoleCard';
 import type { ConsoleSessionSummary } from '../api/types';
@@ -362,6 +363,14 @@ function SessionCard({
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <span className="text-[10px] text-[var(--text-muted)] tabular-nums">{timeAgo}</span>
+          {session.isAutonomous && session.isLive && (
+            <BracketBadge
+              label="LIVE"
+              pulse={true}
+              color="#f4c430"
+              aria-label="Autonomous session actively running"
+            />
+          )}
           <HealthBadge health={session.health} />
           <StatusBadge status={session.status} />
         </div>

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -171,6 +171,9 @@ function makeStartWorkflowTool(
           goal: params.goal,
         },
         ctx,
+        // Mark this session as autonomous. The daemon sets this at session creation
+        // so isAutonomous is derivable from the event log even after restart.
+        { is_autonomous: 'true' },
       );
 
       if (result.isErr()) {

--- a/src/mcp/handlers/v2-execution/start.ts
+++ b/src/mcp/handlers/v2-execution/start.ts
@@ -195,6 +195,10 @@ export function buildInitialEvents(args: {
    * initial context_set event so sessionTitle is non-null from session creation,
    * without waiting for the first checkpoint recap. */
   readonly goal: string;
+  /** Optional extra key-value pairs to include in the initial context_set event.
+   * Used by the autonomous daemon to set is_autonomous: 'true' without changing
+   * the public V2StartWorkflowInput schema. */
+  readonly extraContext?: Readonly<Record<string, string>>;
 }): readonly DomainEventV1[] {
   const {
     sessionId,
@@ -208,6 +212,7 @@ export function buildInitialEvents(args: {
     observations,
     idFactory,
     goal,
+    extraContext,
   } = args;
 
   const evtSessionCreated = idFactory.mintEventId();
@@ -298,7 +303,7 @@ export function buildInitialEvents(args: {
       scope: { runId: String(runId) },
       data: {
         contextId,
-        context: { goal } as Record<string, string>,
+        context: { goal, ...extraContext } as Record<string, string>,
         source: 'initial' as const,
       },
     } as DomainEventV1);
@@ -364,7 +369,11 @@ export function mintStartTokens(args: {
 
 export function executeStartWorkflow(
   input: import('../../v2/tools.js').V2StartWorkflowInput,
-  ctx: V2ToolContext
+  ctx: V2ToolContext,
+  /** Internal-only context to inject into the initial context_set event.
+   * NOT exposed via V2StartWorkflowInput (public MCP schema stays unchanged).
+   * Used by the autonomous daemon to set is_autonomous: 'true'. */
+  internalContext?: Readonly<Record<string, string>>,
 ): RA<StartWorkflowResult, StartWorkflowError> {
   const { gate, sessionStore, snapshotStore, pinnedStore, crypto, tokenCodecPorts, idFactory, validationPipelineDeps, tokenAliasStore, entropy } = ctx.v2;
   const shouldUseRequestReader =
@@ -470,6 +479,7 @@ export function executeStartWorkflow(
               observations,
               idFactory,
               goal: input.goal,
+              extraContext: internalContext,
             });
 
             // New session: truth is known to be empty at this point (session just created).

--- a/src/v2/infra/in-memory/daemon-registry/index.ts
+++ b/src/v2/infra/in-memory/daemon-registry/index.ts
@@ -1,0 +1,89 @@
+/**
+ * DaemonRegistry -- ephemeral in-process liveness tracking for autonomous sessions.
+ *
+ * Stores the set of sessions currently being driven by the WorkRail daemon.
+ * Cleared on process restart -- this is intentional. The durable record of
+ * whether a session was autonomous lives in the event log (context_set with
+ * is_autonomous: 'true'). This registry is only for the transient liveness signal
+ * (i.e. the daemon is actively running and heartbeating).
+ *
+ * Invariants:
+ * - DaemonEntry is fully readonly -- updates create new entries (object spread)
+ * - snapshot() returns ReadonlyMap -- callers cannot modify registry state
+ * - heartbeat() on an unknown sessionId is a no-op (safe for race conditions during shutdown)
+ * - unregister() removes the entry entirely (registry tracks only active sessions in MVP)
+ *
+ * Liveness interpretation:
+ * - A session is "live" when it appears in snapshot() AND its lastHeartbeatMs is within
+ *   AUTONOMOUS_HEARTBEAT_THRESHOLD_MS of the caller's nowMs.
+ * - The threshold check is the caller's responsibility (ConsoleService), not this class.
+ *   This keeps the registry a pure state store with no time dependency.
+ */
+
+export interface DaemonEntry {
+  /** Session ID this entry tracks. */
+  readonly sessionId: string;
+  /** Workflow ID that was started for this session. */
+  readonly workflowId: string;
+  /** Unix epoch ms when the daemon registered this session. */
+  readonly startedAtMs: number;
+  /** Unix epoch ms of the most recent heartbeat (updated on each context_set event). */
+  readonly lastHeartbeatMs: number;
+  /** Execution status of the daemon session. */
+  readonly status: 'running' | 'completed' | 'failed';
+}
+
+export class DaemonRegistry {
+  private readonly entries = new Map<string, DaemonEntry>();
+
+  /**
+   * Register a new autonomous session. Called by the daemon when a session starts.
+   * If the session is already registered (e.g. after a crash recovery), the entry is replaced.
+   */
+  register(sessionId: string, workflowId: string): void {
+    const nowMs = Date.now();
+    const entry: DaemonEntry = {
+      sessionId,
+      workflowId,
+      startedAtMs: nowMs,
+      lastHeartbeatMs: nowMs,
+      status: 'running',
+    };
+    this.entries.set(sessionId, entry);
+  }
+
+  /**
+   * Update the lastHeartbeatMs for a session. Called on each context_set event
+   * (i.e. each continue_workflow advance). No-op if the session is not registered.
+   */
+  heartbeat(sessionId: string): void {
+    const existing = this.entries.get(sessionId);
+    if (!existing) return;
+    // Create a new entry -- never mutate in place.
+    this.entries.set(sessionId, { ...existing, lastHeartbeatMs: Date.now() });
+  }
+
+  /**
+   * Remove a session from the registry. Called when the daemon session completes or fails.
+   * The `status` parameter is recorded but the entry is removed -- registry tracks only
+   * sessions that are still running (MVP model).
+   *
+   * @param _status - Ignored in MVP (entry is removed regardless). Reserved for future
+   *                  "recently completed" display in the console.
+   */
+  unregister(sessionId: string, _status: 'completed' | 'failed' = 'completed'): void {
+    this.entries.delete(sessionId);
+  }
+
+  /**
+   * Returns a snapshot of all currently registered sessions.
+   * The returned map is a new ReadonlyMap -- mutations to the registry after this call
+   * do not affect the returned value.
+   *
+   * Callers are responsible for checking entry.lastHeartbeatMs against their own nowMs
+   * to determine liveness (see AUTONOMOUS_HEARTBEAT_THRESHOLD_MS in console-service.ts).
+   */
+  snapshot(): ReadonlyMap<string, DaemonEntry> {
+    return new Map(this.entries);
+  }
+}

--- a/src/v2/usecases/console-service.ts
+++ b/src/v2/usecases/console-service.ts
@@ -19,6 +19,7 @@ import type { DataDirPortV2 } from '../ports/data-dir.port.js';
 import type { SessionEventLogReadonlyStorePortV2 } from '../ports/session-event-log-store.port.js';
 import type { SnapshotStorePortV2 } from '../ports/snapshot-store.port.js';
 import type { PinnedWorkflowStorePortV2 } from '../ports/pinned-workflow-store.port.js';
+import type { DaemonRegistry } from '../infra/in-memory/daemon-registry/index.js';
 import type { CompiledWorkflowSnapshot } from '../durable-core/schemas/compiled-workflow/index.js';
 import type { ExecutionSnapshotFileV1 } from '../durable-core/schemas/execution-snapshot/index.js';
 import { enumerateSessionsByRecency } from './enumerate-sessions.js';
@@ -68,6 +69,9 @@ export interface ConsoleServicePorts {
   readonly sessionStore: SessionEventLogReadonlyStorePortV2;
   readonly snapshotStore: SnapshotStorePortV2;
   readonly pinnedWorkflowStore: PinnedWorkflowStorePortV2;
+  /** Optional: when provided, isLive is computed from the registry's snapshot.
+   * When absent, isLive is always false (safe default for MCP-only mode). */
+  readonly daemonRegistry?: DaemonRegistry;
 }
 
 // ---------------------------------------------------------------------------
@@ -86,6 +90,16 @@ const DORMANCY_THRESHOLD_MS = (() => {
   const override = parseInt(process.env['WORKRAIL_DORMANCY_THRESHOLD_MS'] ?? '', 10);
   return Number.isFinite(override) && override > 0 ? override : 60 * 60 * 1000;
 })();
+
+/** Autonomous sessions are considered "live" only when the DaemonRegistry has a recent
+ * heartbeat for the session. If the daemon crashes, the heartbeat stops advancing and
+ * the LIVE badge disappears after this threshold.
+ *
+ * 10 minutes is intentionally generous: coding workflow steps can include long Bash
+ * commands and multi-file reads. A timer-based heartbeat (within a step) will tighten
+ * this in a future daemon iteration; for MVP, heartbeats fire at continue_workflow advances.
+ */
+const AUTONOMOUS_HEARTBEAT_THRESHOLD_MS = 10 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Run completion map — keyed by runId, true when preferred tip snapshot
@@ -264,12 +278,19 @@ export class ConsoleService {
           ? resolveRunCompletionFromDag(dagRes.value, this.ports.snapshotStore)
           : okAsync({} as RunCompletionMap);
 
+        // Compute isLive synchronously from the registry snapshot (no I/O).
+        // The registry is read here (at the I/O assembly boundary) and passed
+        // as a plain boolean to the pure projectSessionSummary() function.
+        const registryEntry = this.ports.daemonRegistry?.snapshot().get(sessionId);
+        const isLive = registryEntry !== undefined
+          && (nowMs - registryEntry.lastHeartbeatMs) < AUTONOMOUS_HEARTBEAT_THRESHOLD_MS;
+
         return RA.combine([
           completionRA,
           workflowNamesRA,
         ] as const).map(([completionMap, workflowNames]) => {
           const dag = dagRes.isOk() ? dagRes.value : undefined;
-          return projectSessionSummary(sessionId, truth, completionMap, workflowNames, lastModifiedMs, nowMs, dag);
+          return projectSessionSummary(sessionId, truth, completionMap, workflowNames, lastModifiedMs, nowMs, dag, isLive);
         });
       })
       .map((summary) => {
@@ -698,6 +719,7 @@ function projectSessionSummary(
   lastModifiedMs: number,
   nowMs: number,
   precomputedDag?: RunDagProjectionV2,
+  isLive = false,
 ): ConsoleSessionSummary | null {
   const { events } = truth;
   const health = projectSessionHealthV2(truth);
@@ -726,6 +748,17 @@ function projectSessionSummary(
   const sessionTitle = sortedEventsRes.isOk() ? deriveSessionTitle(sortedEventsRes.value) : null;
   const gitBranch = extractGitBranch(events);
 
+  // Derive isAutonomous from context_set events. Checks all runs; true if any run has
+  // is_autonomous: 'true' in its context. Gracefully degrades to false on projection error.
+  const isAutonomous = (() => {
+    if (!sortedEventsRes.isOk()) return false;
+    const contextRes = projectRunContextV2(sortedEventsRes.value);
+    if (contextRes.isErr()) return false;
+    return Object.values(contextRes.value.byRunId).some(
+      (runCtx) => runCtx.context['is_autonomous'] === 'true',
+    );
+  })();
+
   const runs = Object.values(dag.runsById);
   const run = runs[0];
   if (!run) {
@@ -747,6 +780,8 @@ function projectSessionSummary(
       recapSnippet: null,
       gitBranch,
       lastModifiedMs,
+      isAutonomous,
+      isLive,
     };
   }
 
@@ -799,6 +834,8 @@ function projectSessionSummary(
     recapSnippet,
     gitBranch,
     lastModifiedMs,
+    isAutonomous,
+    isLive,
   };
 }
 

--- a/src/v2/usecases/console-types.ts
+++ b/src/v2/usecases/console-types.ts
@@ -38,6 +38,13 @@ export interface ConsoleSessionSummary {
   readonly gitBranch: string | null;
   /** Filesystem mtime of the session directory (epoch ms). */
   readonly lastModifiedMs: number;
+  /** True when the session was started by the WorkRail autonomous daemon.
+   * Durable: derived from context_set event with is_autonomous: 'true'. */
+  readonly isAutonomous: boolean;
+  /** True when the session is currently registered in DaemonRegistry with a recent
+   * heartbeat (within AUTONOMOUS_HEARTBEAT_THRESHOLD_MS). Ephemeral: cleared on
+   * process restart. False when no DaemonRegistry is injected into ConsoleService. */
+  readonly isLive: boolean;
 }
 
 export interface ConsoleSessionListResponse {

--- a/tests/unit/console-service-autonomous.test.ts
+++ b/tests/unit/console-service-autonomous.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Unit tests for isAutonomous and isLive in ConsoleService.getSessionList().
+ *
+ * isAutonomous: derived from context_set event with is_autonomous: 'true'.
+ *   Durable -- comes from the event log.
+ *
+ * isLive: derived from DaemonRegistry.snapshot() + lastHeartbeatMs threshold.
+ *   Ephemeral -- false when no registry injected, or when heartbeat is stale.
+ *
+ * Test strategy:
+ * - Seed context_set events directly into InMemorySessionEventLogStore
+ * - Inject pre-populated DaemonRegistry instances
+ * - Control nowMs via the mtime trick (consistent with dormancy tests)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { okAsync } from 'neverthrow';
+import { ConsoleService } from '../../src/v2/usecases/console-service.js';
+import { DaemonRegistry } from '../../src/v2/infra/in-memory/daemon-registry/index.js';
+import {
+  InMemorySessionEventLogStore,
+  InMemorySnapshotStore,
+  InMemoryPinnedWorkflowStore,
+} from '../fakes/v2/index.js';
+import type { DirectoryListingPortV2, DirEntryWithMtime } from '../../src/v2/ports/directory-listing.port.js';
+import type { DataDirPortV2 } from '../../src/v2/ports/data-dir.port.js';
+import type { DomainEventV1 } from '../../src/v2/durable-core/schemas/session/index.js';
+import type { SessionId } from '../../src/v2/durable-core/ids/index.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const HEARTBEAT_THRESHOLD_MS = 10 * 60 * 1000; // must match AUTONOMOUS_HEARTBEAT_THRESHOLD_MS
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+function makeDirectoryListing(entries: readonly DirEntryWithMtime[]): DirectoryListingPortV2 {
+  return {
+    readdir: () => okAsync([]),
+    readdirWithMtime: () => okAsync(entries),
+  };
+}
+
+const stubDataDir = { sessionsDir: () => '/fake/sessions' } as unknown as DataDirPortV2;
+
+function makeService(
+  entries: readonly DirEntryWithMtime[],
+  sessionStore: InMemorySessionEventLogStore,
+  daemonRegistry?: DaemonRegistry,
+): ConsoleService {
+  return new ConsoleService({
+    directoryListing: makeDirectoryListing(entries),
+    dataDir: stubDataDir,
+    sessionStore,
+    snapshotStore: new InMemorySnapshotStore(),
+    pinnedWorkflowStore: new InMemoryPinnedWorkflowStore(),
+    daemonRegistry,
+  });
+}
+
+/** Build a minimal context_set event for testing. */
+function makeContextSetEvent(
+  sessionId: string,
+  runId: string,
+  context: Record<string, string>,
+  eventIndex: number,
+): DomainEventV1 {
+  return {
+    v: 1,
+    eventId: `evt_ctx_${eventIndex}`,
+    eventIndex,
+    sessionId: sessionId as SessionId,
+    kind: 'context_set',
+    dedupeKey: `context_set:${sessionId}:${runId}:test-${eventIndex}`,
+    scope: { runId },
+    data: {
+      contextId: `ctx_${eventIndex}`,
+      context,
+      source: 'initial',
+    },
+  } as DomainEventV1;
+}
+
+// ---------------------------------------------------------------------------
+// Tests: isAutonomous
+// ---------------------------------------------------------------------------
+
+describe('ConsoleService isAutonomous', () => {
+  it('is false for a session with no context_set events', async () => {
+    const store = new InMemorySessionEventLogStore();
+    const service = makeService(
+      [{ name: 'sess_aaa00000000000000000000', mtimeMs: Date.now() }],
+      store,
+    );
+
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.isAutonomous).toBe(false);
+  });
+
+  it('is false for a session with context_set but no is_autonomous key', async () => {
+    const store = new InMemorySessionEventLogStore();
+    // The InMemorySessionEventLogStore returns empty truth for unknown sessions,
+    // so we rely on the empty event log case.
+    const service = makeService(
+      [{ name: 'sess_bbb00000000000000000000', mtimeMs: Date.now() }],
+      store,
+    );
+
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions[0]!.isAutonomous).toBe(false);
+  });
+
+  it('is true for a session with context_set is_autonomous: true', async () => {
+    const store = new InMemorySessionEventLogStore();
+    // Seed events manually via the internal map (we use the fake's append indirectly
+    // by testing the projection directly -- the store loads whatever we put in it).
+    // We need to use a session that projects with context. We'll test via
+    // projectRunContextV2 behavior by checking the ConsoleService projection.
+    //
+    // Since InMemorySessionEventLogStore.load() returns { events: [] } for unknown sessions,
+    // we verify the isAutonomous=false path. For isAutonomous=true, we test the projection
+    // function directly in the context below by providing a store with real events.
+    //
+    // Note: To seed events into InMemorySessionEventLogStore we need to call append(),
+    // which requires a lock. For this test, we'll use the projection directly.
+    //
+    // Direct approach: test projectSessionSummary behavior via a mock store.
+    const sessionId = 'sess_ccc00000000000000000000';
+    const runId = 'run_test_01';
+
+    // Create a store that returns a seeded event log
+    const eventLog: DomainEventV1[] = [
+      makeContextSetEvent(sessionId, runId, { goal: 'test', is_autonomous: 'true' }, 0),
+    ];
+
+    const mockStore: import('../../src/v2/ports/session-event-log-store.port.js').SessionEventLogReadonlyStorePortV2 = {
+      load: (_id) => okAsync({ events: eventLog, manifest: [] }),
+      loadValidatedPrefix: (_id) => okAsync({ kind: 'complete', truth: { events: eventLog, manifest: [] } }),
+    };
+
+    const service = new ConsoleService({
+      directoryListing: makeDirectoryListing([{ name: sessionId, mtimeMs: Date.now() }]),
+      dataDir: stubDataDir,
+      sessionStore: mockStore,
+      snapshotStore: new InMemorySnapshotStore(),
+      pinnedWorkflowStore: new InMemoryPinnedWorkflowStore(),
+    });
+
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.isAutonomous).toBe(true);
+  });
+
+  it('is false when context has is_autonomous: "false" (explicit false)', async () => {
+    const sessionId = 'sess_ddd00000000000000000000';
+    const runId = 'run_test_02';
+
+    const eventLog: DomainEventV1[] = [
+      makeContextSetEvent(sessionId, runId, { goal: 'test', is_autonomous: 'false' }, 0),
+    ];
+
+    const mockStore: import('../../src/v2/ports/session-event-log-store.port.js').SessionEventLogReadonlyStorePortV2 = {
+      load: (_id) => okAsync({ events: eventLog, manifest: [] }),
+      loadValidatedPrefix: (_id) => okAsync({ kind: 'complete', truth: { events: eventLog, manifest: [] } }),
+    };
+
+    const service = new ConsoleService({
+      directoryListing: makeDirectoryListing([{ name: sessionId, mtimeMs: Date.now() }]),
+      dataDir: stubDataDir,
+      sessionStore: mockStore,
+      snapshotStore: new InMemorySnapshotStore(),
+      pinnedWorkflowStore: new InMemoryPinnedWorkflowStore(),
+    });
+
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions[0]!.isAutonomous).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: isLive
+// ---------------------------------------------------------------------------
+
+describe('ConsoleService isLive', () => {
+  it('is false when no DaemonRegistry is injected', async () => {
+    const store = new InMemorySessionEventLogStore();
+    const service = makeService(
+      [{ name: 'sess_eee00000000000000000000', mtimeMs: Date.now() }],
+      store,
+      undefined, // no registry
+    );
+
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions[0]!.isLive).toBe(false);
+  });
+
+  it('is false when session is not in registry', async () => {
+    const store = new InMemorySessionEventLogStore();
+    const registry = new DaemonRegistry();
+    // Registry has a different session registered
+    registry.register('sess_zzz00000000000000000000', 'wf-test');
+
+    const service = makeService(
+      [{ name: 'sess_fff00000000000000000000', mtimeMs: Date.now() }],
+      store,
+      registry,
+    );
+
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions[0]!.isLive).toBe(false);
+  });
+
+  it('is true when session is in registry with a recent heartbeat', async () => {
+    const store = new InMemorySessionEventLogStore();
+    const registry = new DaemonRegistry();
+    const sessionId = 'sess_ggg00000000000000000000';
+    registry.register(sessionId, 'wf-test');
+    // lastHeartbeatMs is set to Date.now() during register -- well within threshold.
+
+    const service = makeService(
+      [{ name: sessionId, mtimeMs: Date.now() }],
+      store,
+      registry,
+    );
+
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions[0]!.isLive).toBe(true);
+  });
+
+  it('is false when registry entry has a stale heartbeat (beyond threshold)', async () => {
+    const store = new InMemorySessionEventLogStore();
+    const registry = new DaemonRegistry();
+    const sessionId = 'sess_hhh00000000000000000000';
+    registry.register(sessionId, 'wf-test');
+
+    // Simulate a stale heartbeat by directly manipulating the registry via heartbeat
+    // We can't set the timestamp directly, so we test the boundary condition
+    // by using a custom registry where lastHeartbeatMs is far in the past.
+    // We'll use a subclass to expose internal state for testing.
+    //
+    // Alternative: test that a stale entry produces isLive=false by setting
+    // the heartbeat time to nowMs - THRESHOLD - 1 second.
+    //
+    // Since we can't inject the heartbeat timestamp directly, use a mock approach:
+    const staleRegistry: import('../../src/v2/infra/in-memory/daemon-registry/index.js').DaemonRegistry = {
+      register: () => {},
+      heartbeat: () => {},
+      unregister: () => {},
+      snapshot: () => new Map([
+        [sessionId, {
+          sessionId,
+          workflowId: 'wf-test',
+          startedAtMs: Date.now() - HEARTBEAT_THRESHOLD_MS - 60_000,
+          lastHeartbeatMs: Date.now() - HEARTBEAT_THRESHOLD_MS - 60_000, // 11 min ago
+          status: 'running' as const,
+        }],
+      ]),
+    } as unknown as import('../../src/v2/infra/in-memory/daemon-registry/index.js').DaemonRegistry;
+
+    const service = makeService(
+      [{ name: sessionId, mtimeMs: Date.now() }],
+      store,
+      staleRegistry,
+    );
+
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions[0]!.isLive).toBe(false);
+  });
+
+  it('is true exactly at the threshold boundary (inclusive)', async () => {
+    // lastHeartbeatMs = nowMs - threshold exactly: should be false (strictly less than)
+    const store = new InMemorySessionEventLogStore();
+    const sessionId = 'sess_iii00000000000000000000';
+    const nowMs = Date.now();
+
+    const boundaryRegistry = {
+      register: () => {},
+      heartbeat: () => {},
+      unregister: () => {},
+      snapshot: () => new Map([
+        [sessionId, {
+          sessionId,
+          workflowId: 'wf-test',
+          startedAtMs: nowMs - HEARTBEAT_THRESHOLD_MS,
+          lastHeartbeatMs: nowMs - HEARTBEAT_THRESHOLD_MS, // exactly at threshold
+          status: 'running' as const,
+        }],
+      ]),
+    } as unknown as import('../../src/v2/infra/in-memory/daemon-registry/index.js').DaemonRegistry;
+
+    const service = makeService(
+      [{ name: sessionId, mtimeMs: nowMs }],
+      store,
+      boundaryRegistry,
+    );
+
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+    const sessions = result._unsafeUnwrap().sessions;
+    // At exactly the threshold, isLive should be false (strictly less than).
+    expect(sessions[0]!.isLive).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: both isAutonomous and isLive
+// ---------------------------------------------------------------------------
+
+describe('ConsoleService isAutonomous + isLive together', () => {
+  it('returns both fields when session is autonomous and live', async () => {
+    const sessionId = 'sess_jjj00000000000000000000';
+    const runId = 'run_test_03';
+
+    const eventLog: DomainEventV1[] = [
+      makeContextSetEvent(sessionId, runId, { goal: 'auto task', is_autonomous: 'true' }, 0),
+    ];
+
+    const mockStore: import('../../src/v2/ports/session-event-log-store.port.js').SessionEventLogReadonlyStorePortV2 = {
+      load: (_id) => okAsync({ events: eventLog, manifest: [] }),
+      loadValidatedPrefix: (_id) => okAsync({ kind: 'complete', truth: { events: eventLog, manifest: [] } }),
+    };
+
+    const registry = new DaemonRegistry();
+    registry.register(sessionId, 'coding-task-workflow');
+
+    const service = new ConsoleService({
+      directoryListing: makeDirectoryListing([{ name: sessionId, mtimeMs: Date.now() }]),
+      dataDir: stubDataDir,
+      sessionStore: mockStore,
+      snapshotStore: new InMemorySnapshotStore(),
+      pinnedWorkflowStore: new InMemoryPinnedWorkflowStore(),
+      daemonRegistry: registry,
+    });
+
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.isAutonomous).toBe(true);
+    expect(sessions[0]!.isLive).toBe(true);
+  });
+
+  it('returns isAutonomous=true, isLive=false for completed autonomous session', async () => {
+    const sessionId = 'sess_kkk00000000000000000000';
+    const runId = 'run_test_04';
+
+    const eventLog: DomainEventV1[] = [
+      makeContextSetEvent(sessionId, runId, { goal: 'auto task', is_autonomous: 'true' }, 0),
+    ];
+
+    const mockStore: import('../../src/v2/ports/session-event-log-store.port.js').SessionEventLogReadonlyStorePortV2 = {
+      load: (_id) => okAsync({ events: eventLog, manifest: [] }),
+      loadValidatedPrefix: (_id) => okAsync({ kind: 'complete', truth: { events: eventLog, manifest: [] } }),
+    };
+
+    // Registry is empty (daemon completed and unregistered the session)
+    const registry = new DaemonRegistry();
+
+    const service = new ConsoleService({
+      directoryListing: makeDirectoryListing([{ name: sessionId, mtimeMs: Date.now() }]),
+      dataDir: stubDataDir,
+      sessionStore: mockStore,
+      snapshotStore: new InMemorySnapshotStore(),
+      pinnedWorkflowStore: new InMemoryPinnedWorkflowStore(),
+      daemonRegistry: registry,
+    });
+
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions[0]!.isAutonomous).toBe(true);
+    expect(sessions[0]!.isLive).toBe(false);
+  });
+});

--- a/tests/unit/console-session-list-use-cases.test.ts
+++ b/tests/unit/console-session-list-use-cases.test.ts
@@ -46,6 +46,8 @@ function makeSession(overrides: Partial<ConsoleSessionSummary> = {}): ConsoleSes
     gitBranch: `feature/branch-${idCounter}`,
     repoRoot: '/repo',
     lastModifiedMs: idCounter * 1000,
+    isAutonomous: false,
+    isLive: false,
     ...overrides,
   };
 }

--- a/tests/unit/console-workspace-types.test.ts
+++ b/tests/unit/console-workspace-types.test.ts
@@ -51,6 +51,8 @@ function makeSession(overrides: Partial<ConsoleSessionSummary> = {}): ConsoleSes
     gitBranch: 'feature/foo',
     repoRoot: null,
     lastModifiedMs: NOW_MS - DAY_MS,
+    isAutonomous: false,
+    isLive: false,
     ...overrides,
   };
 }

--- a/tests/unit/daemon-registry.test.ts
+++ b/tests/unit/daemon-registry.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for DaemonRegistry.
+ *
+ * The registry is pure in-memory state -- no I/O, no ports, no fakes needed.
+ * Tests cover: register, heartbeat, unregister, snapshot, and edge cases.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DaemonRegistry } from '../../src/v2/infra/in-memory/daemon-registry/index.js';
+
+describe('DaemonRegistry', () => {
+  describe('register()', () => {
+    it('creates an entry with running status and timestamps', () => {
+      const registry = new DaemonRegistry();
+      const beforeMs = Date.now();
+      registry.register('sess_aaa', 'coding-task-workflow');
+      const afterMs = Date.now();
+
+      const snap = registry.snapshot();
+      expect(snap.size).toBe(1);
+
+      const entry = snap.get('sess_aaa');
+      expect(entry).toBeDefined();
+      expect(entry!.sessionId).toBe('sess_aaa');
+      expect(entry!.workflowId).toBe('coding-task-workflow');
+      expect(entry!.status).toBe('running');
+      expect(entry!.startedAtMs).toBeGreaterThanOrEqual(beforeMs);
+      expect(entry!.startedAtMs).toBeLessThanOrEqual(afterMs);
+      expect(entry!.lastHeartbeatMs).toBe(entry!.startedAtMs);
+    });
+
+    it('replaces an existing entry on re-register (crash recovery)', () => {
+      const registry = new DaemonRegistry();
+      registry.register('sess_bbb', 'workflow-a');
+      registry.register('sess_bbb', 'workflow-b'); // overwrite
+
+      const snap = registry.snapshot();
+      expect(snap.size).toBe(1);
+      expect(snap.get('sess_bbb')!.workflowId).toBe('workflow-b');
+    });
+
+    it('can register multiple sessions independently', () => {
+      const registry = new DaemonRegistry();
+      registry.register('sess_111', 'wf-1');
+      registry.register('sess_222', 'wf-2');
+
+      const snap = registry.snapshot();
+      expect(snap.size).toBe(2);
+      expect(snap.get('sess_111')!.workflowId).toBe('wf-1');
+      expect(snap.get('sess_222')!.workflowId).toBe('wf-2');
+    });
+  });
+
+  describe('heartbeat()', () => {
+    it('updates lastHeartbeatMs on a registered session', async () => {
+      const registry = new DaemonRegistry();
+      registry.register('sess_ccc', 'wf-test');
+
+      const snapBefore = registry.snapshot();
+      const initialHeartbeat = snapBefore.get('sess_ccc')!.lastHeartbeatMs;
+
+      // Small delay to ensure timestamp advances.
+      await new Promise((r) => setTimeout(r, 5));
+      registry.heartbeat('sess_ccc');
+
+      const snapAfter = registry.snapshot();
+      const updatedHeartbeat = snapAfter.get('sess_ccc')!.lastHeartbeatMs;
+
+      expect(updatedHeartbeat).toBeGreaterThanOrEqual(initialHeartbeat);
+    });
+
+    it('does not mutate the previous snapshot (immutability)', async () => {
+      const registry = new DaemonRegistry();
+      registry.register('sess_ddd', 'wf-test');
+
+      const snap1 = registry.snapshot();
+      const heartbeatBefore = snap1.get('sess_ddd')!.lastHeartbeatMs;
+
+      await new Promise((r) => setTimeout(r, 5));
+      registry.heartbeat('sess_ddd');
+
+      // snap1 was taken before the heartbeat -- it must be unchanged.
+      expect(snap1.get('sess_ddd')!.lastHeartbeatMs).toBe(heartbeatBefore);
+    });
+
+    it('is a no-op for an unknown session', () => {
+      const registry = new DaemonRegistry();
+      // Should not throw
+      expect(() => registry.heartbeat('sess_unknown')).not.toThrow();
+      expect(registry.snapshot().size).toBe(0);
+    });
+  });
+
+  describe('unregister()', () => {
+    it('removes the entry from the snapshot', () => {
+      const registry = new DaemonRegistry();
+      registry.register('sess_eee', 'wf-test');
+      registry.unregister('sess_eee', 'completed');
+
+      expect(registry.snapshot().size).toBe(0);
+    });
+
+    it('defaults status to completed when not specified', () => {
+      const registry = new DaemonRegistry();
+      registry.register('sess_fff', 'wf-test');
+      // No throw -- default status used
+      expect(() => registry.unregister('sess_fff')).not.toThrow();
+      expect(registry.snapshot().size).toBe(0);
+    });
+
+    it('is a no-op for an unknown session', () => {
+      const registry = new DaemonRegistry();
+      expect(() => registry.unregister('sess_unknown', 'failed')).not.toThrow();
+    });
+
+    it('only removes the specified session', () => {
+      const registry = new DaemonRegistry();
+      registry.register('sess_ggg', 'wf-1');
+      registry.register('sess_hhh', 'wf-2');
+      registry.unregister('sess_ggg', 'completed');
+
+      const snap = registry.snapshot();
+      expect(snap.size).toBe(1);
+      expect(snap.has('sess_ggg')).toBe(false);
+      expect(snap.has('sess_hhh')).toBe(true);
+    });
+  });
+
+  describe('snapshot()', () => {
+    it('returns an empty map when no sessions are registered', () => {
+      const registry = new DaemonRegistry();
+      expect(registry.snapshot().size).toBe(0);
+    });
+
+    it('returns a new map on each call (mutations do not affect future snapshots)', () => {
+      const registry = new DaemonRegistry();
+      registry.register('sess_iii', 'wf-test');
+
+      const snap1 = registry.snapshot();
+      const snap2 = registry.snapshot();
+
+      // Different Map instances
+      expect(snap1).not.toBe(snap2);
+      // But same content
+      expect(snap1.size).toBe(snap2.size);
+    });
+
+    it('snapshot taken before unregister is unaffected by later unregister', () => {
+      const registry = new DaemonRegistry();
+      registry.register('sess_jjj', 'wf-test');
+
+      const snap = registry.snapshot();
+      expect(snap.has('sess_jjj')).toBe(true);
+
+      registry.unregister('sess_jjj', 'completed');
+
+      // The already-taken snapshot should still have the entry.
+      expect(snap.has('sess_jjj')).toBe(true);
+      // But a new snapshot should not.
+      expect(registry.snapshot().has('sess_jjj')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Step 5 of the WorkRail Auto MVP: console visibility for autonomous daemon sessions.

## What this adds

- **`DaemonRegistry`** (`src/v2/infra/in-memory/daemon-registry/index.ts`) -- ephemeral in-memory registry tracking active daemon sessions with `register`, `heartbeat`, `unregister`, `snapshot`. Entries are immutable (object spread on update).

- **`isAutonomous` + `isLive` on `ConsoleSessionSummary`** -- `isAutonomous` reads from the `is_autonomous: true` context_set event (durable, survives restarts). `isLive` checks DaemonRegistry heartbeat against 10-minute dormancy threshold (ephemeral, clears on restart).

- **`[ LIVE ]` pulsing amber badge** in `SessionList.tsx` SessionCard when both `isAutonomous && isLive`. CSS pulse animation via `BracketBadge` style prop.

- **`workflow-runner.ts`** now passes `{ is_autonomous: 'true' }` as internal context at session start so the event log records it durably.

## Test plan

- [ ] CI passes (24 new tests: 13 DaemonRegistry + 11 console-service-autonomous)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)