### PR TITLE
feat(mcp): workspace namespacing Phase 1 -- per-workspace soul file isolation

### DIFF
--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -275,7 +275,16 @@ export function loadWorkspacesFromConfigFile(): Result<Record<string, WorkspaceC
       );
       continue;
     }
-    result[name] = parseResult.data;
+    const data = parseResult.data;
+    // Expand `~/` tilde prefix in soulFile defensively at config-load time.
+    // WHY: Node.js fs APIs do not perform shell-style tilde expansion. Expanding
+    // here ensures WorkspaceConfig objects never carry unexpanded tilde paths,
+    // even before they reach validateAndResolveTrigger.
+    if (data.soulFile?.startsWith('~/')) {
+      result[name] = { ...data, soulFile: path.join(os.homedir(), data.soulFile.slice(2)) };
+    } else {
+      result[name] = data;
+    }
   }
 
   return ok(result);

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs';
 import { z } from 'zod';
 import type { Result } from '../runtime/result.js';
 import { ok } from '../runtime/result.js';
+import type { WorkspaceConfig } from '../trigger/types.js';
 
 // =============================================================================
 // Allowed keys (all supported env var names, minus excluded set)
@@ -201,4 +202,81 @@ export function loadWorkrailConfigFile(): Result<Record<string, string>, ConfigF
   }
 
   return ok(validated);
+}
+
+// =============================================================================
+// Workspace config loader
+// =============================================================================
+
+const WorkspaceConfigEntrySchema = z.object({
+  path: z.string().min(1),
+  soulFile: z.string().min(1).optional(),
+});
+
+/**
+ * Load the "workspaces" map from ~/.workrail/config.json.
+ *
+ * Returns ok(Record<string, WorkspaceConfig>) on success.
+ * Returns ok({}) when:
+ * - Config file is absent (ENOENT)
+ * - Config file has no "workspaces" key
+ * - VITEST is set (test isolation -- never reads disk in tests)
+ * Invalid entries are warned about and skipped; the rest are returned.
+ * This function NEVER errors -- callers can always trust ok(result).
+ *
+ * WHY a separate function from loadWorkrailConfigFile:
+ * The existing loader returns a flat Record<string, string> for env-merging.
+ * The workspace map is a nested object serving a different consumer (trigger loading).
+ */
+export function loadWorkspacesFromConfigFile(): Result<Record<string, WorkspaceConfig>, never> {
+  if (process.env['VITEST']) return ok({});
+
+  const configPath = path.join(os.homedir(), '.workrail', 'config.json');
+
+  let rawContent: string;
+  try {
+    rawContent = fs.readFileSync(configPath, 'utf-8');
+  } catch {
+    return ok({});
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawContent);
+  } catch {
+    return ok({});
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return ok({});
+  }
+
+  const workspacesRaw = (parsed as Record<string, unknown>)['workspaces'];
+
+  if (workspacesRaw === undefined || workspacesRaw === null) {
+    return ok({});
+  }
+
+  if (typeof workspacesRaw !== 'object' || Array.isArray(workspacesRaw)) {
+    console.warn(
+      '[WorkRail] config file: "workspaces" must be an object (map of name -> { path, soulFile? }). Ignoring.',
+    );
+    return ok({});
+  }
+
+  const result: Record<string, WorkspaceConfig> = {};
+  for (const [name, entry] of Object.entries(workspacesRaw as Record<string, unknown>)) {
+    const parseResult = WorkspaceConfigEntrySchema.safeParse(entry);
+    if (!parseResult.success) {
+      console.warn(
+        `[WorkRail] config file: workspace "${name}" has invalid shape -- skipped. ` +
+        `Expected { path: string; soulFile?: string }. ` +
+        `Issues: ${parseResult.error.issues.map((i) => i.message).join(', ')}`,
+      );
+      continue;
+    }
+    result[name] = parseResult.data;
+  }
+
+  return ok(result);
 }

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -196,6 +196,13 @@ export interface WorkflowTrigger {
    * dispatch HTTP handler.
    */
   readonly _preAllocatedStartResponse?: import('zod').infer<typeof V2StartWorkflowOutputSchema>;
+  /**
+   * Optional resolved soul file path. Sourced from TriggerDefinition.soulFile
+   * (already cascade-resolved by trigger-store.ts: trigger soulFile -> workspace soulFile).
+   * When absent, loadDaemonSoul() falls back to ~/.workrail/daemon-soul.md.
+   * Kept here so workflow-runner.ts remains decoupled from trigger system types.
+   */
+  readonly soulFile?: string;
 }
 
 /** Successful completion of a workflow run. */
@@ -511,17 +518,22 @@ async function clearStrayTmpFiles(sessionsDir: string): Promise<void> {
 // ---------------------------------------------------------------------------
 
 /**
- * Load the operator-customizable agent rules from ~/.workrail/daemon-soul.md.
+ * Load the operator-customizable agent rules from a soul file.
  *
- * On first run (file absent), writes a template to disk so the operator can
- * discover and customize it. The write is best-effort: if it fails (e.g. read-only
- * filesystem), the warning is logged and the default content is returned anyway.
+ * @param resolvedPath - Optional resolved path from the cascade in trigger-store.ts:
+ *   TriggerDefinition.soulFile (trigger override) -> WorkspaceConfig.soulFile (workspace default).
+ *   When absent, falls back to ~/.workrail/daemon-soul.md (global default).
  *
- * WHY synchronous default path: soul content must be ready before Agent construction.
- * The function is async only because first-run template creation requires an fs.writeFile.
+ * On first run (file absent), writes a template to disk so the operator can discover
+ * and customize it. The write is best-effort: if it fails, the warning is logged and
+ * DAEMON_SOUL_DEFAULT is returned anyway.
+ *
+ * WHY path.dirname(soulPath) for mkdir: for workspace-scoped paths like
+ * ~/.workrail/workspaces/my-project/daemon-soul.md, the parent dir must be created --
+ * not WORKRAIL_DIR (~/.workrail) which is already present.
  */
-async function loadDaemonSoul(): Promise<string> {
-  const soulPath = path.join(WORKRAIL_DIR, 'daemon-soul.md');
+async function loadDaemonSoul(resolvedPath?: string): Promise<string> {
+  const soulPath = resolvedPath ?? path.join(WORKRAIL_DIR, 'daemon-soul.md');
   try {
     return await fs.readFile(soulPath, 'utf8');
   } catch (err: unknown) {
@@ -531,7 +543,7 @@ async function loadDaemonSoul(): Promise<string> {
     if (isEnoent) {
       // Best-effort template creation -- failure is logged but never fatal.
       try {
-        await fs.mkdir(WORKRAIL_DIR, { recursive: true });
+        await fs.mkdir(path.dirname(soulPath), { recursive: true });
         await fs.writeFile(soulPath, DAEMON_SOUL_TEMPLATE, 'utf8');
         console.log(`[WorkflowRunner] Created daemon-soul.md template at ${soulPath}`);
       } catch (writeErr: unknown) {
@@ -1223,8 +1235,10 @@ export async function runWorkflow(
   // WHY system prompt instead of agent.steer(): steer() fires AFTER LLM responses,
   // not before. Populating the system prompt at construction time is the correct
   // pre-step-1 injection point.
+  // trigger.soulFile is already cascade-resolved by trigger-store.ts:
+  //   trigger soulFile -> workspace soulFile -> undefined (global fallback in loadDaemonSoul)
   const [soulContent, workspaceContext, sessionNotes] = await Promise.all([
-    loadDaemonSoul(),
+    loadDaemonSoul(trigger.soulFile),
     loadWorkspaceContext(trigger.workspacePath),
     startContinueToken ? loadSessionNotes(startContinueToken, ctx) : Promise.resolve([] as readonly string[]),
   ]);

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -26,9 +26,9 @@ import type { V2ToolContext } from '../mcp/types.js';
 import { loadTriggerConfigFromFile, buildTriggerIndex } from './trigger-store.js';
 import type { TriggerStoreError } from './trigger-store.js';
 import { TriggerRouter, type RunWorkflowFn } from './trigger-router.js';
-import { loadWorkrailConfigFile } from '../config/config-file.js';
+import { loadWorkrailConfigFile, loadWorkspacesFromConfigFile } from '../config/config-file.js';
 import { runWorkflow, runStartupRecovery } from '../daemon/workflow-runner.js';
-import type { WebhookEvent } from './types.js';
+import type { WebhookEvent, WorkspaceConfig } from './types.js';
 import { asTriggerId } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -69,6 +69,13 @@ export interface StartTriggerListenerOptions {
   readonly env?: Record<string, string | undefined>;
   /** Override runWorkflow() for testing. */
   readonly runWorkflowFn?: RunWorkflowFn;
+  /**
+   * Optional workspace map for workspace namespacing (Phase 1).
+   * When provided, trigger workspaceName fields are resolved against this map.
+   * When absent, loadWorkspacesFromConfigFile() is called to load from config.json.
+   * Pass {} to explicitly disable workspace namespacing (e.g. in tests).
+   */
+  readonly workspaces?: Readonly<Record<string, WorkspaceConfig>>;
 }
 
 // ---------------------------------------------------------------------------
@@ -183,8 +190,17 @@ export async function startTriggerListener(
     return { _kind: 'err', error: { kind: 'missing_api_key' } };
   }
 
+  // Load workspace namespacing map (Phase 1).
+  // If workspaces is explicitly provided (e.g. in tests), use it directly.
+  // Otherwise load from ~/.workrail/config.json.
+  // loadWorkspacesFromConfigFile() never errors (error type is `never`), so the kind
+  // is always 'ok'. The discriminant check satisfies TypeScript's narrowing requirement.
+  const workspaceResult = loadWorkspacesFromConfigFile();
+  const loadedWorkspaces = workspaceResult.kind === 'ok' ? workspaceResult.value : {};
+  const workspaces = options.workspaces ?? loadedWorkspaces;
+
   // Load triggers.yml
-  const configResult = await loadTriggerConfigFromFile(options.workspacePath, env);
+  const configResult = await loadTriggerConfigFromFile(options.workspacePath, env, workspaces);
 
   let triggerIndex: Map<string, import('./types.js').TriggerDefinition>;
 

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -497,6 +497,8 @@ export class TriggerRouter {
       context: workflowContext,
       ...(trigger.referenceUrls !== undefined ? { referenceUrls: trigger.referenceUrls } : {}),
       ...(trigger.agentConfig !== undefined ? { agentConfig: trigger.agentConfig } : {}),
+      // soulFile is cascade-resolved in trigger-store.ts (trigger -> workspace -> undefined).
+      ...(trigger.soulFile !== undefined ? { soulFile: trigger.soulFile } : {}),
     };
 
     // Enqueue asynchronously.

--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -38,7 +38,10 @@ import {
   type ContextMapping,
   type ContextMappingEntry,
   type GitLabPollingSource,
+  type WorkspaceConfig,
+  type WorkspaceName,
   asTriggerId,
+  asWorkspaceName,
 } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -51,6 +54,7 @@ export type TriggerStoreError =
   | { readonly kind: 'missing_field'; readonly field: string; readonly triggerId: string }
   | { readonly kind: 'invalid_field_value'; readonly field: string; readonly triggerId: string }
   | { readonly kind: 'unknown_provider'; readonly provider: string; readonly triggerId: string }
+  | { readonly kind: 'unknown_workspace'; readonly workspaceName: string; readonly triggerId: string }
   | { readonly kind: 'file_not_found'; readonly filePath: string }
   | { readonly kind: 'io_error'; readonly message: string }
   | { readonly kind: 'duplicate_id'; readonly triggerId: string };
@@ -100,6 +104,9 @@ interface ParsedTriggerRaw {
   onComplete?: { runOn?: string; workflowId?: string; goal?: string };
   autoCommit?: string;   // 'true' | 'false' scalar
   autoOpenPR?: string;   // 'true' | 'false' scalar
+  // Workspace namespacing (Phase 1).
+  workspaceName?: string;  // raw string; validated + branded in validateAndResolveTrigger
+  soulFile?: string;       // raw path; cascade-resolved in validateAndResolveTrigger
   // Polling trigger source (present only when provider === 'gitlab_poll').
   // Stored as raw strings; resolved and validated in validateAndResolveTrigger().
   source?: {
@@ -449,7 +456,9 @@ function setTriggerField(trigger: ParsedTriggerRaw, key: string, value: string):
     case 'callbackUrl':      trigger.callbackUrl = value; break;
     case 'autoCommit':       trigger.autoCommit = value; break;
     case 'autoOpenPR':       trigger.autoOpenPR = value; break;
-    // contextMapping, agentConfig, onComplete handled as sub-object blocks
+    case 'workspaceName':    trigger.workspaceName = value; break;
+    case 'soulFile':         trigger.soulFile = value; break;
+    // contextMapping, agentConfig, onComplete, source handled as sub-object blocks
     default:
       // Unknown fields silently ignored for forward compatibility
       break;
@@ -499,16 +508,17 @@ function assembleContextMapping(
 function validateAndResolveTrigger(
   raw: ParsedTriggerRaw,
   env: Record<string, string | undefined>,
+  workspaces: Readonly<Record<string, WorkspaceConfig>> = {},
 ): Result<TriggerDefinition, TriggerStoreError> {
   const rawId = raw.id?.trim() ?? '';
   if (!rawId) {
     return err({ kind: 'missing_field', field: 'id', triggerId: '(unknown)' });
   }
 
-  const requiredStringFields: Array<Extract<keyof ParsedTriggerRaw, 'provider' | 'workflowId' | 'workspacePath' | 'goal'>> = [
+  // Fields required unconditionally (workspacePath is handled separately below).
+  const requiredStringFields: Array<Extract<keyof ParsedTriggerRaw, 'provider' | 'workflowId' | 'goal'>> = [
     'provider',
     'workflowId',
-    'workspacePath',
     'goal',
   ];
   for (const field of requiredStringFields) {
@@ -521,6 +531,65 @@ function validateAndResolveTrigger(
   const provider = raw.provider!.trim();
   if (!SUPPORTED_PROVIDERS.has(provider)) {
     return err({ kind: 'unknown_provider', provider, triggerId: rawId });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Workspace namespacing (Phase 1): resolve workspacePath and soulFile.
+  //
+  // If workspaceName is provided:
+  //   1. Validate format: ^[a-zA-Z0-9_-]+$
+  //   2. Look up in workspaces map (unknown_workspace = per-trigger soft error)
+  //   3. Validate path is absolute
+  //   4. Soul cascade: trigger YAML soulFile > workspace soulFile > undefined
+  // If workspaceName is absent, workspacePath is required.
+  // If both are provided, warn and use workspaceName.
+  // ---------------------------------------------------------------------------
+  let resolvedWorkspacePath: string;
+  let resolvedWorkspaceName: WorkspaceName | undefined;
+  let resolvedSoulFile: string | undefined;
+
+  const rawWorkspaceName = raw.workspaceName?.trim();
+  const rawWorkspacePath = raw.workspacePath?.trim();
+  const rawSoulFile = raw.soulFile?.trim();
+
+  if (rawWorkspaceName) {
+    if (!/^[a-zA-Z0-9_-]+$/.test(rawWorkspaceName)) {
+      return err({
+        kind: 'invalid_field_value',
+        field: `workspaceName (must match ^[a-zA-Z0-9_-]+$, got: "${rawWorkspaceName}")`,
+        triggerId: rawId,
+      });
+    }
+
+    const workspaceConfig = workspaces[rawWorkspaceName];
+    if (!workspaceConfig) {
+      return err({ kind: 'unknown_workspace', workspaceName: rawWorkspaceName, triggerId: rawId });
+    }
+
+    if (!path.isAbsolute(workspaceConfig.path)) {
+      return err({
+        kind: 'invalid_field_value',
+        field: `workspace "${rawWorkspaceName}".path (must be absolute, got: "${workspaceConfig.path}")`,
+        triggerId: rawId,
+      });
+    }
+
+    if (rawWorkspacePath) {
+      console.warn(
+        `[TriggerStore] WARNING: trigger "${rawId}" has both workspaceName and workspacePath. ` +
+        `workspaceName takes precedence; workspacePath "${rawWorkspacePath}" is ignored.`,
+      );
+    }
+
+    resolvedWorkspacePath = workspaceConfig.path;
+    resolvedWorkspaceName = asWorkspaceName(rawWorkspaceName);
+    resolvedSoulFile = rawSoulFile ?? workspaceConfig.soulFile;
+  } else {
+    if (!rawWorkspacePath) {
+      return err({ kind: 'missing_field', field: 'workspacePath', triggerId: rawId });
+    }
+    resolvedWorkspacePath = rawWorkspacePath;
+    resolvedSoulFile = rawSoulFile;
   }
 
   // Resolve hmacSecret if present
@@ -756,7 +825,8 @@ function validateAndResolveTrigger(
     id: asTriggerId(rawId),
     provider,
     workflowId: raw.workflowId!.trim(),
-    workspacePath: raw.workspacePath!.trim(),
+    // workspacePath: always set -- from workspaceName resolution or from raw YAML.
+    workspacePath: resolvedWorkspacePath,
     goal: raw.goal!.trim(),
     concurrencyMode,
     ...(hmacSecret !== undefined ? { hmacSecret } : {}),
@@ -771,6 +841,9 @@ function validateAndResolveTrigger(
     ...(autoCommit ? { autoCommit } : {}),
     ...(autoOpenPR ? { autoOpenPR } : {}),
     ...(pollingSource !== undefined ? { pollingSource } : {}),
+    // Workspace namespacing (Phase 1).
+    ...(resolvedWorkspaceName !== undefined ? { workspaceName: resolvedWorkspaceName } : {}),
+    ...(resolvedSoulFile ? { soulFile: resolvedSoulFile } : {}),
   };
 
   return ok(trigger);
@@ -791,6 +864,7 @@ function validateAndResolveTrigger(
 export function loadTriggerConfig(
   yamlContent: string,
   env: Record<string, string | undefined> = process.env,
+  workspaces: Readonly<Record<string, WorkspaceConfig>> = {},
 ): Result<TriggerConfig, TriggerStoreError> {
   const parsedResult = parseTriggersYaml(yamlContent);
   if (parsedResult.kind === 'err') return parsedResult;
@@ -800,7 +874,7 @@ export function loadTriggerConfig(
   const validTriggers: TriggerDefinition[] = [];
   const validationErrors: TriggerStoreError[] = [];
   for (const rawTrigger of parsedResult.value) {
-    const triggerResult = validateAndResolveTrigger(rawTrigger, env);
+    const triggerResult = validateAndResolveTrigger(rawTrigger, env, workspaces);
     if (triggerResult.kind === 'err') {
       console.warn(`[TriggerStore] Skipping invalid trigger: ${JSON.stringify(triggerResult.error)}`);
       validationErrors.push(triggerResult.error);
@@ -831,6 +905,7 @@ export function loadTriggerConfig(
 export async function loadTriggerConfigFromFile(
   workspacePath: string,
   env: Record<string, string | undefined> = process.env,
+  workspaces: Readonly<Record<string, WorkspaceConfig>> = {},
 ): Promise<Result<TriggerConfig, TriggerStoreError>> {
   const filePath = path.join(workspacePath, 'triggers.yml');
 
@@ -845,7 +920,7 @@ export async function loadTriggerConfigFromFile(
     return err({ kind: 'io_error', message: error.message ?? String(e) });
   }
 
-  return loadTriggerConfig(content, env);
+  return loadTriggerConfig(content, env, workspaces);
 }
 
 /**

--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -28,6 +28,7 @@
  *   goal: Review: MR #123     # Parse error
  */
 
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import type { Result } from '../runtime/result.js';
@@ -466,6 +467,26 @@ function setTriggerField(trigger: ParsedTriggerRaw, key: string, value: string):
 }
 
 // ---------------------------------------------------------------------------
+// Path utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Expand a leading `~/` in a file path to the user's home directory.
+ *
+ * WHY: Node.js `fs.readFile` (and all other fs APIs) do NOT perform shell-style
+ * tilde expansion. A path like `~/.workrail/soul.md` passed directly to fs will
+ * produce ENOENT because `~` is treated as a literal directory name, not the
+ * home directory. This function converts `~/foo` to `/home/<user>/foo` so that
+ * paths written with the common shell convention work correctly.
+ *
+ * Only the `~/` prefix is handled (the most common case). `~username/` forms are
+ * not supported and are returned unchanged.
+ */
+function expandTildePath(p: string): string {
+  return p.startsWith('~/') ? path.join(os.homedir(), p.slice(2)) : p;
+}
+
+// ---------------------------------------------------------------------------
 // Secret resolution
 //
 // Values starting with "$" are treated as environment variable references.
@@ -590,6 +611,22 @@ function validateAndResolveTrigger(
     }
     resolvedWorkspacePath = rawWorkspacePath;
     resolvedSoulFile = rawSoulFile;
+  }
+
+  // Expand `~/` tilde prefix in soulFile, if present.
+  // Node.js fs APIs do not perform shell-style tilde expansion; without this, a
+  // path like `~/.workrail/soul.md` would produce ENOENT and silently fall through
+  // to the default soul with no warning.
+  if (resolvedSoulFile) {
+    resolvedSoulFile = expandTildePath(resolvedSoulFile);
+  }
+
+  // Validate soulFile absoluteness after tilde expansion.
+  // WHY: a relative soulFile silently resolves against process.cwd(), which is almost
+  // certainly wrong. This mirrors the workspace.path absoluteness check above and
+  // ensures fail-fast at load time rather than a confusing runtime failure.
+  if (resolvedSoulFile && !path.isAbsolute(resolvedSoulFile)) {
+    return err({ kind: 'invalid_field_value', field: 'soulFile', triggerId: rawId });
   }
 
   // Resolve hmacSecret if present

--- a/src/trigger/types.ts
+++ b/src/trigger/types.ts
@@ -16,6 +16,8 @@
  *   It is an optional additive field on TriggerDefinition alongside the webhook fields.
  *   This is a stepping-stone design -- at 3+ polling adapter types, migrate to a
  *   discriminated union on TriggerDefinition. TODO(follow-up): migrate at adapter #2.
+ * - WorkspaceName / WorkspaceConfig implement Phase 1 of workspace namespacing.
+ *   Phase 2 (session metadata) and Phase 3 (per-workspace concurrency) are deferred.
  */
 
 // ---------------------------------------------------------------------------
@@ -26,6 +28,43 @@ export type TriggerId = string & { readonly _brand: 'TriggerId' };
 
 export function asTriggerId(value: string): TriggerId {
   return value as TriggerId;
+}
+
+// ---------------------------------------------------------------------------
+// WorkspaceName: branded string to prevent bare-string substitution
+//
+// Identifies a named workspace entry in ~/.workrail/config.json.
+// Format: ^[a-zA-Z0-9_-]+$ (validated at parse time by trigger-store.ts).
+// Follows the same pattern as TriggerId.
+// ---------------------------------------------------------------------------
+
+export type WorkspaceName = string & { readonly _brand: 'WorkspaceName' };
+
+export function asWorkspaceName(value: string): WorkspaceName {
+  return value as WorkspaceName;
+}
+
+// ---------------------------------------------------------------------------
+// WorkspaceConfig: per-workspace configuration entry from ~/.workrail/config.json
+//
+// Phase 1: path + soulFile only.
+// Phase 3 (future): add maxConcurrentSessions when the concurrency gate ships.
+//   Do NOT add maxConcurrentSessions here until then.
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceConfig {
+  /** Absolute path to the workspace directory. */
+  readonly path: string;
+  /**
+   * Optional workspace-specific daemon soul file path.
+   * Cascade (most-to-least specific):
+   *   1. TriggerDefinition.soulFile (trigger-level override in triggers.yml)
+   *   2. WorkspaceConfig.soulFile (this field -- workspace default)
+   *   3. ~/.workrail/daemon-soul.md (global fallback, applied at runtime)
+   *   4. DAEMON_SOUL_DEFAULT (built-in constant)
+   * Resolved at trigger parse time by trigger-store.ts into TriggerDefinition.soulFile.
+   */
+  readonly soulFile?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -308,6 +347,24 @@ export interface TriggerDefinition {
    * TODO(follow-up): migrate to discriminated union at adapter #2.
    */
   readonly pollingSource?: GitLabPollingSource;
+
+  /**
+   * Optional named workspace this trigger belongs to.
+   * When set, trigger-store.ts resolves workspacePath from WorkspaceConfig.path
+   * at parse time. Unknown names cause a per-trigger soft error (daemon continues).
+   * Format: ^[a-zA-Z0-9_-]+$ (validated at parse time).
+   * Phase 2 (future): DaemonEntry.workspaceName for console filtering.
+   */
+  readonly workspaceName?: WorkspaceName;
+
+  /**
+   * Optional resolved soul file path for this trigger's agent runs.
+   * Set by trigger-store.ts after cascade resolution:
+   *   trigger YAML soulFile -> workspace soulFile -> undefined.
+   * When absent, workflow-runner.ts falls back to ~/.workrail/daemon-soul.md.
+   * In YAML:   soulFile: "~/.workrail/workspaces/my-project/daemon-soul.md"
+   */
+  readonly soulFile?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/trigger-store.test.ts
+++ b/tests/unit/trigger-store.test.ts
@@ -523,3 +523,193 @@ triggers:
     expect(result.value.triggers).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Workspace namespacing (Phase 1)
+// ---------------------------------------------------------------------------
+
+describe('workspace namespacing (Phase 1)', () => {
+  const WORKSPACE_MAP = {
+    'my-project': { path: '/Users/me/git/my-project' },
+    'with-soul': { path: '/Users/me/git/with-soul', soulFile: '/home/me/.workrail/workspaces/with-soul/daemon-soul.md' },
+  };
+
+  it('happy path: resolves workspacePath from workspaceName', () => {
+    const yaml = `
+triggers:
+  - id: my-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspaceName: my-project
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, WORKSPACE_MAP);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.value.triggers).toHaveLength(1);
+    const trigger = result.value.triggers[0]!;
+    expect(trigger.workspacePath).toBe('/Users/me/git/my-project');
+    expect(trigger.workspaceName).toBe('my-project');
+    expect(trigger.soulFile).toBeUndefined();
+  });
+
+  it('resolves workspace soulFile into trigger soulFile when no trigger-level override', () => {
+    const yaml = `
+triggers:
+  - id: soul-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspaceName: with-soul
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, WORKSPACE_MAP);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    const trigger = result.value.triggers[0]!;
+    expect(trigger.soulFile).toBe('/home/me/.workrail/workspaces/with-soul/daemon-soul.md');
+  });
+
+  it('trigger-level soulFile overrides workspace soulFile', () => {
+    const yaml = `
+triggers:
+  - id: override-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspaceName: with-soul
+    soulFile: /custom/soul.md
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, WORKSPACE_MAP);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    const trigger = result.value.triggers[0]!;
+    expect(trigger.soulFile).toBe('/custom/soul.md');
+  });
+
+  it('trigger with soulFile only (no workspaceName) stores soulFile directly', () => {
+    const yaml = `
+triggers:
+  - id: soul-only-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    soulFile: /my/soul.md
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, {});
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    const trigger = result.value.triggers[0]!;
+    expect(trigger.soulFile).toBe('/my/soul.md');
+    expect(trigger.workspaceName).toBeUndefined();
+    expect(trigger.workspacePath).toBe('/path/to/repo');
+  });
+
+  it('emits unknown_workspace per-trigger error when workspaceName not in map', () => {
+    const yaml = `
+triggers:
+  - id: bad-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspaceName: nonexistent
+    goal: Review this MR
+  - id: good-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, WORKSPACE_MAP);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    // bad-trigger is skipped; good-trigger loads successfully
+    expect(result.value.triggers).toHaveLength(1);
+    expect(result.value.triggers[0]!.id).toBe('good-trigger');
+  });
+
+  it('warns and uses workspaceName when both workspaceName and workspacePath are specified', () => {
+    const yaml = `
+triggers:
+  - id: conflict-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspaceName: my-project
+    workspacePath: /some/other/path
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, WORKSPACE_MAP);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    const trigger = result.value.triggers[0]!;
+    // workspaceName takes precedence
+    expect(trigger.workspacePath).toBe('/Users/me/git/my-project');
+  });
+
+  it('rejects workspaceName with invalid format (contains slash)', () => {
+    const yaml = `
+triggers:
+  - id: bad-name-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspaceName: my/project
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, WORKSPACE_MAP);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    // Invalid format -- trigger is skipped
+    expect(result.value.triggers).toHaveLength(0);
+  });
+
+  it('rejects workspace config with relative path', () => {
+    const workspacesWithRelative = {
+      'relative': { path: 'relative/path' },
+    };
+    const yaml = `
+triggers:
+  - id: relative-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspaceName: relative
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, workspacesWithRelative);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    // Trigger skipped due to relative path in workspace config
+    expect(result.value.triggers).toHaveLength(0);
+  });
+
+  it('backward compat: existing triggers without workspaceName work unchanged', () => {
+    const yaml = `
+triggers:
+  - id: existing-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /existing/path
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, {}); // no workspaces map
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.value.triggers).toHaveLength(1);
+    expect(result.value.triggers[0]!.workspacePath).toBe('/existing/path');
+    expect(result.value.triggers[0]!.workspaceName).toBeUndefined();
+  });
+
+  it('backward compat: calling without workspaces param works (existing API)', () => {
+    const yaml = `
+triggers:
+  - id: compat-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /compat/path
+    goal: Review this MR
+`;
+    // Calling with only 2 params (existing callers) still works
+    const result = loadTriggerConfig(yaml, {});
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.value.triggers).toHaveLength(1);
+  });
+});

--- a/tests/unit/trigger-store.test.ts
+++ b/tests/unit/trigger-store.test.ts
@@ -13,6 +13,8 @@
  * - File-not-found handling (loadTriggerConfigFromFile)
  */
 
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { loadTriggerConfig } from '../../src/trigger/trigger-store.js';
 
@@ -711,5 +713,110 @@ triggers:
     expect(result.kind).toBe('ok');
     if (result.kind !== 'ok') return;
     expect(result.value.triggers).toHaveLength(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // F1: Tilde path expansion for soulFile
+  // ---------------------------------------------------------------------------
+
+  it('F1: expands ~/... soulFile in trigger YAML (workspacePath branch)', () => {
+    // WHY this test: Node.js fs.readFile does not expand ~; without expandTildePath,
+    // a soulFile: ~/foo/soul.md would produce ENOENT and silently fall through.
+    const yaml = `
+triggers:
+  - id: tilde-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    soulFile: ~/foo/daemon-soul.md
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, {});
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    const trigger = result.value.triggers[0]!;
+    expect(trigger.soulFile).toBe(path.join(os.homedir(), 'foo/daemon-soul.md'));
+    // The resolved path must be absolute (no leading ~)
+    expect(trigger.soulFile!.startsWith('~')).toBe(false);
+  });
+
+  it('F1: expands ~/... soulFile from workspace config cascade (workspaceName branch)', () => {
+    // Tilde expansion must also work when the soulFile comes from the workspace map
+    // (not the trigger YAML), since the cascade sets resolvedSoulFile from workspaceConfig.soulFile.
+    const workspacesWithTilde = {
+      'tilde-workspace': { path: '/Users/me/git/project', soulFile: '~/.workrail/workspaces/my/soul.md' },
+    };
+    const yaml = `
+triggers:
+  - id: tilde-ws-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspaceName: tilde-workspace
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, workspacesWithTilde);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    const trigger = result.value.triggers[0]!;
+    expect(trigger.soulFile).toBe(path.join(os.homedir(), '.workrail/workspaces/my/soul.md'));
+    expect(trigger.soulFile!.startsWith('~')).toBe(false);
+  });
+
+  it('F1: does not alter already-absolute soulFile path', () => {
+    const yaml = `
+triggers:
+  - id: abs-soul-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    soulFile: /absolute/soul.md
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, {});
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.value.triggers[0]!.soulFile).toBe('/absolute/soul.md');
+  });
+
+  // ---------------------------------------------------------------------------
+  // F2: Absoluteness validation for soulFile after tilde expansion
+  // ---------------------------------------------------------------------------
+
+  it('F2: rejects trigger with relative soulFile (trigger-level, workspacePath branch)', () => {
+    // WHY: a relative soulFile silently resolves against process.cwd(), which is
+    // almost certainly wrong. Mirrors workspace.path absoluteness check.
+    const yaml = `
+triggers:
+  - id: relative-soul-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /path/to/repo
+    soulFile: relative/soul.md
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, {});
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    // Trigger with relative soulFile is skipped
+    expect(result.value.triggers).toHaveLength(0);
+  });
+
+  it('F2: rejects trigger with relative soulFile from workspace config cascade', () => {
+    const workspacesWithRelativeSoul = {
+      'relative-soul-ws': { path: '/Users/me/git/project', soulFile: 'relative/soul.md' },
+    };
+    const yaml = `
+triggers:
+  - id: relative-soul-ws-trigger
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspaceName: relative-soul-ws
+    goal: Review this MR
+`;
+    const result = loadTriggerConfig(yaml, {}, workspacesWithRelativeSoul);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    // Trigger with relative soulFile from workspace cascade is skipped
+    expect(result.value.triggers).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `WorkspaceName = string & { readonly _brand: 'WorkspaceName' }` branded type and `WorkspaceConfig = { path: string; soulFile?: string }` interface to `src/trigger/types.ts`, following the `TriggerId` pattern exactly.
- Adds `loadWorkspacesFromConfigFile()` to `src/config/config-file.ts` -- reads the `workspaces` map from `~/.workrail/config.json` and returns `ok({})` when absent (never errors). Separate from the flat env loader to preserve its return type.
- Extends `trigger-store.ts` with workspace resolution: `workspaceName` YAML field is validated (format `^[a-zA-Z0-9_-]+$`), looked up in the workspace map, and resolves `workspacePath` from `WorkspaceConfig.path`. Unknown workspace names emit a per-trigger `unknown_workspace` soft error (daemon continues). Cascade: trigger `soulFile` -> workspace `soulFile` -> `undefined` (global default at runtime).
- Updates `loadDaemonSoul(resolvedPath?: string)` in `workflow-runner.ts` to accept an optional resolved path. Uses `path.dirname(soulPath)` for mkdir so workspace-scoped soul file parent dirs are created correctly.
- Threads `soulFile?` through `WorkflowTrigger` and `trigger-router.ts` to the runner call site.
- Updates `trigger-listener.ts` to load the workspace map and pass it to `loadTriggerConfigFromFile`.
- All changes are additive -- existing triggers without `workspaceName` or `soulFile` work unchanged.

## Test plan

- [x] 10 new tests in `tests/unit/trigger-store.test.ts`: happy path, unknown_workspace soft error, both fields conflict (workspaceName wins), bad format rejection, relative path rejection, soul file cascade, trigger-level override, backward compat (2-param callers)
- [x] All 105 existing + new tests pass (`trigger-store`, `trigger-router`, `delivery-action`, `trigger-store-gap8`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Manual: configure a trigger with `workspaceName` pointing to a workspace in `config.json`, start daemon, verify it uses that workspace's path and soul file

## Example config.json

```json
{
  "workspaces": {
    "workrail": {
      "path": "/Users/etienneb/git/personal/workrail",
      "soulFile": "~/.workrail/workspaces/workrail/daemon-soul.md"
    }
  }
}
```

## Example triggers.yml

```yaml
triggers:
  - id: workrail-mr-review
    provider: generic
    workflowId: coding-task-workflow-agentic
    workspaceName: workrail   # resolves to workspacePath at parse time
    goal: "Review incoming MR"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)