### PR TITLE
feat(mcp): add maxConcurrentSessions global semaphore to TriggerRouter

### DIFF
--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -71,6 +71,11 @@ const ALLOWED_CONFIG_FILE_KEYS = new Set([
 
   // daemon workspace default -- written by `worktrain init`, read by the daemon command
   'WORKRAIL_DEFAULT_WORKSPACE',
+
+  // daemon concurrency settings (numeric; NOT merged into process.env -- parsed directly
+  // in trigger-listener.ts and passed to TriggerRouter as a number).
+  // Example in config.json: "maxConcurrentSessions": "3"
+  'maxConcurrentSessions',
 ]);
 
 // =============================================================================

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -219,9 +219,8 @@ export async function startTriggerListener(
   const maxConcurrencyRaw = workrailConfig.kind === 'ok'
     ? workrailConfig.value['maxConcurrentSessions']
     : undefined;
-  const maxConcurrentSessions = maxConcurrencyRaw !== undefined
-    ? (parseInt(maxConcurrencyRaw, 10) || undefined)
-    : undefined;
+  const parsed = parseInt(maxConcurrencyRaw ?? '', 10);
+  const maxConcurrentSessions = !isNaN(parsed) ? parsed : undefined;
 
   // Create router and Express app
   const runWorkflowFn: RunWorkflowFn = options.runWorkflowFn ?? runWorkflow;

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -26,6 +26,7 @@ import type { V2ToolContext } from '../mcp/types.js';
 import { loadTriggerConfigFromFile, buildTriggerIndex } from './trigger-store.js';
 import type { TriggerStoreError } from './trigger-store.js';
 import { TriggerRouter, type RunWorkflowFn } from './trigger-router.js';
+import { loadWorkrailConfigFile } from '../config/config-file.js';
 import { runWorkflow, runStartupRecovery } from '../daemon/workflow-runner.js';
 import type { WebhookEvent } from './types.js';
 import { asTriggerId } from './types.js';
@@ -210,9 +211,21 @@ export async function startTriggerListener(
     );
   }
 
+  // Read maxConcurrentSessions from ~/.workrail/config.json.
+  // The config-file loader returns a flat Record<string, string>; the value is a
+  // string (schema constraint) and must be parsed to an integer here.
+  // A missing or non-numeric value falls back to TriggerRouter's default (3).
+  const workrailConfig = loadWorkrailConfigFile();
+  const maxConcurrencyRaw = workrailConfig.kind === 'ok'
+    ? workrailConfig.value['maxConcurrentSessions']
+    : undefined;
+  const maxConcurrentSessions = maxConcurrencyRaw !== undefined
+    ? (parseInt(maxConcurrencyRaw, 10) || undefined)
+    : undefined;
+
   // Create router and Express app
   const runWorkflowFn: RunWorkflowFn = options.runWorkflowFn ?? runWorkflow;
-  const router = new TriggerRouter(triggerIndex, ctx, apiKey, runWorkflowFn);
+  const router = new TriggerRouter(triggerIndex, ctx, apiKey, runWorkflowFn, undefined, maxConcurrentSessions);
   const app = createTriggerApp(router);
 
   // Startup crash recovery: detect and clear any orphaned session files left by a

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -329,13 +329,81 @@ async function maybeRunDelivery(
   }
 }
 
+
+// ---------------------------------------------------------------------------
+// Semaphore: global concurrency cap for runWorkflow() calls
+// ---------------------------------------------------------------------------
+
+/**
+ * Promise-based counting semaphore.
+ *
+ * WHY a semaphore instead of a simple counter:
+ * A plain counter with "if at capacity, drop" would silently lose dispatches after
+ * the caller has already received a 202 Accepted response. Queue-and-wait is required
+ * so every accepted dispatch eventually executes.
+ *
+ * WHY acquire() is called INSIDE the queue callback (not before enqueue()):
+ * route() and dispatch() must return immediately -- the 202 response is sent before
+ * enqueue(). Acquiring the semaphore before enqueue() would block route()/dispatch()
+ * until a slot is free, breaking the fire-and-forget contract.
+ * Instead, the semaphore is acquired inside the async queue callback, where blocking
+ * is safe: the callback is already running on the promise chain, not on the hot path.
+ *
+ * WHY default max = 3:
+ * A conservative default prevents resource exhaustion for concurrencyMode:'parallel'
+ * triggers without requiring any user configuration. Configurable via
+ * maxConcurrentSessions in ~/.workrail/config.json.
+ *
+ * Invariants:
+ * - acquire() returns a Promise that resolves when a slot is available (FIFO order).
+ * - release() must be called in a finally block -- never conditional.
+ * - max is always >= 1 (enforced by TriggerRouter constructor).
+ */
+class Semaphore {
+  private active = 0;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(readonly max: number) {}
+
+  acquire(): Promise<void> {
+    if (this.active < this.max) {
+      this.active++;
+      return Promise.resolve();
+    }
+    // At capacity: enqueue a waiter that resolves when a slot opens.
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  release(): void {
+    const next = this.waiters.shift();
+    if (next !== undefined) {
+      // Hand the slot directly to the next waiter (active count stays the same).
+      next();
+    } else {
+      this.active--;
+    }
+  }
+
+  /** Current count of active (running) sessions. */
+  get activeCount(): number {
+    return this.active;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // TriggerRouter class
 // ---------------------------------------------------------------------------
 
+/** Default maximum concurrent runWorkflow() calls across all triggers. */
+const DEFAULT_MAX_CONCURRENT_SESSIONS = 3;
+
 export class TriggerRouter {
   private readonly queue = new KeyedAsyncQueue();
   private readonly execFn: ExecFn;
+  private readonly semaphore: Semaphore;
+  private readonly _maxConcurrentSessions: number;
 
   constructor(
     private readonly index: ReadonlyMap<string, TriggerDefinition>,
@@ -348,8 +416,31 @@ export class TriggerRouter {
      * Override in tests to use a fake without calling child_process.
      */
     execFn?: ExecFn,
+    maxConcurrentSessions?: number,
   ) {
     this.execFn = execFn ?? execFileAsync;
+    // Validate and clamp: maxConcurrentSessions must be >= 1.
+    // A value of 0 or negative would deadlock all dispatches -- make it impossible.
+    const requested = maxConcurrentSessions ?? DEFAULT_MAX_CONCURRENT_SESSIONS;
+    if (requested < 1) {
+      console.warn(
+        `[TriggerRouter] maxConcurrentSessions must be >= 1; received ${requested}, clamping to 1.`,
+      );
+      this._maxConcurrentSessions = 1;
+    } else {
+      this._maxConcurrentSessions = requested;
+    }
+    this.semaphore = new Semaphore(this._maxConcurrentSessions);
+  }
+
+  /** Current count of active (running) runWorkflow() calls. */
+  get activeSessions(): number {
+    return this.semaphore.activeCount;
+  }
+
+  /** Configured maximum concurrent runWorkflow() calls. */
+  get maxConcurrentSessions(): number {
+    return this._maxConcurrentSessions;
   }
 
   /**
@@ -417,7 +508,23 @@ export class TriggerRouter {
       ? `${trigger.id}:${crypto.randomUUID()}`
       : trigger.id;
     void this.queue.enqueue(queueKey, async () => {
-      let result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey);
+      // Acquire the global semaphore before starting runWorkflowFn().
+      // WHY inside the callback (not before enqueue): route() must return immediately.
+      // Blocking here is safe; blocking before enqueue() would break the 202 contract.
+      if (this.semaphore.activeCount >= this._maxConcurrentSessions) {
+        console.warn(
+          `[TriggerRouter] Concurrency limit reached ` +
+          `(${this.semaphore.activeCount}/${this._maxConcurrentSessions} active): ` +
+          `queuing dispatch for triggerId=${trigger.id}`,
+        );
+      }
+      await this.semaphore.acquire();
+      let result: WorkflowRunResult;
+      try {
+        result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey);
+      } finally {
+        this.semaphore.release();
+      }
 
       // POST result to callbackUrl if configured (GAP-3: deliveryContext).
       // WHY: bind delivery target at trigger-config time, post result at completion time.
@@ -500,7 +607,22 @@ export class TriggerRouter {
    */
   dispatch(workflowTrigger: WorkflowTrigger): string {
     void this.queue.enqueue(workflowTrigger.workflowId, async () => {
-      const result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey);
+      // Same semaphore pattern as route(): acquire inside the callback so dispatch()
+      // returns immediately, then wait for a slot before calling runWorkflowFn().
+      if (this.semaphore.activeCount >= this._maxConcurrentSessions) {
+        console.warn(
+          `[TriggerRouter] Concurrency limit reached ` +
+          `(${this.semaphore.activeCount}/${this._maxConcurrentSessions} active): ` +
+          `queuing dispatch for workflowId=${workflowTrigger.workflowId}`,
+        );
+      }
+      await this.semaphore.acquire();
+      let result: WorkflowRunResult;
+      try {
+        result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey);
+      } finally {
+        this.semaphore.release();
+      }
       if (result._tag === 'success') {
         console.log(
           `[TriggerRouter] Dispatch completed: workflowId=${workflowTrigger.workflowId} ` +

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -422,15 +422,19 @@ export class TriggerRouter {
     // Validate and clamp: maxConcurrentSessions must be >= 1.
     // A value of 0 or negative would deadlock all dispatches -- make it impossible.
     const requested = maxConcurrentSessions ?? DEFAULT_MAX_CONCURRENT_SESSIONS;
-    if (requested < 1) {
+    // WHY: ?? does not catch NaN (NaN is type number, not null/undefined). If NaN reaches
+    // Semaphore(), acquire() deadlocks silently because 0 < NaN is false.
+    const cap = Number.isNaN(requested) ? DEFAULT_MAX_CONCURRENT_SESSIONS : requested;
+    if (cap < 1) {
       console.warn(
-        `[TriggerRouter] maxConcurrentSessions must be >= 1; received ${requested}, clamping to 1.`,
+        `[TriggerRouter] maxConcurrentSessions must be >= 1; received ${cap}, clamping to 1.`,
       );
       this._maxConcurrentSessions = 1;
     } else {
-      this._maxConcurrentSessions = requested;
+      this._maxConcurrentSessions = cap;
     }
     this.semaphore = new Semaphore(this._maxConcurrentSessions);
+    console.log(`[TriggerRouter] maxConcurrentSessions=${this._maxConcurrentSessions}`);
   }
 
   /** Current count of active (running) runWorkflow() calls. */

--- a/tests/unit/trigger-router.test.ts
+++ b/tests/unit/trigger-router.test.ts
@@ -783,3 +783,178 @@ describe('TriggerRouter.route callbackUrl delivery', () => {
     logSpy.mockRestore();
   });
 });
+
+// ---------------------------------------------------------------------------
+// maxConcurrentSessions: global semaphore
+// ---------------------------------------------------------------------------
+
+describe('TriggerRouter maxConcurrentSessions semaphore', () => {
+  /**
+   * Helper: creates a RunWorkflowFn that blocks until release() is called per call.
+   * Each call increments inFlightCount on start and decrements on release.
+   * releaseNext() resolves the oldest pending call.
+   * releaseAll() resolves all pending calls.
+   */
+  function makeLatchedRunWorkflow(): {
+    fn: RunWorkflowFn;
+    inFlight: () => number;
+    releaseNext: () => void;
+    releaseAll: () => void;
+  } {
+    let inFlightCount = 0;
+    const releaseFns: Array<() => void> = [];
+
+    const fn: RunWorkflowFn = async (trigger) => {
+      inFlightCount++;
+      await new Promise<void>((resolve) => {
+        releaseFns.push(resolve);
+      });
+      inFlightCount--;
+      return { _tag: 'success', workflowId: trigger.workflowId, stopReason: 'stop' };
+    };
+
+    return {
+      fn,
+      inFlight: () => inFlightCount,
+      releaseNext: () => { releaseFns.shift()?.(); },
+      releaseAll: () => { releaseFns.splice(0).forEach((r) => r()); },
+    };
+  }
+
+  it('limits concurrent runWorkflow() calls to maxConcurrentSessions', async () => {
+    // Proves the semaphore caps at the configured limit.
+    // With cap=2 and 3 fires: first two should start, third should be queued.
+    const trigger = makeTrigger({ concurrencyMode: 'parallel' });
+    const { fn, inFlight, releaseAll } = makeLatchedRunWorkflow();
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn, undefined, 2);
+
+    router.route(makeEvent());
+    router.route(makeEvent());
+    router.route(makeEvent());
+
+    // Drain: give semaphore time to start the first two (third is blocked, waiting for slot).
+    await new Promise<void>((r) => setImmediate(r));
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(inFlight()).toBe(2);
+    expect(router.activeSessions).toBe(2);
+    expect(router.maxConcurrentSessions).toBe(2);
+
+    releaseAll();
+    // Multiple drains needed: releaseAll() unblocks latches, but the third dispatch
+    // still needs to acquire the semaphore and run -- give it time.
+    await new Promise<void>((r) => setTimeout(r, 20));
+    releaseAll(); // release the third dispatch (which started after first two completed)
+    await new Promise<void>((r) => setTimeout(r, 20));
+    expect(inFlight()).toBe(0);
+  });
+
+  it('queue-and-wait: third dispatch proceeds after one of the first two completes', async () => {
+    // Proves that queued dispatches are not dropped -- they execute once a slot opens.
+    const trigger = makeTrigger({ concurrencyMode: 'parallel' });
+    const { fn, inFlight, releaseNext, releaseAll } = makeLatchedRunWorkflow();
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn, undefined, 2);
+
+    router.route(makeEvent());
+    router.route(makeEvent());
+    router.route(makeEvent());
+
+    await new Promise<void>((r) => setImmediate(r));
+    await new Promise<void>((r) => setImmediate(r));
+
+    // First two in-flight, third queued
+    expect(inFlight()).toBe(2);
+
+    // Release one slot -- third should start
+    releaseNext();
+    await new Promise<void>((r) => setImmediate(r));
+    await new Promise<void>((r) => setImmediate(r));
+
+    // Second original + third should now be in-flight
+    expect(inFlight()).toBe(2);
+
+    releaseAll();
+    await new Promise<void>((r) => setImmediate(r));
+    await new Promise<void>((r) => setImmediate(r));
+    expect(inFlight()).toBe(0);
+  });
+
+  it('releases semaphore slot when runWorkflowFn returns error result (finally block)', async () => {
+    // ORANGE-1: proves the finally block releases the slot even when runWorkflowFn
+    // returns an error result (workflow failed but slot must still be freed).
+    // Without the finally block, a failing workflow would permanently consume a slot.
+    const trigger = makeTrigger({ concurrencyMode: 'parallel' });
+    let firstCallUnblock!: () => void;
+    let secondCallResolved = false;
+
+    const fn: RunWorkflowFn = async (t) => {
+      if (!firstCallUnblock) {
+        // First call: block until explicitly unblocked, then return error result
+        await new Promise<void>((resolve) => { firstCallUnblock = resolve; });
+        return { _tag: 'error', workflowId: t.workflowId, message: 'simulated failure', stopReason: 'stop' };
+      }
+      // Second call: resolves immediately -- proves slot was released after first finished
+      secondCallResolved = true;
+      return { _tag: 'success', workflowId: t.workflowId, stopReason: 'stop' };
+    };
+
+    // cap=1 so second dispatch can only run after first releases the semaphore slot
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn, undefined, 1);
+
+    router.route(makeEvent());
+    await new Promise<void>((r) => setImmediate(r));
+
+    // First call is running -- second is queued (cap=1)
+    router.route(makeEvent());
+    expect(secondCallResolved).toBe(false);
+
+    // Unblock the first call (returns error) -- finally MUST release the slot
+    firstCallUnblock();
+    await new Promise<void>((r) => setTimeout(r, 20));
+
+    // Second call must have run (slot was released by finally even though first returned error)
+    expect(secondCallResolved).toBe(true);
+  });
+
+  it('defaults to 3 concurrent sessions when maxConcurrentSessions is not specified', async () => {
+    // Proves the default is 3, not unlimited.
+    const trigger = makeTrigger({ concurrencyMode: 'parallel' });
+    const { fn, inFlight, releaseAll } = makeLatchedRunWorkflow();
+    // No maxConcurrentSessions argument -- should default to 3
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn);
+
+    expect(router.maxConcurrentSessions).toBe(3);
+
+    // Fire 4 dispatches -- only 3 should be in-flight simultaneously
+    router.route(makeEvent());
+    router.route(makeEvent());
+    router.route(makeEvent());
+    router.route(makeEvent());
+
+    await new Promise<void>((r) => setImmediate(r));
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(inFlight()).toBe(3);
+
+    releaseAll();
+    // Fourth dispatch was queued -- now it starts. Release it too.
+    await new Promise<void>((r) => setTimeout(r, 20));
+    releaseAll();
+    await new Promise<void>((r) => setTimeout(r, 20));
+    expect(inFlight()).toBe(0);
+  });
+
+  it('clamps maxConcurrentSessions=0 to 1 and warns', () => {
+    // Proves the illegal-state invariant: 0 or negative is clamped to 1.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const trigger = makeTrigger({ concurrencyMode: 'serial' });
+    const { fn } = makeFakeRunWorkflow();
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn, undefined, 0);
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('clamping to 1'));
+    expect(router.maxConcurrentSessions).toBe(1);
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a configurable global cap on concurrent `runWorkflow()` calls via a promise-based semaphore in `TriggerRouter`
- New dispatches queue and wait (backpressure) when at capacity -- no silent drops after the caller receives 202 Accepted
- Default cap is 3, configurable via `~/.workrail/config.json` `maxConcurrentSessions` field
- Exposes `activeSessions` and `maxConcurrentSessions` public readonly getters for future console display
- Covers both `route()` (webhook path) and `dispatch()` (console path)

## Design notes
The semaphore acquires **inside** the `KeyedAsyncQueue` callback, not before `enqueue()`. This preserves the fire-and-forget contract (route/dispatch return immediately) while still providing true backpressure. The `KeyedAsyncQueue` per-key serialization is unchanged -- the semaphore is a global cap on top.

`maxConcurrentSessions` in `config.json` is stored as a string per the existing schema and parsed with `parseInt` in `trigger-listener.ts`.

## Test plan
- [x] Semaphore caps at configured limit (3 fires, cap=2: only 2 in-flight simultaneously)
- [x] Queue-and-wait: third dispatch starts after one of the first two completes
- [x] Semaphore slot released even when `runWorkflowFn` returns error result (finally block)
- [x] Default of 3 applies when `maxConcurrentSessions` is not configured
- [x] `maxConcurrentSessions=0` clamped to 1 with warning
- [x] All 34 pre-existing tests continue to pass (39 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)