### PR TITLE
feat(daemon): add observability logs -- agent loop start/end and tool invocations

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -3907,3 +3907,21 @@ WorkTrain uses the user's git identity and GitHub account (via user's token) to 
 4. Plain-English status line ("Step 3/8: analyzing diff" vs just a spinner)
 
 This makes the console genuinely useful as a standalone monitoring surface -- not just for developers who understand the DAG topology, but for anyone who wants to know if WorkTrain is doing useful work or spinning.
+
+---
+
+### Orphaned daemon session state: smarter recovery (Apr 16, 2026)
+
+**The problem:** When the daemon is killed mid-session, the session's in-process `KeyedAsyncQueue` promise chain is lost. On restart, the startup recovery reads orphaned session files and clears them from disk -- but the `serial` concurrency queue key based on `trigger.id` is an in-memory construct. Any external state (e.g. a lock file, a flag in the session store) that was tied to the queue is now inconsistent.
+
+More critically: if a session is restarted by the daemon but then stalls (Bedrock call hangs, exception suppressed), the daemon log shows nothing after "Injecting workspace context" -- no error, no completion. The session is in limbo.
+
+**What needs to happen:**
+
+1. **Startup recovery should also clear any pending queue slots.** If a session file exists in `~/.workrail/daemon-sessions/` at startup, that trigger's queue key should be treated as free -- no prior promise is alive.
+
+2. **Session liveness detection.** If a session has been `in_progress` for more than N minutes with no `advance_recorded` events, the daemon watchdog should log a warning and optionally abort the session. Currently a hung session is invisible.
+
+3. **Orphaned session cleanup should be user-facing.** `worktrain cleanup` or `worktrain status` should surface orphaned sessions with their age and offer to clear them. Right now they silently accumulate.
+
+4. **Better logging when runWorkflow() swallows errors.** The `void runWorkflow(...)` pattern in `console-routes.ts` and `trigger-router.ts` drops errors silently. Every path that ends in silence (no log, no session advance, no error) should at minimum log `[WorkflowRunner] Session died silently` with the session ID.

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -803,6 +803,7 @@ function makeContinueWorkflowTool(
       _toolCallId: string,
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
+      console.log(`[WorkflowRunner] Tool: continue_workflow sessionId=${sessionId}`);
       const result = await executeContinueWorkflow(
         {
           continueToken: params.continueToken,
@@ -869,6 +870,7 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
       _toolCallId: string,
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
+      console.log(`[WorkflowRunner] Tool: bash "${String(params.command).slice(0, 80)}"`);
       const cwd = params.cwd ?? workspacePath;
       try {
         const { stdout, stderr } = await execAsync(params.command, {
@@ -1369,6 +1371,7 @@ export async function runWorkflow(
         reject(new Error('Workflow timed out'));
       }, sessionTimeoutMs);
     });
+    console.log(`[WorkflowRunner] Agent loop started: sessionId=${sessionId} workflowId=${trigger.workflowId} modelId=${modelId}`);
     await Promise.race([agent.prompt(buildUserMessage(initialPrompt)), timeoutPromise])
       .catch((err: unknown) => {
         agent.abort();
@@ -1398,6 +1401,7 @@ export async function runWorkflow(
     // and mutate the closed-over timeoutReason variable. clearTimeout on an
     // already-fired or undefined handle is a safe no-op.
     if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+    console.log(`[WorkflowRunner] Agent loop ended: sessionId=${sessionId} stopReason=${stopReason}${errorMessage ? ` error=${errorMessage.slice(0, 120)}` : ''}`);
   }
 
   // ---- Timeout result (wall-clock or max-turn limit) ----


### PR DESCRIPTION
Adds log lines so operators can see the daemon is actively working rather than appearing silently stuck. Adds: agent loop started/ended, continue_workflow called, bash command executed.