### PR TITLE
fix(mcp): prevent infinite CPU loop on uncaught exception

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -3787,3 +3787,99 @@ This is especially critical when WorkTrain is managing 10 concurrent sessions --
 
 ---
 
+
+---
+
+### Thin spots: ideas that need fuller spec (Apr 16, 2026)
+
+These were mentioned and partially captured but need more detail when the time comes:
+
+**`worktrain feedback` command:**
+Explicit quality feedback loop. `worktrain feedback "the PR #402 review missed the temp file cleanup issue"` appends to `~/.workrail/feedback.jsonl`. The workflow-effectiveness-assessment picks these up alongside statistical patterns. User feedback is weighted higher than inferred signals.
+
+**`worktrain idea` command:**
+Lightweight idea capture without interrupting active work. `worktrain idea "nested subagents up to N depth"` appends to `~/.workrail/ideas-buffer.jsonl`. The `worktrain talk` session reviews the buffer at conversation start and decides what to groom into the backlog. Prevents good ideas from getting lost when 10 agents are running.
+
+**Audience-aware status briefings (`--audience` flag):**
+`worktrain status --audience owner` (full technical detail, default) vs `--audience stakeholder` (capability level, no PR numbers) vs `--audience external` (outcome level, no internal terminology). Same underlying data, different presentation layer. The Haiku-level routine adjusts verbosity and replaces technical terms with plain language.
+
+**`worktrain queue` CLI commands:**
+```bash
+worktrain queue list [--workspace <name>]    # show queue with priorities and status
+worktrain queue pause [--workspace <name>]   # stop draining
+worktrain queue resume [--workspace <name>]  # resume draining
+worktrain queue remove <id>                  # remove item
+worktrain queue bump <id>                    # move to top
+worktrain queue show <id>                    # full item details + pipeline plan
+```
+
+**Workspace-scoped soul and config:**
+Each workspace has its own `daemon-soul.md` at a configurable path. Soul resolution cascade: trigger-level override → workspace soul → global `~/.workrail/daemon-soul.md` → built-in default. Enables TypeScript and Python workspaces to have different behavioral profiles on the same WorkTrain instance.
+
+**Automatic worktree cleanup:**
+After any session completes (success or failure), the daemon automatically runs `git worktree prune` and removes any worktrees whose branches are merged to main. Prevents the main-worktree-lock issue encountered today.
+
+---
+
+### The single-conversation problem: WorkTrain needs multi-threaded interaction (Apr 16, 2026)
+
+A single chat where everything is happening at the same time is not ideal. When WorkTrain is managing 10 concurrent agents, it becomes impossible to know what's been captured vs what's floating, follow any one thread, or distinguish "in progress" from "needs a decision."
+
+**Threaded conversations per work group:**
+Each active work group gets its own conversation thread. You can follow the polling-triggers work in thread A without seeing the spawn/await implementation in thread B. Threads are persistent -- come back 2 hours later and pick up exactly where you left off.
+
+**`worktrain talk` shows a thread list:**
+```
+Threads:
+  ● WorkRail development     [3 active agents, 2 waiting]
+  ● Storyforge chapter work  [idle]
+  → Select thread or type to start a new one
+```
+
+**`worktrain idea` for mid-conversation capture:**
+When a new idea comes up while 10 agents are running, `worktrain idea "..."` appends to an ideas buffer without interrupting active work. The talk session reviews the buffer at the start of each conversation.
+
+**Build order:** thread model → thread list console view → cross-thread notifications → idea capture buffer.
+
+---
+
+### Nested subagent depth: configurable delegation chains (Apr 16, 2026)
+
+WorkTrain should support nested subagents -- an agent spawning a subagent, which spawns its own -- up to a configurable depth limit.
+
+```yaml
+workspaces:
+  workrail:
+    agentDefaults:
+      maxSubagentDepth: 3     # coordinator=0, worker=1, subagent=2, sub-subagent=3
+      maxTotalAgentsPerTask: 10  # hard cap across all depths for a single task
+```
+
+**Depth semantics:**
+- Depth 0: coordinator script (no LLM, pure script)
+- Depth 1: main worker (coding-task, mr-review)
+- Depth 2: subagent from workflow step (routine-context-gathering, etc.)
+- Depth 3: sub-subagent (rare, deep investigation chains)
+- Depth 4+: almost certainly a bug or runaway loop
+
+**The `maxTotalAgentsPerTask` budget** prevents exponential explosion -- a depth-3 tree with 3 agents per node = 27 concurrent agents without this cap.
+
+**Console DAG view** shows nesting depth as indentation. Makes over-delegation immediately visible.
+
+---
+
+### WorkTrain attribution and acting as the user (Apr 16, 2026)
+
+**Attribution / signing:**
+1. **Commit signatures:** commits made by WorkTrain include `Co-Authored-By: WorkTrain <worktrain@etienneb.dev>`. The configured `worktrain-bot` identity is consistent across all workspaces.
+2. **PR/MR description footer:** `---\n🤖 Implemented by WorkTrain · Session: sess_abc123 · Workflows run: coding-task, mr-review`. Links to session for full audit trail.
+3. **Issue/comment attribution:** WorkTrain comments include "WorkTrain investigation" with session link. Clearly not a human.
+
+**Value:** audit trail, trust calibration for reviewers, "how much of our code was WorkTrain-authored?" becomes queryable, open-source visibility.
+
+**Acting as the user:**
+WorkTrain uses the user's git identity and GitHub account (via user's token) to act as them. PRs appear from @EtienneBBeaulac, commits show as Etienne Beaulac.
+
+**Why useful:** normal PR approval flows, no bot account permissions needed, personal git history stays personal even for WorkTrain-authored work.
+
+**Trust guardrails:** `actAsUser: true` explicit opt-in, only for commits/PRs (never emails or Slack without additional permission), PR description always notes "Created by WorkTrain," full audit log in `~/.workrail/actions-as-user.jsonl`.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -3409,3 +3409,381 @@ When the system is under load, WorkTrain should degrade gracefully rather than f
 5. Adaptive throttling based on observed latency (automatic backpressure)
 
 **The meta-point:** WorkTrain running at full capacity on itself is the best stress test for these constraints. Every day we run 10 simultaneous agents, we discover the edges of what the system can handle. Those discoveries should directly inform the resource management implementation.
+
+
+---
+
+### Universal integration layer: WorkTrain interfaces with everything (Apr 15, 2026)
+
+**The principle:** WorkTrain is not opinionated about your stack. It works with whatever version control, project management, communication, monitoring, and documentation systems you use -- cloud or self-hosted, SaaS or on-prem. The integration layer is the boundary where WorkTrain connects to the outside world.
+
+---
+
+#### Integration categories
+
+**Version control**
+| System | Interface | Notes |
+|--------|-----------|-------|
+| GitHub (cloud) | REST API + polling | Primary target, already designed |
+| GitLab (cloud + self-hosted) | REST API + polling | Already in polling triggers |
+| Bitbucket | REST API + polling | Same pattern as GitLab |
+| Azure DevOps | REST API + polling | Large enterprise share |
+| Gitea / Forgejo | REST API + polling | Self-hosted open source |
+| Gerrit | REST API | Google's code review system |
+| Raw git | git CLI + filesystem | No API needed -- just a remote |
+
+All VCS integrations share the same polling adapter pattern. The difference is the API schema -- the `GitLabPoller` becomes a template: implement `fetchEvents(since: Date): Event[]` and WorkTrain handles the rest.
+
+**Project management / ticketing**
+| System | Interface | Notes |
+|--------|-----------|-------|
+| GitHub Issues | REST API (same token as VCS) | Zero extra config for GitHub users |
+| GitLab Issues | REST API (same token as VCS) | Zero extra config for GitLab users |
+| Jira (Cloud + Server + Data Center) | REST API + polling | Dominant enterprise tracker |
+| Linear | GraphQL API | Dominant startup tracker |
+| Asana | REST API | Common in non-engineering teams |
+| Notion | REST API | Database + docs hybrid |
+| Monday.com | REST API | Common in agencies/SMB |
+| Azure Boards | REST API | Azure ecosystem |
+| Shortcut (formerly Clubhouse) | REST API | Engineering-focused |
+
+WorkTrain reads tickets to understand context, writes comments/status updates when work completes, creates new tickets when investigations surface issues, and transitions ticket status when PRs merge.
+
+**Communication / notifications**
+| System | Interface | Notes |
+|--------|-----------|-------|
+| Slack | Incoming webhooks + Bot API | Most common dev team chat |
+| Microsoft Teams | Incoming webhooks + Graph API | Enterprise dominant |
+| Discord | Webhooks + Bot API | Common in open source |
+| Telegram | Bot API | Common for personal/small team |
+| Email | SMTP | Universal fallback |
+| PagerDuty | Events API | Incident escalation |
+| OpsGenie | REST API | Alerting + on-call |
+| Webhook (generic) | HTTP POST | Any system that accepts webhooks |
+
+WorkTrain posts to the right channel based on the event type: PR review findings → the team's dev channel, critical incidents → #incidents + on-call, weekly health summary → #engineering, ideas → #product.
+
+**Monitoring / observability**
+| System | Interface | Notes |
+|--------|-----------|-------|
+| Sentry | REST API + polling | Error tracking |
+| Datadog | REST API + polling | Metrics, traces, logs |
+| New Relic | REST API | APM |
+| Grafana / Prometheus | HTTP API | Self-hosted metrics |
+| PagerDuty | Events API | Incident triggers |
+| CloudWatch | AWS SDK | AWS-native |
+| Custom HTTP endpoint | HTTP GET/POST | Any system with an API |
+
+WorkTrain polls for threshold breaches (same `PollingTriggerSource` pattern as VCS), investigates anomalies, and posts findings back.
+
+**Documentation**
+| System | Interface | Notes |
+|--------|-----------|-------|
+| Confluence (Cloud + Server) | REST API | Most common enterprise wiki |
+| Notion | REST API | Also a project management system |
+| Google Docs / Drive | Google API | Common in startups |
+| Markdown in repo | git + filesystem | Zero extra config |
+| ReadTheDocs / Sphinx | Filesystem | Generated docs |
+| Docusaurus | Filesystem | Modern static docs |
+
+WorkTrain reads doc systems as reference context for agents (same as `referenceUrls` today). It writes back when documentation needs updating after code changes.
+
+---
+
+#### The integration architecture
+
+**Three integration modes:**
+
+1. **Polling source** (already built for GitLab) -- WorkTrain calls the external API on a schedule, deduplicates events, dispatches workflows. Works for: VCS (new PRs/issues), ticketing (new tickets), monitoring (threshold breaches).
+
+2. **Delivery target** (already built for `callbackUrl`) -- WorkTrain POSTs results to an external system when a workflow completes. Works for: Slack/Teams/Discord notifications, Jira status updates, GitLab MR comments, PagerDuty incident resolution.
+
+3. **Reference context** (already built for `referenceUrls`) -- WorkTrain fetches external documents and injects them into the agent's context. Works for: Confluence pages, Google Docs, Notion databases, external API docs.
+
+**The integration manifest in triggers.yml:**
+```yaml
+integrations:
+  github:
+    token: $GITHUB_TOKEN
+    baseUrl: https://api.github.com    # override for GitHub Enterprise
+  
+  jira:
+    token: $JIRA_TOKEN
+    baseUrl: https://mycompany.atlassian.net
+    projectKey: ENG
+  
+  slack:
+    webhookUrl: $SLACK_WEBHOOK_URL
+    channels:
+      reviews: "#code-review"
+      incidents: "#incidents"
+      weekly: "#engineering"
+  
+  datadog:
+    apiKey: $DATADOG_API_KEY
+    appKey: $DATADOG_APP_KEY
+
+triggers:
+  - id: new-jira-bug
+    type: jira_poll
+    source:
+      integration: jira
+      jql: "project = ENG AND issuetype = Bug AND status = Open AND created >= -1h"
+      pollIntervalSeconds: 300
+    workflowId: bug-investigation.agentic.v2
+    goalTemplate: "Investigate Jira bug {{$.key}}: {{$.fields.summary}}"
+    callbackUrl: "{{jira.baseUrl}}/rest/api/3/issue/{{$.key}}/comment"
+```
+
+**The adapter pattern:**
+Each integration is a standalone adapter module in `src/trigger/adapters/`:
+- `github-poller.ts` -- `fetchEvents(since): GitHubEvent[]`
+- `gitlab-poller.ts` -- (already exists) `fetchEvents(since): GitLabMR[]`
+- `jira-poller.ts` -- `fetchEvents(since): JiraIssue[]`
+- `linear-poller.ts` -- `fetchEvents(since): LinearIssue[]`
+- `sentry-poller.ts` -- `fetchEvents(since): SentryError[]`
+- `datadog-poller.ts` -- `fetchEvents(since): DatadogAlert[]`
+
+Each adapter implements the same interface. The `PollingScheduler` doesn't know which adapter it's running -- it just calls `fetchEvents()` and dispatches. Adding a new integration is: implement the adapter, add a type to `TriggerDefinition`, handle it in `trigger-store.ts`. No changes to the scheduler or router.
+
+**Delivery adapters** follow the same pattern for writing back:
+- `slack-delivery.ts` -- formats and POSTs to Slack webhook
+- `jira-delivery.ts` -- adds comment to Jira issue, transitions status
+- `github-delivery.ts` -- posts PR review comment, creates issue
+- `pagerduty-delivery.ts` -- resolves or escalates incident
+
+**The `callbackUrl` field becomes `deliveryTarget`** with a richer schema:
+```yaml
+deliveryTarget:
+  type: slack           # or: jira, github, gitlab, pagerduty, webhook
+  integration: slack    # reference to integrations block
+  channel: "#code-review"
+  # OR for generic webhook:
+  url: https://hooks.example.com/worktrain
+```
+
+---
+
+#### What this enables
+
+A fully connected WorkTrain for a typical engineering team:
+
+```
+New Jira bug filed
+  → WorkTrain investigates → posts findings as Jira comment
+  → if auto-fixable → opens GitHub PR → reviews it → merges
+  → transitions Jira ticket to "In Review" / "Done"
+  → posts to #engineering: "Fixed JIRA-1234 autonomously -- PR #456"
+
+Datadog alert fires
+  → WorkTrain investigates logs + recent commits
+  → posts to #incidents with root cause + affected files
+  → if config fix → deploys fix → resolves PagerDuty incident
+  → updates Confluence runbook with new pattern
+
+Weekly
+  → WorkTrain posts health summary to #engineering
+  → files Linear tickets for technical debt items found in audit
+  → updates Google Doc "Architecture Notes" with recent decisions
+```
+
+Zero humans needed unless the circuit breaker fires.
+
+---
+
+#### Build order
+
+**Now (already works):** generic `callbackUrl` (HTTP POST to any endpoint). Any system that accepts webhooks works immediately.
+
+**Near-term:** GitHub polling adapter (same as GitLab, already written as template), Slack delivery adapter (format + post to webhook).
+
+**Medium-term:** Jira polling + delivery (high enterprise value), Linear polling (high startup value), PagerDuty delivery (incident escalation).
+
+**Long-term:** the full matrix above. Each adapter is a bounded, testable, independently shippable unit. The architecture supports adding them without touching the core engine.
+
+---
+
+
+
+---
+
+### Multi-project WorkTrain: workspace isolation vs cross-project knowledge (to investigate, Apr 15, 2026)
+
+**The problem:** WorkTrain needs to handle multiple completely unrelated projects simultaneously, but some projects are related and need to share knowledge. These are contradictory requirements if handled naively.
+
+**Three axes of tension:**
+
+1. **Isolation vs shared context** -- project A's TypeScript symbols should never pollute project B's Python context. But if A and B share architectural patterns (both use WorkTrain, both follow the same auth pattern), that shared knowledge is valuable.
+
+2. **Independent execution vs cross-project tasks** -- most tasks are scoped to one project. But some tasks span projects: "update the mobile app AND the backend API for this feature", "apply the same refactor pattern we used in workrail to storyforge".
+
+3. **One daemon vs many** -- one daemon is easier to manage (one config, one console, one binary). Multiple daemons give true blast-radius isolation. The right answer is probably workspace namespacing inside one process, but with cross-namespace knowledge queries for when projects are related.
+
+**The cross-project knowledge requirement:**
+When two projects are related (share patterns, have a dependency relationship, or are being worked on together), the knowledge graph should be queryable across project boundaries -- but opt-in, not default. A session working on project A can explicitly query "what's the equivalent pattern in project B?" but never sees project B's context by default.
+
+**Proposed model:** workspace namespacing with explicit cross-workspace links
+
+```yaml
+workspaces:
+  workrail:
+    path: ~/git/personal/workrail
+    soul: ~/.workrail/souls/workrail.md
+    knowledgeGraph: ~/.workrail/graphs/workrail.db
+    maxConcurrentSessions: 3
+    relatedWorkspaces: [storyforge]   # can query storyforge graph when explicitly needed
+    
+  storyforge:
+    path: ~/git/personal/storyforge
+    soul: ~/.workrail/souls/storyforge.md
+    knowledgeGraph: ~/.workrail/graphs/storyforge.db
+    maxConcurrentSessions: 1
+    relatedWorkspaces: [workrail]
+```
+
+A session in `workrail` gets `workrail` context by default. If it calls `query_knowledge_graph(workspace: 'storyforge', ...)`, it gets storyforge context explicitly. The coordinator script can spawn workers in multiple workspaces for cross-project tasks.
+
+**Investigation needed (discovery agent running):**
+- Is workspace namespacing inside one process the right architecture, or should each project run a separate daemon?
+- What exactly needs to be workspace-scoped vs globally shared?
+- How do cross-project coordinator tasks work? (spawn worker in workspace A, spawn worker in workspace B, coordinator synthesizes)
+- What's the knowledge graph query interface for cross-workspace queries?
+- How does the console show multi-workspace activity without being overwhelming?
+- What's the blast radius if one workspace's agent goes rogue?
+
+**What CAN be shared globally (no namespace needed):**
+- The WorkTrain binary and workflow library
+- Token usage / billing tracking
+- The message queue (`~/.workrail/message-queue.jsonl`)
+- The merge audit log
+- The outbox (notifications to the user)
+- The `worktrain talk` session (can discuss any workspace)
+
+**What MUST be workspace-scoped:**
+- Knowledge graph (symbols from different codebases must not mix)
+- daemon-soul.md (different stacks need different principles)
+- Session store (project A's sessions should not appear in project B's console view by default)
+- Concurrency limits (project A should not starve project B)
+- Triggers and polling sources (each workspace has its own event sources)
+
+---
+
+
+
+---
+
+### Never worktree main: branch safety rules for WorkTrain (Apr 16, 2026)
+
+**Critical invariant:** WorkTrain must never check out `main` or `master` into a worktree. Locking main in a worktree blocks all other agents from checking out main and prevents fast-forward merges.
+
+**The rule:**
+- All agent worktrees must use feature branches, never `main` or `master` or any protected branch
+- When creating a worktree for a task, WorkTrain always creates a new branch: `git worktree add <path> -b <branch-name>`
+- If an agent needs to read main's state, it uses `git show origin/main:<file>` without checking out the branch
+- Stale worktrees (branches that have been merged) must be cleaned up automatically after session completion
+
+**How it breaks today:**
+The `--isolation worktree` flag on subagents creates a worktree. If the agent's task involves reading and committing to main directly (e.g. a merge task), it can end up with main locked. This happened during today's session.
+
+**The fix (two parts):**
+
+1. **In the daemon worktree creation code:** before creating a worktree, check if the requested branch is `main`, `master`, or any branch in a configurable `protectedBranches` list. If so, create a new branch from it instead.
+
+2. **In the daemon-soul.md:** add explicit rule:
+```
+## Branch Safety
+- NEVER check out main, master, or any protected branch into a worktree
+- NEVER use 'git checkout main' -- always work on a feature branch
+- When merging to main, use 'gh pr merge' (via PR), never direct git push
+- After a PR merges, immediately clean up the local worktree
+```
+
+3. **Automatic stale worktree cleanup:** after each session completes (success or failure), the daemon should run `git worktree prune` and remove any worktrees whose branches have been merged to main.
+
+
+---
+
+
+---
+
+### Communication agent: Slack monitoring, email management, and suggested responses (Apr 16, 2026)
+
+**The idea:** WorkTrain monitors your communication channels, understands context, and either responds on your behalf or prepares vetted drafts for you to send.
+
+**Slack:**
+- Monitor specified channels and DMs for messages that mention you, reference your projects, or require a response
+- Understand context: "who is asking, what do they need, what's the relevant project state?"
+- Options: auto-respond for routine questions ("what's the status of X?" → WorkTrain knows), draft a response for you to review and send, or surface with a notification "someone needs your input on Y"
+- Configurable per-channel: some channels auto-respond, some always require your review
+- Filter noise: identify which Slack threads are actually important vs chatter
+
+**Email:**
+- Same pattern as Slack -- monitor inbox, understand context, draft responses
+- Suggest email filters, folder rules, and unsubscribe candidates based on patterns WorkTrain observes
+- "You've received 47 newsletters this month from 12 senders and never opened them -- want me to unsubscribe?"
+- Priority surfacing: "3 emails in your inbox need a response, here are the drafts"
+
+**Important constraint:** WorkTrain never sends on your behalf without explicit approval for anything that goes to other people. Auto-respond is opt-in per-channel, with a review window before sending. You always see what was sent and can recall/edit.
+
+---
+
+
+
+---
+
+### Local file organization and maintenance (Apr 16, 2026)
+
+- WorkTrain scans specified directories for stale, duplicate, and disorganized files
+- Suggests folder structures based on file content and usage patterns
+- Identifies documents that are out of date and offers to update them
+- Keeps project-related files in sync with the repo (e.g. local design files linked to Figma specs, local notes linked to Confluence pages)
+- "~/Downloads has 847 files, most untouched for 6 months -- here's what's safe to delete and what should be archived"
+- Connects to the knowledge graph: files that reference code or projects get indexed alongside the code
+
+---
+
+
+
+---
+
+### Git worktrees and branch management as a first-class capability (Apr 16, 2026)
+
+**Critical for parallel work.** WorkTrain needs native, sophisticated git management -- not just running git commands but understanding the full branching topology and managing it intelligently.
+
+**What this means:**
+
+**Worktree management:**
+- Create, list, switch between, and clean up worktrees automatically
+- Each concurrent task gets its own worktree (WorkTrain already does this via `.claude/worktrees/`)
+- Detect and warn about stale worktrees (branches that have been merged or abandoned)
+- The `cw <branch>` command pattern already exists -- WorkTrain should be able to invoke it for any task that needs isolation
+
+**Branch lifecycle:**
+- Know which branches are: active (being worked on), stale (no commits in N days), merged (on main), or orphaned (created but abandoned)
+- Automatic cleanup proposals: "14 branches are merged and safe to delete, 3 are stale, 2 have uncommitted work"
+- Rebase management: when main advances, WorkTrain knows which in-flight branches need rebasing and does it automatically (or queues it)
+- Conflict detection: before spawning a new session, check if any in-flight branch would conflict with the planned changes
+
+**Parallel work coordination:**
+- When multiple tasks touch the same files, WorkTrain detects potential conflicts before they happen
+- Sequences tasks that would conflict, parallelizes those that won't
+- Maintains a "file lock" mental model: this file is being modified by session A, session B should wait or work on a different scope
+- When a feature branch is ready, WorkTrain handles the full merge/rebase/PR creation flow
+
+**Branch naming and organization:**
+- Enforces consistent branch naming conventions (already partially done via daemon soul)
+- Groups related branches: `feat/github-polling-*` are all part of the same epic
+- Links branches to tickets/queue items: opening a PR creates the Jira transition, closing a PR cleans up the branch
+
+**The `worktrain worktree` command family:**
+```bash
+worktrain worktree list                    # all worktrees and their status
+worktrain worktree clean                   # remove merged/stale worktrees
+worktrain worktree new <branch> [--task]   # create worktree + optionally link to queue item
+worktrain worktree status                  # which files are locked by active sessions
+```
+
+This is especially critical when WorkTrain is managing 10 concurrent sessions -- without explicit worktree management, two sessions could clobber each other's changes on the same branch.
+
+---
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,11 @@
         "zod": "^3.22.4"
       },
       "bin": {
-        "workrail": "dist/mcp-server.js"
+        "workrail": "dist/mcp-server.js",
+        "worktrain": "dist/cli-worktrain.js"
       },
       "devDependencies": {
+        "@duckdb/node-api": "^1.5.2-r.1",
         "@playwright/test": "^1.55.1",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^7.1.0",
@@ -1741,6 +1743,115 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@duckdb/node-api": {
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.2-r.1.tgz",
+      "integrity": "sha512-OzBBnS0JGXMoS5mzKNY/Ylr7SshcRQiLFIoxQ4AlePwJ2fNeDL/fbHu/knjxUrXwW1fJBTUgwWftmxDdnZZb3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@duckdb/node-bindings": "1.5.2-r.1"
+      }
+    },
+    "node_modules/@duckdb/node-bindings": {
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.2-r.1.tgz",
+      "integrity": "sha512-bUg3bLVj70YVku6fKyQJS8ASORl7kM7YFVFznsEB9pWbtazPj+ME2x2FUk0WiTzjJdutjzSSGXF066mB4bGGZA==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@duckdb/node-bindings-darwin-arm64": "1.5.2-r.1",
+        "@duckdb/node-bindings-darwin-x64": "1.5.2-r.1",
+        "@duckdb/node-bindings-linux-arm64": "1.5.2-r.1",
+        "@duckdb/node-bindings-linux-x64": "1.5.2-r.1",
+        "@duckdb/node-bindings-win32-arm64": "1.5.2-r.1",
+        "@duckdb/node-bindings-win32-x64": "1.5.2-r.1"
+      }
+    },
+    "node_modules/@duckdb/node-bindings-darwin-arm64": {
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.2-r.1.tgz",
+      "integrity": "sha512-v35FyKOb8EJCvaiPF7k0gvKiJTXR7PPQDNoWR0Gu+YSX5O9b+DIguzt1348Of3HebHy6ATSMzlUekaVA9YXu+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-darwin-x64": {
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.2-r.1.tgz",
+      "integrity": "sha512-SU9dIJ1BluKkkGxi4UsP4keqkkstB2YDySF9KcYu3EZKIVM3FTv2zc7XO38dXnHOq6+F3WqhWWZvD+XU945p7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64": {
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.2-r.1.tgz",
+      "integrity": "sha512-3Tra9xM3aM3denaER4KhJ6//6PpmPbik9ECBQ+sh9PyKaEgHw/0kAcKnLm5EzWUnXF0qYmZlewvkCrse8KmOYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64": {
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.2-r.1.tgz",
+      "integrity": "sha512-pcQvZRHiIfJ9cq8parkSQczQHEml/IeGfnDCMAbEgD6+jaV9Y9Y5Ph1kP9aR+bm6him1S5ZIEr3kZbihjKnWbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-arm64": {
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.2-r.1.tgz",
+      "integrity": "sha512-Ji8tym+N3LkrhVt0Up3bsacD/kpg4/JXFJQqxswiYvBaNCQOk+D+aiVS0GN5pcqvmnG7V7TpsDRzkLEFaWp1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-x64": {
+      "version": "1.5.2-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.2-r.1.tgz",
+      "integrity": "sha512-5XqcqC+4R8ghBEEbnc2a0sqfz1zyPBRb9YcmIWfiuDoCYSYFbKhmHcEyNftZDHcwCoLOHXnUin45jraex4STqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",

--- a/src/mcp/transports/bridge-entry.ts
+++ b/src/mcp/transports/bridge-entry.ts
@@ -335,7 +335,7 @@ export async function startBridgeServer(
   // during bridge startup exit cleanly rather than spinning. See fatal-exit.ts.
   registerFatalHandlers('bridge');
   logStartup('bridge', { primaryPort });
-  logBridgeEvent({ kind: 'started', primaryPort });
+  logBridgeEvent({ kind: 'started', primaryPort, ppid: process.ppid });
 
   const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
   const { StreamableHTTPClientTransport } = await import(
@@ -472,6 +472,12 @@ export async function startBridgeServer(
         // swallowed by the void discard. The loop is dead at this point; if the
         // primary is still alive the bridge will continue forwarding; if not, the
         // next t.onclose will start a fresh loop.
+        const errObj = err instanceof Error ? err : new Error(String(err));
+        logBridgeEvent({
+          kind: 'reconnect_loop_error',
+          message: errObj.message,
+          stack: errObj.stack ?? null,
+        });
         console.error('[Bridge] Unexpected error in reconnect loop:', err);
       });
   };

--- a/src/mcp/transports/bridge-entry.ts
+++ b/src/mcp/transports/bridge-entry.ts
@@ -33,6 +33,7 @@
 
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import { registerFatalHandlers, logStartup } from './fatal-exit.js';
+import { logBridgeEvent } from './bridge-events.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -191,6 +192,7 @@ export async function spawnPrimary(
   // Post-jitter check: another bridge may have already spawned the primary.
   const alreadyUp = await detectHealthyPrimary(port, { retries: 1, fetch: deps.fetch });
   if (alreadyUp != null) {
+    logBridgeEvent({ kind: 'spawn_skipped', reason: 'primary already up after jitter' });
     console.error('[Bridge] Primary already available after jitter — skipping spawn');
     return;
   }
@@ -201,6 +203,7 @@ export async function spawnPrimary(
     return;
   }
 
+  logBridgeEvent({ kind: 'spawn_primary', port });
   console.error('[Bridge] Spawning new WorkRail primary process');
   try {
     const child = deps.spawn(process.execPath, [scriptPath], {
@@ -290,6 +293,7 @@ export async function handleReconnectOutcome(
     case 'reconnected':
       // State was set to 'connected' atomically inside buildConnectedTransport
       // when t.start() resolved. Single owner; no duplicate set here.
+      logBridgeEvent({ kind: 'reconnected', attempt: reconnectingState.attempt });
       console.error('[Bridge] Reconnected to primary');
       return;
 
@@ -309,6 +313,7 @@ export async function handleReconnectOutcome(
         });
         deps.startReconnectLoop();
       } else {
+        logBridgeEvent({ kind: 'budget_exhausted', budgetUsed: reconnectingState.maxAttempts });
         deps.setConnectionState({ kind: 'closed' });
         deps.performShutdown('respawn budget exhausted — primary repeatedly unavailable');
       }
@@ -330,6 +335,7 @@ export async function startBridgeServer(
   // during bridge startup exit cleanly rather than spinning. See fatal-exit.ts.
   registerFatalHandlers('bridge');
   logStartup('bridge', { primaryPort });
+  logBridgeEvent({ kind: 'started', primaryPort });
 
   const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
   const { StreamableHTTPClientTransport } = await import(
@@ -366,7 +372,7 @@ export async function startBridgeServer(
   const performShutdown = (reason: string): void => {
     if (shutdownSignal.aborted) return;
     shutdownController.abort();
-    // Structured shutdown log — visible in stderr and parseable for monitoring.
+    logBridgeEvent({ kind: 'shutdown', reason });
     process.stderr.write(
       `[Bridge] Shutdown pid=${process.pid} reason="${reason}" ts=${new Date().toISOString()}\n`,
     );
@@ -400,6 +406,7 @@ export async function startBridgeServer(
       if (shutdownSignal.aborted) return;
       const current = connectionState;
       if (current.kind === 'connecting' || current.kind === 'reconnecting') return;
+      logBridgeEvent({ kind: 'disconnected' });
       console.error('[Bridge] Primary connection lost — reconnecting');
       setConnectionState({
         kind: 'reconnecting',
@@ -437,6 +444,7 @@ export async function startBridgeServer(
       signal: shutdownSignal,
       config,
       detect: async (attempt) => {
+        logBridgeEvent({ kind: 'reconnect_attempt', attempt: attempt + 1, maxAttempts: config.reconnectMaxAttempts });
         console.error(`[Bridge] Reconnect attempt ${attempt + 1}/${config.reconnectMaxAttempts}`);
         const detected = await detectHealthyPrimary(primaryPort, { retries: 1, fetch: deps.fetch });
         if (detected == null) return false;
@@ -512,6 +520,7 @@ export async function startBridgeServer(
   if (initialTransport == null) {
     throw new Error(`[Bridge] Failed to connect to primary on port ${primaryPort}`);
   }
+  logBridgeEvent({ kind: 'connected', primaryPort });
   console.error('[Bridge] Connected to primary');
 
   process.stdout.on('error', (err) => {

--- a/src/mcp/transports/bridge-entry.ts
+++ b/src/mcp/transports/bridge-entry.ts
@@ -32,6 +32,7 @@
  */
 
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { registerFatalHandlers } from './fatal-exit.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -325,6 +326,10 @@ export async function startBridgeServer(
   // Injectable side effects for testability. Production callers use defaults.
   deps: { spawn?: SpawnLike; fetch?: FetchLike } = {},
 ): Promise<void> {
+  // Register early — before any async work — so that exceptions thrown
+  // during bridge startup exit cleanly rather than spinning. See fatal-exit.ts.
+  registerFatalHandlers();
+
   console.error(`[Bridge] Forwarding stdio → http://localhost:${primaryPort}/mcp`);
 
   const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');

--- a/src/mcp/transports/bridge-entry.ts
+++ b/src/mcp/transports/bridge-entry.ts
@@ -32,7 +32,7 @@
  */
 
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
-import { registerFatalHandlers } from './fatal-exit.js';
+import { registerFatalHandlers, logStartup } from './fatal-exit.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -328,9 +328,8 @@ export async function startBridgeServer(
 ): Promise<void> {
   // Register early — before any async work — so that exceptions thrown
   // during bridge startup exit cleanly rather than spinning. See fatal-exit.ts.
-  registerFatalHandlers();
-
-  console.error(`[Bridge] Forwarding stdio → http://localhost:${primaryPort}/mcp`);
+  registerFatalHandlers('bridge');
+  logStartup('bridge', { primaryPort });
 
   const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
   const { StreamableHTTPClientTransport } = await import(
@@ -367,7 +366,10 @@ export async function startBridgeServer(
   const performShutdown = (reason: string): void => {
     if (shutdownSignal.aborted) return;
     shutdownController.abort();
-    console.error(`[Bridge] Shutting down: ${reason}`);
+    // Structured shutdown log — visible in stderr and parseable for monitoring.
+    process.stderr.write(
+      `[Bridge] Shutdown pid=${process.pid} reason="${reason}" ts=${new Date().toISOString()}\n`,
+    );
     const state = connectionState;
     void (state.kind === 'connected' ? state.transport.close() : Promise.resolve()).finally(
       () => process.exit(0),

--- a/src/mcp/transports/bridge-events.ts
+++ b/src/mcp/transports/bridge-events.ts
@@ -26,7 +26,7 @@ const BRIDGE_LOG_MAX_BYTES = 512 * 1024; // 512 KB
 // ---------------------------------------------------------------------------
 
 export type BridgeEvent =
-  | { readonly kind: 'started'; readonly primaryPort: number }
+  | { readonly kind: 'started'; readonly primaryPort: number; readonly ppid: number }
   | { readonly kind: 'connected'; readonly primaryPort: number }
   | { readonly kind: 'disconnected' }
   | { readonly kind: 'reconnect_attempt'; readonly attempt: number; readonly maxAttempts: number }
@@ -34,6 +34,7 @@ export type BridgeEvent =
   | { readonly kind: 'spawn_primary'; readonly port: number }
   | { readonly kind: 'spawn_skipped'; readonly reason: string }
   | { readonly kind: 'budget_exhausted'; readonly budgetUsed: number }
+  | { readonly kind: 'reconnect_loop_error'; readonly message: string; readonly stack: string | null }
   | { readonly kind: 'shutdown'; readonly reason: string };
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/transports/bridge-events.ts
+++ b/src/mcp/transports/bridge-events.ts
@@ -1,0 +1,65 @@
+/**
+ * Bridge connection event log — append-only JSONL at ~/.workrail/bridge.log.
+ *
+ * Records the lifecycle of each bridge process so that post-mortem diagnosis
+ * can reconstruct exactly what happened: when it connected, when it lost
+ * connection, how many reconnect attempts it made, whether it spawned a
+ * primary, and why it ultimately shut down.
+ *
+ * Without this log, diagnosing orphaned high-CPU bridge processes requires
+ * reading stale CPU stats and guessing at the state machine. With it, the
+ * history is immediate and unambiguous.
+ *
+ * Format: one JSON object per line (JSONL), appended synchronously.
+ * Each entry carries ts, pid, and event plus event-specific fields.
+ */
+
+import { appendFileSync, mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+const BRIDGE_LOG_PATH = join(homedir(), '.workrail', 'bridge.log');
+const BRIDGE_LOG_MAX_BYTES = 512 * 1024; // 512 KB
+
+// ---------------------------------------------------------------------------
+// Event types — sealed union so all callers are exhaustive
+// ---------------------------------------------------------------------------
+
+export type BridgeEvent =
+  | { readonly kind: 'started'; readonly primaryPort: number }
+  | { readonly kind: 'connected'; readonly primaryPort: number }
+  | { readonly kind: 'disconnected' }
+  | { readonly kind: 'reconnect_attempt'; readonly attempt: number; readonly maxAttempts: number }
+  | { readonly kind: 'reconnected'; readonly attempt: number }
+  | { readonly kind: 'spawn_primary'; readonly port: number }
+  | { readonly kind: 'spawn_skipped'; readonly reason: string }
+  | { readonly kind: 'budget_exhausted'; readonly budgetUsed: number }
+  | { readonly kind: 'shutdown'; readonly reason: string };
+
+// ---------------------------------------------------------------------------
+// Append
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a bridge lifecycle event to ~/.workrail/bridge.log.
+ *
+ * Uses synchronous I/O so entries are written even if the process crashes
+ * immediately after. Silently no-ops on any write error — never throws.
+ */
+export function logBridgeEvent(event: BridgeEvent): void {
+  try {
+    mkdirSync(join(homedir(), '.workrail'), { recursive: true });
+
+    // Rotate if oversized
+    try {
+      const { statSync } = require('fs') as typeof import('fs');
+      if (statSync(BRIDGE_LOG_PATH).size > BRIDGE_LOG_MAX_BYTES) {
+        const { writeFileSync } = require('fs') as typeof import('fs');
+        writeFileSync(BRIDGE_LOG_PATH, '');
+      }
+    } catch { /* file doesn't exist yet */ }
+
+    const entry = { ts: new Date().toISOString(), pid: process.pid, ...event };
+    appendFileSync(BRIDGE_LOG_PATH, JSON.stringify(entry) + '\n');
+  } catch { /* log write failed — silently ignore */ }
+}

--- a/src/mcp/transports/fatal-exit.ts
+++ b/src/mcp/transports/fatal-exit.ts
@@ -1,5 +1,5 @@
 /**
- * Last-resort fatal exit for all MCP transport entry points.
+ * Last-resort fatal exit and observability for all MCP transport entry points.
  *
  * WHY process.stderr.write instead of console.error:
  * The V8 inspector hooks console.* calls. If the inspector itself has a
@@ -16,35 +16,115 @@
  * If process.stderr.write itself throws (e.g. EBADF), the uncaughtException
  * handler would fire again and loop. The guard ensures we exit on the first
  * invocation no matter what.
+ *
+ * CRASH LOG:
+ * On fatal exit, a structured JSON entry is appended synchronously to
+ * ~/.workrail/crash.log. Survives process death because the write is sync.
+ * Useful for diagnosing why the primary or a bridge died.
  */
 
+import { writeFileSync, mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TransportKind = 'stdio' | 'http' | 'bridge';
+
+// ---------------------------------------------------------------------------
+// Module-level state — intentionally mutable (last-resort handlers)
+// ---------------------------------------------------------------------------
+
 const fatalHandlerActive = { value: false };
+let registeredTransport: TransportKind | null = null;
+const startedAtMs = Date.now();
+
+// ---------------------------------------------------------------------------
+// Crash log
+// ---------------------------------------------------------------------------
+
+const CRASH_LOG_PATH = join(homedir(), '.workrail', 'crash.log');
+const CRASH_LOG_MAX_BYTES = 512 * 1024; // 512 KB — rotate at this size
+
+/**
+ * Synchronously append a crash entry to ~/.workrail/crash.log.
+ * Uses sync I/O so it completes before process.exit(1) is called.
+ * Silently no-ops if the write fails — we're already crashing.
+ */
+function writeCrashLog(label: string, reason: unknown): void {
+  try {
+    mkdirSync(join(homedir(), '.workrail'), { recursive: true });
+
+    // Rotate if oversized — truncate to empty so the file doesn't grow forever
+    try {
+      const { statSync } = require('fs') as typeof import('fs');
+      const stat = statSync(CRASH_LOG_PATH);
+      if (stat.size > CRASH_LOG_MAX_BYTES) {
+        writeFileSync(CRASH_LOG_PATH, '');
+      }
+    } catch {
+      // File doesn't exist yet — that's fine
+    }
+
+    const entry = {
+      ts: new Date().toISOString(),
+      pid: process.pid,
+      transport: registeredTransport ?? 'unknown',
+      uptimeMs: Date.now() - startedAtMs,
+      label,
+      message: reason instanceof Error ? reason.message : String(reason),
+      stack: reason instanceof Error ? (reason.stack ?? null) : null,
+    };
+
+    writeFileSync(CRASH_LOG_PATH, JSON.stringify(entry) + '\n', { flag: 'a' });
+  } catch {
+    // Crash log write failed — silently ignore, we're exiting anyway
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
 
 /**
  * Format an unknown thrown value into a human-readable string that includes
  * the stack trace when available.
  */
-function formatFatal(reason: unknown): string {
+export function formatFatal(reason: unknown): string {
   if (reason instanceof Error) {
     return reason.stack ?? `${reason.name}: ${reason.message}`;
   }
   return String(reason);
 }
 
+// ---------------------------------------------------------------------------
+// Fatal exit
+// ---------------------------------------------------------------------------
+
 /**
- * Write a fatal error message to stderr and exit with code 1.
+ * Write a fatal error message to stderr and crash.log, then exit with code 1.
  * Re-entrant calls (e.g. if stderr.write itself throws) are silently ignored.
  */
 export function fatalExit(label: string, reason: unknown): void {
   if (fatalHandlerActive.value) return;
   fatalHandlerActive.value = true;
+
+  writeCrashLog(label, reason);
+
   try {
     process.stderr.write(`[MCP] ${label}: ${formatFatal(reason)}\n`);
   } catch {
     // stderr itself failed — nothing we can do, just exit
   }
+
   process.exit(1);
 }
+
+// ---------------------------------------------------------------------------
+// Handler registration
+// ---------------------------------------------------------------------------
 
 /**
  * Register uncaughtException and unhandledRejection handlers that call
@@ -53,8 +133,42 @@ export function fatalExit(label: string, reason: unknown): void {
  * Must be called early — before any async work — so that exceptions thrown
  * during startup (e.g. in composeServer()) are caught and the process exits
  * cleanly rather than spinning in an infinite loop.
+ *
+ * @param transport  Which transport this process is running as. Used in
+ *                   crash log entries and startup observability output.
  */
-export function registerFatalHandlers(): void {
+export function registerFatalHandlers(transport: TransportKind): void {
+  registeredTransport = transport;
   process.on('uncaughtException', (err) => fatalExit('Uncaught exception', err));
   process.on('unhandledRejection', (reason) => fatalExit('Unhandled promise rejection', reason));
+}
+
+// ---------------------------------------------------------------------------
+// Startup observability
+// ---------------------------------------------------------------------------
+
+/**
+ * Emit a structured startup line to stderr so every process start is
+ * visible in logs. Format is parseable but also human-readable.
+ *
+ * Example:
+ *   [Startup] transport=stdio pid=12345 version=3.24.4
+ */
+export function logStartup(transport: TransportKind, extra?: Record<string, string | number>): void {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const version = (() => {
+    try {
+      return (require('../../package.json') as { version: string }).version;
+    } catch {
+      return 'unknown';
+    }
+  })();
+
+  const parts = [
+    `[Startup] transport=${transport}`,
+    `pid=${process.pid}`,
+    `version=${version}`,
+    ...(extra ? Object.entries(extra).map(([k, v]) => `${k}=${v}`) : []),
+  ];
+  process.stderr.write(parts.join(' ') + '\n');
 }

--- a/src/mcp/transports/fatal-exit.ts
+++ b/src/mcp/transports/fatal-exit.ts
@@ -71,6 +71,8 @@ function writeCrashLog(label: string, reason: unknown): void {
     const entry = {
       ts: new Date().toISOString(),
       pid: process.pid,
+      ppid: process.ppid,       // which process spawned us — identifies orphans
+      cwd: process.cwd(),       // which project/worktree this process belongs to
       transport: registeredTransport ?? 'unknown',
       uptimeMs: Date.now() - startedAtMs,
       label,

--- a/src/mcp/transports/fatal-exit.ts
+++ b/src/mcp/transports/fatal-exit.ts
@@ -1,0 +1,60 @@
+/**
+ * Last-resort fatal exit for all MCP transport entry points.
+ *
+ * WHY process.stderr.write instead of console.error:
+ * The V8 inspector hooks console.* calls. If the inspector itself has a
+ * bug or triggers re-entrant JS (e.g. an uncaughtException thrown inside
+ * a console.error call), the uncaughtException handler fires again, which
+ * calls console.error again — infinite loop at 100% CPU. process.stderr.write
+ * is a raw libuv syscall with no JS re-entrancy risk.
+ *
+ * WHY err.stack instead of String(err):
+ * String(Error) gives only the message. err.stack includes the full call
+ * chain, which is the only way to diagnose what actually went wrong.
+ *
+ * WHY a re-entrancy guard:
+ * If process.stderr.write itself throws (e.g. EBADF), the uncaughtException
+ * handler would fire again and loop. The guard ensures we exit on the first
+ * invocation no matter what.
+ */
+
+const fatalHandlerActive = { value: false };
+
+/**
+ * Format an unknown thrown value into a human-readable string that includes
+ * the stack trace when available.
+ */
+function formatFatal(reason: unknown): string {
+  if (reason instanceof Error) {
+    return reason.stack ?? `${reason.name}: ${reason.message}`;
+  }
+  return String(reason);
+}
+
+/**
+ * Write a fatal error message to stderr and exit with code 1.
+ * Re-entrant calls (e.g. if stderr.write itself throws) are silently ignored.
+ */
+export function fatalExit(label: string, reason: unknown): void {
+  if (fatalHandlerActive.value) return;
+  fatalHandlerActive.value = true;
+  try {
+    process.stderr.write(`[MCP] ${label}: ${formatFatal(reason)}\n`);
+  } catch {
+    // stderr itself failed — nothing we can do, just exit
+  }
+  process.exit(1);
+}
+
+/**
+ * Register uncaughtException and unhandledRejection handlers that call
+ * fatalExit. Safe to call in any transport entry point.
+ *
+ * Must be called early — before any async work — so that exceptions thrown
+ * during startup (e.g. in composeServer()) are caught and the process exits
+ * cleanly rather than spinning in an infinite loop.
+ */
+export function registerFatalHandlers(): void {
+  process.on('uncaughtException', (err) => fatalExit('Uncaught exception', err));
+  process.on('unhandledRejection', (reason) => fatalExit('Unhandled promise rejection', reason));
+}

--- a/src/mcp/transports/http-entry.ts
+++ b/src/mcp/transports/http-entry.ts
@@ -14,7 +14,7 @@
 import { composeServer } from '../server.js';
 import { bindWithPortFallback } from './http-listener.js';
 import { wireShutdownHooks } from './shutdown-hooks.js';
-import { registerFatalHandlers } from './fatal-exit.js';
+import { registerFatalHandlers, logStartup } from './fatal-exit.js';
 import * as crypto from 'crypto';
 import express from 'express';
 
@@ -23,7 +23,8 @@ const HTTP_PORT_SCAN_END = 3199;
 
 export async function startHttpServer(port: number): Promise<void> {
   // Register early — before composeServer() — so startup failures exit cleanly.
-  registerFatalHandlers();
+  registerFatalHandlers('http');
+  logStartup('http', { port });
 
   const { server, ctx } = await composeServer();
 

--- a/src/mcp/transports/http-entry.ts
+++ b/src/mcp/transports/http-entry.ts
@@ -14,6 +14,7 @@
 import { composeServer } from '../server.js';
 import { bindWithPortFallback } from './http-listener.js';
 import { wireShutdownHooks } from './shutdown-hooks.js';
+import { registerFatalHandlers } from './fatal-exit.js';
 import * as crypto from 'crypto';
 import express from 'express';
 
@@ -21,6 +22,9 @@ import express from 'express';
 const HTTP_PORT_SCAN_END = 3199;
 
 export async function startHttpServer(port: number): Promise<void> {
+  // Register early — before composeServer() — so startup failures exit cleanly.
+  registerFatalHandlers();
+
   const { server, ctx } = await composeServer();
 
   // Scan from the requested port up to HTTP_PORT_SCAN_END so a second

--- a/src/mcp/transports/stdio-entry.ts
+++ b/src/mcp/transports/stdio-entry.ts
@@ -26,18 +26,24 @@ export async function startStdioServer(): Promise<void> {
   // terminates. Without these, crashes are silent (exit code 1, no message).
   // Note: wireStdoutShutdown() handles the primary EPIPE crash path;
   // these handlers catch anything else that slips through.
-  process.on('uncaughtException', (err) => {
-    console.error('[MCP] Uncaught exception -- process will exit:', err);
-    // Do not call process.exit() here: let the default Node.js behavior
-    // handle termination so the exit code is correct.
-  });
-  process.on('unhandledRejection', (reason) => {
-    console.error('[MCP] Unhandled promise rejection:', reason);
-    // Node.js v15+: registering this handler suppresses the runtime's default
-    // exit-on-unhandled-rejection behavior. Explicitly exit so the process
-    // does not silently continue in an undefined state.
+  // Re-entrancy guard: if the error handler itself throws, we must not loop.
+  // Uses process.stderr.write instead of console.error — the inspector hooks
+  // console.error which can itself throw or re-enter, causing an infinite loop
+  // that pegs the process at 100% CPU instead of exiting.
+  let fatalHandlerActive = false;
+  const fatalExit = (label: string, reason: unknown): void => {
+    if (fatalHandlerActive) return; // prevent re-entrant loop
+    fatalHandlerActive = true;
+    try {
+      process.stderr.write(`[MCP] ${label}: ${String(reason)}\n`);
+    } catch {
+      // stderr itself failed — nothing we can do, just exit
+    }
     process.exit(1);
-  });
+  };
+
+  process.on('uncaughtException', (err) => fatalExit('Uncaught exception', err));
+  process.on('unhandledRejection', (reason) => fatalExit('Unhandled promise rejection', reason));
 
   const { server, ctx, rootsManager } = await composeServer();
 

--- a/src/mcp/transports/stdio-entry.ts
+++ b/src/mcp/transports/stdio-entry.ts
@@ -7,7 +7,7 @@
 
 import { composeServer } from '../server.js';
 import { wireShutdownHooks, wireStdinShutdown, wireStdoutShutdown } from './shutdown-hooks.js';
-import { registerFatalHandlers } from './fatal-exit.js';
+import { registerFatalHandlers, logStartup } from './fatal-exit.js';
 
 const INITIAL_ROOTS_TIMEOUT_MS = 1000;
 
@@ -30,7 +30,8 @@ export async function startStdioServer(): Promise<void> {
   // Register last-resort fatal handlers early — before any async work —
   // so that exceptions thrown during startup are caught and the process exits
   // cleanly rather than spinning in an infinite loop. See fatal-exit.ts.
-  registerFatalHandlers();
+  registerFatalHandlers('stdio');
+  logStartup('stdio');
 
   const { server, ctx, rootsManager } = await composeServer();
 

--- a/src/mcp/transports/stdio-entry.ts
+++ b/src/mcp/transports/stdio-entry.ts
@@ -7,6 +7,7 @@
 
 import { composeServer } from '../server.js';
 import { wireShutdownHooks, wireStdinShutdown, wireStdoutShutdown } from './shutdown-hooks.js';
+import { registerFatalHandlers } from './fatal-exit.js';
 
 const INITIAL_ROOTS_TIMEOUT_MS = 1000;
 
@@ -26,24 +27,10 @@ export async function startStdioServer(): Promise<void> {
   // terminates. Without these, crashes are silent (exit code 1, no message).
   // Note: wireStdoutShutdown() handles the primary EPIPE crash path;
   // these handlers catch anything else that slips through.
-  // Re-entrancy guard: if the error handler itself throws, we must not loop.
-  // Uses process.stderr.write instead of console.error — the inspector hooks
-  // console.error which can itself throw or re-enter, causing an infinite loop
-  // that pegs the process at 100% CPU instead of exiting.
-  let fatalHandlerActive = false;
-  const fatalExit = (label: string, reason: unknown): void => {
-    if (fatalHandlerActive) return; // prevent re-entrant loop
-    fatalHandlerActive = true;
-    try {
-      process.stderr.write(`[MCP] ${label}: ${String(reason)}\n`);
-    } catch {
-      // stderr itself failed — nothing we can do, just exit
-    }
-    process.exit(1);
-  };
-
-  process.on('uncaughtException', (err) => fatalExit('Uncaught exception', err));
-  process.on('unhandledRejection', (reason) => fatalExit('Unhandled promise rejection', reason));
+  // Register last-resort fatal handlers early — before any async work —
+  // so that exceptions thrown during startup are caught and the process exits
+  // cleanly rather than spinning in an infinite loop. See fatal-exit.ts.
+  registerFatalHandlers();
 
   const { server, ctx, rootsManager } = await composeServer();
 

--- a/tests/unit/mcp/transports/fatal-exit.test.ts
+++ b/tests/unit/mcp/transports/fatal-exit.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
- * Tests for fatal-exit.ts — last-resort error handler for all transport entry points.
+ * Tests for fatal-exit.ts — last-resort error handler and startup observability.
  *
- * We test fatalExit in isolation by importing it after resetting module state.
- * process.exit is replaced with a throw so tests can assert on it without
- * actually exiting the test process.
+ * We test fatalExit and logStartup in isolation by importing after module reset.
+ * process.exit is replaced with a throw so tests can assert without actually exiting.
  */
 
 describe('fatalExit', () => {
@@ -17,17 +16,15 @@ describe('fatalExit', () => {
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
-  it('writes the error message and stack trace to stderr then exits 1', async () => {
+  it('writes the error message and full stack trace to stderr then exits 1', async () => {
     const { fatalExit } = await import('../../../../src/mcp/transports/fatal-exit.js');
     const err = new Error('boom');
     expect(() => fatalExit('Uncaught exception', err)).toThrow('process.exit(1)');
     expect(process.stderr.write).toHaveBeenCalledWith(
       expect.stringContaining('Uncaught exception'),
     );
-    // Should include the stack, not just the message
-    expect(process.stderr.write).toHaveBeenCalledWith(
-      expect.stringContaining('Error: boom'),
-    );
+    // Must include stack, not just message
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('Error: boom'));
   });
 
   it('includes the full stack trace for Error instances', async () => {
@@ -35,7 +32,7 @@ describe('fatalExit', () => {
     const err = new Error('stack test');
     try { fatalExit('label', err); } catch { /* exit mock */ }
     const written = vi.mocked(process.stderr.write).mock.calls[0]?.[0] as string;
-    expect(written).toContain('at '); // stack trace lines start with "at "
+    expect(written).toContain('at '); // stack frames start with "at "
   });
 
   it('handles non-Error thrown values (strings, objects)', async () => {
@@ -49,9 +46,7 @@ describe('fatalExit', () => {
   it('is re-entrant safe — second call is a no-op', async () => {
     const { fatalExit } = await import('../../../../src/mcp/transports/fatal-exit.js');
     try { fatalExit('first', new Error('first')); } catch { /* exit mock */ }
-    // Second call must not throw again (process.exit already fired)
     expect(() => fatalExit('second', new Error('second'))).not.toThrow();
-    // stderr should only have been written once
     expect(process.stderr.write).toHaveBeenCalledTimes(1);
   });
 
@@ -59,5 +54,64 @@ describe('fatalExit', () => {
     vi.mocked(process.stderr.write).mockImplementation(() => { throw new Error('EBADF'); });
     const { fatalExit } = await import('../../../../src/mcp/transports/fatal-exit.js');
     expect(() => fatalExit('label', new Error('test'))).toThrow('process.exit(1)');
+  });
+});
+
+describe('registerFatalHandlers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    // Remove any handlers added by previous test runs
+    process.removeAllListeners('uncaughtException');
+    process.removeAllListeners('unhandledRejection');
+  });
+
+  it('registers handlers that exit on uncaughtException', async () => {
+    const { registerFatalHandlers } = await import('../../../../src/mcp/transports/fatal-exit.js');
+    registerFatalHandlers('stdio');
+    expect(() =>
+      process.emit('uncaughtException', new Error('test'), 'uncaughtException'),
+    ).toThrow('exit');
+  });
+
+  it('registers handlers that exit on unhandledRejection', async () => {
+    const { registerFatalHandlers } = await import('../../../../src/mcp/transports/fatal-exit.js');
+    registerFatalHandlers('http');
+    expect(() =>
+      process.emit('unhandledRejection', new Error('test'), Promise.reject()),
+    ).toThrow('exit');
+  });
+});
+
+describe('logStartup', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  it('emits transport, pid, and version', async () => {
+    const { logStartup } = await import('../../../../src/mcp/transports/fatal-exit.js');
+    logStartup('stdio');
+    const written = vi.mocked(process.stderr.write).mock.calls[0]?.[0] as string;
+    expect(written).toContain('transport=stdio');
+    expect(written).toContain(`pid=${process.pid}`);
+    expect(written).toContain('version=');
+    expect(written).toContain('[Startup]');
+  });
+
+  it('includes extra fields when provided', async () => {
+    const { logStartup } = await import('../../../../src/mcp/transports/fatal-exit.js');
+    logStartup('bridge', { primaryPort: 3100 });
+    const written = vi.mocked(process.stderr.write).mock.calls[0]?.[0] as string;
+    expect(written).toContain('primaryPort=3100');
+  });
+
+  it('emits http transport with port', async () => {
+    const { logStartup } = await import('../../../../src/mcp/transports/fatal-exit.js');
+    logStartup('http', { port: 3100 });
+    const written = vi.mocked(process.stderr.write).mock.calls[0]?.[0] as string;
+    expect(written).toContain('transport=http');
+    expect(written).toContain('port=3100');
   });
 });

--- a/tests/unit/mcp/transports/fatal-exit.test.ts
+++ b/tests/unit/mcp/transports/fatal-exit.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for fatal-exit.ts — last-resort error handler for all transport entry points.
+ *
+ * We test fatalExit in isolation by importing it after resetting module state.
+ * process.exit is replaced with a throw so tests can assert on it without
+ * actually exiting the test process.
+ */
+
+describe('fatalExit', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.spyOn(process, 'exit').mockImplementation((code?: number | string | null | undefined) => {
+      throw new Error(`process.exit(${code})`);
+    });
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  it('writes the error message and stack trace to stderr then exits 1', async () => {
+    const { fatalExit } = await import('../../../../src/mcp/transports/fatal-exit.js');
+    const err = new Error('boom');
+    expect(() => fatalExit('Uncaught exception', err)).toThrow('process.exit(1)');
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('Uncaught exception'),
+    );
+    // Should include the stack, not just the message
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('Error: boom'),
+    );
+  });
+
+  it('includes the full stack trace for Error instances', async () => {
+    const { fatalExit } = await import('../../../../src/mcp/transports/fatal-exit.js');
+    const err = new Error('stack test');
+    try { fatalExit('label', err); } catch { /* exit mock */ }
+    const written = vi.mocked(process.stderr.write).mock.calls[0]?.[0] as string;
+    expect(written).toContain('at '); // stack trace lines start with "at "
+  });
+
+  it('handles non-Error thrown values (strings, objects)', async () => {
+    const { fatalExit } = await import('../../../../src/mcp/transports/fatal-exit.js');
+    expect(() => fatalExit('label', 'plain string error')).toThrow('process.exit(1)');
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('plain string error'),
+    );
+  });
+
+  it('is re-entrant safe — second call is a no-op', async () => {
+    const { fatalExit } = await import('../../../../src/mcp/transports/fatal-exit.js');
+    try { fatalExit('first', new Error('first')); } catch { /* exit mock */ }
+    // Second call must not throw again (process.exit already fired)
+    expect(() => fatalExit('second', new Error('second'))).not.toThrow();
+    // stderr should only have been written once
+    expect(process.stderr.write).toHaveBeenCalledTimes(1);
+  });
+
+  it('still exits even if stderr.write throws', async () => {
+    vi.mocked(process.stderr.write).mockImplementation(() => { throw new Error('EBADF'); });
+    const { fatalExit } = await import('../../../../src/mcp/transports/fatal-exit.js');
+    expect(() => fatalExit('label', new Error('test'))).toThrow('process.exit(1)');
+  });
+});


### PR DESCRIPTION
## Problem

`uncaughtException` handler called `console.error()` but did not call `process.exit()`. The comment said "let Node.js default behavior handle termination" — but Node.js default when a handler IS registered is to **continue running**. The exception re-fired in a tight loop pegging the CPU at 100% forever.

Observed in production: 11 orphaned bridge processes each consuming ~100% CPU for 6+ hours. Stack trace showed all time in `TriggerUncaughtException → InspectorConsoleCall` — `console.error` going through the V8 inspector hook, which itself re-entered the handler.

## Fix

1. Both `uncaughtException` and `unhandledRejection` handlers now call `process.exit(1)` unconditionally.
2. Use `process.stderr.write` instead of `console.error` — raw syscall, no JS re-entrancy.
3. Re-entrancy guard `fatalHandlerActive` prevents handler→handler loops if either throws before exit.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)