### PR TITLE
fix(mcp): forward-compat tsconfig fixes for TypeScript 6 (unblocks #244, #231)

### DIFF
--- a/console/tsconfig.json
+++ b/console/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
## Summary

- Add `scripts/tsconfig.json` with `types: ["node"]` so ts-node resolves Node globals (`fs`, `path`, `process`) when compiling `scripts/generate-lock-coverage.ts` and `scripts/codemods/run.ts`. Under TS6's stricter defaults, these globals are no longer available without an explicit `types` declaration.
- Bump `console/tsconfig.json` lib from `ES2020` to `ES2022` so `Array.prototype.at()` and other ES2022 built-ins type-check correctly. The `target` stays `ES2020`; only the lib (type declarations) is updated, which is correct for a bundler-managed project (`noEmit: true`).

Both changes are forwards-compatible with the current TS 5.9.3 and will unblock CI once the TS6 dep bump PRs (#244 root, #231 console) merge.

PR #391 (already merged) fixed `tsconfig.web.json` moduleResolution. This PR addresses the two remaining failures.

## Context

The `scripts/tsconfig.json` approach follows the exact pattern established by `tsconfig.test.json` (extends root, adds scoped types). ts-node resolves tsconfig by walking up from the script file's directory, so this config covers the entire `scripts/` subtree without polluting the root `src/` compilation context.

## Test plan

- [x] `npm run typecheck` passes (no regressions in src/)
- [x] `npm run build` passes (root tsc + console vite build)
- [x] `npx ts-node scripts/generate-lock-coverage.ts --check` runs without type errors
- [x] `npx ts-node scripts/codemods/run.ts --mod report` runs without type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)