### PR TITLE
fix(mcp): migrate tsconfig.web.json to moduleResolution: bundler for TypeScript 6

### DIFF
--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -6,17 +6,16 @@
     "maxNodeModuleJsDepth": 1,
     
     // Better IDE support for web files
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["web/assets/*"]
+      "@/*": ["./web/assets/*"]
     },
-    
+
     // DOM types for web files
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    
+
     // Module resolution
     "module": "ES2022",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "target": "ES2022",
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- Fixes the one breaking change in this codebase for TypeScript 6: `moduleResolution: "node"` in `tsconfig.web.json` is a hard TS5107 error in TypeScript 6
- Changes `moduleResolution` from `"node"` to `"bundler"` (matching the pattern already used in `console/tsconfig.json`)
- Removes `baseUrl: "."` and updates the `@/*` paths alias to use an explicit `./` prefix (semantically identical change)
- Unblocks Dependabot PRs #244 (root `package.json`) and #231 (`console/package.json`) which bump `typescript` from `^5.9.3` to `^6.0.2`

## Why this approach

`moduleResolution: "bundler"` is the correct setting for an IDE-support-only config (`noEmit: true`) serving browser assets. It directly mirrors `console/tsconfig.json`. The alternative (`ignoreDeprecations: "6.0"`) would silence the error while leaving deprecated options in place.

## What this PR does NOT include

- No TypeScript version bump (that is Dependabot PRs #244 and #231)
- No `ts-morph` v28 bump (separate PR, after ~1 week of community testing -- v28 was released 2026-04-12)
- No changes to `src/`, `console/src/`, `web/`, or any other files

## Test plan

- [x] `npm run build` passes with 0 errors (verified locally)
- [x] The `@/*` paths alias resolves to the same `./web/assets/` directory as before
- [ ] After merging Dependabot PRs #244 and #231: `npm run web:typecheck` should pass with 0 TS5107 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)