### PR TITLE
fix(mcp): add configurable session timeout and max-turn limit to daemon runs

### DIFF
--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -47,11 +47,17 @@ const execAsync = promisify(exec);
 const BASH_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
- * Maximum wall-clock time allowed for a single workflow run (30 minutes).
+ * Default wall-clock time limit (in minutes) for a single workflow run.
+ *
+ * WHY: a stuck tool call, infinite retry loop, or runaway LLM can hold a
+ * queue slot indefinitely. This cap is the safety valve.
+ *
+ * This default is used when no agentConfig.maxSessionMinutes is configured.
+ * Per-trigger overrides are set via triggers.yml agentConfig.maxSessionMinutes.
  * If the agent loop does not complete within this window, runWorkflow() aborts
- * the agent and returns { _tag: 'error', message: 'Workflow timed out' }.
+ * the agent and returns { _tag: 'timeout', reason: 'wall_clock' }.
  */
-const WORKFLOW_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_SESSION_TIMEOUT_MINUTES = 30;
 
 /**
  * Directory that holds per-session crash-recovery state files.
@@ -162,6 +168,18 @@ export interface WorkflowTrigger {
    */
   readonly agentConfig?: {
     readonly model?: string;
+    /**
+     * Maximum wall-clock time (in minutes) for this workflow run.
+     * See TriggerDefinition.agentConfig.maxSessionMinutes for full documentation.
+     * Default: 30 minutes.
+     */
+    readonly maxSessionMinutes?: number;
+    /**
+     * Maximum number of LLM response turns for this workflow run.
+     * See TriggerDefinition.agentConfig.maxTurns for full documentation.
+     * Default: no limit.
+     */
+    readonly maxTurns?: number;
   };
 }
 
@@ -180,8 +198,31 @@ export interface WorkflowRunError {
   readonly stopReason: string;
 }
 
+/**
+ * Workflow run aborted due to a configurable time or turn limit.
+ *
+ * WHY a separate discriminant: timeout is categorically different from a
+ * workflow-logic error. Callers (delivery systems, alerting) need to
+ * distinguish "this workflow ran too long / looped" from "a tool failed".
+ * Encoding this as a string inside WorkflowRunError.message would require
+ * string-parsing, violating 'make illegal states unrepresentable'.
+ */
+export interface WorkflowRunTimeout {
+  readonly _tag: 'timeout';
+  readonly workflowId: string;
+  /**
+   * Which limit was hit.
+   * - 'wall_clock': the configured maxSessionMinutes elapsed
+   * - 'max_turns': the configured maxTurns count was reached
+   */
+  readonly reason: 'wall_clock' | 'max_turns';
+  readonly message: string;
+  /** Always 'aborted' -- the agent loop was stopped via agent.abort(). */
+  readonly stopReason: string;
+}
+
 /** Result of a runWorkflow() call. Never throws. */
-export type WorkflowRunResult = WorkflowRunSuccess | WorkflowRunError;
+export type WorkflowRunResult = WorkflowRunSuccess | WorkflowRunError | WorkflowRunTimeout;
 
 /**
  * A session file found in DAEMON_SESSIONS_DIR during startup recovery.
@@ -1020,12 +1061,41 @@ export async function runWorkflow(
     toolExecution: 'sequential',
   });
 
-  // ---- Event subscription: steer() for step injection ----
+  // ---- Session limits (wall-clock timeout + max-turn limit) ----
+  // Resolved from trigger.agentConfig with hardcoded defaults as fallback.
+  // WHY: per-trigger configurability lets operators tune limits per workflow type
+  // (e.g. a fast code-review trigger vs. a slow coding-task trigger).
+  const sessionTimeoutMs =
+    (trigger.agentConfig?.maxSessionMinutes ?? DEFAULT_SESSION_TIMEOUT_MINUTES) * 60 * 1000;
+  const maxTurns = trigger.agentConfig?.maxTurns ?? 0; // 0 = no limit
+
+  // ---- Timeout reason flag ----
+  // Tracks which limit fired first. Set synchronously before agent.abort() so the
+  // catch block can read it on the next microtask tick. JS single-thread guarantees
+  // no race condition. Guard: first writer wins -- ignore if already set.
+  let timeoutReason: 'wall_clock' | 'max_turns' | null = null;
+
+  // ---- Turn counter ----
+  // Incremented on each turn_end event (one complete LLM response turn).
+  let turnCount = 0;
+
+  // ---- Event subscription: steer() for step injection + turn-limit enforcement ----
   // Using steer() NOT followUp(): steer fires after each tool batch inside the
   // inner loop; followUp fires only when the agent would otherwise stop
   // (adding an extra LLM turn per workflow step).
   const unsubscribe = agent.subscribe(async (event: AgentEvent) => {
     if (event.type !== 'turn_end') return;
+
+    // Track turns for the max-turn limit.
+    turnCount++;
+
+    // Max-turn limit: abort if the turn count reaches the configured limit.
+    // Guard: skip if wall-clock timeout already fired.
+    if (maxTurns > 0 && turnCount >= maxTurns && timeoutReason === null) {
+      timeoutReason = 'max_turns';
+      agent.abort();
+      return; // Do not inject the next step -- we are aborting.
+    }
 
     // If a step was advanced and workflow is not yet complete, inject the next step.
     if (pendingSteerText !== null && !isComplete) {
@@ -1042,11 +1112,16 @@ export async function runWorkflow(
 
   try {
     // ---- Whole-workflow timeout ----
-    // If the agent loop does not complete within WORKFLOW_TIMEOUT_MS, abort the
-    // agent and propagate a timeout error through the existing error-handling path.
+    // If the agent loop does not complete within sessionTimeoutMs, abort the agent
+    // and propagate a timeout through the existing error-handling path.
     // agent.abort() is idempotent (optional-chained on activeRun in pi-agent-core).
     const timeoutPromise = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error('Workflow timed out')), WORKFLOW_TIMEOUT_MS),
+      setTimeout(() => {
+        if (timeoutReason === null) {
+          timeoutReason = 'wall_clock';
+        }
+        reject(new Error('Workflow timed out'));
+      }, sessionTimeoutMs),
     );
     await Promise.race([agent.prompt(buildUserMessage(initialPrompt)), timeoutPromise])
       .catch((err: unknown) => {
@@ -1073,6 +1148,23 @@ export async function runWorkflow(
     stopReason = 'error';
   } finally {
     unsubscribe();
+  }
+
+  // ---- Timeout result (wall-clock or max-turn limit) ----
+  // timeoutReason is set before agent.abort() in both abort paths; by the time we
+  // reach here the catch has completed and it is safe to read synchronously.
+  if (timeoutReason !== null) {
+    daemonRegistry?.unregister(sessionId, 'failed');
+    const limitDescription = timeoutReason === 'wall_clock'
+      ? `${trigger.agentConfig?.maxSessionMinutes ?? DEFAULT_SESSION_TIMEOUT_MINUTES} minutes`
+      : `${trigger.agentConfig?.maxTurns} turns`;
+    return {
+      _tag: 'timeout',
+      workflowId: trigger.workflowId,
+      reason: timeoutReason,
+      message: `Workflow ${timeoutReason === 'wall_clock' ? 'timed out' : 'exceeded turn limit'} after ${limitDescription}`,
+      stopReason: 'aborted',
+    };
   }
 
   if (stopReason === 'error' || errorMessage) {

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -1109,20 +1109,26 @@ export async function runWorkflow(
 
   let stopReason = 'stop';
   let errorMessage: string | undefined;
+  // WHY hoisted: timeoutHandle must be accessible in the finally block to cancel the
+  // timer on successful completion. Promise constructor callbacks are synchronous
+  // (ES6 spec), so timeoutHandle is always assigned before the await resolves.
+  // The undefined initial value is required by TypeScript types; the undefined guard
+  // in finally is defensive (technically unreachable in a spec-compliant JS engine).
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
   try {
     // ---- Whole-workflow timeout ----
     // If the agent loop does not complete within sessionTimeoutMs, abort the agent
     // and propagate a timeout through the existing error-handling path.
     // agent.abort() is idempotent (optional-chained on activeRun in pi-agent-core).
-    const timeoutPromise = new Promise<never>((_, reject) =>
-      setTimeout(() => {
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => {
         if (timeoutReason === null) {
           timeoutReason = 'wall_clock';
         }
         reject(new Error('Workflow timed out'));
-      }, sessionTimeoutMs),
-    );
+      }, sessionTimeoutMs);
+    });
     await Promise.race([agent.prompt(buildUserMessage(initialPrompt)), timeoutPromise])
       .catch((err: unknown) => {
         agent.abort();
@@ -1148,6 +1154,10 @@ export async function runWorkflow(
     stopReason = 'error';
   } finally {
     unsubscribe();
+    // Cancel the wall-clock timer so it does not fire after successful completion
+    // and mutate the closed-over timeoutReason variable. clearTimeout on an
+    // already-fired or undefined handle is a safe no-op.
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
   }
 
   // ---- Timeout result (wall-clock or max-turn limit) ----

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -317,6 +317,11 @@ export class TriggerRouter {
           `[TriggerRouter] Workflow completed: triggerId=${trigger.id} ` +
           `workflowId=${trigger.workflowId} stopReason=${result.stopReason}`,
         );
+      } else if (result._tag === 'timeout') {
+        console.log(
+          `[TriggerRouter] Workflow timed out: triggerId=${trigger.id} ` +
+          `workflowId=${trigger.workflowId} reason=${result.reason} message=${result.message}`,
+        );
       } else {
         console.log(
           `[TriggerRouter] Workflow failed: triggerId=${trigger.id} ` +
@@ -347,6 +352,11 @@ export class TriggerRouter {
         console.log(
           `[TriggerRouter] Dispatch completed: workflowId=${workflowTrigger.workflowId} ` +
           `stopReason=${result.stopReason}`,
+        );
+      } else if (result._tag === 'timeout') {
+        console.log(
+          `[TriggerRouter] Dispatch timed out: workflowId=${workflowTrigger.workflowId} ` +
+          `reason=${result.reason} message=${result.message}`,
         );
       } else {
         console.log(

--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -502,28 +502,34 @@ function validateAndResolveTrigger(
 
     let maxSessionMinutes: number | undefined;
     if (raw.agentConfig.maxSessionMinutes !== undefined) {
-      const parsed = parseInt(raw.agentConfig.maxSessionMinutes, 10);
-      if (isNaN(parsed) || parsed <= 0) {
+      // WHY Number.isInteger instead of parseInt: parseInt('1.5', 10) silently returns 1,
+      // so an operator writing maxSessionMinutes: 1.5 would get 1 minute with no warning.
+      // Number.isInteger(Number(raw)) catches both non-numeric strings (NaN -> false) and
+      // decimal values (1.5 -> false) in one check. Scientific notation integers like 1e2
+      // pass correctly (Number('1e2') === 100, which is a valid integer).
+      const asNumber = Number(raw.agentConfig.maxSessionMinutes);
+      if (!Number.isInteger(asNumber) || asNumber <= 0) {
         return err({
           kind: 'missing_field',
           field: 'agentConfig.maxSessionMinutes (must be a positive integer)',
           triggerId: rawId,
         });
       }
-      maxSessionMinutes = parsed;
+      maxSessionMinutes = asNumber;
     }
 
     let maxTurns: number | undefined;
     if (raw.agentConfig.maxTurns !== undefined) {
-      const parsed = parseInt(raw.agentConfig.maxTurns, 10);
-      if (isNaN(parsed) || parsed <= 0) {
+      // WHY Number.isInteger: same rationale as maxSessionMinutes above.
+      const asNumber = Number(raw.agentConfig.maxTurns);
+      if (!Number.isInteger(asNumber) || asNumber <= 0) {
         return err({
           kind: 'missing_field',
           field: 'agentConfig.maxTurns (must be a positive integer)',
           triggerId: rawId,
         });
       }
-      maxTurns = parsed;
+      maxTurns = asNumber;
     }
 
     if (model !== undefined || maxSessionMinutes !== undefined || maxTurns !== undefined) {

--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -91,7 +91,10 @@ interface ParsedTriggerRaw {
   goalTemplate?: string;
   referenceUrls?: string;   // space-separated scalar in YAML; split at assemble time
   concurrencyMode?: string; // validated as 'serial' | 'parallel' at assemble time
-  agentConfig?: { model?: string };
+  // Note: maxSessionMinutes and maxTurns are stored as raw strings here because
+  // the YAML parser returns all scalars as strings. Numeric conversion and
+  // validation happen in validateAndResolveTrigger at the boundary.
+  agentConfig?: { model?: string; maxSessionMinutes?: string; maxTurns?: string };
   onComplete?: { runOn?: string; workflowId?: string; goal?: string };
 }
 
@@ -275,7 +278,7 @@ function parseTriggersYaml(
         // agentConfig is a sub-object block with scalar string values.
         // Baseline indent: lineIndent (indent of the "agentConfig:" key line).
         lineIndex++;
-        const agentConfig: { model?: string } = {};
+        const agentConfig: { model?: string; maxSessionMinutes?: string; maxTurns?: string } = {};
         while (lineIndex < lines.length) {
           const acLine = lines[lineIndex];
           if (acLine === undefined) break;
@@ -301,6 +304,8 @@ function parseTriggersYaml(
             const acValueResult = parseScalar(acRawValue, lineIndex + 1);
             if (acValueResult.kind === 'err') return acValueResult;
             if (acKey === 'model') agentConfig.model = acValueResult.value;
+            else if (acKey === 'maxSessionMinutes') agentConfig.maxSessionMinutes = acValueResult.value;
+            else if (acKey === 'maxTurns') agentConfig.maxTurns = acValueResult.value;
           }
           lineIndex++;
         }
@@ -488,10 +493,47 @@ function validateAndResolveTrigger(
     }
   }
 
-  // agentConfig: only include if at least one sub-field is present
-  const agentConfig = raw.agentConfig?.model?.trim()
-    ? { model: raw.agentConfig.model.trim() }
-    : undefined;
+  // agentConfig: only include if at least one sub-field is present.
+  // maxSessionMinutes and maxTurns are stored as strings by the YAML parser
+  // (all scalars are strings). Convert to integers here at the validation boundary.
+  let agentConfig: TriggerDefinition['agentConfig'] | undefined;
+  if (raw.agentConfig) {
+    const model = raw.agentConfig.model?.trim() || undefined;
+
+    let maxSessionMinutes: number | undefined;
+    if (raw.agentConfig.maxSessionMinutes !== undefined) {
+      const parsed = parseInt(raw.agentConfig.maxSessionMinutes, 10);
+      if (isNaN(parsed) || parsed <= 0) {
+        return err({
+          kind: 'missing_field',
+          field: 'agentConfig.maxSessionMinutes (must be a positive integer)',
+          triggerId: rawId,
+        });
+      }
+      maxSessionMinutes = parsed;
+    }
+
+    let maxTurns: number | undefined;
+    if (raw.agentConfig.maxTurns !== undefined) {
+      const parsed = parseInt(raw.agentConfig.maxTurns, 10);
+      if (isNaN(parsed) || parsed <= 0) {
+        return err({
+          kind: 'missing_field',
+          field: 'agentConfig.maxTurns (must be a positive integer)',
+          triggerId: rawId,
+        });
+      }
+      maxTurns = parsed;
+    }
+
+    if (model !== undefined || maxSessionMinutes !== undefined || maxTurns !== undefined) {
+      agentConfig = {
+        ...(model !== undefined ? { model } : {}),
+        ...(maxSessionMinutes !== undefined ? { maxSessionMinutes } : {}),
+        ...(maxTurns !== undefined ? { maxTurns } : {}),
+      };
+    }
+  }
 
   // concurrencyMode: validate and default to 'serial' at parse time (not at use time).
   // Why: the default must be explicit in the TriggerDefinition so the router never

--- a/src/trigger/types.ts
+++ b/src/trigger/types.ts
@@ -114,6 +114,36 @@ export interface TriggerDefinition {
      * When absent, env-based model detection applies.
      */
     readonly model?: string;
+    /**
+     * Maximum wall-clock time (in minutes) for a single workflow run.
+     * If the agent loop does not complete within this window, the run is
+     * aborted and returns { _tag: 'timeout', reason: 'wall_clock' }.
+     *
+     * WHY: a stuck tool call, infinite retry loop, or runaway LLM can hold a
+     * queue slot indefinitely. This cap is the safety valve.
+     *
+     * Default: 30 minutes (when absent or undefined).
+     * Must be a positive integer (>= 1). Value of 0 is invalid -- omit the field
+     * to use the default.
+     */
+    readonly maxSessionMinutes?: number;
+    /**
+     * Maximum number of LLM response turns allowed for a single workflow run.
+     * If the agent exceeds this count, the run is aborted and returns
+     * { _tag: 'timeout', reason: 'max_turns' }.
+     *
+     * WHY: an LLM that loops (repeatedly calling tools without advancing the
+     * workflow) would otherwise run until the wall-clock timeout. A turn limit
+     * catches this class of runaway loop more aggressively.
+     *
+     * A "turn" is one complete LLM response (which may include multiple tool
+     * calls). Counted via pi-agent-core's turn_end event.
+     *
+     * Default: no limit (when absent or undefined).
+     * Must be a positive integer (>= 1). Value of 0 is invalid -- omit the field
+     * for no turn limit.
+     */
+    readonly maxTurns?: number;
   };
 
   /**

--- a/src/v2/usecases/console-routes.ts
+++ b/src/v2/usecases/console-routes.ts
@@ -563,6 +563,8 @@ export function mountConsoleRoutes(
       ).then((result) => {
         if (result._tag === 'success') {
           console.log(`[ConsoleRoutes] Auto dispatch completed: workflowId=${workflowId} stopReason=${result.stopReason}`);
+        } else if (result._tag === 'timeout') {
+          console.log(`[ConsoleRoutes] Auto dispatch timed out: workflowId=${workflowId} reason=${result.reason} message=${result.message}`);
         } else {
           console.log(`[ConsoleRoutes] Auto dispatch failed: workflowId=${workflowId} error=${result.message}`);
         }

--- a/tests/unit/trigger-store-gap8.test.ts
+++ b/tests/unit/trigger-store-gap8.test.ts
@@ -101,6 +101,17 @@ triggers:
       maxSessionMinutes: -5
 `;
 
+const WITH_NEGATIVE_MAX_TURNS = `
+triggers:
+  - id: test-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    goal: Run workflow
+    agentConfig:
+      maxTurns: -1
+`;
+
 const WITH_ZERO_MAX_SESSION_MINUTES = `
 triggers:
   - id: test-trigger
@@ -178,6 +189,13 @@ describe('trigger-store.ts -- GAP-8 agentConfig limits', () => {
 
     it('rejects trigger when maxTurns is non-numeric', () => {
       const result = loadTriggerConfig(WITH_INVALID_MAX_TURNS_ALPHA);
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') return;
+      expect(result.value.triggers).toHaveLength(0);
+    });
+
+    it('rejects trigger when maxTurns is negative', () => {
+      const result = loadTriggerConfig(WITH_NEGATIVE_MAX_TURNS);
       expect(result.kind).toBe('ok');
       if (result.kind !== 'ok') return;
       expect(result.value.triggers).toHaveLength(0);

--- a/tests/unit/trigger-store-gap8.test.ts
+++ b/tests/unit/trigger-store-gap8.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for GAP-8: maxSessionMinutes and maxTurns parsing in trigger-store.ts.
+ *
+ * Strategy: pass real YAML strings to loadTriggerConfig() (pure function, no I/O).
+ * Follows the pattern established in tests/unit/trigger-store.test.ts.
+ *
+ * Coverage:
+ * - maxSessionMinutes parses to a number
+ * - maxTurns parses to a number
+ * - both together
+ * - invalid (non-numeric) maxSessionMinutes rejects trigger
+ * - invalid (non-numeric) maxTurns rejects trigger
+ * - negative maxSessionMinutes rejects trigger
+ * - zero maxSessionMinutes rejects trigger (must be positive)
+ * - zero maxTurns rejects trigger (must be positive)
+ * - missing maxSessionMinutes and maxTurns -- trigger is still valid
+ * - values propagate to TriggerDefinition.agentConfig
+ */
+
+import { describe, expect, it } from 'vitest';
+import { loadTriggerConfig } from '../../src/trigger/trigger-store.js';
+
+// ---------------------------------------------------------------------------
+// YAML fixtures
+// ---------------------------------------------------------------------------
+
+const BASE = `
+triggers:
+  - id: test-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    goal: Run workflow
+`;
+
+const WITH_MAX_SESSION_MINUTES = `
+triggers:
+  - id: test-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    goal: Run workflow
+    agentConfig:
+      maxSessionMinutes: 45
+`;
+
+const WITH_MAX_TURNS = `
+triggers:
+  - id: test-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    goal: Run workflow
+    agentConfig:
+      maxTurns: 20
+`;
+
+const WITH_BOTH = `
+triggers:
+  - id: test-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    goal: Run workflow
+    agentConfig:
+      model: amazon-bedrock/claude-sonnet-4-6
+      maxSessionMinutes: 60
+      maxTurns: 50
+`;
+
+const WITH_INVALID_MAX_SESSION_MINUTES_ALPHA = `
+triggers:
+  - id: test-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    goal: Run workflow
+    agentConfig:
+      maxSessionMinutes: abc
+`;
+
+const WITH_INVALID_MAX_TURNS_ALPHA = `
+triggers:
+  - id: test-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    goal: Run workflow
+    agentConfig:
+      maxTurns: not-a-number
+`;
+
+const WITH_NEGATIVE_MAX_SESSION_MINUTES = `
+triggers:
+  - id: test-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    goal: Run workflow
+    agentConfig:
+      maxSessionMinutes: -5
+`;
+
+const WITH_ZERO_MAX_SESSION_MINUTES = `
+triggers:
+  - id: test-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    goal: Run workflow
+    agentConfig:
+      maxSessionMinutes: 0
+`;
+
+const WITH_ZERO_MAX_TURNS = `
+triggers:
+  - id: test-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    goal: Run workflow
+    agentConfig:
+      maxTurns: 0
+`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('trigger-store.ts -- GAP-8 agentConfig limits', () => {
+  describe('maxSessionMinutes', () => {
+    it('parses maxSessionMinutes as a number', () => {
+      const result = loadTriggerConfig(WITH_MAX_SESSION_MINUTES);
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') return;
+
+      const trigger = result.value.triggers[0];
+      expect(trigger).toBeDefined();
+      expect(trigger!.agentConfig?.maxSessionMinutes).toBe(45);
+      expect(typeof trigger!.agentConfig?.maxSessionMinutes).toBe('number');
+    });
+
+    it('rejects trigger when maxSessionMinutes is non-numeric', () => {
+      const result = loadTriggerConfig(WITH_INVALID_MAX_SESSION_MINUTES_ALPHA);
+      // loadTriggerConfig logs a warning and skips invalid triggers; the result is ok
+      // but with 0 valid triggers (invalid trigger is skipped).
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') return;
+      expect(result.value.triggers).toHaveLength(0);
+    });
+
+    it('rejects trigger when maxSessionMinutes is negative', () => {
+      const result = loadTriggerConfig(WITH_NEGATIVE_MAX_SESSION_MINUTES);
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') return;
+      expect(result.value.triggers).toHaveLength(0);
+    });
+
+    it('rejects trigger when maxSessionMinutes is zero', () => {
+      const result = loadTriggerConfig(WITH_ZERO_MAX_SESSION_MINUTES);
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') return;
+      expect(result.value.triggers).toHaveLength(0);
+    });
+  });
+
+  describe('maxTurns', () => {
+    it('parses maxTurns as a number', () => {
+      const result = loadTriggerConfig(WITH_MAX_TURNS);
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') return;
+
+      const trigger = result.value.triggers[0];
+      expect(trigger).toBeDefined();
+      expect(trigger!.agentConfig?.maxTurns).toBe(20);
+      expect(typeof trigger!.agentConfig?.maxTurns).toBe('number');
+    });
+
+    it('rejects trigger when maxTurns is non-numeric', () => {
+      const result = loadTriggerConfig(WITH_INVALID_MAX_TURNS_ALPHA);
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') return;
+      expect(result.value.triggers).toHaveLength(0);
+    });
+
+    it('rejects trigger when maxTurns is zero', () => {
+      const result = loadTriggerConfig(WITH_ZERO_MAX_TURNS);
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') return;
+      expect(result.value.triggers).toHaveLength(0);
+    });
+  });
+
+  describe('combined', () => {
+    it('parses model, maxSessionMinutes, and maxTurns together', () => {
+      const result = loadTriggerConfig(WITH_BOTH);
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') return;
+
+      const trigger = result.value.triggers[0];
+      expect(trigger).toBeDefined();
+      expect(trigger!.agentConfig?.model).toBe('amazon-bedrock/claude-sonnet-4-6');
+      expect(trigger!.agentConfig?.maxSessionMinutes).toBe(60);
+      expect(trigger!.agentConfig?.maxTurns).toBe(50);
+    });
+
+    it('trigger without agentConfig limits is still valid', () => {
+      const result = loadTriggerConfig(BASE);
+      expect(result.kind).toBe('ok');
+      if (result.kind !== 'ok') return;
+
+      const trigger = result.value.triggers[0];
+      expect(trigger).toBeDefined();
+      expect(trigger!.agentConfig).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the hardcoded 30-minute wall-clock timeout in `runWorkflow()` with a per-trigger configurable `maxSessionMinutes` field in `triggers.yml` (default: 30)
- Adds an optional `maxTurns` limit that aborts the agent loop when the LLM exceeds a configured number of response turns -- catches infinite retry loops that the wall-clock timeout would miss
- Adds a `WorkflowRunTimeout` discriminant (`_tag: 'timeout'`) to `WorkflowRunResult` so callers can distinguish timeout from tool errors at the type level
- Validates numeric fields at parse time in `trigger-store.ts` (NaN + range check) so a misconfigured `triggers.yml` is rejected at load time, not at runtime

## Test plan

- [ ] `npx tsc --noEmit` -- compiles clean (verified)
- [ ] `npx vitest run tests/unit/trigger-store-gap8.test.ts` -- 9 new tests pass (verified)
- [ ] `npx vitest run tests/unit/ --exclude tests/unit/cli-*` -- 3066/3069 pass, 3 pre-existing skips (verified)
- [ ] Manual: configure `maxSessionMinutes: 1` in a triggers.yml and verify the daemon returns `_tag: 'timeout'` after 1 minute

## Files changed

- `src/trigger/types.ts` -- new `maxSessionMinutes?` and `maxTurns?` fields on `TriggerDefinition.agentConfig`
- `src/daemon/workflow-runner.ts` -- same fields on `WorkflowTrigger.agentConfig`; `WorkflowRunTimeout` type; runtime enforcement
- `src/trigger/trigger-store.ts` -- YAML parser extension + integer validation
- `src/trigger/trigger-router.ts` -- handle `_tag: 'timeout'` in route() and dispatch() log paths
- `tests/unit/trigger-store-gap8.test.ts` -- new unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)