### PR TITLE
fix(tests): replace hardcoded /tmp/ literals with tmpPath() helper

### DIFF
--- a/tests/unit/cli-worktrain-spawn.test.ts
+++ b/tests/unit/cli-worktrain-spawn.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import * as path from 'node:path';
+import { tmpPath } from '../helpers/platform.js';
 import {
   executeWorktrainSpawnCommand,
   type WorktrainSpawnCommandDeps,
@@ -61,7 +62,7 @@ function makeBaseDeps(overrides: Partial<WorktrainSpawnCommandDeps> = {}): {
 const VALID_OPTS = {
   workflow: 'coding-task-workflow-agentic',
   goal: 'test goal',
-  workspace: '/tmp/workspace',
+  workspace: tmpPath('workspace'),
 };
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit/workflow-runner-pre-allocated.test.ts
+++ b/tests/unit/workflow-runner-pre-allocated.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { tmpPath } from '../helpers/platform.js';
 
 // ── Mock variables (hoisted alongside vi.mock) ────────────────────────────────
 //
@@ -94,7 +95,7 @@ describe('runWorkflow() with _preAllocatedStartResponse', () => {
     const trigger: WorkflowTrigger = {
       workflowId: 'coding-task-workflow-agentic',
       goal: 'test goal',
-      workspacePath: '/tmp/test-workspace',
+      workspacePath: tmpPath('test-workspace'),
       _preAllocatedStartResponse: makePreAllocatedResponse({ isComplete: true }),
     };
 


### PR DESCRIPTION
Two test files used hardcoded `/tmp/` paths, triggering the `codemod:test-platform-guard` CI check and blocking the release workflow. Fixed by importing and using the existing `tmpPath()` helper from `tests/helpers/platform.ts`.