### PR TITLE
fix(mcp): release MCP stability fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Triggers a patch release for the MCP stability fixes already on main: EPIPE crash handler, spawn storm prevention, zombie bridge cleanup, atomic lock, and related fixes.