### PR TITLE
fix(daemon): use Zillow Bedrock instead of personal Anthropic key

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -245,9 +245,18 @@ program
     }
     const ctx = v2Guard.ctx;
 
+    // Use AWS Bedrock when AWS_PROFILE is set (Zillow corp account).
+    // Otherwise require ANTHROPIC_API_KEY for direct Anthropic access.
+    const usesBedrock = !!process.env['AWS_PROFILE'] || !!process.env['AWS_ACCESS_KEY_ID'];
+    const apiKey = process.env['ANTHROPIC_API_KEY'];
+    if (!usesBedrock && !apiKey) {
+      console.error('No LLM credentials found. Set AWS_PROFILE (for Bedrock) or ANTHROPIC_API_KEY (for direct Anthropic).');
+      process.exit(1);
+    }
+
     const handle = await startTriggerListener(ctx, {
       workspacePath: options.workspace,
-      apiKey: process.env['ANTHROPIC_API_KEY'],
+      apiKey: apiKey,
       env: process.env,
     });
 

--- a/src/daemon/pi-mono-loader.ts
+++ b/src/daemon/pi-mono-loader.ts
@@ -35,13 +35,34 @@ const esmImport = new Function('specifier', 'return import(specifier)') as (spec
 
 let _piAi: AnyModule | null = null;
 let _piAgentCore: AnyModule | null = null;
+let _bedrockRegistered = false;
 
 /**
  * Load @mariozechner/pi-ai via dynamic import (ESM interop).
+ * Also registers the Bedrock provider module so Bedrock models are available.
  * Cached after first call.
  */
 export async function loadPiAi(): Promise<AnyModule> {
-  if (!_piAi) _piAi = await esmImport('@mariozechner/pi-ai');
+  if (!_piAi) {
+    _piAi = await esmImport('@mariozechner/pi-ai');
+    // Register Bedrock provider if not already registered.
+    // The bedrock-provider module is loaded via its dist path since pi-ai
+    // doesn't export it as a named subpath.
+    if (!_bedrockRegistered) {
+      try {
+        // Resolve path relative to this file's location at runtime
+        const path = await import('node:path');
+        const bedrockPath = path.resolve(__dirname, '..', '..', 'node_modules', '@mariozechner', 'pi-ai', 'dist', 'bedrock-provider.js');
+        const bedrockMod = await esmImport(`file://${bedrockPath}`).catch(() => null);
+        if (bedrockMod?.bedrockProviderModule && _piAi.setBedrockProviderModule) {
+          _piAi.setBedrockProviderModule(bedrockMod.bedrockProviderModule);
+          _bedrockRegistered = true;
+        }
+      } catch {
+        // Bedrock registration is best-effort -- Anthropic direct API still works
+      }
+    }
+  }
   return _piAi;
 }
 

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -482,10 +482,17 @@ export async function runWorkflow(
   daemonRegistry?.register(sessionId, trigger.workflowId);
 
   // ---- Model setup ----
+  // Use Bedrock when AWS_PROFILE is set (Zillow's corp account), otherwise
+  // fall back to direct Anthropic API. This avoids personal API key charges.
   let model;
   try {
     const { getModel } = await loadPiAi();
-    model = getModel('anthropic', 'claude-sonnet-4-5');
+    const usesBedrock = !!process.env['AWS_PROFILE'] || !!process.env['AWS_ACCESS_KEY_ID'];
+    if (usesBedrock) {
+      model = getModel('bedrock-converse-stream', 'us.anthropic.claude-sonnet-4-6');
+    } else {
+      model = getModel('anthropic', 'claude-sonnet-4-5');
+    }
   } catch (err) {
     daemonRegistry?.unregister(sessionId, 'failed');
     return {
@@ -536,7 +543,9 @@ export async function runWorkflow(
       model,
       tools,
     },
-    getApiKey: async (_provider: string) => apiKey,
+    // Bedrock uses AWS credentials from env (AWS_PROFILE etc.) -- no API key needed.
+    // For direct Anthropic, pass the provided key.
+    getApiKey: async (_provider: string) => apiKey ?? '',
 
     // Sequential execution: continue_workflow must complete before Bash begins
     // on the next step. Workflow tools have ordering requirements.


### PR DESCRIPTION
When `AWS_PROFILE` or `AWS_ACCESS_KEY_ID` is set, use Bedrock (`us.anthropic.claude-sonnet-4-6`) instead of direct Anthropic API. Registers `bedrockProviderModule` from pi-ai's dist/ at startup. Falls back to `ANTHROPIC_API_KEY` for non-Zillow setups. Fails fast at startup if neither credential source is available.