### PR TITLE
chore(ci): upgrade create-github-app-token to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
v1 runs on deprecated Node.js 20. v3 uses Node.js 22+ and may resolve the bypass token issue.