### PR TITLE
fix(daemon): surface blocked workflow responses instead of silently advancing

### DIFF
--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -783,13 +783,15 @@ function getSchemas(): Record<string, any> {
 // Tool factories
 // ---------------------------------------------------------------------------
 
-function makeContinueWorkflowTool(
+export function makeContinueWorkflowTool(
   sessionId: string,
   ctx: V2ToolContext,
   onAdvance: (nextStepText: string, continueToken: string) => void,
   onComplete: (notes: string | undefined) => void,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   schemas: Record<string, any>,
+  // Optional injection point for testing -- defaults to the real implementation.
+  _executeContinueWorkflowFn: typeof executeContinueWorkflow = executeContinueWorkflow,
 ): AgentTool {
   return {
     name: 'continue_workflow',
@@ -804,7 +806,7 @@ function makeContinueWorkflowTool(
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
       console.log(`[WorkflowRunner] Tool: continue_workflow sessionId=${sessionId}`);
-      const result = await executeContinueWorkflow(
+      const result = await _executeContinueWorkflowFn(
         {
           continueToken: params.continueToken,
           intent: (params.intent ?? 'advance') as 'advance' | 'rehydrate',
@@ -823,10 +825,62 @@ function makeContinueWorkflowTool(
       const out = result.value.response;
 
       // Persist tokens atomically before returning -- crash safety invariant.
+      // WHY continueToken vs retryToken: for a blocked response, nextCall.params.continueToken
+      // is the retry token (retryContinueToken for retryable, or continueToken for non-retryable).
+      // Persisting this ensures crash recovery resumes with the correct token.
       const continueToken = out.continueToken ?? '';
       const checkpointToken = out.checkpointToken ?? null;
-      if (continueToken) {
-        await persistTokens(sessionId, continueToken, checkpointToken);
+      const persistToken = (out.kind === 'blocked' ? out.nextCall?.params.continueToken : undefined) ?? continueToken;
+      if (persistToken) {
+        await persistTokens(sessionId, persistToken, checkpointToken);
+      }
+
+      // WHY: when the engine returns a blocked response, the step did NOT advance.
+      // Calling onAdvance() would erroneously signal advancement and cause the agent
+      // to loop forever believing it moved forward. Return feedback instead so the
+      // agent knows what to fix and can retry the same step.
+      if (out.kind === 'blocked') {
+        const retryToken = out.nextCall?.params.continueToken ?? continueToken;
+        const lines: string[] = ['## Step blocked -- action required\n'];
+
+        for (const blocker of out.blockers.blockers) {
+          lines.push(blocker.message);
+          if (blocker.suggestedFix) {
+            lines.push(`\nWhat to do: ${blocker.suggestedFix}`);
+          }
+          lines.push('');
+        }
+
+        if (out.validation) {
+          if (out.validation.issues.length > 0) {
+            lines.push('**Issues:**');
+            for (const issue of out.validation.issues) lines.push(`- ${issue}`);
+            lines.push('');
+          }
+          if (out.validation.suggestions.length > 0) {
+            lines.push('**Suggestions:**');
+            for (const s of out.validation.suggestions) lines.push(`- ${s}`);
+            lines.push('');
+          }
+        }
+
+        if (out.assessmentFollowup) {
+          lines.push(`**Follow-up required:** ${out.assessmentFollowup.title}`);
+          lines.push(out.assessmentFollowup.guidance);
+          lines.push('');
+        }
+
+        if (out.retryable) {
+          lines.push(`Retry the same step with corrected output.\n\ncontinueToken: ${retryToken}`);
+        } else {
+          lines.push(`You cannot proceed without resolving this. Inform the user and wait for their response, then call continue_workflow.\n\ncontinueToken: ${retryToken}`);
+        }
+
+        const feedback = lines.join('\n');
+        return {
+          content: [{ type: 'text', text: feedback }],
+          details: out,
+        };
       }
 
       if (out.isComplete) {

--- a/tests/unit/workflow-runner-continue-workflow-blocked.test.ts
+++ b/tests/unit/workflow-runner-continue-workflow-blocked.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Unit tests for blocked-response handling in makeContinueWorkflowTool().
+ *
+ * Strategy: inject a fake executeContinueWorkflow that returns deterministic
+ * blocked responses. Verify that:
+ * - Blocked responses return human-readable feedback
+ * - onAdvance() is NOT called (step did not advance)
+ * - onComplete() is NOT called
+ * - Retryable vs non-retryable blocked produce appropriate guidance
+ *
+ * WHY fake injection over mocking: follows the "prefer fakes over mocks"
+ * principle from CLAUDE.md. The optional `_executeContinueWorkflowFn`
+ * parameter accepts a real fake, keeping tests deterministic and realistic.
+ *
+ * Note: persistTokens() writes to ~/.workrail/daemon-sessions/<sessionId>.json.
+ * Each test uses a unique UUID session ID so files never collide. Files are
+ * cleaned up in afterEach.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, afterEach } from 'vitest';
+import { okAsync } from 'neverthrow';
+import type { V2ToolContext } from '../../src/mcp/types.js';
+import { makeContinueWorkflowTool } from '../../src/daemon/workflow-runner.js';
+import { DAEMON_SESSIONS_DIR } from '../../src/daemon/workflow-runner.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/** A minimal blocked response with one blocker and validation details. */
+function makeBlockedResponse(overrides: {
+  retryable?: boolean;
+  retryToken?: string;
+  validationIssues?: string[];
+  validationSuggestions?: string[];
+  assessmentFollowup?: { title: string; guidance: string };
+} = {}) {
+  const retryToken = overrides.retryToken ?? 'ct_retrytoken123456789012345678';
+  return {
+    kind: 'blocked' as const,
+    continueToken: 'ct_sessiontoken1234567890123456',
+    checkpointToken: undefined,
+    isComplete: false,
+    pending: {
+      stepId: 'step-1',
+      title: 'Step 1',
+      prompt: 'Do the work.',
+    },
+    preferences: {
+      autonomy: 'full_auto_never_stop' as const,
+      riskPolicy: 'balanced' as const,
+    },
+    nextIntent: 'perform_pending_then_continue' as const,
+    nextCall: {
+      tool: 'continue_workflow' as const,
+      params: { continueToken: retryToken },
+    },
+    blockers: {
+      blockers: [
+        {
+          code: 'MISSING_REQUIRED_NOTES' as const,
+          pointer: { kind: 'workflow_step' as const, stepId: 'step-1' },
+          message: 'Notes are required for this step. Provide substantive notes describing what you did.',
+          suggestedFix: 'Include output.notesMarkdown with at least 10 lines describing your work.',
+        },
+      ],
+    },
+    retryable: overrides.retryable ?? true,
+    retryContinueToken: overrides.retryToken,
+    validation: {
+      issues: overrides.validationIssues ?? ['Notes are missing or too short'],
+      suggestions: overrides.validationSuggestions ?? ['Add at least 10 lines to notesMarkdown'],
+    },
+    assessmentFollowup: overrides.assessmentFollowup,
+  };
+}
+
+/** Fake executeContinueWorkflow that returns a blocked response. */
+function makeFakeBlockedExec(blockedResponse: ReturnType<typeof makeBlockedResponse>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (_input: any, _ctx: any) => okAsync({ response: blockedResponse as any });
+}
+
+/** Null V2ToolContext -- not used by the fake. */
+const NULL_CTX = {} as unknown as V2ToolContext;
+
+/** Stub schemas -- ContinueWorkflowParams not used in tests. */
+const STUB_SCHEMAS = { ContinueWorkflowParams: {} };
+
+/** Params passed to continue_workflow execute. */
+function makeParams(continueToken = 'ct_agenttoken12345678901234567') {
+  return {
+    continueToken,
+    intent: 'advance',
+    notesMarkdown: 'My notes',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+const sessionIdsToClean: string[] = [];
+
+afterEach(async () => {
+  for (const sessionId of sessionIdsToClean) {
+    const filePath = path.join(DAEMON_SESSIONS_DIR, `${sessionId}.json`);
+    await fs.unlink(filePath).catch(() => { /* ignore if not created */ });
+  }
+  sessionIdsToClean.length = 0;
+});
+
+function makeSessionId(): string {
+  const id = randomUUID();
+  sessionIdsToClean.push(id);
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('makeContinueWorkflowTool() -- blocked response handling', () => {
+  describe('feedback content', () => {
+    it('returns feedback containing the blocker message when blocked', async () => {
+      const sessionId = makeSessionId();
+      const blocked = makeBlockedResponse();
+      const tool = makeContinueWorkflowTool(
+        sessionId,
+        NULL_CTX,
+        () => { throw new Error('onAdvance must not be called'); },
+        () => { throw new Error('onComplete must not be called'); },
+        STUB_SCHEMAS,
+        makeFakeBlockedExec(blocked),
+      );
+
+      const result = await tool.execute('call-1', makeParams());
+      const text = (result.content[0] as { type: string; text: string }).text;
+
+      expect(text).toContain('Notes are required for this step');
+    });
+
+    it('includes validation issues in feedback', async () => {
+      const sessionId = makeSessionId();
+      const blocked = makeBlockedResponse({
+        validationIssues: ['Custom issue: foo is missing'],
+        validationSuggestions: ['Add foo to your output'],
+      });
+      const tool = makeContinueWorkflowTool(
+        sessionId, NULL_CTX, () => {}, () => {}, STUB_SCHEMAS,
+        makeFakeBlockedExec(blocked),
+      );
+
+      const result = await tool.execute('call-1', makeParams());
+      const text = (result.content[0] as { type: string; text: string }).text;
+
+      expect(text).toContain('Custom issue: foo is missing');
+      expect(text).toContain('Add foo to your output');
+    });
+
+    it('includes assessment followup in feedback when present', async () => {
+      const sessionId = makeSessionId();
+      const blocked = makeBlockedResponse({
+        assessmentFollowup: {
+          title: 'Design soundness matched "low"',
+          guidance: 'Commit to a design approach before proceeding.',
+        },
+      });
+      const tool = makeContinueWorkflowTool(
+        sessionId, NULL_CTX, () => {}, () => {}, STUB_SCHEMAS,
+        makeFakeBlockedExec(blocked),
+      );
+
+      const result = await tool.execute('call-1', makeParams());
+      const text = (result.content[0] as { type: string; text: string }).text;
+
+      expect(text).toContain('Design soundness matched "low"');
+      expect(text).toContain('Commit to a design approach before proceeding.');
+    });
+
+    it('includes the retry token in feedback', async () => {
+      const sessionId = makeSessionId();
+      const retryToken = 'ct_retrytoken123456789012345678';
+      const blocked = makeBlockedResponse({ retryToken });
+      const tool = makeContinueWorkflowTool(
+        sessionId, NULL_CTX, () => {}, () => {}, STUB_SCHEMAS,
+        makeFakeBlockedExec(blocked),
+      );
+
+      const result = await tool.execute('call-1', makeParams());
+      const text = (result.content[0] as { type: string; text: string }).text;
+
+      expect(text).toContain(retryToken);
+    });
+
+    it('tells agent to retry when retryable=true', async () => {
+      const sessionId = makeSessionId();
+      const blocked = makeBlockedResponse({ retryable: true });
+      const tool = makeContinueWorkflowTool(
+        sessionId, NULL_CTX, () => {}, () => {}, STUB_SCHEMAS,
+        makeFakeBlockedExec(blocked),
+      );
+
+      const result = await tool.execute('call-1', makeParams());
+      const text = (result.content[0] as { type: string; text: string }).text;
+
+      expect(text).toMatch(/retry/i);
+    });
+
+    it('tells agent to inform user when retryable=false', async () => {
+      const sessionId = makeSessionId();
+      const blocked = makeBlockedResponse({ retryable: false });
+      const tool = makeContinueWorkflowTool(
+        sessionId, NULL_CTX, () => {}, () => {}, STUB_SCHEMAS,
+        makeFakeBlockedExec(blocked),
+      );
+
+      const result = await tool.execute('call-1', makeParams());
+      const text = (result.content[0] as { type: string; text: string }).text;
+
+      expect(text).toMatch(/inform.*user|user.*response/i);
+    });
+  });
+
+  describe('onAdvance invariant', () => {
+    it('does NOT call onAdvance when blocked', async () => {
+      const sessionId = makeSessionId();
+      let advanceCalled = false;
+      const blocked = makeBlockedResponse();
+      const tool = makeContinueWorkflowTool(
+        sessionId,
+        NULL_CTX,
+        () => { advanceCalled = true; },
+        () => {},
+        STUB_SCHEMAS,
+        makeFakeBlockedExec(blocked),
+      );
+
+      await tool.execute('call-1', makeParams());
+
+      expect(advanceCalled).toBe(false);
+    });
+  });
+
+  describe('onComplete invariant', () => {
+    it('does NOT call onComplete when blocked', async () => {
+      const sessionId = makeSessionId();
+      let completeCalled = false;
+      const blocked = makeBlockedResponse();
+      const tool = makeContinueWorkflowTool(
+        sessionId,
+        NULL_CTX,
+        () => {},
+        () => { completeCalled = true; },
+        STUB_SCHEMAS,
+        makeFakeBlockedExec(blocked),
+      );
+
+      await tool.execute('call-1', makeParams());
+
+      expect(completeCalled).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- When `executeContinueWorkflow` returns a blocked response (validation failure, missing notes, assessment gate), the daemon's `makeContinueWorkflowTool` was calling `onAdvance()` unconditionally -- signaling step advancement that never happened, causing the agent to loop forever with no feedback
- Add an explicit `if (out.kind === 'blocked')` branch that returns human-readable feedback (blocker messages, validation issues, suggestions, assessment followup, retry token) without calling `onAdvance()` or `onComplete()`
- Fix token persistence: use `nextCall.params.continueToken` (the retry token) instead of `continueToken` for the blocked path
- Export `makeContinueWorkflowTool` and add optional `_executeContinueWorkflowFn` injection parameter for direct unit testing (follows `makeBashTool` pattern)
- Add 8 unit tests covering: feedback content, onAdvance not called, onComplete not called, retryable vs non-retryable guidance

## Test plan

- [ ] `npx vitest run tests/unit/workflow-runner-continue-workflow-blocked.test.ts` -- 8 new tests pass
- [ ] `npx vitest run tests/unit/` -- all 268 existing test files pass (2 pre-existing CLI binary test failures unrelated to this change)
- [ ] `npx tsc --noEmit` -- TypeScript compiles clean
- [ ] End-to-end: run a workflow that produces a validation failure; agent should receive the error message and retry instead of looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)