### PR TITLE
test: fix posix_tmp_literal CI violation in trigger-router.test.ts

### DIFF
--- a/tests/unit/trigger-router.test.ts
+++ b/tests/unit/trigger-router.test.ts
@@ -20,6 +20,7 @@ import type { RunWorkflowFn } from '../../src/trigger/trigger-router.js';
 import type { TriggerDefinition, WebhookEvent } from '../../src/trigger/types.js';
 import { asTriggerId } from '../../src/trigger/types.js';
 import type { V2ToolContext } from '../../src/mcp/types.js';
+import { tmpPath } from '../helpers/platform.js';
 
 // ---------------------------------------------------------------------------
 // Fakes and helpers
@@ -315,7 +316,7 @@ describe('startTriggerListener feature flag', () => {
   it('starts with empty config when triggers.yml is missing', async () => {
     const { fn } = makeFakeRunWorkflow();
     const result = await startTriggerListener(FAKE_CTX, {
-      workspacePath: '/tmp/nonexistent-workspace-xyz',
+      workspacePath: tmpPath('nonexistent-workspace-xyz'),
       apiKey: 'test-key',
       env: { WORKRAIL_TRIGGERS_ENABLED: 'true' },
       runWorkflowFn: fn,


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `'/tmp/nonexistent-workspace-xyz'` string literal in `tests/unit/trigger-router.test.ts` with `tmpPath('nonexistent-workspace-xyz')` from `tests/helpers/platform.ts`
- This removes the `posix_tmp_literal` violation that was blocking CI on multiple PRs
- Uses the established cross-platform temp path helper already used in `tests/di/test-container.ts` and other test files

## Test plan

- [ ] `npx vitest run tests/unit/trigger-router.test.ts` passes (21/21 tests green, verified locally)
- [ ] No `/tmp/` string literals remain in the file
- [ ] CI platform-guard codemod check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)