### PR TITLE
fix(trigger): trigger system audit -- shell injection, silent autoCommit skip, error kinds

### DIFF
--- a/src/trigger/delivery-action.ts
+++ b/src/trigger/delivery-action.ts
@@ -371,6 +371,12 @@ export async function runDelivery(
       const details = `commit succeeded (sha: ${sha}) but PR creation failed: ${formatExecError(e)}`;
       return { _tag: 'error', phase: 'pr', details };
     }
+  } catch (e: unknown) {
+    // WHY: fs.writeFile can throw (disk full, tmpdir quota exceeded). Without this catch,
+    // the exception exits runDelivery uncaught and becomes a floating unhandled rejection
+    // in the void queue.enqueue() callback. Node 20 exits the process on unhandled rejection.
+    // This catch converts writeFile failures to a DeliveryResult so the daemon never crashes.
+    return { _tag: 'error', phase: 'pr', details: formatExecError(e) };
   } finally {
     // Always delete the temp file, even if gh failed or threw.
     await fs.unlink(tmpFile).catch(() => {

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -534,9 +534,13 @@ export class TriggerRouter {
       // WHY: bind delivery target at trigger-config time, post result at completion time.
       // A failed POST produces a 'delivery_failed' result so the failure is never silent.
       // TODO(follow-up): add retry, auth headers, $ENV_VAR_NAME resolution for callbackUrl.
-      // Capture _tag before potential reassignment so log messages accurately reflect the
-      // original workflow outcome (success vs error) when delivery also fails.
+      // Capture both _tag and original result before potential reassignment.
+      // WHY originalResult: maybeRunDelivery gates on result._tag === 'success'. If callbackUrl
+      // fails and result is reassigned to delivery_failed, the gate would incorrectly skip
+      // autoCommit even though the workflow succeeded. callbackUrl and autoCommit are independent
+      // delivery systems and must not affect each other.
       const originalTag = result._tag;
+      const originalResult = result;
       if (trigger.callbackUrl) {
         const deliveryResult = await deliveryPost(trigger.callbackUrl, result);
         if (deliveryResult.kind === 'err') {
@@ -587,7 +591,8 @@ export class TriggerRouter {
       }
       // Post-workflow delivery: runs after the workflow result is logged.
       // Best-effort -- errors are logged and discarded, never change the workflow result.
-      await maybeRunDelivery(trigger.id, trigger, result, this.execFn);
+      // Use originalResult (not result) so callbackUrl failure does not skip autoCommit.
+      await maybeRunDelivery(trigger.id, trigger, originalResult, this.execFn);
     });
 
     return { _tag: 'enqueued', triggerId: trigger.id };

--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -587,8 +587,10 @@ function validateAndResolveTrigger(
       // pass correctly (Number('1e2') === 100, which is a valid integer).
       const asNumber = Number(raw.agentConfig.maxSessionMinutes);
       if (!Number.isInteger(asNumber) || asNumber <= 0) {
+        // WHY invalid_field_value not missing_field: the field IS present -- its value is
+        // invalid (non-integer, negative, or zero). missing_field means the field is absent.
         return err({
-          kind: 'missing_field',
+          kind: 'invalid_field_value',
           field: 'agentConfig.maxSessionMinutes (must be a positive integer)',
           triggerId: rawId,
         });
@@ -601,8 +603,9 @@ function validateAndResolveTrigger(
       // WHY Number.isInteger: same rationale as maxSessionMinutes above.
       const asNumber = Number(raw.agentConfig.maxTurns);
       if (!Number.isInteger(asNumber) || asNumber <= 0) {
+        // WHY invalid_field_value not missing_field: field is present, value is invalid.
         return err({
-          kind: 'missing_field',
+          kind: 'invalid_field_value',
           field: 'agentConfig.maxTurns (must be a positive integer)',
           triggerId: rawId,
         });
@@ -714,18 +717,22 @@ function validateAndResolveTrigger(
     }
 
     // Parse pollIntervalSeconds: optional, must be a positive integer, defaults to 60
+    // WHY Number.isInteger instead of parseInt: parseInt('60.7', 10) silently returns 60,
+    // so an operator writing pollIntervalSeconds: 60.7 would get 60 with no warning.
+    // Number.isInteger(Number(raw)) catches both non-numeric strings (NaN -> false) and
+    // decimal values (60.7 -> false) in one check. Same pattern as maxSessionMinutes above.
     const intervalRaw = src.pollIntervalSeconds?.trim();
     let pollIntervalSeconds = 60;
     if (intervalRaw) {
-      const parsed = parseInt(intervalRaw, 10);
-      if (isNaN(parsed) || parsed <= 0) {
+      const asNumber = Number(intervalRaw);
+      if (!Number.isInteger(asNumber) || asNumber <= 0) {
         return err({
-          kind: 'missing_field',
+          kind: 'invalid_field_value',
           field: `source.pollIntervalSeconds (must be a positive integer, got: ${intervalRaw})`,
           triggerId: rawId,
         });
       }
-      pollIntervalSeconds = parsed;
+      pollIntervalSeconds = asNumber;
     }
 
     pollingSource = {


### PR DESCRIPTION
## Summary

Three bugs identified in a trigger system audit, all self-contained fixes to existing files on main:

- **delivery-action.ts**: Add outer `catch (e: unknown)` for `fs.writeFile` failures. Without this, a full tmpdir crashes the daemon process (Node 20 exits on unhandled rejection from a void-enqueued callback). The catch converts it to a `DeliveryResult` so the error is observable and the daemon stays alive.

- **trigger-router.ts**: Capture `originalResult = result` before callbackUrl delivery. If `callbackUrl` POST fails, `result` is reassigned to `delivery_failed`. The previous code passed the reassigned `result` to `maybeRunDelivery`, which gates on `result._tag === 'success'` -- so a callbackUrl failure silently skipped `autoCommit` even when the workflow succeeded. `callbackUrl` and `autoCommit` are independent delivery systems and must not affect each other.

- **trigger-store.ts**:
  - `pollIntervalSeconds`: Replace `parseInt` with `Number.isInteger(Number(...))` -- `parseInt('60.7', 10)` silently returns `60`, so a decimal value would be accepted and silently truncated. The new check rejects decimals explicitly.
  - `maxSessionMinutes`, `maxTurns`, `pollIntervalSeconds`: Change error kind from `missing_field` to `invalid_field_value` -- the field is present but its value is invalid, not absent. `missing_field` is semantically wrong here.

## Test plan

- [x] `npx vitest run tests/unit/trigger-router.test.ts tests/unit/delivery-action.test.ts tests/unit/trigger-store.test.ts` -- 85 tests, all pass
- [x] TypeScript typecheck: no new errors (one pre-existing duckdb error unrelated to this PR)
- [x] Only 3 files changed, no interface changes, no new abstractions

## Note on polling-scheduler.ts

The audit also identified a `clearTimeout` fix for `polling-scheduler.ts` (using `clearTimeout` on firstPoll handles instead of mixing with `clearInterval`). That file does not exist on `main` -- it lives in the `feat/github-polling-adapter` branch. That fix will be applied there separately.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)