### PR TITLE
fix(engine): treat exit 1 with empty stderr as no-match, not failure

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -3883,3 +3883,27 @@ WorkTrain uses the user's git identity and GitHub account (via user's token) to 
 **Why useful:** normal PR approval flows, no bot account permissions needed, personal git history stays personal even for WorkTrain-authored work.
 
 **Trust guardrails:** `actAsUser: true` explicit opt-in, only for commits/PRs (never emails or Slack without additional permission), PR description always notes "Created by WorkTrain," full audit log in `~/.workrail/actions-as-user.jsonl`.
+
+---
+
+### Console session detail: more than the DAG when running standalone (Apr 16, 2026)
+
+**The gap:** the session DAG shows structure (steps, edges, progress) but not meaning. When you're watching a session run in the console without being in Claude Code, you want to know what the agent is *actually doing* -- not just which step it's on.
+
+**What's missing from the current DAG view:**
+- The latest step output note, rendered inline and updating as it streams (not hidden behind a click)
+- A plain-English summary of what the agent is doing right now ("Analyzing the diff for shell injection risks")
+- Current step prompt visible on demand (so you know what the agent was asked to do)
+- Token count and cost estimate for the session so far
+- Time elapsed + estimated time remaining based on step history
+- A live feed of tool calls as they happen ("Reading trigger-router.ts", "Running npm test")
+
+**The streaming step output** is the most valuable addition. Right now the DAG shows a step as "in progress" with a spinner. It should show the last few lines of the step's output note as it's being written, similar to how a terminal streams command output.
+
+**Build order:**
+1. Inline latest step output in the session detail panel (read from session store, poll every 2s)
+2. Live tool call feed alongside the DAG (SSE from the daemon, log each tool call as it fires)
+3. Token/cost counter (daemon tracks tokens per session, expose via GET /api/v2/sessions/:id)
+4. Plain-English status line ("Step 3/8: analyzing diff" vs just a spinner)
+
+This makes the console genuinely useful as a standalone monitoring surface -- not just for developers who understand the DAG topology, but for anyone who wants to know if WorkTrain is doing useful work or spinning.

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -858,7 +858,9 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
   return {
     name: 'Bash',
     description:
-      'Execute a shell command. Throws on non-zero exit code. ' +
+      'Execute a shell command. Throws on failure (non-zero exit with stderr, or exit code 2+). ' +
+      'Exit code 1 with empty stderr is treated as "no match found" (standard grep semantics) and ' +
+      'returns empty output without throwing. ' +
       `Maximum execution time: ${BASH_TIMEOUT_MS / 1000}s.`,
     inputSchema: schemas['BashParams'],
     label: 'Bash',
@@ -891,6 +893,23 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
         const stderr = String(e.stderr ?? '');
         const rawCode = e.code;
         const signal = e.signal;
+
+        // Exit code 1 with empty stderr is "no match found" -- not a real error.
+        // This is standard POSIX semantics for grep (exit 1 = no lines matched,
+        // exit 2 = genuine error). Applying the same rule to any command that exits
+        // 1 with no error output is safe: a command that fails silently is almost
+        // always reporting "nothing found", not a broken execution.
+        // WHY `rawCode === 1 && !stderr.trim()`: rawCode is a number when set by
+        // normal process exit; the trim() guard ignores purely-whitespace stderr.
+        // This branch is NOT entered for exit 2+ (always an error) or when stderr
+        // is non-empty (the process wrote a diagnostic message, so it is a real error).
+        if (rawCode === 1 && !stderr.trim()) {
+          return {
+            content: [{ type: 'text', text: stdout || '(no output)' }],
+            details: { stdout, stderr },
+          };
+        }
+
         const exitInfo = rawCode != null
           ? `exit ${String(rawCode)}`
           : signal

--- a/tests/unit/workflow-runner-bash-tool.test.ts
+++ b/tests/unit/workflow-runner-bash-tool.test.ts
@@ -29,6 +29,7 @@ const CMD_NOOP = 'node -e ""';
 const CMD_STDOUT_AND_STDERR =
   'node -e "process.stdout.write(\'out\'); process.stderr.write(\'err\')"';
 const CMD_EXIT_1 = 'node -e "process.exit(1)"';
+const CMD_EXIT_2 = 'node -e "process.exit(2)"';
 const CMD_EXIT_42 = 'node -e "process.exit(42)"';
 const CMD_STDOUT_THEN_EXIT_1 =
   'node -e "process.stdout.write(\'stdout-content\'); process.exit(1)"';
@@ -36,6 +37,9 @@ const CMD_STDERR_THEN_EXIT_1 =
   'node -e "process.stderr.write(\'stderr-content\'); process.exit(1)"';
 const CMD_BOTH_THEN_EXIT_1 =
   'node -e "process.stdout.write(\'my-out\'); process.stderr.write(\'my-err\'); process.exit(1)"';
+// Exit 2 with stderr -- simulates grep "Usage error" or real grep error
+const CMD_STDERR_THEN_EXIT_2 =
+  'node -e "process.stderr.write(\'grep: invalid option\'); process.exit(2)"';
 
 describe('makeBashTool()', () => {
   describe('success cases (exit 0)', () => {
@@ -82,19 +86,80 @@ describe('makeBashTool()', () => {
     });
   });
 
-  describe('failure cases (non-zero exit)', () => {
-    it('throws an error when command exits with non-zero code', async () => {
+  describe('exit-1 with empty stderr (grep "no match" semantics)', () => {
+    it('returns empty stdout when exit 1 and no stderr (grep finds nothing)', async () => {
+      // Simulates: ls docs/plans/ | grep -i trigger  -- grep finds no lines, exits 1
+      const tool = makeBashTool(WORKSPACE, stubSchemas);
+      const result = await tool.execute('test-call-id', {
+        command: CMD_EXIT_1,
+        cwd: WORKSPACE,
+      });
+      const text = (result.content[0] as { type: string; text: string }).text;
+      // Should NOT throw; should return "(no output)" since stdout is also empty
+      expect(text).toBe('(no output)');
+    });
+
+    it('returns stdout content when exit 1 and no stderr', async () => {
+      // Edge case: command exits 1 but wrote something to stdout before exiting
+      const tool = makeBashTool(WORKSPACE, stubSchemas);
+      const result = await tool.execute('test-call-id', {
+        command: CMD_STDOUT_THEN_EXIT_1,
+        cwd: WORKSPACE,
+      });
+      const text = (result.content[0] as { type: string; text: string }).text;
+      expect(text).toContain('stdout-content');
+    });
+
+    it('returns details with stdout and stderr when exit 1 and no stderr', async () => {
+      const tool = makeBashTool(WORKSPACE, stubSchemas);
+      const result = await tool.execute('test-call-id', {
+        command: CMD_EXIT_1,
+        cwd: WORKSPACE,
+      });
+      const details = result.details as { stdout: string; stderr: string };
+      expect(details).toHaveProperty('stdout');
+      expect(details).toHaveProperty('stderr');
+    });
+
+    it('still throws when exit 1 with non-empty stderr (real grep error)', async () => {
+      // Simulates: grep writes a diagnostic to stderr before exiting 1
       const tool = makeBashTool(WORKSPACE, stubSchemas);
       await expect(
-        tool.execute('test-call-id', { command: CMD_EXIT_1, cwd: WORKSPACE }),
+        tool.execute('test-call-id', { command: CMD_STDERR_THEN_EXIT_1, cwd: WORKSPACE }),
+      ).rejects.toThrow('stderr-content');
+    });
+
+    it('throws when exit 2 regardless of stderr (grep usage/IO error)', async () => {
+      // Exit code 2 from grep always means a real error, never "no match"
+      const tool = makeBashTool(WORKSPACE, stubSchemas);
+      await expect(
+        tool.execute('test-call-id', { command: CMD_EXIT_2, cwd: WORKSPACE }),
+      ).rejects.toThrow('exit 2');
+    });
+
+    it('throws when exit 2 even with non-empty stderr (grep IO/usage error)', async () => {
+      const tool = makeBashTool(WORKSPACE, stubSchemas);
+      await expect(
+        tool.execute('test-call-id', { command: CMD_STDERR_THEN_EXIT_2, cwd: WORKSPACE }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('failure cases (non-zero exit)', () => {
+    it('throws an error when command exits with non-zero code and has stderr', async () => {
+      // CMD_EXIT_1 alone no longer throws (exit 1, empty stderr = "no match" semantics).
+      // Use a command that writes to stderr so the throw path is exercised.
+      const tool = makeBashTool(WORKSPACE, stubSchemas);
+      await expect(
+        tool.execute('test-call-id', { command: CMD_STDERR_THEN_EXIT_1, cwd: WORKSPACE }),
       ).rejects.toThrow();
     });
 
     it('includes the failed command in the thrown error message', async () => {
       const tool = makeBashTool(WORKSPACE, stubSchemas);
       await expect(
-        tool.execute('test-call-id', { command: CMD_EXIT_1, cwd: WORKSPACE }),
-      ).rejects.toThrow(CMD_EXIT_1);
+        tool.execute('test-call-id', { command: CMD_STDERR_THEN_EXIT_1, cwd: WORKSPACE }),
+      ).rejects.toThrow(CMD_STDERR_THEN_EXIT_1);
     });
 
     it('includes the exit code in the thrown error message', async () => {
@@ -104,11 +169,13 @@ describe('makeBashTool()', () => {
       ).rejects.toThrow('42');
     });
 
-    it('includes stdout in the thrown error when command produces output before failing', async () => {
+    it('includes stdout in the thrown error when command writes to stdout and stderr before failing', async () => {
+      // CMD_STDOUT_THEN_EXIT_1 exits 1 with empty stderr, which is now a "no match" success.
+      // Use CMD_BOTH_THEN_EXIT_1 (stdout + stderr + exit 1) to verify the stdout-in-error path.
       const tool = makeBashTool(WORKSPACE, stubSchemas);
       await expect(
-        tool.execute('test-call-id', { command: CMD_STDOUT_THEN_EXIT_1, cwd: WORKSPACE }),
-      ).rejects.toThrow('stdout-content');
+        tool.execute('test-call-id', { command: CMD_BOTH_THEN_EXIT_1, cwd: WORKSPACE }),
+      ).rejects.toThrow('my-out');
     });
 
     it('includes stderr in the thrown error when command writes to stderr before failing', async () => {


### PR DESCRIPTION
## Summary

- `grep` exits 1 when no lines match -- that is standard POSIX behavior, not an error. The daemon Bash tool was throwing on any non-zero exit, forcing the agent to write `grep ... || true` for every exploratory command.
- New rule in `makeBashTool()` (in `src/daemon/workflow-runner.ts`): exit code 1 with empty stderr is returned as success (stdout may be empty); exit code 1 with non-empty stderr still throws; exit code 2+ always throws.
- Updated `tests/unit/workflow-runner-bash-tool.test.ts` with 6 new cases covering the grep-no-match path, the real-error paths, and the exit-2 path; updated 2 existing tests whose command choices no longer exercise the throw path.

## Test plan

- [ ] `npx vitest run tests/unit/workflow-runner-bash-tool.test.ts` -- all 16 tests pass
- [ ] `npx vitest run tests/unit/workflow-runner-crash-recovery.test.ts tests/unit/workflow-runner-system-prompt.test.ts tests/unit/workflow-runner-pre-allocated.test.ts` -- no regressions in related tests
- [ ] Manually run `ls docs/plans/ | grep -i trigger` in a daemon session to confirm no throw on empty result

🤖 Generated with [Claude Code](https://claude.com/claude-code)