### PR TITLE
fix(mcp): sync package.json version and restore semantic-release git push-back

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -54,6 +54,13 @@ module.exports = {
         publishCmd: "npm publish --access public"
       }
     ],
+    [
+      "@semantic-release/git",
+      {
+        assets: ["package.json", "package-lock.json"],
+        message: "chore(release): ${nextRelease.version} [skip ci]"
+      }
+    ],
     "@semantic-release/github"
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@exaudeus/workrail",
-  "version": "3.26.0",
+  "version": "3.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@exaudeus/workrail",
-      "version": "3.26.0",
+      "version": "3.26.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@exaudeus/workrail",
-  "version": "3.16.0",
+  "version": "3.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@exaudeus/workrail",
-      "version": "3.16.0",
+      "version": "3.26.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exaudeus/workrail",
-  "version": "3.16.0",
+  "version": "3.26.0",
   "description": "Step-by-step workflow enforcement for AI agents via MCP",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exaudeus/workrail",
-  "version": "3.26.0",
+  "version": "3.26.2",
   "description": "Step-by-step workflow enforcement for AI agents via MCP",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- `package.json` and `package-lock.json` were stuck at `3.16.0` while npm had `3.26.0` published. The mismatch caused `workrail version` (which reads from the local `package.json` via `require('../package.json')`) to report a stale version.
- Root cause: `.releaserc.cjs` used `@semantic-release/exec` to stamp the version with `npm pkg set version=X` on the CI runner, but **never committed it back** -- `@semantic-release/git` was missing from the plugins list.
- This PR bumps the local files to `3.26.0` (one-time catch-up) and adds `@semantic-release/git` so every future release commits `package.json` + `package-lock.json` back to `main` with `[skip ci]`, closing the loop permanently.

## Changes

- `.releaserc.cjs`: add `@semantic-release/git` plugin (already in `devDependencies`) after `@semantic-release/exec`, committing `package.json` and `package-lock.json` with `chore(release): X.Y.Z [skip ci]`
- `package.json`: bump `version` from `3.16.0` to `3.26.0`
- `package-lock.json`: bump root `version` from `3.16.0` to `3.26.0`

## Why `@semantic-release/git` is safe here

- The release workflow already has `contents: write` permission and `persist-credentials: true` on checkout
- The `[skip ci]` tag in the commit message prevents the version-bump commit from triggering a new CI run / release cycle
- Plugin ordering is correct: exec (stamp) -> git (commit) -> github (create release)

## Test plan

- [ ] Verify `workrail version` locally reports `3.26.0` after building
- [ ] Merge and confirm the next release creates a `chore(release): X.Y.Z [skip ci]` commit on `main`
- [ ] Confirm `package.json` in the repo reflects the released version after the next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)