### PR TITLE
fix(mcp): replace console.error with safe stderr writes in shutdown handlers

### DIFF
--- a/src/infrastructure/session/HttpServer.ts
+++ b/src/infrastructure/session/HttpServer.ts
@@ -658,7 +658,11 @@ export class HttpServer {
         // HTTP responsiveness is NOT a reliable signal -- a busy event loop (e.g.
         // processing a tool call) will fail a 2s health check while the process is
         // perfectly healthy. Yield unconditionally to the existing primary.
-        console.error(`[Dashboard] Secondary mode: primary lock valid (PID ${lockData.pid}), yielding`);
+        //
+        // WHY process.stderr.write: reclaimStaleLock runs during startup. If the MCP
+        // client disconnects immediately after spawning, stderr may be a broken pipe.
+        // console.error() would throw EPIPE here (confirmed in crash.log). See printBanner().
+        try { process.stderr.write(`[Dashboard] Secondary mode: primary lock valid (PID ${lockData.pid}), yielding\n`); } catch { /* ignore */ }
         return false;
       } else {
         // shouldReclaimLock() determined the lock should be reclaimed (version mismatch,
@@ -669,7 +673,7 @@ export class HttpServer {
         // 3456, startAsPrimary() will throw EADDRINUSE and fall back to legacy mode on
         // port 3457+. That is the correct outcome -- the old instance keeps its port
         // and its sessions; the new instance starts on an available port.
-        console.error(`[Dashboard] Lock reclaim needed: ${reason}`);
+        try { process.stderr.write(`[Dashboard] Lock reclaim needed: ${reason}\n`); } catch { /* ignore */ }
       }
 
       // ATOMIC RECLAIM: Write new lock to temp file, then rename
@@ -706,35 +710,35 @@ export class HttpServer {
           }
         }
         
-        console.error('[Dashboard] Lock reclaimed successfully');
+        try { process.stderr.write('[Dashboard] Lock reclaimed successfully\n'); } catch { /* ignore */ }
         this.isPrimary = true;
         this.setupPrimaryCleanup();
         this.heartbeat.start();
         return true;
-        
+
       } catch (error: any) {
         // Clean up temp file on any error
         await fs.unlink(tempPath).catch(() => {});
-        
+
         if (error.code === 'ENOENT') {
           // Lock file was deleted by another process - try fresh
-          console.error('[Dashboard] Lock deleted during reclaim, trying fresh');
+          try { process.stderr.write('[Dashboard] Lock deleted during reclaim, trying fresh\n'); } catch { /* ignore */ }
           return await this.tryBecomePrimary();
         }
-        
+
         // Other error (permission, disk full, etc.)
-        console.error('[Dashboard] Lock reclaim failed:', error.message);
+        try { process.stderr.write(`[Dashboard] Lock reclaim failed: ${(error as Error).message}\n`); } catch { /* ignore */ }
         return false;
       }
-      
+
     } catch (error: any) {
       if (error.code === 'ENOENT') {
         // Lock file deleted - try to become primary fresh
         return await this.tryBecomePrimary();
       }
-      
+
       // Corrupt JSON or other read error
-      console.error('[Dashboard] Lock file corrupted, attempting fresh claim');
+      try { process.stderr.write('[Dashboard] Lock file corrupted, attempting fresh claim\n'); } catch { /* ignore */ }
       await fs.unlink(this.lockFile).catch(() => {});
       return await this.tryBecomePrimary();
     }
@@ -874,17 +878,24 @@ export class HttpServer {
   
   /**
    * Print startup banner
+   *
+   * WHY process.stderr.write with try/catch instead of console.error:
+   * This runs right after the HTTP server starts listening. If the MCP client
+   * disconnects almost immediately (fast restart, test reconnect), both stdout
+   * and stderr pipes may already be broken. console.error() writes through
+   * Node's console.value() which does a synchronous socket write -- on a broken
+   * pipe it throws EPIPE with no handler, crashing the process. Confirmed in
+   * crash.log. See shutdown-hooks.ts for the full pattern explanation.
    */
   private printBanner(): void {
     const line = '═'.repeat(60);
-    console.error(`\n${line}`);
-    console.error(`🔧 Workrail MCP Server Started`);
-    console.error(line);
-    console.error(`📊 Dashboard: ${this.baseUrl} ${this.isPrimary ? '(PRIMARY - All Projects)' : '(Legacy Mode)'}`);
-    console.error(`💾 Sessions:  ${this.sessionManager.getSessionsRoot()}`);
-    console.error(`🏗️  Project:   ${this.sessionManager.getProjectId()}`);
-    console.error(line);
-    console.error();
+    try { process.stderr.write(`\n${line}\n`); } catch { /* ignore */ }
+    try { process.stderr.write(`🔧 Workrail MCP Server Started\n`); } catch { /* ignore */ }
+    try { process.stderr.write(`${line}\n`); } catch { /* ignore */ }
+    try { process.stderr.write(`📊 Dashboard: ${this.baseUrl} ${this.isPrimary ? '(PRIMARY - All Projects)' : '(Legacy Mode)'}\n`); } catch { /* ignore */ }
+    try { process.stderr.write(`💾 Sessions:  ${this.sessionManager.getSessionsRoot()}\n`); } catch { /* ignore */ }
+    try { process.stderr.write(`🏗️  Project:   ${this.sessionManager.getProjectId()}\n`); } catch { /* ignore */ }
+    try { process.stderr.write(`${line}\n\n`); } catch { /* ignore */ }
   }
   
   /**

--- a/src/mcp/transports/shutdown-hooks.ts
+++ b/src/mcp/transports/shutdown-hooks.ts
@@ -81,11 +81,14 @@ export function wireShutdownHooks(opts: ShutdownHookOptions): void {
 
     void (async () => {
       try {
-        console.error(`[Shutdown] Requested by ${event.signal}. Stopping services...`);
+        // WHY process.stderr.write: see wireStdoutShutdown for full explanation.
+        // Shutdown handlers fire when the connection is closing -- stderr may be
+        // a broken pipe at this point, so console.error would throw a second EPIPE.
+        try { process.stderr.write(`[Shutdown] Requested by ${event.signal}. Stopping services...\n`); } catch { /* ignore */ }
         await opts.onBeforeTerminate();
         terminator.terminate({ kind: 'success' });
       } catch (err) {
-        console.error('[Shutdown] Error while stopping services:', err);
+        try { process.stderr.write(`[Shutdown] Error while stopping services: ${(err as Error)?.stack ?? String(err)}\n`); } catch { /* ignore */ }
         terminator.terminate({ kind: 'failure' });
       }
     })();
@@ -123,13 +126,20 @@ export function wireStdoutShutdown(opts?: StdoutShutdownOptions): void {
 
   stdout.on('error', (err) => {
     const code = (err as NodeJS.ErrnoException).code;
+    // WHY process.stderr.write with try/catch instead of console.error:
+    // In an MCP stdio process, process.stderr is a Socket pipe to the host.
+    // When the client closes the connection, both stdout AND stderr break.
+    // console.error() calls console.value() internally which does a synchronous
+    // socket write -- if stderr is also broken it throws a second EPIPE with no
+    // handler, crashing the process. process.stderr.write() wrapped in try/catch
+    // absorbs that failure safely. See fatal-exit.ts for the canonical explanation.
     if (code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED') {
       // Pipe broken: MCP client disconnected. Initiate clean shutdown rather
       // than crashing -- this ensures the HTTP server and lock files are
       // cleaned up gracefully.
-      console.error('[MCP] stdout pipe broken (client disconnected), initiating shutdown');
+      try { process.stderr.write('[MCP] stdout pipe broken (client disconnected), initiating shutdown\n'); } catch { /* ignore */ }
     } else {
-      console.error('[MCP] stdout error:', err);
+      try { process.stderr.write(`[MCP] stdout error: ${(err as Error).message}\n`); } catch { /* ignore */ }
     }
     shutdownEvents.emit({ kind: 'shutdown_requested', signal: 'SIGHUP' });
   });
@@ -163,7 +173,9 @@ export function wireStdinShutdown(opts?: StdinShutdownOptions): void {
   // Using once prevents listener accumulation if wireStdinShutdown() is ever
   // called more than once in the same process.
   stdin.once('end', () => {
-    console.error('[MCP] stdin closed, initiating shutdown');
+    // WHY process.stderr.write: see wireStdoutShutdown for full explanation.
+    // stdin 'end' fires on client disconnect -- stderr may be broken at this point.
+    try { process.stderr.write('[MCP] stdin closed, initiating shutdown\n'); } catch { /* ignore */ }
     shutdownEvents.emit({ kind: 'shutdown_requested', signal: 'SIGHUP' });
   });
 }


### PR DESCRIPTION
## Summary

- In an MCP stdio process, both stdout AND stderr are Socket pipes to the MCP host. When the client closes the connection, both pipes break simultaneously.
- `console.error()` goes through `console.value()` internally, which does a synchronous socket write. If stderr is broken, it throws EPIPE with no handler -- crashing the server instead of shutting down gracefully.
- Three crash sites confirmed in `~/.workrail/crash.log`: `wireStdoutShutdown`, `HttpServer.reclaimStaleLock`, and `HttpServer.printBanner`.

## Fix

Replace `console.error(...)` with `try { process.stderr.write('...\n') } catch { /* ignore */ }` at all event-handler and startup call sites in:
- `src/mcp/transports/shutdown-hooks.ts` -- `wireStdoutShutdown`, `wireShutdownHooks`, `wireStdinShutdown`
- `src/infrastructure/session/HttpServer.ts` -- `printBanner()`, `reclaimStaleLock()`

This follows the established pattern in `fatal-exit.ts`, which documents the same mechanism and uses the same fix.

## Test plan

- [x] `npx vitest run tests/unit/` -- 269 test files, 3307 tests passing
- [x] `npm run build` -- clean build
- [x] Crash mechanism verified via actual stack traces in `~/.workrail/crash.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)