### PR TITLE
feat(mcp): add workrail version CLI command

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -1271,3 +1271,25 @@ WorkTrain updated to v4.1.0 ✦ One new capability to configure:
 
   Press Enter to continue, or 's' to skip this setup.
 ```
+
+---
+
+### Multi-agent support: concurrent sessions + agent collaboration (high importance, post-MVP)
+
+**Concurrent sessions (near-term):**
+WorkTrain should run multiple workflows in parallel -- different agents on different repos or different tasks simultaneously. The current architecture supports this (per-session state files, `KeyedAsyncQueue` serializes per trigger ID), but the global concurrency cap from the arch audit needs implementing:
+- `maxConcurrentSessions: N` config in `~/.workrail/config.json`
+- Global semaphore in `TriggerRouter` -- queues new dispatches when at capacity
+- Console shows all concurrent sessions in QueuePane
+- Mobile monitoring shows live count
+
+**Agent collaboration on a single task (longer-term):**
+Multiple agents coordinating on one task. Two patterns:
+
+1. **Coordinator + worker subagents** -- already possible today via WorkRail's existing `mcp__nested-subagent__Task` delegation in workflow steps. A coordinator workflow spawns subagents with scoped tasks (e.g. one agent writes Android code, another writes iOS). Each subagent has its own WorkRail session and reports back to the coordinator.
+
+2. **Parallel agent teams** -- multiple agents working independently on separate parts of a task (e.g. separate feature branches) with a final merge/review step. Requires cross-repo execution and a workflow that understands how to partition and recombine work.
+
+**MVP path:** Concurrent sessions with `maxConcurrentSessions` first (small change). Coordinator + subagent delegation second (already works, just needs workflow authoring). Full parallel teams is the longer-term investment.
+
+**Key open question:** When two agents work on the same repo concurrently, file conflicts are possible. The right answer is git worktrees -- each agent gets its own worktree, merges at the end. This is what the `cw` command does for human developers. WorkTrain should do the same autonomously.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,7 @@ import {
   executeStartCommand,
   executeCleanupCommand,
   executeMigrateCommand,
+  executeVersionCommand,
 } from './cli/commands/index.js';
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -308,6 +309,19 @@ program
     };
     process.on('SIGINT', shutdown);
     process.on('SIGTERM', shutdown);
+  });
+
+program
+  .command('version')
+  .description('Print the WorkRail version')
+  .action(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require('../package.json') as { version: string };
+    const result = executeVersionCommand({
+      getVersion: () => pkg.version,
+      print: (msg) => console.log(msg),
+    });
+    interpretCliResultWithoutDI(result);
   });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -8,6 +8,7 @@ export { executeListCommand, type ListCommandDeps, type ListCommandOptions } fro
 export { executeValidateCommand, type ValidateCommandDeps } from './validate.js';
 export { executeStartCommand, type StartCommandDeps, type RpcServer } from './start.js';
 export { executeCleanupCommand, type CleanupCommandDeps, type CleanupCommandOptions } from './cleanup.js';
+export { executeVersionCommand, type VersionCommandDeps } from './version.js';
 export {
   executeMigrateCommand,
   migrateWorkflow,

--- a/src/cli/commands/version.ts
+++ b/src/cli/commands/version.ts
@@ -1,0 +1,38 @@
+/**
+ * Version Command
+ *
+ * Prints the current WorkRail version from package.json.
+ * Pure function with dependency injection.
+ */
+
+import type { CliResult } from '../types/cli-result.js';
+import { success, failure } from '../types/cli-result.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════════════════
+
+export interface VersionCommandDeps {
+  readonly getVersion: () => string;
+  readonly print: (message: string) => void;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// COMMAND EXECUTION
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Execute the version command.
+ * Prints "WorkRail v<version>" to stdout and returns a no-output success.
+ */
+export function executeVersionCommand(deps: VersionCommandDeps): CliResult {
+  try {
+    const version = deps.getVersion();
+    deps.print(`WorkRail v${version}`);
+    return success();
+  } catch (error) {
+    return failure(
+      `Failed to read version: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}

--- a/tests/unit/cli-version.test.ts
+++ b/tests/unit/cli-version.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { executeVersionCommand } from '../../src/cli/commands/version.js';
+
+describe('executeVersionCommand', () => {
+  it('prints WorkRail v<version> and returns success', () => {
+    const printed: string[] = [];
+    const result = executeVersionCommand({
+      getVersion: () => '3.16.0',
+      print: (msg) => printed.push(msg),
+    });
+
+    expect(result.kind).toBe('success');
+    expect(printed).toEqual(['WorkRail v3.16.0']);
+  });
+
+  it('returns failure when getVersion throws', () => {
+    const result = executeVersionCommand({
+      getVersion: () => { throw new Error('file not found'); },
+      print: vi.fn(),
+    });
+
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.output.message).toContain('file not found');
+    }
+  });
+
+  it('does not call print on failure', () => {
+    const print = vi.fn();
+    executeVersionCommand({
+      getVersion: () => { throw new Error('boom'); },
+      print,
+    });
+
+    expect(print).not.toHaveBeenCalled();
+  });
+});
+
+describe('workrail version CLI integration', () => {
+  it('outputs WorkRail v<version> to stdout with exit code 0', () => {
+    const { execSync } = require('child_process');
+    const path = require('path');
+    const cliPath = path.join(__dirname, '../../dist/cli.js');
+
+    let output: string;
+    try {
+      output = execSync(`node ${cliPath} version`, { encoding: 'utf-8' });
+    } catch (err: any) {
+      throw new Error(`CLI exited with non-zero code: ${err.message}`);
+    }
+
+    expect(output.trim()).toMatch(/^WorkRail v\d+\.\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `workrail version` CLI command that prints `WorkRail v<version>`
- Wires into `src/cli.ts` and exports from `src/cli/commands/index.ts`
- Includes unit tests and an integration test against the built CLI

Note: the implementation was autonomously written by the WorkRail daemon itself (WorkTrain ate its own dog food on the `coding-task-workflow-agentic` workflow). This PR adds the wiring that was missing from the auto-generated code.

## Test plan

- [x] `node dist/cli.js version` prints `WorkRail v3.16.0`
- [x] Unit tests cover success path, failure path, and no-print-on-failure
- [x] Build passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)