### PR TITLE
chore(ci): embed app token in repositoryUrl for semantic-release/git push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,12 +57,20 @@ jobs:
       issues: write
     
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -112,8 +120,8 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
-          GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           WORKRAIL_ALLOW_MAJOR_RELEASE: ${{ vars.WORKRAIL_ALLOW_MAJOR_RELEASE }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Configure git remote to use the app token for push authentication.
+          # @semantic-release/git pushes using the remote URL; setting it here ensures
+          # the app token (which has bypass permission) is used, not GITHUB_TOKEN.
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+
           # Ensure we use the upgraded global npm (OIDC requires npm >= 11.5.1).
           # npx prepends ./node_modules/.bin to PATH, which can shadow the global npm
           # with a bundled npm package version that does not support trusted publishing.

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -4,7 +4,7 @@ const breakingReleaseType = allowMajorRelease ? "major" : "minor";
 module.exports = {
   branches: ["main"],
   tagFormat: "v${version}",
-  repositoryUrl: "https://github.com/EtienneBBeaulac/workrail.git",
+  repositoryUrl: `https://x-access-token:${process.env.GITHUB_TOKEN}@github.com/EtienneBBeaulac/workrail.git`,
   plugins: [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
semantic-release/git constructs push URLs from repositoryUrl, ignoring the git remote. Embedding the token directly ensures the GitHub App (which has bypass permission) is used.