### PR TITLE
fix(mcp): isolate fatal-exit tests from production crash.log

### DIFF
--- a/tests/unit/mcp/transports/fatal-exit.test.ts
+++ b/tests/unit/mcp/transports/fatal-exit.test.ts
@@ -1,19 +1,70 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
 /**
  * Tests for fatal-exit.ts — last-resort error handler and startup observability.
  *
- * We test fatalExit and logStartup in isolation by importing after module reset.
- * process.exit is replaced with a throw so tests can assert without actually exiting.
+ * WHY os.homedir() is mocked:
+ * `fatal-exit.ts` computes CRASH_LOG_PATH = join(homedir(), '.workrail', 'crash.log')
+ * at module load time. Without this mock, every call to `fatalExit()` in tests would
+ * write to the PRODUCTION crash log (~/.workrail/crash.log) — the same file the live
+ * MCP server bridge reads to detect crashes. This would cause the bridge to lose
+ * connection and die when tests run alongside a live WorkRail session.
+ *
+ * The mock redirects homedir() to a per-test temp directory so crash log writes are
+ * isolated and automatically cleaned up. This follows the pattern established in
+ * tests/unit/config/config-file.test.ts.
+ *
+ * WHY vi.resetModules() + dynamic import:
+ * `fatal-exit.ts` has module-level state (fatalHandlerActive re-entrancy guard,
+ * registeredTransport). vi.resetModules() forces a fresh module evaluation on each
+ * dynamic import, resetting those guards between tests.
+ *
+ * WHY process listeners are cleaned up in afterEach:
+ * registerFatalHandlers() attaches global process.on('uncaughtException') and
+ * process.on('unhandledRejection') handlers. With vitest pool:threads, the global
+ * process is shared across test files. Without cleanup, handlers from one test
+ * accumulate and interfere with subsequent tests and other test files in the same
+ * worker thread.
  */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Redirect crash log writes to a per-test temp directory.
+//
+// fatal-exit.ts evaluates CRASH_LOG_PATH at module load time:
+//   const CRASH_LOG_PATH = join(homedir(), '.workrail', 'crash.log')
+//
+// vi.mock is hoisted before any imports, so this mock is in place when the
+// module is first evaluated. vi.resetModules() + dynamic await import() then
+// forces re-evaluation on each test, picking up the current tmpHome value.
+// ---------------------------------------------------------------------------
+
+let tmpHome: string;
+
+vi.mock('os', async (importOriginal) => {
+  const original = await importOriginal<typeof os>();
+  return {
+    ...original,
+    homedir: () => tmpHome ?? original.homedir(),
+  };
+});
 
 describe('fatalExit', () => {
   beforeEach(() => {
+    // Create a fresh temp dir for this test so crash log writes are isolated.
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'workrail-fatal-test-'));
     vi.resetModules();
     vi.spyOn(process, 'exit').mockImplementation((code?: number | string | null | undefined) => {
       throw new Error(`process.exit(${code})`);
     });
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    // Clean up the temp dir created for this test.
+    fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
   it('writes the error message and full stack trace to stderr then exits 1', async () => {
@@ -59,12 +110,23 @@ describe('fatalExit', () => {
 
 describe('registerFatalHandlers', () => {
   beforeEach(() => {
+    // Create a fresh temp dir for this test so crash log writes are isolated.
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'workrail-fatal-test-'));
     vi.resetModules();
     vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    // Remove any handlers added by previous test runs
+    // Remove any handlers added by previous test runs before this test starts.
     process.removeAllListeners('uncaughtException');
     process.removeAllListeners('unhandledRejection');
+  });
+
+  afterEach(() => {
+    // Remove handlers added by this test so they don't leak into other tests
+    // or other test files running in the same vitest worker thread (pool:threads).
+    process.removeAllListeners('uncaughtException');
+    process.removeAllListeners('unhandledRejection');
+    // Clean up the temp dir created for this test.
+    fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
   it('registers handlers that exit on uncaughtException', async () => {
@@ -78,8 +140,13 @@ describe('registerFatalHandlers', () => {
   it('registers handlers that exit on unhandledRejection', async () => {
     const { registerFatalHandlers } = await import('../../../../src/mcp/transports/fatal-exit.js');
     registerFatalHandlers('http');
+    // Use a pre-rejected-and-caught promise to avoid a real unhandled rejection
+    // in the Node.js event loop -- we only want to test that the registered handler
+    // fires when process.emit('unhandledRejection') is called.
+    const handledRejection = Promise.reject(new Error('test rejection'));
+    handledRejection.catch(() => { /* suppress real unhandled rejection */ });
     expect(() =>
-      process.emit('unhandledRejection', new Error('test'), Promise.reject()),
+      process.emit('unhandledRejection', new Error('test'), handledRejection),
     ).toThrow('exit');
   });
 });


### PR DESCRIPTION
## Summary

- Mock `os.homedir()` in `fatal-exit.test.ts` to redirect crash log writes to a per-test temp directory, so tests never touch `~/.workrail/crash.log`
- Add `afterEach` listener cleanup in `registerFatalHandlers` tests to remove global `process.on` handlers after each test (prevents leakage in `pool: 'threads'`)
- Fix a pre-existing unhandled rejection in the `unhandledRejection` test (bare `Promise.reject()` was creating a real Node.js unhandled rejection event)

## Root Cause

`fatal-exit.ts` computes `CRASH_LOG_PATH = join(homedir(), '.workrail', 'crash.log')` at module load time. Every call to `fatalExit()` in tests wrote to the production crash log. When vitest ran alongside a live WorkRail session, these writes caused the bridge to lose connection and die (crash.log entries at 17:48:24 and 17:48:43 from `fatal-exit.test.ts` confirmed in `~/.workrail/crash.log`).

## Test Plan

- [x] `npx vitest run tests/unit/mcp/transports/fatal-exit.test.ts` -- 10/10 tests pass
- [x] `~/.workrail/crash.log` size verified unchanged before and after test run (32885 bytes both ways)
- [x] All original test assertions preserved -- no test logic changed, only isolation scaffolding added

## Pattern

Follows the exact pattern established in `tests/unit/config/config-file.test.ts` (same `vi.mock('os', async (importOriginal) => {...})` approach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)