### PR TITLE
fix(daemon): add crash recovery reader -- detect and clear orphaned sessions on startup

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -274,32 +274,9 @@ program
     console.log(`Workspace: ${options.workspace}`);
     console.log('Waiting for webhook triggers...');
 
-    // ---- Crash recovery: log any orphaned sessions from a previous daemon crash ----
-    // Sessions that were in-flight when the daemon last crashed leave state files in
-    // DAEMON_SESSIONS_DIR. We log their IDs here so operators can investigate.
-    // Full resume is a follow-up -- the important invariant is that state is per-session
-    // and not clobbered by concurrent or new sessions.
-    try {
-      const { readdir } = await import('node:fs/promises');
-      const { DAEMON_SESSIONS_DIR } = await import('./daemon/workflow-runner.js');
-      const entries = await readdir(DAEMON_SESSIONS_DIR).catch((err: NodeJS.ErrnoException) => {
-        if (err.code === 'ENOENT') return [] as string[];
-        throw err;
-      });
-      const orphanIds = entries
-        .filter((f) => f.endsWith('.json') && !f.endsWith('.tmp'))
-        .map((f) => f.slice(0, -5)); // strip .json
-      if (orphanIds.length > 0) {
-        console.log(
-          `[Daemon] Found ${orphanIds.length} orphaned session(s) from previous run:`,
-          orphanIds,
-        );
-        console.log('[Daemon] Full session resume is not yet implemented. These sessions did not complete.');
-      }
-    } catch (err) {
-      // Non-fatal: crash recovery scan failure should not prevent the daemon from starting.
-      console.warn('[Daemon] Could not scan for orphaned sessions:', err);
-    }
+    // Crash recovery runs inside startTriggerListener() before server.listen().
+    // Orphaned session files from a previous daemon crash are detected and cleared
+    // automatically. See runStartupRecovery() in src/daemon/workflow-runner.ts.
 
     // Keep alive
     const shutdown = async () => {

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -254,8 +254,10 @@ export async function readDaemonSessionState(
  * Read all orphaned session files from ~/.workrail/daemon-sessions/.
  *
  * Returns an array of valid, parseable session entries. Corrupt files (JSON parse
- * errors, missing required fields) are skipped and logged -- they will be cleared
- * by runStartupRecovery() via a separate readdir pass.
+ * errors, missing required fields) are skipped with a warning log and left on disk --
+ * runStartupRecovery() only deletes files returned by this function. This is an
+ * accepted limitation: cleaning up corrupt files would require a second readdir pass,
+ * which is not implemented at MVP.
  *
  * Returns an empty array if the directory does not exist (ENOENT on first run) or
  * if no valid session files are found. Never throws.

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -65,6 +65,15 @@ const WORKFLOW_TIMEOUT_MS = 30 * 60 * 1000;
 export const DAEMON_SESSIONS_DIR = path.join(os.homedir(), '.workrail', 'daemon-sessions');
 
 /**
+ * Maximum age for an orphaned session file before it is treated as definitely stale.
+ *
+ * Sessions older than this threshold are cleared immediately during startup recovery
+ * without additional checks. Tokens from a 2h+ old crash are expired in all realistic
+ * configurations -- retaining them is noise.
+ */
+const MAX_ORPHAN_AGE_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+/**
  * Root directory for WorkRail user data (crash recovery, soul file, etc.).
  * WHY: daemon-soul.md lives alongside daemon-sessions/ in ~/.workrail/, not in
  * the data/ subdirectory controlled by WORKRAIL_DATA_DIR. This is consistent with
@@ -174,6 +183,25 @@ export interface WorkflowRunError {
 /** Result of a runWorkflow() call. Never throws. */
 export type WorkflowRunResult = WorkflowRunSuccess | WorkflowRunError;
 
+/**
+ * A session file found in DAEMON_SESSIONS_DIR during startup recovery.
+ *
+ * Each active runWorkflow() call writes a per-session file to DAEMON_SESSIONS_DIR.
+ * A file that survives daemon restart is an orphan: the session that created it
+ * did not complete cleanly (crash or kill). readAllDaemonSessions() surfaces these
+ * so runStartupRecovery() can log and clear them.
+ */
+export interface OrphanedSession {
+  /** The process-local UUID that was used to key the session file. */
+  readonly sessionId: string;
+  /** The last persisted continueToken for this session. */
+  readonly continueToken: string;
+  /** The last persisted checkpointToken (null if none was written). */
+  readonly checkpointToken: string | null;
+  /** Unix timestamp (ms) when the token was last written. Used for staleness checks. */
+  readonly ts: number;
+}
+
 // ---------------------------------------------------------------------------
 // Token persistence (crash safety)
 // ---------------------------------------------------------------------------
@@ -219,6 +247,176 @@ export async function readDaemonSessionState(
   } catch {
     // ENOENT or parse error -- treat as no persisted state
     return null;
+  }
+}
+
+/**
+ * Read all orphaned session files from ~/.workrail/daemon-sessions/.
+ *
+ * Returns an array of valid, parseable session entries. Corrupt files (JSON parse
+ * errors, missing required fields) are skipped and logged -- they will be cleared
+ * by runStartupRecovery() via a separate readdir pass.
+ *
+ * Returns an empty array if the directory does not exist (ENOENT on first run) or
+ * if no valid session files are found. Never throws.
+ *
+ * WHY exported: called by runStartupRecovery() and testable in isolation without
+ * starting the full daemon listener.
+ *
+ * @param sessionsDir - Optional override for the sessions directory. Defaults to
+ *   DAEMON_SESSIONS_DIR. Pass a temp dir in tests to avoid touching real state.
+ */
+export async function readAllDaemonSessions(
+  sessionsDir: string = DAEMON_SESSIONS_DIR,
+): Promise<OrphanedSession[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(sessionsDir);
+  } catch (err: unknown) {
+    const isEnoent = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+    if (!isEnoent) {
+      console.warn(
+        `[WorkflowRunner] Could not read sessions directory ${sessionsDir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return [];
+  }
+
+  const sessions: OrphanedSession[] = [];
+
+  for (const entry of entries) {
+    // Only consider complete session files. Temp files are named <sessionId>.json.tmp
+    // (i.e. they end with .tmp, not .json) -- the endsWith('.json') check already
+    // excludes them. The belt-and-suspenders check keeps this robust to naming changes.
+    if (!entry.endsWith('.json')) continue;
+
+    const sessionId = entry.slice(0, -5); // strip .json
+    const filePath = path.join(sessionsDir, entry);
+
+    try {
+      const raw = await fs.readFile(filePath, 'utf8');
+      const parsed = JSON.parse(raw) as {
+        continueToken?: unknown;
+        checkpointToken?: unknown;
+        ts?: unknown;
+      };
+
+      if (typeof parsed.continueToken !== 'string' || typeof parsed.ts !== 'number') {
+        console.warn(`[WorkflowRunner] Skipping malformed session file: ${filePath}`);
+        continue;
+      }
+
+      sessions.push({
+        sessionId,
+        continueToken: parsed.continueToken,
+        checkpointToken: typeof parsed.checkpointToken === 'string' ? parsed.checkpointToken : null,
+        ts: parsed.ts,
+      });
+    } catch (err: unknown) {
+      console.warn(
+        `[WorkflowRunner] Skipping unreadable session file ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return sessions;
+}
+
+/**
+ * Scan DAEMON_SESSIONS_DIR for orphaned session files and clear them.
+ *
+ * Called once during daemon startup, before the HTTP server begins accepting
+ * webhook requests. This ensures no new workflow triggers arrive while recovery
+ * is in progress.
+ *
+ * WHY this function and not a rehydrate call: clearing orphans satisfies the
+ * crash recovery invariant (abandoned sessions do not persist indefinitely).
+ * Calling executeContinueWorkflow({ intent: 'rehydrate' }) would only add a
+ * 'token valid vs. expired' log distinction while requiring a V2ToolContext
+ * dependency and risking transient engine startup errors. Clear-regardless-of-result
+ * is the correct MVP behavior.
+ *
+ * KNOWN LIMITATION: a planned deployment restart clears in-flight sessions just as
+ * a crash does. Distinguishing crash from planned restart requires out-of-band
+ * state (e.g. a shutdown token written on clean stop). Not implemented at MVP.
+ *
+ * Non-fatal: any error during recovery is caught and logged. The daemon starts
+ * regardless of whether recovery succeeds.
+ *
+ * @param sessionsDir - Optional override for the sessions directory. Defaults to
+ *   DAEMON_SESSIONS_DIR. Pass a temp dir in tests to avoid touching real state.
+ */
+export async function runStartupRecovery(
+  sessionsDir: string = DAEMON_SESSIONS_DIR,
+): Promise<void> {
+  // Read all parseable session files.
+  const sessions = await readAllDaemonSessions(sessionsDir);
+
+  if (sessions.length === 0) {
+    // Also attempt to clear any stray .tmp files left from a crash mid-write.
+    await clearStrayTmpFiles(sessionsDir);
+    return;
+  }
+
+  console.log(`[WorkflowRunner] Startup recovery: found ${sessions.length} orphaned session(s).`);
+
+  const now = Date.now();
+  let cleared = 0;
+
+  for (const session of sessions) {
+    const ageMs = now - session.ts;
+    const isStale = ageMs > MAX_ORPHAN_AGE_MS;
+    const ageSec = Math.round(ageMs / 1000);
+
+    const label = isStale ? 'stale orphaned session' : 'orphaned session';
+    console.log(
+      `[WorkflowRunner] Clearing ${label}: sessionId=${session.sessionId} age=${ageSec}s`,
+    );
+
+    try {
+      await fs.unlink(path.join(sessionsDir, `${session.sessionId}.json`));
+      cleared++;
+    } catch (err: unknown) {
+      // Best-effort: ENOENT means already gone, any other error is logged.
+      const isEnoent = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+      if (!isEnoent) {
+        console.warn(
+          `[WorkflowRunner] Could not clear session file ${session.sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
+  // Also clear any stray .tmp files left from a crash mid-write.
+  await clearStrayTmpFiles(sessionsDir);
+
+  console.log(`[WorkflowRunner] Startup recovery complete: cleared ${cleared}/${sessions.length} orphaned session(s).`);
+}
+
+/**
+ * Best-effort cleanup of stray .tmp files in the sessions directory.
+ *
+ * These are written by persistTokens() as part of the atomic temp-rename pattern.
+ * If the daemon crashes between writeFile(tmp) and rename(tmp, final), the .tmp
+ * file is orphaned. It holds no useful state (the rename never completed), so we
+ * discard it unconditionally.
+ */
+async function clearStrayTmpFiles(sessionsDir: string): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(sessionsDir);
+  } catch {
+    return; // ENOENT or permission error -- nothing to clean up
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith('.tmp')) continue;
+    try {
+      await fs.unlink(path.join(sessionsDir, entry));
+      console.log(`[WorkflowRunner] Cleared stray temp file: ${entry}`);
+    } catch {
+      // Best-effort -- ignore all errors
+    }
   }
 }
 

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -26,7 +26,7 @@ import type { V2ToolContext } from '../mcp/types.js';
 import { loadTriggerConfigFromFile, buildTriggerIndex } from './trigger-store.js';
 import type { TriggerStoreError } from './trigger-store.js';
 import { TriggerRouter, type RunWorkflowFn } from './trigger-router.js';
-import { runWorkflow } from '../daemon/workflow-runner.js';
+import { runWorkflow, runStartupRecovery } from '../daemon/workflow-runner.js';
 import type { WebhookEvent } from './types.js';
 import { asTriggerId } from './types.js';
 
@@ -214,6 +214,19 @@ export async function startTriggerListener(
   const runWorkflowFn: RunWorkflowFn = options.runWorkflowFn ?? runWorkflow;
   const router = new TriggerRouter(triggerIndex, ctx, apiKey, runWorkflowFn);
   const app = createTriggerApp(router);
+
+  // Startup crash recovery: detect and clear any orphaned session files left by a
+  // previous daemon crash. Run BEFORE server.listen() so no new webhooks can arrive
+  // while recovery is in progress.
+  // WHY: runStartupRecovery() is non-fatal -- any error is caught internally and the
+  // daemon starts regardless. The additional catch here defends against unexpected
+  // throws from the function's own error-handling path.
+  await runStartupRecovery().catch((err: unknown) => {
+    console.warn(
+      '[TriggerListener] Startup recovery encountered an unexpected error:',
+      err instanceof Error ? err.message : String(err),
+    );
+  });
 
   // Determine port
   const portEnv = env['WORKRAIL_TRIGGER_PORT'];

--- a/tests/unit/workflow-runner-crash-recovery.test.ts
+++ b/tests/unit/workflow-runner-crash-recovery.test.ts
@@ -220,7 +220,7 @@ describe('runStartupRecovery()', () => {
     ).rejects.toThrow();
   });
 
-  it('clears corrupt session files during .tmp cleanup pass (skipped in read, still deleteable)', async () => {
+  it('does not throw when corrupt session files are present; corrupt files remain on disk', async () => {
     // A corrupt file is skipped by readAllDaemonSessions() but should not prevent
     // the recovery from running for other sessions. The corrupt file itself remains
     // (runStartupRecovery only deletes files found by readAllDaemonSessions).

--- a/tests/unit/workflow-runner-crash-recovery.test.ts
+++ b/tests/unit/workflow-runner-crash-recovery.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for crash recovery functions in workflow-runner.ts.
+ *
+ * Tests: readAllDaemonSessions(), runStartupRecovery()
+ *
+ * Strategy: each test writes real files to a temp directory and passes the
+ * temp dir as the optional sessionsDir parameter. This avoids mocking fs and
+ * avoids touching the real ~/.workrail/daemon-sessions/ directory.
+ *
+ * WHY real fs over mocks: the functions are I/O-heavy and the real behavior
+ * (ENOENT, parse errors, file deletion) is most accurately verified against
+ * a real filesystem. Temp directories are cheap and clean up after each test.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  readAllDaemonSessions,
+  runStartupRecovery,
+} from '../../src/daemon/workflow-runner.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workrail-test-sessions-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function writeSession(
+  dir: string,
+  sessionId: string,
+  data: object,
+): Promise<void> {
+  return fs.writeFile(
+    path.join(dir, `${sessionId}.json`),
+    JSON.stringify(data, null, 2),
+    'utf8',
+  );
+}
+
+function validSessionData(tsOffset = 0) {
+  return {
+    continueToken: `ct_test_${Date.now()}`,
+    checkpointToken: `ck_test_${Date.now()}`,
+    ts: Date.now() + tsOffset,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// readAllDaemonSessions()
+// ---------------------------------------------------------------------------
+
+describe('readAllDaemonSessions()', () => {
+  it('returns empty array when directory does not exist', async () => {
+    const nonExistentDir = path.join(os.tmpdir(), `workrail-nonexistent-${Date.now()}`);
+    const result = await readAllDaemonSessions(nonExistentDir);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when directory is empty', async () => {
+    const result = await readAllDaemonSessions(tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it('returns parsed sessions from valid .json files', async () => {
+    const sessionId = 'aaaaaaaa-0000-0000-0000-000000000001';
+    const data = validSessionData();
+    await writeSession(tmpDir, sessionId, data);
+
+    const result = await readAllDaemonSessions(tmpDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessionId).toBe(sessionId);
+    expect(result[0]!.continueToken).toBe(data.continueToken);
+    expect(result[0]!.checkpointToken).toBe(data.checkpointToken);
+    expect(result[0]!.ts).toBe(data.ts);
+  });
+
+  it('returns multiple sessions when multiple files exist', async () => {
+    const id1 = 'aaaaaaaa-0000-0000-0000-000000000001';
+    const id2 = 'aaaaaaaa-0000-0000-0000-000000000002';
+    await writeSession(tmpDir, id1, validSessionData());
+    await writeSession(tmpDir, id2, validSessionData());
+
+    const result = await readAllDaemonSessions(tmpDir);
+    expect(result).toHaveLength(2);
+
+    const ids = result.map((s) => s.sessionId).sort();
+    expect(ids).toEqual([id1, id2].sort());
+  });
+
+  it('skips corrupt files (invalid JSON)', async () => {
+    const goodId = 'aaaaaaaa-0000-0000-0000-000000000001';
+    const badId = 'aaaaaaaa-0000-0000-0000-000000000002';
+
+    await writeSession(tmpDir, goodId, validSessionData());
+    await fs.writeFile(path.join(tmpDir, `${badId}.json`), 'this is not json', 'utf8');
+
+    const result = await readAllDaemonSessions(tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessionId).toBe(goodId);
+  });
+
+  it('skips files with missing required fields (no continueToken)', async () => {
+    const sessionId = 'aaaaaaaa-0000-0000-0000-000000000001';
+    await writeSession(tmpDir, sessionId, { ts: Date.now() }); // missing continueToken
+
+    const result = await readAllDaemonSessions(tmpDir);
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips files with missing required fields (no ts)', async () => {
+    const sessionId = 'aaaaaaaa-0000-0000-0000-000000000001';
+    await writeSession(tmpDir, sessionId, { continueToken: 'ct_test' }); // missing ts
+
+    const result = await readAllDaemonSessions(tmpDir);
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes .tmp files (partial writes)', async () => {
+    const sessionId = 'aaaaaaaa-0000-0000-0000-000000000001';
+    // Temp files are named <sessionId>.json.tmp -- they do NOT end in .json
+    await fs.writeFile(
+      path.join(tmpDir, `${sessionId}.json.tmp`),
+      JSON.stringify(validSessionData()),
+      'utf8',
+    );
+
+    const result = await readAllDaemonSessions(tmpDir);
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles null checkpointToken gracefully', async () => {
+    const sessionId = 'aaaaaaaa-0000-0000-0000-000000000001';
+    await writeSession(tmpDir, sessionId, {
+      continueToken: 'ct_test',
+      checkpointToken: null,
+      ts: Date.now(),
+    });
+
+    const result = await readAllDaemonSessions(tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.checkpointToken).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runStartupRecovery()
+// ---------------------------------------------------------------------------
+
+describe('runStartupRecovery()', () => {
+  it('is a no-op when directory does not exist', async () => {
+    const nonExistentDir = path.join(os.tmpdir(), `workrail-nonexistent-${Date.now()}`);
+    // Should not throw
+    await expect(runStartupRecovery(nonExistentDir)).resolves.toBeUndefined();
+  });
+
+  it('is a no-op when directory is empty', async () => {
+    await expect(runStartupRecovery(tmpDir)).resolves.toBeUndefined();
+  });
+
+  it('clears orphaned session files', async () => {
+    const sessionId = 'aaaaaaaa-0000-0000-0000-000000000001';
+    await writeSession(tmpDir, sessionId, validSessionData());
+
+    await runStartupRecovery(tmpDir);
+
+    // File should be gone
+    await expect(
+      fs.access(path.join(tmpDir, `${sessionId}.json`)),
+    ).rejects.toThrow();
+  });
+
+  it('clears multiple orphaned session files', async () => {
+    const id1 = 'aaaaaaaa-0000-0000-0000-000000000001';
+    const id2 = 'aaaaaaaa-0000-0000-0000-000000000002';
+    await writeSession(tmpDir, id1, validSessionData());
+    await writeSession(tmpDir, id2, validSessionData());
+
+    await runStartupRecovery(tmpDir);
+
+    await expect(fs.access(path.join(tmpDir, `${id1}.json`))).rejects.toThrow();
+    await expect(fs.access(path.join(tmpDir, `${id2}.json`))).rejects.toThrow();
+  });
+
+  it('clears stale sessions (age > 2h) without error', async () => {
+    const sessionId = 'aaaaaaaa-0000-0000-0000-000000000001';
+    // Write a session with a timestamp 3 hours ago
+    const staleTs = Date.now() - 3 * 60 * 60 * 1000;
+    await writeSession(tmpDir, sessionId, {
+      continueToken: 'ct_stale',
+      checkpointToken: null,
+      ts: staleTs,
+    });
+
+    await runStartupRecovery(tmpDir);
+
+    await expect(
+      fs.access(path.join(tmpDir, `${sessionId}.json`)),
+    ).rejects.toThrow();
+  });
+
+  it('clears stray .tmp files', async () => {
+    const tmpFile = 'some-session.json.tmp';
+    await fs.writeFile(path.join(tmpDir, tmpFile), 'partial write', 'utf8');
+
+    await runStartupRecovery(tmpDir);
+
+    await expect(
+      fs.access(path.join(tmpDir, tmpFile)),
+    ).rejects.toThrow();
+  });
+
+  it('clears corrupt session files during .tmp cleanup pass (skipped in read, still deleteable)', async () => {
+    // A corrupt file is skipped by readAllDaemonSessions() but should not prevent
+    // the recovery from running for other sessions. The corrupt file itself remains
+    // (runStartupRecovery only deletes files found by readAllDaemonSessions).
+    // This test verifies that a corrupt file does not cause runStartupRecovery to throw.
+    const goodId = 'aaaaaaaa-0000-0000-0000-000000000001';
+    const badId = 'aaaaaaaa-0000-0000-0000-000000000002';
+
+    await writeSession(tmpDir, goodId, validSessionData());
+    await fs.writeFile(path.join(tmpDir, `${badId}.json`), 'not json', 'utf8');
+
+    await expect(runStartupRecovery(tmpDir)).resolves.toBeUndefined();
+
+    // Good session is cleared
+    await expect(fs.access(path.join(tmpDir, `${goodId}.json`))).rejects.toThrow();
+    // Corrupt session remains (not in the parseable list -- would need a separate cleanup step)
+    // This is an accepted limitation: corrupt files are logged but not auto-cleared
+    // by the current implementation. Verify the test doesn't crash.
+  });
+});


### PR DESCRIPTION
## Summary

- Implements GAP-1 (BLOCKER) from the daemon gap analysis: the crash recovery invariant was half-implemented -- `persistTokens()` wrote session state files but there was no read side
- Adds `OrphanedSession` type, `readAllDaemonSessions()`, and `runStartupRecovery()` to `workflow-runner.ts` as peers to `persistTokens()`
- Calls `runStartupRecovery()` in `startTriggerListener()` before `server.listen()` -- no new webhooks arrive during recovery
- Removes the 'Full session resume is not yet implemented' stub from `cli.ts` (recovery now happens inside `startTriggerListener()`)
- Adds 16 unit tests in `tests/unit/workflow-runner-crash-recovery.test.ts` covering ENOENT, corrupt files, .tmp filtering, stale sessions (>2h), and multi-session cleanup

## Design decisions

- **No rehydrate call**: clearing orphans satisfies the crash recovery invariant; calling `executeContinueWorkflow({ intent: 'rehydrate' })` would only add a 'token valid vs. expired' log line while requiring a `V2ToolContext` dependency. Clear-regardless-of-result is correct MVP behavior. The WHY is documented in the `runStartupRecovery()` JSDoc.
- **Co-located with session state I/O**: all session state management (write, read single, read all, clear, recover) lives in `workflow-runner.ts`. The trigger listener calls one clean function.
- **`sessionsDir` optional parameter**: both `readAllDaemonSessions()` and `runStartupRecovery()` accept an optional `sessionsDir` override -- enables test isolation without mocking or writing to real `~/.workrail/daemon-sessions/`.
- **MAX_ORPHAN_AGE_MS = 2h**: sessions older than 2 hours are flagged as stale in the log. Same clear behavior regardless of age.
- **Known limitation (documented in JSDoc)**: a planned deployment restart clears valid in-flight sessions just as a crash does. Distinguishing crash from planned restart requires out-of-band state. Not implemented at MVP.

## Test plan

- [x] `npx tsc --noEmit` -- no errors
- [x] `npx vitest run tests/unit/workflow-runner-crash-recovery.test.ts` -- 16/16 pass
- [x] `npx vitest run tests/unit/workflow-runner-system-prompt.test.ts` -- 16/16 pass
- [x] `npx vitest run tests/unit/trigger-router.test.ts` -- 21/21 pass (startTriggerListener tests verify recovery is a no-op when sessions dir is empty)

Generated with [Claude Code](https://claude.com/claude-code)