### PR TITLE
feat(mcp): replace private pi-mono deps with first-party agent loop

### DIFF
--- a/design-candidates.md
+++ b/design-candidates.md
@@ -1,4 +1,4 @@
-# Design Candidates: Merge PRs #397, #403, #392
+# Design Candidates: PR #417 Fixes (maxConcurrentSessions semaphore)
 
 **Date:** 2026-04-15
 **Status:** Ready for main-agent review
@@ -9,89 +9,77 @@
 
 ### Core Tensions
 
-1. **Order dependency**: Merging #397 changes main, which affects whether #403 and #392 remain cleanly mergeable. Must merge sequentially and re-verify mergeability before each step.
+1. **Silent falsy coercion vs. explicit validation**: `parseInt('0') || undefined` looks
+   idiomatic but treats `0` (a valid user intent) the same as `NaN` or absent.
 
-2. **Conflict resolution in workflow-runner.ts**: PR #397 is CONFLICTING because main advanced (concurrencyMode support, hono bump) after the branch was cut. The conflict must keep both sides -- dropping either the GAP-8 timeout logic or main's concurrencyMode changes would be wrong.
+2. **TypeScript type safety vs. runtime NaN**: TypeScript types `NaN` as `number`, so the
+   type system cannot prevent `NaN` from reaching `new Semaphore(NaN)`. The runtime guard
+   in the constructor is the only defense against a silent deadlock.
 
-3. **Stale mergeability**: GitHub reports #403 and #392 as MERGEABLE against current main. After #397 lands, this assessment is stale -- both also touch `workflow-runner.ts`, so conflicts could emerge.
-
-### What Makes This Hard
-
-- `workflow-runner.ts` is a 1097-line central orchestration file. A wrong conflict resolution could silently break daemon behavior.
-- `git rebase -Xours` or `-Xtheirs` would silently drop one side's changes -- must resolve manually or verify auto-resolution keeps both.
-- After each merge, must re-verify the next PR is still cleanly mergeable before proceeding.
+3. **Boundary responsibility**: Config values should be validated where they cross from
+   string to typed number (listener), but the constructor should also enforce its own
+   invariant (class boundary). Both are correct; neither replaces the other.
 
 ### Likely Seam
 
-The rebase conflict in `src/daemon/workflow-runner.ts` for #397 is the only real technical challenge. Everything else is sequential execution.
+- **F1**: `trigger-listener.ts`, the expression `parseInt(maxConcurrencyRaw, 10) || undefined`
+- **F2**: `trigger-router.ts` constructor, after the `??` fallback, before the `< 1` clamp
+- **F5**: `trigger-router.ts` constructor, after `this.semaphore = new Semaphore(...)`
+
+### What Makes This Hard
+
+- `|| undefined` idiom looks correct at a glance; falsy case for `0` is easy to miss.
+- `??` guards against `null | undefined` but not `NaN`.
+- A deadlock in `Semaphore(NaN)` is silent: `acquire()` enqueues a waiter that never resolves.
 
 ---
 
 ## Philosophy Constraints
 
-- **Double-check before destructive actions**: Verify `--json mergeable` before and after each merge.
-- **Surface information, don't hide it**: Report what merged and what (if anything) was skipped.
-- **Errors are data**: If a merge fails or a rebase has unresolvable conflicts, stop and report rather than proceeding blindly.
-- **NEVER push directly to main**: Merging via `gh pr merge --squash` is the correct path. Force-with-lease push is only to the PR branch.
+- **Make illegal states unrepresentable**: NaN as a semaphore cap is an illegal state.
+- **Validate at boundaries, trust inside**: Listener = config-string boundary; constructor = class invariant boundary.
+- **Determinism over cleverness**: Replace `||` with `!isNaN()`.
+- **Document 'why', not 'what'**: The NaN guard needs a `// WHY:` comment.
+- **Errors are data**: Invalid config -> `console.warn` + safe fallback (not throw).
+
+No philosophy conflicts.
 
 ---
 
 ## Impact Surface
 
-- `src/daemon/workflow-runner.ts` -- touched by all three PRs
-- `src/trigger/trigger-router.ts`, `trigger-store.ts`, `trigger/types.ts` -- #397 only
-- `src/v2/usecases/console-routes.ts` -- #397 only
-- `src/cli-worktrain.ts`, `cli.ts`, `cli/commands/`, `config/config-file.ts`, `daemon/soul-template.ts` -- #403 only
+- `src/trigger/trigger-listener.ts`: one expression change
+- `src/trigger/trigger-router.ts`: two-line guard insertion + one `console.log`
+- No test changes required
 
 ---
 
 ## Candidates
 
-### Candidate 1 (only viable approach): Rebase + squash merge in order
+All candidates converge. Noted honestly.
 
-**Summary:** Checkout `fix/gap-8-session-timeout`, rebase onto `origin/main`, resolve conflicts by keeping both sides, push with `--force-with-lease`, then squash-merge all three PRs in order (#397, #403, #392), pulling main and re-verifying mergeability between each.
+### Candidate 1 (Selected): Surgical three-expression fixes
 
-**Tensions resolved:**
-- Order dependency: sequential execution with re-verification
-- Conflict resolution: manual inspection ensures both sides kept
-- Stale mergeability: re-check after each merge before proceeding
+Fix `|| undefined` to `!isNaN()` in listener, add NaN guard before `< 1` clamp in constructor
+with `// WHY:` comment, add startup log line.
 
-**Tensions accepted:** Minor risk that #403/#392 develop new conflicts after #397 lands; handled by re-checking mergeability.
+- **Tensions resolved**: All three.
+- **Failure mode**: Variable name divergence during editing (`requested` vs `cap`).
+- **Repo pattern**: Follows exactly. Same `console.warn` + clamp style.
+- **Scope**: Best-fit.
 
-**Boundary solved at:** The rebase conflict in `workflow-runner.ts` -- the only real seam.
+### Candidate 2 (Rejected): Parse and validate in constructor only
 
-**Why that boundary is the best fit:** There is no alternative seam for this task.
-
-**Failure mode:** Conflict resolution drops one side's changes. Mitigation: grep for `sessionTimeoutMs` and `concurrencyMode` after rebase.
-
-**Repo-pattern relationship:** Follows exactly. All merges in this repo are squash merges (evidenced by PR number parentheticals throughout git log).
-
-**Gains:** Clean linear history, atomic per-PR changes, minimal risk.
-
-**Losses:** Nothing -- no alternatives exist.
-
-**Scope judgment:** Best-fit.
-
-**Philosophy fit:** Honors all relevant principles. No conflicts.
+Accept `string | number | undefined` in constructor. Rejected: wrong boundary, architectural
+regression violating 'validate at boundaries'.
 
 ---
 
-## Comparison and Recommendation
+## Recommendation
 
-Only one candidate. Proceeding with rebase + squash merge in order.
+Candidate 1. Surgical, correct, consistent with repo patterns and philosophy.
 
----
+**Self-critique**: F2 NaN guard is redundant given F1 fix. Counter: defense-in-depth when
+failure is a silent deadlock costs two lines. Worth it.
 
-## Self-Critique
-
-**Strongest counter-argument:** None. The approach is dictated by the task.
-
-**Assumption that would invalidate this:** If #403 or #392 develop unresolvable conflicts after #397 lands, they would also need rebasing. This is detected by re-checking `--json mergeable` before each merge.
-
-**Pivot conditions:** If #403 or #392 show CONFLICTING after #397 merges, apply the same rebase procedure.
-
----
-
-## Open Questions for the Main Agent
-
-None. The task is fully specified and the approach is unambiguous.
+**Open questions**: None.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@duckdb/node-api": "^1.5.2-r.1",
-        "@mariozechner/pi-agent-core": "0.67.2",
-        "@mariozechner/pi-ai": "0.67.2",
+        "@anthropic-ai/bedrock-sdk": "^0.28.1",
+        "@anthropic-ai/sdk": "^0.73.0",
         "@modelcontextprotocol/sdk": "^1.24.0",
         "@scure/base": "1.1.9",
         "ajv": "^8.17.1",
@@ -111,6 +110,559 @@
       "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/bedrock-sdk/-/bedrock-sdk-0.28.1.tgz",
+      "integrity": "sha512-aoDcMjeRBZK+f8nIUquJE/7pyanFKbnv99kF3k0RRpron+W745M9MhNAbTc7tjMQ9y4ETVwQqdc94/aCOGtxcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": ">=0.50.3 <1",
+        "@aws-crypto/sha256-js": "^4.0.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.797.0",
+        "@aws-sdk/credential-providers": "^3.796.0",
+        "@smithy/eventstream-serde-node": "^2.0.10",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/signature-v4": "^3.1.1",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/util-base64": "^2.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@aws-crypto/crc32/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@aws-crypto/sha256-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-4.0.0.tgz",
+      "integrity": "sha512-MHGJyjE7TX9aaqXj7zk2ppnFUOhaDs5sP+HtNS0evOxn72c+5njUmyJmpGd7TfyoDznZlHMmdo/xGUdu2NIjNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^4.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@aws-crypto/util": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-4.0.0.tgz",
+      "integrity": "sha512-2EnmPy2gsFZ6m8bwUQN4jq+IyXV3quHAcwPOS6ZA3k+geujiqI8aRokO2kFJe+idJ/P3v4qWI186rVMo0+zLDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/eventstream-codec": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+      "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/eventstream-serde-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
+      "integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/eventstream-serde-universal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.2.0.tgz",
+      "integrity": "sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/middleware-endpoint": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+      "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/middleware-endpoint/node_modules/@smithy/util-middleware": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/middleware-serde": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+      "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/middleware-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+      "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/node-config-provider": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+      "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/node-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+      "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/property-provider": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+      "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/querystring-builder": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+      "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/querystring-builder/node_modules/@smithy/util-uri-escape": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/querystring-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+      "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+      "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/signature-v4": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
+      "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/signature-v4/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/smithy-client": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+      "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/url-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+      "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-hex-encoding": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-middleware": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-middleware/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+      "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+      "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.73.0",
@@ -368,6 +920,56 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.1030.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1030.0.tgz",
+      "integrity": "sha512-PD9RIT5eJEXsP+Dq8fncTXOFAOI+EP3fRa/z1te2xehAVawixEpAJkjEE03A4msqPWGJ2S0TM2bb6zDbP66w3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-node": "^3.972.30",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/core": {
       "version": "3.973.27",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
@@ -386,6 +988,22 @@
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.13",
         "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.22.tgz",
+      "integrity": "sha512-ih6ORpme4i2qJqGckOQ9Lt2iiZ+5tm3bnfsT5TwoPyFnuDURXv3OdhYa3Nr/m0iJr38biqKYKdGKb5GR1KB2hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -561,6 +1179,37 @@
         "@aws-sdk/types": "^3.973.7",
         "@smithy/property-provider": "^4.2.13",
         "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.1030.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1030.0.tgz",
+      "integrity": "sha512-hQhRax7MzsG40mc6Es2Muvfai+jfWt1j1odqP4UQtUok6Fu4qbJNRGgQ/EAi7Sb6VAL0EdY5JGGMevHz2oO+AA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.1030.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-cognito-identity": "^3.972.22",
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-ini": "^3.972.29",
+        "@aws-sdk/credential-provider-login": "^3.972.29",
+        "@aws-sdk/credential-provider-node": "^3.972.30",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
         "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
@@ -861,6 +1510,15 @@
         }
       }
     },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/@aws-sdk/xml-builder": {
       "version": "3.972.17",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
@@ -1030,6 +1688,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1078,110 +1737,10 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
-    },
-    "node_modules/@duckdb/node-api": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.2-r.1.tgz",
-      "integrity": "sha512-OzBBnS0JGXMoS5mzKNY/Ylr7SshcRQiLFIoxQ4AlePwJ2fNeDL/fbHu/knjxUrXwW1fJBTUgwWftmxDdnZZb3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@duckdb/node-bindings": "1.5.2-r.1"
-      }
-    },
-    "node_modules/@duckdb/node-bindings": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.2-r.1.tgz",
-      "integrity": "sha512-bUg3bLVj70YVku6fKyQJS8ASORl7kM7YFVFznsEB9pWbtazPj+ME2x2FUk0WiTzjJdutjzSSGXF066mB4bGGZA==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "@duckdb/node-bindings-darwin-arm64": "1.5.2-r.1",
-        "@duckdb/node-bindings-darwin-x64": "1.5.2-r.1",
-        "@duckdb/node-bindings-linux-arm64": "1.5.2-r.1",
-        "@duckdb/node-bindings-linux-x64": "1.5.2-r.1",
-        "@duckdb/node-bindings-win32-arm64": "1.5.2-r.1",
-        "@duckdb/node-bindings-win32-x64": "1.5.2-r.1"
-      }
-    },
-    "node_modules/@duckdb/node-bindings-darwin-arm64": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.2-r.1.tgz",
-      "integrity": "sha512-v35FyKOb8EJCvaiPF7k0gvKiJTXR7PPQDNoWR0Gu+YSX5O9b+DIguzt1348Of3HebHy6ATSMzlUekaVA9YXu+g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@duckdb/node-bindings-darwin-x64": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.2-r.1.tgz",
-      "integrity": "sha512-SU9dIJ1BluKkkGxi4UsP4keqkkstB2YDySF9KcYu3EZKIVM3FTv2zc7XO38dXnHOq6+F3WqhWWZvD+XU945p7A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@duckdb/node-bindings-linux-arm64": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.2-r.1.tgz",
-      "integrity": "sha512-3Tra9xM3aM3denaER4KhJ6//6PpmPbik9ECBQ+sh9PyKaEgHw/0kAcKnLm5EzWUnXF0qYmZlewvkCrse8KmOYw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@duckdb/node-bindings-linux-x64": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.2-r.1.tgz",
-      "integrity": "sha512-pcQvZRHiIfJ9cq8parkSQczQHEml/IeGfnDCMAbEgD6+jaV9Y9Y5Ph1kP9aR+bm6him1S5ZIEr3kZbihjKnWbA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@duckdb/node-bindings-win32-arm64": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.2-r.1.tgz",
-      "integrity": "sha512-Ji8tym+N3LkrhVt0Up3bsacD/kpg4/JXFJQqxswiYvBaNCQOk+D+aiVS0GN5pcqvmnG7V7TpsDRzkLEFaWp1vw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@duckdb/node-bindings-win32-x64": {
-      "version": "1.5.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.2-r.1.tgz",
-      "integrity": "sha512-5XqcqC+4R8ghBEEbnc2a0sqfz1zyPBRb9YcmIWfiuDoCYSYFbKhmHcEyNftZDHcwCoLOHXnUin45jraex4STqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -1643,29 +2202,6 @@
         }
       }
     },
-    "node_modules/@google/genai": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
-      "integrity": "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@hono/node-server": {
       "version": "1.19.13",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
@@ -1700,55 +2236,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.4.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.67.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.67.2.tgz",
-      "integrity": "sha512-JlrWk69DMzTxF8arE8Wqj132FTqUpGmGIC1+/eIvvZ4IERAYIXLjuPznSlD+CEGKwSjmcmAsMn8UlkYeva3U+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/pi-ai": "^0.67.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-ai": {
-      "version": "0.67.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.67.2.tgz",
-      "integrity": "sha512-2RZD5GYj1WjLww/m6jN4BIJiJ9qOZLsq4jBecdcnMKOpnxUXYzEAYN8wfRR1H5+5cGOY2AfNkXU3AnPOkiL9Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.73.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.983.0",
-        "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "1.14.1",
-        "@sinclair/typebox": "^0.34.41",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "chalk": "^5.6.2",
-        "openai": "6.26.0",
-        "partial-json": "^0.1.7",
-        "proxy-agent": "^6.5.0",
-        "undici": "^7.19.1",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mistralai/mistralai": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
-      "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
-      "dependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.24.1"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -1807,6 +2294,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2014,70 +2502,6 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.53.3",
@@ -3092,12 +3516,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "license": "MIT"
-    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -3122,6 +3540,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/config-resolver": {
@@ -3825,12 +4268,6 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "license": "MIT"
-    },
     "node_modules/@ts-morph/common": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
@@ -3848,8 +4285,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -3943,6 +4379,7 @@
       "version": "20.19.25",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
       "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3967,12 +4404,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -4133,6 +4564,7 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -4181,6 +4613,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -4319,7 +4752,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4341,18 +4773,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -4361,35 +4781,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/before-after-hook": {
@@ -4407,15 +4798,6 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -4493,12 +4875,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -5141,6 +5517,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5254,20 +5631,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5283,7 +5646,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5306,8 +5668,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -5356,15 +5717,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -5708,49 +6060,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -5759,15 +6068,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -5839,6 +6139,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5894,12 +6195,6 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
     },
     "node_modules/fast-check": {
       "version": "4.6.0",
@@ -6002,6 +6297,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6132,6 +6428,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -6221,34 +6518,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -6322,29 +6591,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-uri": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/git-log-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.1.tgz",
@@ -6371,32 +6617,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -6520,6 +6740,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6597,6 +6818,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -6610,6 +6832,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -7090,15 +7313,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -7161,27 +7375,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/lines-and-columns": {
@@ -7318,12 +7511,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -7344,7 +7531,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7383,6 +7569,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7629,15 +7816,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/netmask": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
-      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/neverthrow": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-8.2.0.tgz",
@@ -7655,6 +7833,7 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7690,6 +7869,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -9646,6 +9826,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9814,27 +9995,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/p-each-series": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
@@ -9939,19 +10099,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-timeout": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
@@ -9973,38 +10120,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/parent-module": {
@@ -10090,12 +10205,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/partial-json": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "license": "MIT"
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
@@ -10322,7 +10431,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10338,7 +10446,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10349,7 +10456,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10387,30 +10493,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -10423,40 +10505,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -10577,8 +10625,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/read-package-up": {
       "version": "11.0.0",
@@ -10713,15 +10760,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.53.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
@@ -10796,6 +10834,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
@@ -10822,8 +10861,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semantic-release": {
       "version": "25.0.3",
@@ -10831,6 +10869,7 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -11508,49 +11547,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.0.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -11990,6 +11991,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12226,6 +12228,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12259,6 +12262,7 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
       "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -12268,6 +12272,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
@@ -12378,6 +12383,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12494,6 +12500,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12507,6 +12514,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -12604,6 +12612,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -12718,6 +12727,7 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -12875,6 +12885,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
     "prepare": "bash scripts/setup-hooks.sh"
   },
   "dependencies": {
-    "@mariozechner/pi-agent-core": "0.67.2",
-    "@mariozechner/pi-ai": "0.67.2",
+    "@anthropic-ai/bedrock-sdk": "^0.28.1",
+    "@anthropic-ai/sdk": "^0.73.0",
     "@modelcontextprotocol/sdk": "^1.24.0",
     "@scure/base": "1.1.9",
     "ajv": "^8.17.1",

--- a/src/daemon/agent-loop.ts
+++ b/src/daemon/agent-loop.ts
@@ -1,0 +1,543 @@
+/**
+ * Self-contained LLM agent loop for the WorkRail daemon.
+ *
+ * WHY this module exists: @mariozechner/pi-agent-core is a private npm package --
+ * anyone outside Zillow gets a module-not-found crash on npm install. This module
+ * replaces pi-agent-core's Agent class with a first-party implementation that
+ * uses only public packages (@anthropic-ai/sdk, @anthropic-ai/bedrock-sdk).
+ *
+ * Design decisions:
+ * - AgentClientInterface is a duck-typed injectable: both new Anthropic({ apiKey })
+ *   and new AnthropicBedrock() satisfy it without any adapter shim. This follows
+ *   the DI-for-boundaries principle from CLAUDE.md.
+ * - Tool schemas are plain JSON Schema objects (Record<string, unknown>). The
+ *   Anthropic SDK accepts raw JSON Schema for tool input_schema -- no TypeBox needed.
+ * - steer() is queue-based, drained after each tool batch (before the next LLM call).
+ *   This matches pi-agent-core's turn_end semantics exactly.
+ * - AbortController is used internally so abort() cancels in-flight API calls.
+ * - Unknown tool names return an error tool_result (is_error: true) and the loop
+ *   continues rather than crashing -- LLMs occasionally hallucinate tool names.
+ * - Tools throw on failure (pi-agent-core contract). AgentLoop propagates throws
+ *   to prompt()'s caller; runWorkflow() catches at the outer boundary.
+ */
+
+import type Anthropic from '@anthropic-ai/sdk';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Injectable LLM client interface.
+ *
+ * Both new Anthropic({ apiKey }) from @anthropic-ai/sdk and
+ * new AnthropicBedrock() from @anthropic-ai/bedrock-sdk satisfy this interface.
+ *
+ * WHY duck-typed: avoids importing concrete SDK types in the interface definition,
+ * keeping this module decoupled from specific SDK versions.
+ */
+export interface AgentClientInterface {
+  messages: {
+    create(
+      params: Anthropic.MessageCreateParamsNonStreaming,
+      options?: { signal?: AbortSignal },
+    ): Promise<Anthropic.Message>;
+  };
+}
+
+/**
+ * Result returned by a tool's execute() function.
+ *
+ * WHY tools return content array: matches the Anthropic messages API format
+ * for tool_result blocks, which accept an array of content blocks.
+ */
+export interface AgentToolResult<T> {
+  readonly content: ReadonlyArray<{ readonly type: 'text'; readonly text: string }>;
+  readonly details: T;
+}
+
+/**
+ * Tool definition used by AgentLoop.
+ *
+ * WHY inputSchema uses Record<string, unknown>: the Anthropic SDK's Tool.input_schema
+ * accepts raw JSON Schema as Record<string, unknown> -- no TypeBox needed.
+ *
+ * WHY execute() throws on failure: pi-agent-core contract. The outer boundary
+ * (runWorkflow) catches and returns a discriminated union error result.
+ */
+export interface AgentTool {
+  readonly name: string;
+  readonly description: string;
+  /**
+   * JSON Schema for the tool's input parameters.
+   * Must be a valid JSON Schema object (type: 'object', properties: {...}).
+   */
+  readonly inputSchema: Record<string, unknown>;
+  /** Human-readable label for logging. */
+  readonly label: string;
+  /**
+   * Execute the tool call.
+   * THROWS on failure (pi-agent-core contract) -- do not encode errors in content.
+   */
+  execute(toolCallId: string, params: Record<string, unknown>): Promise<AgentToolResult<unknown>>;
+}
+
+/**
+ * Events emitted by AgentLoop.
+ *
+ * Only the events used by workflow-runner.ts are defined here (YAGNI).
+ * Additional events can be added additively when needed.
+ *
+ * turn_end: fired after tool results are collected and appended, BEFORE the next
+ *   LLM call. Subscribers may call steer() here to inject a message before the
+ *   next turn. All subscribers are awaited before the steer queue is checked.
+ *
+ * agent_end: fired when the loop exits (end_turn with empty steer queue, or error/abort).
+ */
+export type AgentEvent =
+  | { readonly type: 'turn_end'; readonly toolResults: ReadonlyArray<AgentToolCallResult> }
+  | { readonly type: 'agent_end' };
+
+/** Internal representation of a completed tool call (for turn_end event). */
+export interface AgentToolCallResult {
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly result: AgentToolResult<unknown> | null;
+  readonly isError: boolean;
+}
+
+/** Internal message representation stored in state.messages. */
+export type AgentInternalMessage =
+  | AgentInternalUserMessage
+  | AgentInternalAssistantMessage
+  | AgentInternalToolResultMessage;
+
+export interface AgentInternalUserMessage {
+  readonly role: 'user';
+  readonly content: string;
+  readonly timestamp: number;
+}
+
+export interface AgentInternalAssistantMessage {
+  readonly role: 'assistant';
+  readonly stopReason: 'tool_use' | 'end_turn' | 'error';
+  readonly errorMessage?: string;
+  readonly content: ReadonlyArray<Anthropic.ContentBlock>;
+}
+
+export interface AgentInternalToolResultMessage {
+  readonly role: 'user';
+  readonly content: ReadonlyArray<Anthropic.ToolResultBlockParam>;
+}
+
+/** Options for constructing an AgentLoop. */
+export interface AgentLoopOptions {
+  /** System prompt sent with every LLM request. */
+  readonly systemPrompt: string;
+  /** Tools available to the LLM. */
+  readonly tools: readonly AgentTool[];
+  /** Injectable LLM client (Anthropic direct or AnthropicBedrock). */
+  readonly client: AgentClientInterface;
+  /** Model ID to use (e.g. 'claude-sonnet-4-5' or 'us.anthropic.claude-sonnet-4-6'). */
+  readonly modelId: string;
+  /**
+   * Maximum tokens in the LLM response.
+   * Default: 8192 (sufficient for Claude Sonnet models).
+   */
+  readonly maxTokens?: number;
+  /**
+   * Tool execution strategy.
+   * Only 'sequential' is needed for WorkRail (tools have ordering requirements).
+   */
+  readonly toolExecution?: 'sequential';
+}
+
+// ---------------------------------------------------------------------------
+// AgentLoop
+// ---------------------------------------------------------------------------
+
+/**
+ * Self-contained LLM agent loop.
+ *
+ * Replaces @mariozechner/pi-agent-core's Agent class with identical semantics
+ * for the surface area used by workflow-runner.ts.
+ */
+export class AgentLoop {
+  private readonly _options: AgentLoopOptions;
+  private readonly _listeners: Array<(event: AgentEvent) => Promise<void> | void> = [];
+  private readonly _steerQueue: Array<AgentInternalUserMessage> = [];
+  private _messages: AgentInternalMessage[] = [];
+  private _abortController: AbortController = new AbortController();
+  private _isRunning = false;
+  /**
+   * Tracks whether abort() was called before or during a prompt() call.
+   * WHY separate flag: prompt() resets the AbortController at startup.
+   * If abort() was called BEFORE prompt(), we need to honor it without a
+   * valid AbortController signal.
+   */
+  private _aborted = false;
+
+  constructor(options: AgentLoopOptions) {
+    this._options = options;
+  }
+
+  /**
+   * Subscribe to agent lifecycle events.
+   *
+   * Listeners are awaited in subscription order. Async listeners that call
+   * steer() will have their message consumed in the current prompt() call.
+   *
+   * Returns an unsubscribe function.
+   */
+  subscribe(listener: (event: AgentEvent) => Promise<void> | void): () => void {
+    this._listeners.push(listener);
+    return () => {
+      const idx = this._listeners.indexOf(listener);
+      if (idx !== -1) this._listeners.splice(idx, 1);
+    };
+  }
+
+  /**
+   * Queue a message for injection after the current tool batch.
+   *
+   * WHY queue-based: steer() is called from a turn_end subscriber, which fires
+   * after tool results are collected but before the next LLM call. The queue
+   * is drained synchronously after all subscribers have been awaited.
+   */
+  steer(message: { role: 'user'; content: string; timestamp: number }): void {
+    this._steerQueue.push({ role: 'user', content: message.content, timestamp: message.timestamp });
+  }
+
+  /**
+   * Abort the current in-flight LLM call.
+   *
+   * WHY AbortController: the Anthropic SDK accepts an AbortSignal in request options.
+   * Without this, abort() would only stop the loop from making another call --
+   * the current in-flight call would run to completion.
+   *
+   * A new AbortController is created after each prompt() call so the loop
+   * can be reused (though workflow-runner.ts creates a new AgentLoop per session).
+   */
+  abort(): void {
+    this._aborted = true;
+    this._abortController.abort();
+  }
+
+  /**
+   * Current agent state.
+   *
+   * state.messages is readable after prompt() resolves. workflow-runner.ts
+   * reads state.messages to extract the last assistant message's stopReason
+   * and errorMessage after the loop completes.
+   */
+  get state(): {
+    readonly messages: ReadonlyArray<AgentInternalMessage>;
+  } {
+    return { messages: this._messages };
+  }
+
+  /**
+   * Start the agent loop with the given initial user message.
+   *
+   * Resolves when the loop exits (end_turn + empty steer queue, error, or abort).
+   * Throws if a tool throws (pi-agent-core contract -- outer boundary catches).
+   *
+   * Loop algorithm:
+   * 1. Append userMsg to messages
+   * 2. Call client.messages.create() with AbortSignal
+   * 3. Append assistant response to messages
+   * 4. If tool_use: execute tools sequentially; unknown tools get error tool_result
+   * 5. Emit turn_end; await all subscribers (subscribers may call steer())
+   * 6. If steer queue non-empty: pop, append, go to step 2
+   * 7. If end_turn + empty steer queue: emit agent_end, exit
+   * 8. If error or abort: append error message, emit agent_end, exit
+   */
+  async prompt(message: { role: 'user'; content: string; timestamp: number }): Promise<void> {
+    // Reset abort controller for this prompt() call.
+    // WHY: allows the same AgentLoop instance to be used for multiple prompts
+    // (though workflow-runner.ts creates a new instance per session).
+    // NOTE: if abort() was called before prompt(), _aborted flag is set and
+    // the loop will exit immediately without making an API call.
+    if (!this._aborted) {
+      this._abortController = new AbortController();
+    }
+    this._isRunning = true;
+
+    // Append the initial user message.
+    this._messages.push({ role: 'user', content: message.content, timestamp: message.timestamp });
+
+    try {
+      await this._runLoop();
+    } finally {
+      this._isRunning = false;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: core loop
+  // ---------------------------------------------------------------------------
+
+  private async _runLoop(): Promise<void> {
+    const { client, modelId, systemPrompt, tools, maxTokens = 8192 } = this._options;
+
+    while (true) {
+      // Check abort before each LLM call.
+      // WHY check both: _aborted covers pre-prompt abort; _abortController.signal
+      // covers abort() called during an in-flight API call or between loop iterations.
+      if (this._aborted || this._abortController.signal.aborted) {
+        this._appendErrorMessage('aborted');
+        await this._emitEvent({ type: 'agent_end' });
+        return;
+      }
+
+      // Build the messages array for the API call.
+      // Filter to only LLM-compatible messages (user and assistant).
+      const apiMessages = this._buildApiMessages();
+
+      // Build tool definitions for the API call.
+      const apiTools: Anthropic.Tool[] = tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        input_schema: t.inputSchema as Anthropic.Tool.InputSchema,
+      }));
+
+      let response: Anthropic.Message;
+      try {
+        response = await client.messages.create(
+          {
+            model: modelId,
+            system: systemPrompt,
+            messages: apiMessages,
+            tools: apiTools,
+            max_tokens: maxTokens,
+          },
+          { signal: this._abortController.signal },
+        );
+      } catch (err: unknown) {
+        // Distinguish abort from genuine API error.
+        const isAbort =
+          this._abortController.signal.aborted ||
+          (err instanceof Error && err.name === 'AbortError');
+        const message = err instanceof Error ? err.message : String(err);
+        this._appendErrorMessage(isAbort ? 'aborted' : message);
+        await this._emitEvent({ type: 'agent_end' });
+        return;
+      }
+
+      // Append the assistant response to messages.
+      const stopReason = this._mapStopReason(response.stop_reason);
+      const assistantMsg: AgentInternalAssistantMessage = {
+        role: 'assistant',
+        stopReason,
+        content: response.content,
+      };
+      this._messages.push(assistantMsg);
+
+      // Handle tool use.
+      const toolUseBlocks = response.content.filter(
+        (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use',
+      );
+
+      if (stopReason === 'tool_use' || toolUseBlocks.length > 0) {
+        const toolResults = await this._executeTools(toolUseBlocks);
+
+        // Append tool results as a user message.
+        const toolResultBlocks: Anthropic.ToolResultBlockParam[] = toolResults.map((r) => ({
+          type: 'tool_result' as const,
+          tool_use_id: r.toolCallId,
+          content: r.result?.content.map((c) => ({ type: 'text' as const, text: c.text })) ?? [
+            { type: 'text', text: r.isError ? `Tool error: ${r.toolName}` : '(no output)' },
+          ],
+          is_error: r.isError,
+        }));
+        this._messages.push({ role: 'user', content: toolResultBlocks });
+
+        // Emit turn_end after tool results are appended.
+        // WHY: subscribers (e.g., workflow-runner.ts) call steer() here to inject
+        // the next workflow step BEFORE the next LLM call.
+        await this._emitEvent({ type: 'turn_end', toolResults });
+
+        // Drain steer queue: inject one message at a time before the next LLM call.
+        const steered = this._drainSteerQueue();
+        if (steered > 0) {
+          // Continue loop -- steer messages were added, make another LLM call.
+          continue;
+        }
+
+        // No steer messages -- continue the loop (LLM may have more tool calls).
+        continue;
+      }
+
+      // No tool calls -- agent wants to stop.
+      if (stopReason === 'end_turn') {
+        // Emit turn_end with empty tool results (no tools were called this turn).
+        await this._emitEvent({ type: 'turn_end', toolResults: [] });
+
+        // Drain steer queue: if a subscriber added a steer message, continue.
+        const steered = this._drainSteerQueue();
+        if (steered > 0) {
+          continue;
+        }
+
+        // Loop complete.
+        await this._emitEvent({ type: 'agent_end' });
+        return;
+      }
+
+      // Error or unknown stop reason.
+      const errorMsg = (assistantMsg as AgentInternalAssistantMessage).errorMessage ?? `Unexpected stop_reason: ${response.stop_reason ?? 'unknown'}`;
+      this._appendErrorMessage(errorMsg);
+      await this._emitEvent({ type: 'agent_end' });
+      return;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Execute tool calls sequentially.
+   *
+   * WHY sequential: workflow tools have ordering requirements (continue_workflow
+   * must complete before Bash begins on the next step).
+   *
+   * WHY error tool_result for unknown tools: LLMs occasionally hallucinate tool names.
+   * Crashing the loop would lose all progress. An error tool_result lets the LLM
+   * recover gracefully.
+   */
+  private async _executeTools(
+    toolUseBlocks: readonly Anthropic.ToolUseBlock[],
+  ): Promise<AgentToolCallResult[]> {
+    const results: AgentToolCallResult[] = [];
+
+    for (const block of toolUseBlocks) {
+      // Check abort before each tool execution.
+      if (this._abortController.signal.aborted) {
+        results.push({
+          toolCallId: block.id,
+          toolName: block.name,
+          result: null,
+          isError: true,
+        });
+        continue;
+      }
+
+      const tool = this._options.tools.find((t) => t.name === block.name);
+      if (!tool) {
+        // Unknown tool name -- return error tool_result and continue.
+        // WHY: LLMs occasionally hallucinate tool names. Crashing would lose all progress.
+        results.push({
+          toolCallId: block.id,
+          toolName: block.name,
+          result: {
+            content: [{ type: 'text', text: `Unknown tool: ${block.name}` }],
+            details: null,
+          },
+          isError: true,
+        });
+        continue;
+      }
+
+      // Execute the tool. Tools throw on failure (pi-agent-core contract).
+      // We do NOT catch here -- errors propagate to prompt()'s caller.
+      const params = (block.input ?? {}) as Record<string, unknown>;
+      const result = await tool.execute(block.id, params);
+      results.push({
+        toolCallId: block.id,
+        toolName: block.name,
+        result,
+        isError: false,
+      });
+    }
+
+    return results;
+  }
+
+  /**
+   * Drain the steer queue, appending each message to the conversation.
+   * Returns the number of messages drained.
+   */
+  private _drainSteerQueue(): number {
+    let count = 0;
+    while (this._steerQueue.length > 0) {
+      const msg = this._steerQueue.shift()!;
+      this._messages.push(msg);
+      count++;
+    }
+    return count;
+  }
+
+  /**
+   * Emit an event to all subscribers in order.
+   * All subscribers are awaited before returning.
+   */
+  private async _emitEvent(event: AgentEvent): Promise<void> {
+    for (const listener of this._listeners) {
+      await listener(event);
+    }
+  }
+
+  /**
+   * Append an assistant error message to state.messages.
+   * Used when the loop exits due to abort or API error.
+   */
+  private _appendErrorMessage(errorMessage: string): void {
+    this._messages.push({
+      role: 'assistant',
+      stopReason: 'error',
+      errorMessage,
+      content: [],
+    });
+  }
+
+  /**
+   * Convert the internal messages array to Anthropic API message format.
+   *
+   * The Anthropic API requires alternating user/assistant messages.
+   * Internal messages use typed variants; the API needs MessageParam format.
+   */
+  private _buildApiMessages(): Anthropic.MessageParam[] {
+    const result: Anthropic.MessageParam[] = [];
+
+    for (const msg of this._messages) {
+      if (msg.role === 'assistant') {
+        const assistantMsg = msg as AgentInternalAssistantMessage;
+        result.push({
+          role: 'assistant',
+          content: assistantMsg.content as Anthropic.ContentBlockParam[],
+        });
+      } else if (msg.role === 'user') {
+        const userMsg = msg as AgentInternalUserMessage | AgentInternalToolResultMessage;
+        if (typeof userMsg.content === 'string') {
+          // Plain user message
+          result.push({ role: 'user', content: (userMsg as AgentInternalUserMessage).content });
+        } else {
+          // Tool result message
+          result.push({
+            role: 'user',
+            content: (userMsg as AgentInternalToolResultMessage).content as Anthropic.ContentBlockParam[],
+          });
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Map Anthropic's stop_reason string to our internal stop reason type.
+   */
+  private _mapStopReason(
+    stopReason: string | null | undefined,
+  ): 'tool_use' | 'end_turn' | 'error' {
+    switch (stopReason) {
+      case 'tool_use':
+        return 'tool_use';
+      case 'end_turn':
+        return 'end_turn';
+      default:
+        return 'error';
+    }
+  }
+}

--- a/src/daemon/agent-loop.ts
+++ b/src/daemon/agent-loop.ts
@@ -536,6 +536,11 @@ export class AgentLoop {
         return 'tool_use';
       case 'end_turn':
         return 'end_turn';
+      case 'max_tokens':
+        // WHY end_turn: max_tokens means the model was truncated at the token limit,
+        // not that an error occurred. Treating it as end_turn lets the loop continue
+        // on the next turn so the agent can pick up where it left off.
+        return 'end_turn';
       default:
         return 'error';
     }

--- a/src/daemon/pi-mono-loader.ts
+++ b/src/daemon/pi-mono-loader.ts
@@ -1,5 +1,17 @@
 /**
- * ESM interop shim for pi-mono packages.
+ * @deprecated Use src/daemon/agent-loop.ts instead.
+ *
+ * This module previously loaded @mariozechner/pi-agent-core and @mariozechner/pi-ai
+ * (private npm packages). Those packages have been replaced by the first-party
+ * AgentLoop in src/daemon/agent-loop.ts, which uses @anthropic-ai/sdk and
+ * @anthropic-ai/bedrock-sdk (both public packages on npm).
+ *
+ * This file is kept for backward compatibility but is no longer imported by
+ * workflow-runner.ts. It will be removed in a future version.
+ *
+ * ---
+ *
+ * ESM interop shim for pi-mono packages (DEPRECATED).
  *
  * pi-mono is ESM-only. WorkRail compiles to CommonJS. Node.js allows CJS modules
  * to load ESM via dynamic import() but not via static require(). This module

--- a/src/daemon/pi-mono-loader.ts
+++ b/src/daemon/pi-mono-loader.ts
@@ -27,9 +27,10 @@
  * a true ESM dynamic import at runtime, bypassing the CJS require() rewrite.
  */
 
-// Types are erased at runtime -- safe to import statically from ESM.
-export type { Agent, AgentTool, AgentToolResult, AgentEvent, AgentLoopConfig } from '@mariozechner/pi-agent-core';
-export type { Model, TSchema } from '@mariozechner/pi-ai';
+// Type exports removed: @mariozechner/pi-agent-core and @mariozechner/pi-ai are no
+// longer in package.json. The export lines were deleted because tsc fails on a clean
+// install when they reference packages that do not exist. This file is now a
+// deprecated no-op kept for reference only.
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyModule = Record<string, any>;

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -28,10 +28,10 @@ import * as os from 'node:os';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { randomUUID } from 'node:crypto';
-import { loadPiAi, loadPiAgentCore } from "./pi-mono-loader.js";
-import type { Agent, AgentTool, AgentToolResult, AgentEvent } from "./pi-mono-loader.js";
-import type { TSchema } from "./pi-mono-loader.js";
-import type { UserMessage } from '@mariozechner/pi-ai';
+import Anthropic from '@anthropic-ai/sdk';
+import { AnthropicBedrock } from '@anthropic-ai/bedrock-sdk';
+import { AgentLoop } from "./agent-loop.js";
+import type { AgentTool, AgentToolResult, AgentEvent } from "./agent-loop.js";
 import type { V2ToolContext } from '../mcp/types.js';
 import { executeStartWorkflow } from '../mcp/handlers/v2-execution/start.js';
 import { executeContinueWorkflow } from '../mcp/handlers/v2-execution/index.js';
@@ -687,36 +687,61 @@ async function loadSessionNotes(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _schemas: Record<string, any> | null = null;
 
+// WHY plain JSON Schema: the Anthropic SDK's Tool.input_schema accepts
+// Record<string, unknown>. TypeBox was only needed because pi-agent-core's
+// AgentTool<TSchema> required a TypeBox schema type. The new AgentTool interface
+// (from agent-loop.ts) accepts plain JSON Schema directly.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getSchemas(): Promise<Record<string, any>> {
+function getSchemas(): Record<string, any> {
   if (_schemas) return _schemas;
-  const { Type } = await loadPiAi();
   _schemas = {
-    ContinueWorkflowParams: Type.Object({
-      continueToken: Type.String({
-        description: 'The continueToken from the previous start_workflow or continue_workflow call. Round-trip exactly as received.',
-      }),
-      intent: Type.Optional(Type.Union([Type.Literal('advance'), Type.Literal('rehydrate')], {
-        description: 'advance: I completed this step. rehydrate: remind me what the current step is.',
-      })),
-      notesMarkdown: Type.Optional(Type.String({
-        description: 'Notes on what you did in this step (10-30 lines, markdown).',
-      })),
-      context: Type.Optional(Type.Record(Type.String(), Type.Unknown(), {
-        description: 'Updated context variables (only changed values).',
-      })),
-    }),
-    BashParams: Type.Object({
-      command: Type.String({ description: 'Shell command to execute' }),
-      cwd: Type.Optional(Type.String({ description: 'Working directory for the command' })),
-    }),
-    ReadParams: Type.Object({
-      filePath: Type.String({ description: 'Absolute path to the file to read' }),
-    }),
-    WriteParams: Type.Object({
-      filePath: Type.String({ description: 'Absolute path to the file to write' }),
-      content: Type.String({ description: 'Content to write to the file' }),
-    }),
+    ContinueWorkflowParams: {
+      type: 'object',
+      properties: {
+        continueToken: {
+          type: 'string',
+          description: 'The continueToken from the previous start_workflow or continue_workflow call. Round-trip exactly as received.',
+        },
+        intent: {
+          type: 'string',
+          enum: ['advance', 'rehydrate'],
+          description: 'advance: I completed this step. rehydrate: remind me what the current step is.',
+        },
+        notesMarkdown: {
+          type: 'string',
+          description: 'Notes on what you did in this step (10-30 lines, markdown).',
+        },
+        context: {
+          type: 'object',
+          additionalProperties: true,
+          description: 'Updated context variables (only changed values).',
+        },
+      },
+      required: ['continueToken'],
+    },
+    BashParams: {
+      type: 'object',
+      properties: {
+        command: { type: 'string', description: 'Shell command to execute' },
+        cwd: { type: 'string', description: 'Working directory for the command' },
+      },
+      required: ['command'],
+    },
+    ReadParams: {
+      type: 'object',
+      properties: {
+        filePath: { type: 'string', description: 'Absolute path to the file to read' },
+      },
+      required: ['filePath'],
+    },
+    WriteParams: {
+      type: 'object',
+      properties: {
+        filePath: { type: 'string', description: 'Absolute path to the file to write' },
+        content: { type: 'string', description: 'Content to write to the file' },
+      },
+      required: ['filePath', 'content'],
+    },
   };
   return _schemas;
 }
@@ -732,14 +757,13 @@ function makeContinueWorkflowTool(
   onComplete: (notes: string | undefined) => void,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   schemas: Record<string, any>,
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-): AgentTool<any> {
+): AgentTool {
   return {
     name: 'continue_workflow',
     description:
       'Advance the WorkRail workflow to the next step. Call this after completing all work ' +
       'required by the current step. Include your notes in notesMarkdown.',
-    parameters: schemas['ContinueWorkflowParams'],
+    inputSchema: schemas['ContinueWorkflowParams'],
     label: 'Continue Workflow',
 
     execute: async (
@@ -797,14 +821,13 @@ function makeContinueWorkflowTool(
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function makeBashTool(workspacePath: string, schemas: Record<string, any>// eslint-disable-next-line @typescript-eslint/no-explicit-any
-): AgentTool<any> {
+export function makeBashTool(workspacePath: string, schemas: Record<string, any>): AgentTool {
   return {
     name: 'Bash',
     description:
       'Execute a shell command. Throws on non-zero exit code. ' +
       `Maximum execution time: ${BASH_TIMEOUT_MS / 1000}s.`,
-    parameters: schemas['BashParams'],
+    inputSchema: schemas['BashParams'],
     label: 'Bash',
 
     execute: async (
@@ -849,12 +872,11 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeReadTool(schemas: Record<string, any>// eslint-disable-next-line @typescript-eslint/no-explicit-any
-): AgentTool<any> {
+function makeReadTool(schemas: Record<string, any>): AgentTool {
   return {
     name: 'Read',
     description: 'Read the contents of a file at the given absolute path.',
-    parameters: schemas['ReadParams'],
+    inputSchema: schemas['ReadParams'],
     label: 'Read',
 
     execute: async (
@@ -871,12 +893,11 @@ function makeReadTool(schemas: Record<string, any>// eslint-disable-next-line @t
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeWriteTool(schemas: Record<string, any>// eslint-disable-next-line @typescript-eslint/no-explicit-any
-): AgentTool<any> {
+function makeWriteTool(schemas: Record<string, any>): AgentTool {
   return {
     name: 'Write',
     description: 'Write content to a file at the given absolute path. Creates parent directories if needed.',
-    parameters: schemas['WriteParams'],
+    inputSchema: schemas['WriteParams'],
     label: 'Write',
 
     execute: async (
@@ -998,7 +1019,8 @@ export function buildSystemPrompt(
   return lines.join('\n');
 }
 
-function buildUserMessage(text: string): UserMessage {
+/** Build a user message for the agent loop. */
+function buildUserMessage(text: string): { role: 'user'; content: string; timestamp: number } {
   return {
     role: 'user',
     content: text,
@@ -1043,42 +1065,43 @@ export async function runWorkflow(
   // ---- DaemonRegistry: register session ----
   daemonRegistry?.register(sessionId, trigger.workflowId);
 
-  // ---- Model setup ----
+  // ---- Client and model setup ----
   // Priority: agentConfig.model (trigger-specific override) > env-based detection.
   // agentConfig.model format: "provider/model-id" (e.g. "amazon-bedrock/claude-sonnet-4-6").
-  // Why: per-trigger model overrides allow using different model tiers for different
+  // WHY: per-trigger model overrides allow using different model tiers for different
   // workload types (e.g. a faster/cheaper model for simple automation tasks).
-  let model;
-  try {
-    const { getModel } = await loadPiAi();
-    if (trigger.agentConfig?.model) {
-      // Parse "provider/model-id" -- split on the first slash only
-      const slashIdx = trigger.agentConfig.model.indexOf('/');
-      if (slashIdx === -1) {
-        throw new Error(
-          `agentConfig.model must be in "provider/model-id" format, got: "${trigger.agentConfig.model}"`,
-        );
-      }
-      const provider = trigger.agentConfig.model.slice(0, slashIdx);
-      const modelId = trigger.agentConfig.model.slice(slashIdx + 1);
-      model = getModel(provider, modelId);
-    } else {
-      // Default: use Bedrock when AWS credentials are present (avoids personal API key charges)
-      const usesBedrock = !!process.env['AWS_PROFILE'] || !!process.env['AWS_ACCESS_KEY_ID'];
-      if (usesBedrock) {
-        model = getModel('amazon-bedrock', 'us.anthropic.claude-sonnet-4-6');
-      } else {
-        model = getModel('anthropic', 'claude-sonnet-4-5');
-      }
+  //
+  // WHY @anthropic-ai/sdk + @anthropic-ai/bedrock-sdk: both provide the identical
+  // .messages.create() API, so AgentLoop works with either without any format conversion.
+  // Bedrock uses AWS credentials from env (AWS_PROFILE, AWS_ACCESS_KEY_ID) automatically.
+  let agentClient: Anthropic | AnthropicBedrock;
+  let modelId: string;
+
+  if (trigger.agentConfig?.model) {
+    // Parse "provider/model-id" -- split on the first slash only
+    const slashIdx = trigger.agentConfig.model.indexOf('/');
+    if (slashIdx === -1) {
+      daemonRegistry?.unregister(sessionId, 'failed');
+      return {
+        _tag: 'error',
+        workflowId: trigger.workflowId,
+        message: `agentConfig.model must be in "provider/model-id" format, got: "${trigger.agentConfig.model}"`,
+        stopReason: 'error',
+      };
     }
-  } catch (err) {
-    daemonRegistry?.unregister(sessionId, 'failed');
-    return {
-      _tag: 'error',
-      workflowId: trigger.workflowId,
-      message: `Model not found: ${err instanceof Error ? err.message : String(err)}`,
-      stopReason: 'error',
-    };
+    const provider = trigger.agentConfig.model.slice(0, slashIdx);
+    modelId = trigger.agentConfig.model.slice(slashIdx + 1);
+    agentClient = provider === 'amazon-bedrock' ? new AnthropicBedrock() : new Anthropic({ apiKey });
+  } else {
+    // Default: use Bedrock when AWS credentials are present (avoids personal API key charges).
+    const usesBedrock = !!process.env['AWS_PROFILE'] || !!process.env['AWS_ACCESS_KEY_ID'];
+    if (usesBedrock) {
+      agentClient = new AnthropicBedrock();
+      modelId = 'us.anthropic.claude-sonnet-4-6';
+    } else {
+      agentClient = new Anthropic({ apiKey });
+      modelId = 'claude-sonnet-4-5';
+    }
   }
 
   // ---- Completion bridge ----
@@ -1144,19 +1167,17 @@ export async function runWorkflow(
     return { _tag: 'success', workflowId: trigger.workflowId, stopReason: 'stop' };
   }
 
-  // ---- Schemas (lazy ESM load) ----
-  const schemas = await getSchemas();
+  // ---- Schemas ----
+  const schemas = getSchemas();
 
   // ---- Tools ----
-  // Cast through unknown to satisfy AgentTool<TSchema> -- each tool factory
-  // produces a concrete TypeBox schema type; the agent loop accepts the base type.
   // start_workflow is NOT in this list: the daemon calls executeStartWorkflow()
   // directly above so the LLM cannot call it again.
-  const tools: AgentTool<TSchema>[] = [
-    makeContinueWorkflowTool(sessionId, ctx, onAdvance, onComplete, schemas) as unknown as AgentTool<TSchema>,
-    makeBashTool(trigger.workspacePath, schemas) as unknown as AgentTool<TSchema>,
-    makeReadTool(schemas) as unknown as AgentTool<TSchema>,
-    makeWriteTool(schemas) as unknown as AgentTool<TSchema>,
+  const tools: AgentTool[] = [
+    makeContinueWorkflowTool(sessionId, ctx, onAdvance, onComplete, schemas),
+    makeBashTool(trigger.workspacePath, schemas),
+    makeReadTool(schemas),
+    makeWriteTool(schemas),
   ];
 
   // ---- Context loading (soul + workspace + session notes) ----
@@ -1197,22 +1218,16 @@ export async function runWorkflow(
     contextJson +
     '\n\nComplete all step work, then call continue_workflow with your notes to begin.';
 
-  // ---- Agent (one per runWorkflow() call, not reused) ----
-  const { Agent } = await loadPiAgentCore();
-  const agent = new Agent({
-    initialState: {
-      systemPrompt: buildSystemPrompt(trigger, sessionState, soulContent, workspaceContext),
-      // Future: for mid-session context re-injection after context window compaction,
-      // call agent.steer(buildUserMessage(buildSessionRecap(freshNotes))) in the
-      // turn_end handler after each continue_workflow advance. Not implemented yet --
-      // the system prompt recap is sufficient for the current use case.
-      model,
-      tools,
-    },
-    // Bedrock uses AWS credentials from env (AWS_PROFILE etc.) -- no API key needed.
-    // For direct Anthropic, pass the provided key.
-    getApiKey: async (_provider: string) => apiKey ?? '',
-
+  // ---- AgentLoop (one per runWorkflow() call, not reused) ----
+  // WHY AgentLoop instead of pi-agent-core's Agent: AgentLoop is the first-party
+  // replacement that uses @anthropic-ai/sdk directly, eliminating the private npm
+  // package dependency. The client (Anthropic or AnthropicBedrock) is injected --
+  // AgentLoop has no knowledge of API keys or AWS credentials.
+  const agent = new AgentLoop({
+    systemPrompt: buildSystemPrompt(trigger, sessionState, soulContent, workspaceContext),
+    modelId,
+    tools,
+    client: agentClient,
     // Sequential execution: continue_workflow must complete before Bash begins
     // on the next step. Workflow tools have ordering requirements.
     toolExecution: 'sequential',

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -1204,6 +1204,10 @@ export async function runWorkflow(
   // The daemon has already called executeStartWorkflow() and has the first step.
   // Pass the step content directly -- the LLM starts working on step 1 immediately.
   // Appending the continueToken so the LLM can pass it to continue_workflow.
+  // WHY closing directive: an explicit imperative at the end of the initial prompt directs
+  // the agent to complete the step work before calling continue_workflow. Without this,
+  // the agent may produce a "thinking aloud" turn before the first tool call, which
+  // wastes tokens and delays step execution.
   const contextJson = trigger.context
     ? `\n\nTrigger context:\n\`\`\`json\n${JSON.stringify(trigger.context, null, 2)}\n\`\`\``
     : '';

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Unit tests for AgentLoop in src/daemon/agent-loop.ts.
+ *
+ * Strategy: use a FakeAnthropicClient class that returns deterministic response
+ * sequences. No real API calls. Follows the "prefer fakes over mocks" principle
+ * from CLAUDE.md.
+ *
+ * WHY a fake class instead of a mock library: the FakeAnthropicClient is
+ * a realistic substitute that validates behavior under controlled conditions.
+ * Spy/mock libraries add indirection and don't improve coverage here.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import {
+  AgentLoop,
+  type AgentClientInterface,
+  type AgentTool,
+  type AgentToolResult,
+  type AgentEvent,
+} from '../../src/daemon/agent-loop.js';
+
+// ---------------------------------------------------------------------------
+// FakeAnthropicClient
+// ---------------------------------------------------------------------------
+
+/**
+ * A deterministic fake Anthropic client for testing.
+ *
+ * Initialized with a response sequence. Each call to messages.create()
+ * returns the next response in the sequence. Throws if the sequence is empty.
+ */
+class FakeAnthropicClient implements AgentClientInterface {
+  private _responses: Array<Anthropic.Message>;
+  public callCount = 0;
+  public lastParams: Anthropic.MessageCreateParamsNonStreaming | null = null;
+
+  constructor(responses: Anthropic.Message[]) {
+    this._responses = [...responses];
+  }
+
+  messages = {
+    create: async (
+      params: Anthropic.MessageCreateParamsNonStreaming,
+      _options?: { signal?: AbortSignal },
+    ): Promise<Anthropic.Message> => {
+      this.callCount++;
+      this.lastParams = params;
+      const response = this._responses.shift();
+      if (!response) throw new Error('FakeAnthropicClient: no more responses');
+      return response;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/** Build a minimal Anthropic.Message with end_turn stop reason. */
+function makeEndTurnMessage(text = 'Done.'): Anthropic.Message {
+  return {
+    id: 'msg_test',
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    model: 'claude-test',
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    usage: { input_tokens: 10, output_tokens: 5 },
+  };
+}
+
+/** Build an Anthropic.Message with a single tool_use block. */
+function makeToolUseMessage(
+  toolName: string,
+  toolUseId: string,
+  input: Record<string, unknown> = {},
+): Anthropic.Message {
+  return {
+    id: 'msg_test',
+    type: 'message',
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool_use',
+        id: toolUseId,
+        name: toolName,
+        input,
+      },
+    ],
+    model: 'claude-test',
+    stop_reason: 'tool_use',
+    stop_sequence: null,
+    usage: { input_tokens: 10, output_tokens: 5 },
+  };
+}
+
+/** Build a no-op tool that returns a fixed result. */
+function makeTool(
+  name: string,
+  result: string = '(tool output)',
+): AgentTool & { executionCount: number } {
+  let executionCount = 0;
+  return {
+    name,
+    description: `Test tool: ${name}`,
+    inputSchema: { type: 'object', properties: {} },
+    label: name,
+    get executionCount() { return executionCount; },
+    async execute(_toolCallId: string, _params: Record<string, unknown>): Promise<AgentToolResult<unknown>> {
+      executionCount++;
+      return {
+        content: [{ type: 'text', text: result }],
+        details: { toolName: name },
+      };
+    },
+  };
+}
+
+/** Build a throwing tool. */
+function makeThrowingTool(name: string, errorMessage: string): AgentTool {
+  return {
+    name,
+    description: `Throwing test tool: ${name}`,
+    inputSchema: { type: 'object', properties: {} },
+    label: name,
+    async execute(): Promise<AgentToolResult<unknown>> {
+      throw new Error(errorMessage);
+    },
+  };
+}
+
+const USER_MSG = { role: 'user' as const, content: 'Start the workflow.', timestamp: 0 };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AgentLoop', () => {
+  describe('loop termination', () => {
+    it('terminates on end_turn with no tool calls', async () => {
+      const client = new FakeAnthropicClient([makeEndTurnMessage()]);
+      const agent = new AgentLoop({
+        systemPrompt: 'You are a test agent.',
+        tools: [],
+        client,
+        modelId: 'claude-test',
+      });
+
+      await agent.prompt(USER_MSG);
+
+      expect(client.callCount).toBe(1);
+      const messages = agent.state.messages;
+      const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant') as
+        | { role: 'assistant'; stopReason: string }
+        | undefined;
+      expect(lastAssistant?.stopReason).toBe('end_turn');
+    });
+
+    it('state.messages contains the correct stopReason after end_turn', async () => {
+      const client = new FakeAnthropicClient([makeEndTurnMessage('Workflow complete.')]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [],
+        client,
+        modelId: 'claude-test',
+      });
+
+      await agent.prompt(USER_MSG);
+
+      const messages = agent.state.messages;
+      const lastAssistant = [...messages]
+        .reverse()
+        .find((m) => m.role === 'assistant') as { role: 'assistant'; stopReason: string; errorMessage?: string } | undefined;
+      expect(lastAssistant).toBeDefined();
+      expect(lastAssistant?.stopReason).toBe('end_turn');
+      expect(lastAssistant?.errorMessage).toBeUndefined();
+    });
+  });
+
+  describe('tool execution', () => {
+    it('executes a tool call and makes a second LLM call with results', async () => {
+      const tool = makeTool('my_tool', 'tool result text');
+      const client = new FakeAnthropicClient([
+        makeToolUseMessage('my_tool', 'call_1'),
+        makeEndTurnMessage(),
+      ]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [tool],
+        client,
+        modelId: 'claude-test',
+      });
+
+      await agent.prompt(USER_MSG);
+
+      expect(tool.executionCount).toBe(1);
+      expect(client.callCount).toBe(2);
+    });
+
+    it('includes tool results in the second LLM call messages', async () => {
+      const tool = makeTool('my_tool', 'the result content');
+      const client = new FakeAnthropicClient([
+        makeToolUseMessage('my_tool', 'call_1'),
+        makeEndTurnMessage(),
+      ]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [tool],
+        client,
+        modelId: 'claude-test',
+      });
+
+      await agent.prompt(USER_MSG);
+
+      // The second call should include the tool result in messages
+      expect(client.lastParams).not.toBeNull();
+      const messages = client.lastParams!.messages;
+      // Should have: initial user msg, assistant (tool_use), user (tool_result)
+      expect(messages.length).toBeGreaterThanOrEqual(3);
+      const lastUserMsg = messages[messages.length - 1];
+      expect(lastUserMsg!.role).toBe('user');
+      expect(Array.isArray(lastUserMsg!.content)).toBe(true);
+    });
+
+    it('executes multiple tool calls in one turn sequentially', async () => {
+      const executionOrder: string[] = [];
+
+      const toolA: AgentTool = {
+        name: 'tool_a',
+        description: 'Tool A',
+        inputSchema: { type: 'object', properties: {} },
+        label: 'Tool A',
+        async execute(): Promise<AgentToolResult<unknown>> {
+          executionOrder.push('a');
+          return { content: [{ type: 'text', text: 'A done' }], details: null };
+        },
+      };
+
+      const toolB: AgentTool = {
+        name: 'tool_b',
+        description: 'Tool B',
+        inputSchema: { type: 'object', properties: {} },
+        label: 'Tool B',
+        async execute(): Promise<AgentToolResult<unknown>> {
+          executionOrder.push('b');
+          return { content: [{ type: 'text', text: 'B done' }], details: null };
+        },
+      };
+
+      // Both tools in one assistant message
+      const twoToolMessage: Anthropic.Message = {
+        id: 'msg_test',
+        type: 'message',
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_a', name: 'tool_a', input: {} },
+          { type: 'tool_use', id: 'call_b', name: 'tool_b', input: {} },
+        ],
+        model: 'claude-test',
+        stop_reason: 'tool_use',
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 10 },
+      };
+
+      const client = new FakeAnthropicClient([twoToolMessage, makeEndTurnMessage()]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [toolA, toolB],
+        client,
+        modelId: 'claude-test',
+      });
+
+      await agent.prompt(USER_MSG);
+
+      expect(executionOrder).toEqual(['a', 'b']); // Sequential, in order
+    });
+  });
+
+  describe('steer() injection', () => {
+    it('injects a steer message after tool batch and makes another LLM call', async () => {
+      const tool = makeTool('continue_workflow');
+      const client = new FakeAnthropicClient([
+        makeToolUseMessage('continue_workflow', 'call_1'),
+        makeEndTurnMessage('Injected and done.'),
+      ]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [tool],
+        client,
+        modelId: 'claude-test',
+      });
+
+      // Subscribe and call steer() only on the first turn_end (after tool execution)
+      let steered = false;
+      agent.subscribe(async (event: AgentEvent) => {
+        if (event.type === 'turn_end' && !steered) {
+          steered = true;
+          agent.steer({ role: 'user', content: 'Next step instructions.', timestamp: 1 });
+        }
+      });
+
+      await agent.prompt(USER_MSG);
+
+      // 1st call: initial; 2nd call: after tool result + steer injection
+      expect(client.callCount).toBe(2);
+    });
+
+    it('steer message appears in the next LLM call', async () => {
+      const tool = makeTool('some_tool');
+      const client = new FakeAnthropicClient([
+        makeToolUseMessage('some_tool', 'call_1'),
+        makeEndTurnMessage(),
+      ]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [tool],
+        client,
+        modelId: 'claude-test',
+      });
+
+      let steeredOnce = false;
+      agent.subscribe(async (event: AgentEvent) => {
+        if (event.type === 'turn_end' && !steeredOnce) {
+          steeredOnce = true;
+          agent.steer({ role: 'user', content: 'STEER_CONTENT', timestamp: 1 });
+        }
+      });
+
+      await agent.prompt(USER_MSG);
+
+      // The second call should include the steered message
+      const messages = client.lastParams!.messages;
+      const messageContents = messages
+        .filter((m) => m.role === 'user')
+        .map((m) => (typeof m.content === 'string' ? m.content : JSON.stringify(m.content)));
+      const hasSteer = messageContents.some((c) => c.includes('STEER_CONTENT'));
+      expect(hasSteer).toBe(true);
+    });
+  });
+
+  describe('abort()', () => {
+    it('stops the loop when abort() is called before prompt()', async () => {
+      const client = new FakeAnthropicClient([makeEndTurnMessage()]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [],
+        client,
+        modelId: 'claude-test',
+      });
+
+      agent.abort();
+      await agent.prompt(USER_MSG);
+
+      // Aborted before LLM call -- no API calls made
+      expect(client.callCount).toBe(0);
+      const messages = agent.state.messages;
+      const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant') as
+        | { role: 'assistant'; stopReason: string; errorMessage?: string }
+        | undefined;
+      expect(lastAssistant?.stopReason).toBe('error');
+      expect(lastAssistant?.errorMessage).toContain('aborted');
+    });
+  });
+
+  describe('unknown tool name', () => {
+    it('returns error tool_result for unknown tool and continues the loop', async () => {
+      // LLM calls a tool that doesn't exist, then after error result, returns end_turn
+      const client = new FakeAnthropicClient([
+        makeToolUseMessage('nonexistent_tool', 'call_1'),
+        makeEndTurnMessage('Recovered.'),
+      ]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [], // No tools registered
+        client,
+        modelId: 'claude-test',
+      });
+
+      // Should NOT throw -- loop continues with error tool_result
+      await expect(agent.prompt(USER_MSG)).resolves.toBeUndefined();
+
+      // Two LLM calls: first with tool_use, second after error tool_result
+      expect(client.callCount).toBe(2);
+    });
+
+    it('error tool_result for unknown tool includes the tool name', async () => {
+      const client = new FakeAnthropicClient([
+        makeToolUseMessage('ghost_tool', 'call_1'),
+        makeEndTurnMessage(),
+      ]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [],
+        client,
+        modelId: 'claude-test',
+      });
+
+      // Subscribe to turn_end to capture tool results
+      const capturedResults: Array<{ toolName: string; isError: boolean }> = [];
+      agent.subscribe(async (event: AgentEvent) => {
+        if (event.type === 'turn_end') {
+          event.toolResults.forEach((r: unknown) => {
+            const result = r as { toolName: string; isError: boolean };
+            capturedResults.push({ toolName: result.toolName, isError: result.isError });
+          });
+        }
+      });
+
+      await agent.prompt(USER_MSG);
+
+      expect(capturedResults).toHaveLength(1);
+      expect(capturedResults[0]!.toolName).toBe('ghost_tool');
+      expect(capturedResults[0]!.isError).toBe(true);
+    });
+  });
+
+  describe('tool errors (throwing tools)', () => {
+    it('propagates tool throws to the prompt() caller', async () => {
+      const throwingTool = makeThrowingTool('bad_tool', 'Tool execution failed');
+      const client = new FakeAnthropicClient([
+        makeToolUseMessage('bad_tool', 'call_1'),
+      ]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [throwingTool],
+        client,
+        modelId: 'claude-test',
+      });
+
+      // Tool throws -> prompt() should throw
+      await expect(agent.prompt(USER_MSG)).rejects.toThrow('Tool execution failed');
+    });
+  });
+
+  describe('state.messages shape', () => {
+    it('last assistant message has role, stopReason, and no errorMessage on success', async () => {
+      const client = new FakeAnthropicClient([makeEndTurnMessage()]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [],
+        client,
+        modelId: 'claude-test',
+      });
+
+      await agent.prompt(USER_MSG);
+
+      const messages = agent.state.messages;
+      const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant') as
+        | { role: 'assistant'; stopReason: string; errorMessage?: string }
+        | undefined;
+      expect(lastAssistant).toBeDefined();
+      expect(lastAssistant?.role).toBe('assistant');
+      expect(lastAssistant?.stopReason).toBe('end_turn');
+      expect(lastAssistant?.errorMessage).toBeUndefined();
+    });
+
+    it('messages array starts with the initial user message', async () => {
+      const client = new FakeAnthropicClient([makeEndTurnMessage()]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [],
+        client,
+        modelId: 'claude-test',
+      });
+
+      await agent.prompt(USER_MSG);
+
+      const messages = agent.state.messages;
+      expect(messages.length).toBeGreaterThanOrEqual(2); // user + assistant
+      const firstMsg = messages[0] as { role: string; content?: unknown };
+      expect(firstMsg.role).toBe('user');
+    });
+  });
+
+  describe('subscribe()', () => {
+    it('returns an unsubscribe function that stops future event delivery', async () => {
+      let eventCount = 0;
+      const client = new FakeAnthropicClient([makeEndTurnMessage()]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [],
+        client,
+        modelId: 'claude-test',
+      });
+
+      const unsubscribe = agent.subscribe(() => { eventCount++; });
+      unsubscribe(); // Unsubscribe immediately
+
+      await agent.prompt(USER_MSG);
+
+      expect(eventCount).toBe(0); // No events delivered after unsubscribe
+    });
+
+    it('emits turn_end event with empty toolResults when LLM has no tool calls', async () => {
+      const receivedEvents: AgentEvent[] = [];
+      const client = new FakeAnthropicClient([makeEndTurnMessage()]);
+      const agent = new AgentLoop({
+        systemPrompt: 'System prompt.',
+        tools: [],
+        client,
+        modelId: 'claude-test',
+      });
+
+      agent.subscribe(async (event) => { receivedEvents.push(event); });
+      await agent.prompt(USER_MSG);
+
+      const turnEndEvent = receivedEvents.find((e) => e.type === 'turn_end');
+      expect(turnEndEvent).toBeDefined();
+      expect((turnEndEvent as { type: 'turn_end'; toolResults: unknown[] }).toolResults).toHaveLength(0);
+
+      const agentEndEvent = receivedEvents.find((e) => e.type === 'agent_end');
+      expect(agentEndEvent).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Eliminates `@mariozechner/pi-agent-core` and `@mariozechner/pi-ai` (private npm packages that block `npm install @exaudeus/workrail` for anyone outside Zillow) with a self-contained first-party agent loop
- Adds `src/daemon/agent-loop.ts`: `AgentLoop` class using `@anthropic-ai/sdk` (Anthropic direct) and `@anthropic-ai/bedrock-sdk` (Bedrock) -- both share the identical `.messages.create()` API, so no format conversion is needed
- `AgentLoop` has an injectable `AgentClientInterface`, enabling unit tests with a deterministic `FakeAnthropicClient` (15 new tests, all passing)
- Migrates `getSchemas()` from TypeBox + `loadPiAi()` to plain JSON Schema literals (the Anthropic SDK accepts `Record<string, unknown>` for `input_schema`)
- Deprecates `pi-mono-loader.ts` with a comment pointing to `agent-loop.ts`

## Key design decisions

- `steer()` semantics preserved exactly: queue-based, drained after each tool batch (after `turn_end` event, before next LLM call)
- `AbortController` used internally so `agent.abort()` cancels in-flight API calls
- Unknown tool names return an error `tool_result` block (`is_error: true`) and the loop continues rather than crashing
- Non-streaming `messages.create()` is sufficient for workflow use case; streaming can be added later

## Test plan

- [x] `npm run typecheck` -- 0 new errors (1 pre-existing unrelated error remains)
- [x] 57 tests pass: all 42 existing + 15 new agent-loop tests
- [x] `package.json` has no `@mariozechner/*` dependencies
- [x] `@anthropic-ai/bedrock-sdk` v0.28.1 verified compatible with `@anthropic-ai/sdk` v0.73.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)