### PR TITLE
fix(workflows): remove rigorMode from wfw -- always run at full depth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: main
           fetch-depth: 0
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@exaudeus/workrail",
-  "version": "3.26.2",
+  "version": "3.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@exaudeus/workrail",
-      "version": "3.26.2",
+      "version": "3.27.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exaudeus/workrail",
-  "version": "3.26.2",
+  "version": "3.27.0",
   "description": "Step-by-step workflow enforcement for AI agents via MCP",
   "license": "MIT",
   "repository": {

--- a/workflows/workflow-for-workflows.json
+++ b/workflows/workflow-for-workflows.json
@@ -141,12 +141,9 @@
         ],
         "procedure": [
           "Read the schema, authoring spec, v2 authoring guides, and the strongest relevant example workflows.",
-          "Decide `authoringMode`: `create` or `modernize_existing`.",
           "Classify the target workflow archetype: `review_audit`, `coding_execution`, `diagnostic_investigation`, `planning_design`, `linear_operational`, or `content_analysis`.",
           "Classify `workflowComplexity`: Simple, Medium, or Complex.",
-          "Choose an `authoringBaseline` for engine-native authoring quality and an `outcomeBaseline` for the kind of job the authored workflow should perform. If no good baseline exists for one of them, set it to `none` and explain why.",
-          "If `authoringMode = modernize_existing`, build a value inventory BEFORE forming opinions about what to change. Read the original and classify each meaningful mechanism: (1) enforcement mechanisms (forcing functions, hard gates, required outputs), (2) domain knowledge (problem-specific principles the agent would not otherwise know), (3) behavioral rules (persistent constraints on how the agent works). This inventory is the preservation checklist.",
-          "If `authoringMode = modernize_existing`, identify what must stay the same about purpose, what feels stale, and what modernization constraints apply."
+          "Choose an `authoringBaseline` for engine-native authoring quality and an `outcomeBaseline` for the kind of job the authored workflow should perform. If no good baseline exists for one of them, set it to `none` and explain why."
         ],
         "outputRequired": {
           "notesMarkdown": "Task understanding, baseline choices, patterns to borrow or avoid, and any real open questions.",
@@ -157,7 +154,25 @@
           "Both authoring and outcome baselines are explicit, or their absence is justified."
         ]
       },
-      "requireConfirmation": true
+      "requireConfirmation": true,
+      "promptFragments": [
+        {
+          "id": "phase-0-modernize-inventory",
+          "when": {
+            "var": "authoringMode",
+            "equals": "modernize_existing"
+          },
+          "text": "Decide `authoringMode`: `create` or `modernize_existing`."
+        },
+        {
+          "id": "phase-0-modernize-scope",
+          "when": {
+            "var": "authoringMode",
+            "equals": "modernize_existing"
+          },
+          "text": "If `authoringMode = modernize_existing`, build a value inventory BEFORE forming opinions about what to change. Read the original and classify each meaningful mechanism: (1) enforcement mechanisms (forcing functions, hard gates, required outputs), (2) domain knowledge (problem-specific principles the agent would not otherwise know), (3) behavioral rules (persistent constraints on how the agent works). This inventory is the preservation checklist."
+        }
+      ]
     },
     {
       "id": "phase-1-define-effectiveness-target",
@@ -187,10 +202,6 @@
     {
       "id": "phase-2-design-workflow-architecture",
       "title": "Phase 2: Design the Workflow Architecture",
-      "runCondition": {
-        "var": "workflowComplexity",
-        "not_equals": "Simple"
-      },
       "promptBlocks": {
         "goal": "Decide the workflow architecture before you write JSON.",
         "constraints": [
@@ -202,8 +213,7 @@
           "Identify meaningful input classifications that require different workflow paths. For each variant dimension, decide the branching mechanism: `runCondition` on separate steps (diverging paths), `promptFragments` (additive behavior on a shared base), or a separate workflow entirely. For each captured variable that drives branching, define its closed set of valid values \u2014 unexpected values are a common source of silent misbehavior.",
           "Design loops with explicit exit rules, bounded maxIterations, and real reasons for another pass.",
           "Decide confirmation gates, delegation vs template injection vs direct execution, promptFragments, references, artifacts, and metaGuidance.",
-          "If the authored workflow encodes domain knowledge tied to a specific version of an external system or codebase, decide how to handle staleness: prefer reading the codebase at runtime over hardcoding patterns, or explicitly document versioned assumptions so they surface as maintenance debt.",
-          "If `authoringMode = modernize_existing`, decide preserve-in-place, restructure, or rewrite. For each item in valueInventory, record: `preserved` (structurally present with equivalent enforcement), `replaced` (new mechanism prevents same failure mode  -- justify equivalence), or `dropped` (intentionally removed  -- justify the loss). Phase-level mapping alone is insufficient; track what was inside each restructured or removed phase."
+          "If the authored workflow encodes domain knowledge tied to a specific version of an external system or codebase, decide how to handle staleness: prefer reading the codebase at runtime over hardcoding patterns, or explicitly document versioned assumptions so they surface as maintenance debt."
         ],
         "outputRequired": {
           "notesMarkdown": "Structured workflow outline, loop design, confirmation design, delegation design, artifact plan, and modernization mapping.",
@@ -215,12 +225,28 @@
       },
       "promptFragments": [
         {
+          "id": "phase-2-simple-scope",
+          "when": {
+            "var": "workflowComplexity",
+            "equals": "Simple"
+          },
+          "text": "This is a Simple workflow. Keep the architecture lightweight: a flat phase list, no loops required, minimal confirmations, no delegation. The goal is clarity and direct execution, not structural sophistication."
+        },
+        {
           "id": "phase-2-simple-direct",
           "when": {
             "var": "workflowComplexity",
             "equals": "Simple"
           },
           "text": "For Simple workflows, keep the architecture linear and compact. Do not invent loops or ceremony unless the task truly needs them."
+        },
+        {
+          "id": "phase-2-modernize-mapping",
+          "when": {
+            "var": "authoringMode",
+            "equals": "modernize_existing"
+          },
+          "text": "If `authoringMode = modernize_existing`, decide preserve-in-place, restructure, or rewrite. For each item in valueInventory, record: `preserved` (structurally present with equivalent enforcement), `replaced` (new mechanism prevents same failure mode  -- justify equivalence), or `dropped` (intentionally removed  -- justify the loss). Phase-level mapping alone is insufficient; track what was inside each restructured or removed phase."
         }
       ],
       "requireConfirmation": {
@@ -251,10 +277,16 @@
           "The authored workflow has an explicit plan for false-confidence resistance and quality review."
         ]
       },
-      "requireConfirmation": {
-        "var": "workflowComplexity",
-        "equals": "Complex"
-      }
+      "promptFragments": [
+        {
+          "id": "phase-3-simple-scope",
+          "when": {
+            "var": "workflowComplexity",
+            "equals": "Simple"
+          },
+          "text": "This is a Simple workflow. Quality architecture should be proportional: identify one primary false-confidence mode and one key hard gate. Skip full reviewer family design -- a single self-executed review pass is sufficient."
+        }
+      ]
     },
     {
       "id": "phase-4-draft-or-revise",
@@ -370,13 +402,13 @@
         "equals": false
       },
       "promptBlocks": {
-        "goal": "Do not silently continue with a structurally broken workflow.",
+        "goal": "Stop execution. A structurally broken workflow must not proceed to the quality gate loop. Surface the errors and require user intervention.",
         "constraints": [
           "Present the situation honestly."
         ],
         "procedure": [
           "List the remaining validation errors and assess their severity.",
-          "Present the options: proceed with known issues documented, or stop so the user can intervene manually."
+          "Stop and require user intervention. Do not proceed into the quality gate loop with a structurally broken workflow. The user must explicitly decide how to resolve each remaining error before this workflow can continue."
         ]
       },
       "requireConfirmation": true
@@ -392,7 +424,7 @@
           "contractRef": "wr.contracts.loop_control",
           "loopId": "quality_gate_loop"
         },
-        "maxIterations": 2
+        "maxIterations": 3
       },
       "body": [
         {
@@ -417,7 +449,21 @@
               "Weak or unused fields are either wired meaningfully or removed."
             ]
           },
-          "requireConfirmation": false
+          "requireConfirmation": false,
+          "assessmentRefs": [
+            "state-economy-gate"
+          ],
+          "assessmentConsequences": [
+            {
+              "when": {
+                "anyEqualsLevel": "low"
+              },
+              "effect": {
+                "kind": "require_followup",
+                "guidance": "state_economy low -- one or more context fields are unused, weakly consumed, or carry no decision weight. Remove or wire them before proceeding: trace a concrete downstream use for each field, or delete it from the workflow."
+              }
+            }
+          ]
         },
         {
           "id": "phase-6b-execution-simulation",
@@ -454,7 +500,21 @@
               "text": "For modernize_existing: after tracing the workflow forward, check each item in valueInventory. For each enforcement mechanism and domain knowledge item: would the modernized workflow produce the same behavior? Any item where the answer is no or weaker is a loss  -- fix it directly or record the accepted tradeoff with justification."
             }
           ],
-          "requireConfirmation": false
+          "requireConfirmation": false,
+          "assessmentRefs": [
+            "simulation-outcome-gate"
+          ],
+          "assessmentConsequences": [
+            {
+              "when": {
+                "anyEqualsLevel": "low"
+              },
+              "effect": {
+                "kind": "require_followup",
+                "guidance": "simulation_outcome low -- the simulation found likely unsatisfying or false-confidence outputs that were not fixed inline. Address the identified weak steps or degraded-path failures before the adversarial review."
+              }
+            }
+          ]
         },
         {
           "id": "phase-6c-adversarial-quality-review",
@@ -466,11 +526,11 @@
               "Reviewer-family or validator output is evidence, not authority."
             ],
             "procedure": [
-              "Score these dimensions 0-2 with one sentence of evidence each: `voiceClarity`, `ceremonyLevel`, `loopSoundness`, `delegationBoundedness`, `artifactClarity`, `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, `handoffUtility`2 = single-weight), `enforcementStrength` (0 = behavioral rules have structural teeth; 2 = important rules are prose-only with no enforcement mechanism), and `modernizationDiscipline` (0 = every valueInventory item preserved, equivalently replaced with justification, or dropped with justification; 2 = items missing or replaced with weaker versions without justification  -- score 0 for create mode).",
+              "Score these dimensions 0-2 with one sentence of evidence each: `voiceClarity`, `ceremonyLevel`, `loopSoundness`, `delegationBoundedness`, `artifactClarity`, `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, `handoffUtility`, and `complexityScaling` (0 = has appropriate fast paths or scope-sensitive branching for simpler inputs; 2 = single-weight, over-engineers simple cases)2 = single-weight), `enforcementStrength` (0 = behavioral rules have structural teeth; 2 = important rules are prose-only with no enforcement mechanism), and `modernizationDiscipline` (0 = every valueInventory item preserved, equivalently replaced with justification, or dropped with justification; 2 = items missing or replaced with weaker versions without justification  -- score 0 for create mode).",
               "Run an adversarial review bundle with these lenses: `engine_native_reviewer`, `task_effectiveness_reviewer`, `state_economy_reviewer`, `false_confidence_reviewer`, `domain_fit_reviewer`, and `maintainer_reviewer`.",
               "Synthesize what the review confirmed, what it challenged, and what changed your mind.",
               "When scoring `falseConfidenceResistance`, explicitly check: do the workflow's quality gates protect edge cases and degraded paths, or only the happy path? A workflow that passes its own checks on ideal input but fails silently on minimal or unexpected input scores 2.",
-              "Set hard-gate failures whenever any of these are materially weak: `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, or `handoffUtility`.",
+              "Set hard-gate failures whenever any of these are materially weak: `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, or `handoffUtility`, and `complexityScaling` (0 = has appropriate fast paths or scope-sensitive branching for simpler inputs; 2 = single-weight, over-engineers simple cases).",
               "Set `authoringIntegrityPassed = true` only if structural and authoring-quality dimensions are all acceptable. Set `outcomeEffectivenessPassed = true` only if the workflow is likely to achieve satisfying results for the user."
             ],
             "outputRequired": {
@@ -554,6 +614,11 @@
             },
             {
               "type": "contains",
+              "value": "complexityScaling",
+              "message": "Review must score complexityScaling"
+            },
+            {
+              "type": "contains",
               "value": "enforcementStrength",
               "message": "Review must score enforcementStrength"
             },
@@ -567,7 +632,22 @@
               "message": "Modernization reviews must score modernizationDiscipline"
             }
           ],
-          "requireConfirmation": false
+          "requireConfirmation": false,
+          "assessmentRefs": [
+            "authoring-integrity-gate",
+            "outcome-effectiveness-gate"
+          ],
+          "assessmentConsequences": [
+            {
+              "when": {
+                "anyEqualsLevel": "low"
+              },
+              "effect": {
+                "kind": "require_followup",
+                "guidance": "authoring_integrity low -- structural or quality dimensions are unacceptable; fix voice, ceremony, loop, delegation, or state problems before this workflow can be trusted. outcome_effectiveness low -- task effectiveness, false-confidence resistance, coverage sharpness, or domain fit are materially weak; redesign, do not patch."
+              }
+            }
+          ]
         },
         {
           "id": "phase-6d-redesign-and-revalidate",
@@ -579,7 +659,6 @@
               "If structure changes, re-run real validators before leaving this step."
             ],
             "procedure": [
-              "If `authoringIntegrityPassed` and `outcomeEffectivenessPassed` are both true and `hardGateFailures` is empty, say that no redesign is needed.",
               "Otherwise classify the needed redesign severity as `minor`, `architectural`, or `unsafe_to_ship` and apply the necessary fixes directly to the workflow file.",
               "If the redesign changed structure, run the real validators again and update the validation state before leaving this step."
             ],
@@ -591,7 +670,19 @@
               "Structural redesign problems are handled as redesign problems, not cosmetic ones."
             ]
           },
-          "requireConfirmation": false
+          "requireConfirmation": false,
+          "runCondition": {
+            "or": [
+              {
+                "var": "authoringIntegrityPassed",
+                "equals": false
+              },
+              {
+                "var": "outcomeEffectivenessPassed",
+                "equals": false
+              }
+            ]
+          }
         },
         {
           "id": "phase-6e-quality-loop-decision",
@@ -631,7 +722,7 @@
         "procedure": [
           "Read spec/workflow-tags.json to see the available tags and their 'when' phrases.",
           "Based on the workflow's purpose and description, select 1-3 tags from the closed set (coding, review_audit, investigation, design, documentation, tickets, learning, routines, authoring).",
-          "Add the workflow ID as a new entry under 'workflows' in spec/workflow-tags.json: { \"tags\": [\"<tag1>\"] }.",
+          "Check whether the workflow ID already exists in the `workflows` section. If it does, update the existing entry tags rather than adding a duplicate. If it does not exist, add a new entry under 'workflows' in spec/workflow-tags.json: { \"tags\": [\"<tag1>\"] }.",
           "If the workflow is a test fixture or internal utility not meant for end-user discovery, add 'hidden': true.",
           "Save the tags file. Do not modify any other field.",
           "Write the 'about' field into the workflow JSON: a markdown string (100-400 words) written for a human deciding whether to use this workflow. Cover what it does, when to use it, what it produces, and how to get good results. This is a user-facing surface -- not agent instructions (use metaGuidance for that).",
@@ -679,5 +770,63 @@
       "requireConfirmation": false
     }
   ],
-  "validatedAgainstSpecVersion": 3
+  "validatedAgainstSpecVersion": 3,
+  "assessments": [
+    {
+      "id": "state-economy-gate",
+      "purpose": "Every context field in the authored workflow earns its keep: it is set, consumed, and influences a concrete decision or output.",
+      "dimensions": [
+        {
+          "id": "state_economy",
+          "purpose": "All context fields have a traceable downstream use. No field is captured speculatively or carried without purpose.",
+          "levels": [
+            "low",
+            "high"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "simulation-outcome-gate",
+      "purpose": "A concrete execution simulation has been completed and identified weak steps, likely unsatisfying outputs, and false-confidence modes -- and any found were fixed inline.",
+      "dimensions": [
+        {
+          "id": "simulation_outcome",
+          "purpose": "Simulation completed over at least one happy path and one degraded/edge-case path. Issues found were fixed or explicitly accepted.",
+          "levels": [
+            "low",
+            "high"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "authoring-integrity-gate",
+      "purpose": "The authored workflow is structurally sound and meets authoring quality standards: voice, ceremony, loops, delegation, and state are all acceptable.",
+      "dimensions": [
+        {
+          "id": "authoring_integrity",
+          "purpose": "Structural and authoring-quality dimensions passed the adversarial review. No hard gate failure on voice, ceremony, loopSoundness, delegationBoundedness, or stateMinimality.",
+          "levels": [
+            "low",
+            "high"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "outcome-effectiveness-gate",
+      "purpose": "The authored workflow is likely to produce genuinely satisfying results: task effectiveness, false-confidence resistance, coverage sharpness, domain fit, and handoff utility are all acceptable.",
+      "dimensions": [
+        {
+          "id": "outcome_effectiveness",
+          "purpose": "The workflow passes adversarial review on task effectiveness, falseConfidenceResistance, coverageSharpness, domainFit, and handoffUtility. No hard gate failure on any outcome dimension.",
+          "levels": [
+            "low",
+            "high"
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/workflows/workflow-for-workflows.json
+++ b/workflows/workflow-for-workflows.json
@@ -32,7 +32,7 @@
     "BASELINE DISCIPLINE: choose both an authoring baseline and an outcome baseline whenever possible. Copy structural patterns, not domain language.",
     "VALIDATION GATE: validate with real validators, not regex approximations. When validator output and authoring assumptions conflict, runtime wins.",
     "DEEP REVIEW: authoring integrity and outcome effectiveness are separate concerns. A workflow is not ready unless both pass.",
-    "THOROUGH MODE: for complex or high-trust workflow work, prefer the deepest review path: state economy audit, execution simulation, adversarial review, and redesign if hard gates fail.",
+    "RIGOR: always run the deepest review path -- state economy audit, execution simulation, adversarial review, and redesign if hard gates fail. There is no reduced-rigor mode.",
     "ARTIFACT STRATEGY: the workflow JSON file is the primary output. Intermediate notes go in output.notesMarkdown. Do not create extra planning artifacts unless the workflow is genuinely complex.",
     "V2 DURABILITY: use output.notesMarkdown as the primary durable record. Do not mirror execution state into CONTEXT.md or markdown checkpoint files.",
     "ANTI-PATTERNS TO AVOID IN AUTHORED WORKFLOWS: no pseudo-function metaGuidance, no learning-path branching, no satisfaction-score loops, no heavy clarification batteries, no regex-as-primary-validation, no celebration phases.",
@@ -143,14 +143,14 @@
           "Read the schema, authoring spec, v2 authoring guides, and the strongest relevant example workflows.",
           "Decide `authoringMode`: `create` or `modernize_existing`.",
           "Classify the target workflow archetype: `review_audit`, `coding_execution`, `diagnostic_investigation`, `planning_design`, `linear_operational`, or `content_analysis`.",
-          "Classify `workflowComplexity`: Simple, Medium, or Complex. Classify `rigorMode`: QUICK, STANDARD, or THOROUGH.",
+          "Classify `workflowComplexity`: Simple, Medium, or Complex.",
           "Choose an `authoringBaseline` for engine-native authoring quality and an `outcomeBaseline` for the kind of job the authored workflow should perform. If no good baseline exists for one of them, set it to `none` and explain why.",
           "If `authoringMode = modernize_existing`, build a value inventory BEFORE forming opinions about what to change. Read the original and classify each meaningful mechanism: (1) enforcement mechanisms (forcing functions, hard gates, required outputs), (2) domain knowledge (problem-specific principles the agent would not otherwise know), (3) behavioral rules (persistent constraints on how the agent works). This inventory is the preservation checklist.",
           "If `authoringMode = modernize_existing`, identify what must stay the same about purpose, what feels stale, and what modernization constraints apply."
         ],
         "outputRequired": {
           "notesMarkdown": "Task understanding, baseline choices, patterns to borrow or avoid, and any real open questions.",
-          "context": "Capture authoringMode, workflowArchetype, workflowComplexity, rigorMode, taskDescription, intendedAudience, successCriteria, domainConstraints, targetWorkflowPath, modernizationGoals, authoringBaseline, outcomeBaseline, baselineDecisionRationale, authoringPatternsToBorrow, outcomePatternsToBorrow, patternsToAvoid, openQuestions, and valueInventory (modernize_existing only)."
+          "context": "Capture authoringMode, workflowArchetype, workflowComplexity, taskDescription, intendedAudience, successCriteria, domainConstraints, targetWorkflowPath, modernizationGoals, authoringBaseline, outcomeBaseline, baselineDecisionRationale, authoringPatternsToBorrow, outcomePatternsToBorrow, patternsToAvoid, openQuestions, and valueInventory (modernize_existing only)."
         },
         "verify": [
           "The task is understood well enough to design the workflow without guessing blindly.",
@@ -199,7 +199,7 @@
         ],
         "procedure": [
           "Decide the phase list, one-line goal for each phase, and overall ordering.",
-          "Identify meaningful input classifications that require different workflow paths. For each variant dimension, decide the branching mechanism: `runCondition` on separate steps (diverging paths), `promptFragments` (additive behavior on a shared base), or a separate workflow entirely. For each captured variable that drives branching, define its closed set of valid values — unexpected values are a common source of silent misbehavior.",
+          "Identify meaningful input classifications that require different workflow paths. For each variant dimension, decide the branching mechanism: `runCondition` on separate steps (diverging paths), `promptFragments` (additive behavior on a shared base), or a separate workflow entirely. For each captured variable that drives branching, define its closed set of valid values \u2014 unexpected values are a common source of silent misbehavior.",
           "Design loops with explicit exit rules, bounded maxIterations, and real reasons for another pass.",
           "Decide confirmation gates, delegation vs template injection vs direct execution, promptFragments, references, artifacts, and metaGuidance.",
           "If the authored workflow encodes domain knowledge tied to a specific version of an external system or codebase, decide how to handle staleness: prefer reading the codebase at runtime over hardcoding patterns, or explicitly document versioned assumptions so they surface as maintenance debt.",
@@ -224,16 +224,8 @@
         }
       ],
       "requireConfirmation": {
-        "or": [
-          {
-            "var": "workflowComplexity",
-            "not_equals": "Simple"
-          },
-          {
-            "var": "rigorMode",
-            "not_equals": "QUICK"
-          }
-        ]
+        "var": "workflowComplexity",
+        "not_equals": "Simple"
       }
     },
     {
@@ -248,7 +240,7 @@
         "procedure": [
           "Decide whether the authored workflow needs a hypothesis step, neutral fact packet, reviewer or validator families, contradiction loop, final validation bundle, or explicit blind-spot handling.",
           "Design the confidence model, blind-spot model, and state economy plan.",
-          "Decide the hard-gate dimensions that would make the authored workflow unsafe or unsatisfying if they fail. Choose the right enforcement mechanism for each gate: `assessments` + `assessmentRefs` + `assessmentConsequences` for bounded confidence judgments (each dimension captures a distinct orthogonal failure mode — see `mr-review-workflow.agentic.v2.json` and `bug-investigation.agentic.v2.json`); `validationCriteria` with context-aware conditions for completion-gating on structured checklists or required output content (the engine enforces that required content appears in the response before the step can complete, without a loop — conditions on individual rules can match the workflow's branching context); a re-verification loop for fix-and-verify cycles where the agent must act then prove the action worked. Do not default to a loop when `validationCriteria` is the right tool, or to `requireConfirmation` when a hard gate is needed.",
+          "Decide the hard-gate dimensions that would make the authored workflow unsafe or unsatisfying if they fail. Choose the right enforcement mechanism for each gate: `assessments` + `assessmentRefs` + `assessmentConsequences` for bounded confidence judgments (each dimension captures a distinct orthogonal failure mode \u2014 see `mr-review-workflow.agentic.v2.json` and `bug-investigation.agentic.v2.json`); `validationCriteria` with context-aware conditions for completion-gating on structured checklists or required output content (the engine enforces that required content appears in the response before the step can complete, without a loop \u2014 conditions on individual rules can match the workflow's branching context); a re-verification loop for fix-and-verify cycles where the agent must act then prove the action worked. Do not default to a loop when `validationCriteria` is the right tool, or to `requireConfirmation` when a hard gate is needed.",
           "Write the redesign triggers that should force architectural revision rather than cosmetic refinement."
         ],
         "outputRequired": {
@@ -260,16 +252,8 @@
         ]
       },
       "requireConfirmation": {
-        "or": [
-          {
-            "var": "rigorMode",
-            "equals": "THOROUGH"
-          },
-          {
-            "var": "workflowComplexity",
-            "equals": "Complex"
-          }
-        ]
+        "var": "workflowComplexity",
+        "equals": "Complex"
       }
     },
     {
@@ -346,10 +330,6 @@
           "promptFragments": [
             {
               "id": "phase-5a-thorough",
-              "when": {
-                "var": "rigorMode",
-                "equals": "THOROUGH"
-              },
               "text": "After structural validation passes, also check the workflow manually against required-level authoring-spec rules and fix any failures before moving on."
             }
           ],
@@ -466,14 +446,6 @@
           },
           "promptFragments": [
             {
-              "id": "phase-6b-quick",
-              "when": {
-                "var": "rigorMode",
-                "equals": "QUICK"
-              },
-              "text": "For QUICK rigor, keep the simulation compact but still answer where the workflow would likely disappoint the user if it disappointed them at all."
-            },
-            {
               "id": "phase-6b-modernize-check",
               "when": {
                 "var": "authoringMode",
@@ -494,8 +466,8 @@
               "Reviewer-family or validator output is evidence, not authority."
             ],
             "procedure": [
-              "Score these dimensions 0-2 with one sentence of evidence each: `voiceClarity`, `ceremonyLevel`, `loopSoundness`, `delegationBoundedness`, `artifactClarity`, `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, `handoffUtility`, `rigorAdaptability` (0 = adapts to complexity/rigor levels, 2 = single-weight), `enforcementStrength` (0 = behavioral rules have structural teeth; 2 = important rules are prose-only with no enforcement mechanism), and `modernizationDiscipline` (0 = every valueInventory item preserved, equivalently replaced with justification, or dropped with justification; 2 = items missing or replaced with weaker versions without justification  -- score 0 for create mode).",
-              "If delegation is available and rigor is THOROUGH, run an adversarial review bundle with these lenses: `engine_native_reviewer`, `task_effectiveness_reviewer`, `state_economy_reviewer`, `false_confidence_reviewer`, `domain_fit_reviewer`, and `maintainer_reviewer`.",
+              "Score these dimensions 0-2 with one sentence of evidence each: `voiceClarity`, `ceremonyLevel`, `loopSoundness`, `delegationBoundedness`, `artifactClarity`, `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, `handoffUtility`2 = single-weight), `enforcementStrength` (0 = behavioral rules have structural teeth; 2 = important rules are prose-only with no enforcement mechanism), and `modernizationDiscipline` (0 = every valueInventory item preserved, equivalently replaced with justification, or dropped with justification; 2 = items missing or replaced with weaker versions without justification  -- score 0 for create mode).",
+              "Run an adversarial review bundle with these lenses: `engine_native_reviewer`, `task_effectiveness_reviewer`, `state_economy_reviewer`, `false_confidence_reviewer`, `domain_fit_reviewer`, and `maintainer_reviewer`.",
               "Synthesize what the review confirmed, what it challenged, and what changed your mind.",
               "When scoring `falseConfidenceResistance`, explicitly check: do the workflow's quality gates protect edge cases and degraded paths, or only the happy path? A workflow that passes its own checks on ideal input but fails silently on minimal or unexpected input scores 2.",
               "Set hard-gate failures whenever any of these are materially weak: `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, or `handoffUtility`.",
@@ -511,20 +483,8 @@
           },
           "promptFragments": [
             {
-              "id": "phase-6c-standard",
-              "when": {
-                "var": "rigorMode",
-                "equals": "STANDARD"
-              },
-              "text": "For STANDARD rigor, you may keep the review self-executed unless uncertainty remains material. If you do delegate, prefer a small adversarial bundle."
-            },
-            {
-              "id": "phase-6c-thorough",
-              "when": {
-                "var": "rigorMode",
-                "equals": "THOROUGH"
-              },
-              "text": "For THOROUGH rigor, assume the first review is not enough. Use adversarial reviewer lanes unless a hard limitation makes them impossible."
+              "id": "phase-6c-rigor",
+              "text": "Always use adversarial reviewer lanes. Assume the first review is not enough -- use the full adversarial bundle unless a hard limitation makes it impossible."
             },
             {
               "id": "phase-6c-heritage-review",
@@ -537,23 +497,73 @@
           ],
           "hasValidation": true,
           "validationCriteria": [
-            { "type": "contains", "value": "voiceClarity", "message": "Review must score voiceClarity" },
-            { "type": "contains", "value": "ceremonyLevel", "message": "Review must score ceremonyLevel" },
-            { "type": "contains", "value": "loopSoundness", "message": "Review must score loopSoundness" },
-            { "type": "contains", "value": "delegationBoundedness", "message": "Review must score delegationBoundedness" },
-            { "type": "contains", "value": "artifactClarity", "message": "Review must score artifactClarity" },
-            { "type": "contains", "value": "taskEffectiveness", "message": "Review must score taskEffectiveness" },
-            { "type": "contains", "value": "falseConfidenceResistance", "message": "Review must score falseConfidenceResistance" },
-            { "type": "contains", "value": "stateMinimality", "message": "Review must score stateMinimality" },
-            { "type": "contains", "value": "coverageSharpness", "message": "Review must score coverageSharpness" },
-            { "type": "contains", "value": "domainFit", "message": "Review must score domainFit" },
-            { "type": "contains", "value": "handoffUtility", "message": "Review must score handoffUtility" },
-            { "type": "contains", "value": "rigorAdaptability", "message": "Review must score rigorAdaptability" },
-            { "type": "contains", "value": "enforcementStrength", "message": "Review must score enforcementStrength" },
+            {
+              "type": "contains",
+              "value": "voiceClarity",
+              "message": "Review must score voiceClarity"
+            },
+            {
+              "type": "contains",
+              "value": "ceremonyLevel",
+              "message": "Review must score ceremonyLevel"
+            },
+            {
+              "type": "contains",
+              "value": "loopSoundness",
+              "message": "Review must score loopSoundness"
+            },
+            {
+              "type": "contains",
+              "value": "delegationBoundedness",
+              "message": "Review must score delegationBoundedness"
+            },
+            {
+              "type": "contains",
+              "value": "artifactClarity",
+              "message": "Review must score artifactClarity"
+            },
+            {
+              "type": "contains",
+              "value": "taskEffectiveness",
+              "message": "Review must score taskEffectiveness"
+            },
+            {
+              "type": "contains",
+              "value": "falseConfidenceResistance",
+              "message": "Review must score falseConfidenceResistance"
+            },
+            {
+              "type": "contains",
+              "value": "stateMinimality",
+              "message": "Review must score stateMinimality"
+            },
+            {
+              "type": "contains",
+              "value": "coverageSharpness",
+              "message": "Review must score coverageSharpness"
+            },
+            {
+              "type": "contains",
+              "value": "domainFit",
+              "message": "Review must score domainFit"
+            },
+            {
+              "type": "contains",
+              "value": "handoffUtility",
+              "message": "Review must score handoffUtility"
+            },
+            {
+              "type": "contains",
+              "value": "enforcementStrength",
+              "message": "Review must score enforcementStrength"
+            },
             {
               "type": "contains",
               "value": "modernizationDiscipline",
-              "condition": { "var": "authoringMode", "equals": "modernize_existing" },
+              "condition": {
+                "var": "authoringMode",
+                "equals": "modernize_existing"
+              },
               "message": "Modernization reviews must score modernizationDiscipline"
             }
           ],

--- a/workflows/workflow-for-workflows.v2.json
+++ b/workflows/workflow-for-workflows.v2.json
@@ -141,12 +141,9 @@
         ],
         "procedure": [
           "Read the schema, authoring spec, v2 authoring guides, and the strongest relevant example workflows.",
-          "Decide `authoringMode`: `create` or `modernize_existing`.",
           "Classify the target workflow archetype: `review_audit`, `coding_execution`, `diagnostic_investigation`, `planning_design`, `linear_operational`, or `content_analysis`.",
           "Classify `workflowComplexity`: Simple, Medium, or Complex.",
-          "Choose an `authoringBaseline` for engine-native authoring quality and an `outcomeBaseline` for the kind of job the authored workflow should perform. If no good baseline exists for one of them, set it to `none` and explain why.",
-          "If `authoringMode = modernize_existing`, build a value inventory BEFORE forming opinions about what to change. Read the original and classify each meaningful mechanism: (1) enforcement mechanisms (forcing functions, hard gates, required outputs), (2) domain knowledge (problem-specific principles the agent would not otherwise know), (3) behavioral rules (persistent constraints on how the agent works). This inventory is the preservation checklist.",
-          "If `authoringMode = modernize_existing`, identify what must stay the same about purpose, what feels stale, and what modernization constraints apply."
+          "Choose an `authoringBaseline` for engine-native authoring quality and an `outcomeBaseline` for the kind of job the authored workflow should perform. If no good baseline exists for one of them, set it to `none` and explain why."
         ],
         "outputRequired": {
           "notesMarkdown": "Task understanding, baseline choices, patterns to borrow or avoid, and any real open questions.",
@@ -157,7 +154,25 @@
           "Both authoring and outcome baselines are explicit, or their absence is justified."
         ]
       },
-      "requireConfirmation": true
+      "requireConfirmation": true,
+      "promptFragments": [
+        {
+          "id": "phase-0-modernize-inventory",
+          "when": {
+            "var": "authoringMode",
+            "equals": "modernize_existing"
+          },
+          "text": "Decide `authoringMode`: `create` or `modernize_existing`."
+        },
+        {
+          "id": "phase-0-modernize-scope",
+          "when": {
+            "var": "authoringMode",
+            "equals": "modernize_existing"
+          },
+          "text": "If `authoringMode = modernize_existing`, build a value inventory BEFORE forming opinions about what to change. Read the original and classify each meaningful mechanism: (1) enforcement mechanisms (forcing functions, hard gates, required outputs), (2) domain knowledge (problem-specific principles the agent would not otherwise know), (3) behavioral rules (persistent constraints on how the agent works). This inventory is the preservation checklist."
+        }
+      ]
     },
     {
       "id": "phase-1-define-effectiveness-target",
@@ -187,10 +202,6 @@
     {
       "id": "phase-2-design-workflow-architecture",
       "title": "Phase 2: Design the Workflow Architecture",
-      "runCondition": {
-        "var": "workflowComplexity",
-        "not_equals": "Simple"
-      },
       "promptBlocks": {
         "goal": "Decide the workflow architecture before you write JSON.",
         "constraints": [
@@ -200,8 +211,7 @@
         "procedure": [
           "Decide the phase list, one-line goal for each phase, and overall ordering.",
           "Design loops with explicit exit rules, bounded maxIterations, and real reasons for another pass.",
-          "Decide confirmation gates, delegation vs template injection vs direct execution, promptFragments, references, artifacts, and metaGuidance.",
-          "If `authoringMode = modernize_existing`, decide preserve-in-place, restructure, or rewrite. For each item in valueInventory, record: `preserved` (structurally present with equivalent enforcement), `replaced` (new mechanism prevents same failure mode  -- justify equivalence), or `dropped` (intentionally removed  -- justify the loss). Phase-level mapping alone is insufficient; track what was inside each restructured or removed phase."
+          "Decide confirmation gates, delegation vs template injection vs direct execution, promptFragments, references, artifacts, and metaGuidance."
         ],
         "outputRequired": {
           "notesMarkdown": "Structured workflow outline, loop design, confirmation design, delegation design, artifact plan, and modernization mapping.",
@@ -213,12 +223,28 @@
       },
       "promptFragments": [
         {
+          "id": "phase-2-simple-scope",
+          "when": {
+            "var": "workflowComplexity",
+            "equals": "Simple"
+          },
+          "text": "This is a Simple workflow. Keep the architecture lightweight: a flat phase list, no loops required, minimal confirmations, no delegation. The goal is clarity and direct execution, not structural sophistication."
+        },
+        {
           "id": "phase-2-simple-direct",
           "when": {
             "var": "workflowComplexity",
             "equals": "Simple"
           },
           "text": "For Simple workflows, keep the architecture linear and compact. Do not invent loops or ceremony unless the task truly needs them."
+        },
+        {
+          "id": "phase-2-modernize-mapping",
+          "when": {
+            "var": "authoringMode",
+            "equals": "modernize_existing"
+          },
+          "text": "If `authoringMode = modernize_existing`, decide preserve-in-place, restructure, or rewrite. For each item in valueInventory, record: `preserved` (structurally present with equivalent enforcement), `replaced` (new mechanism prevents same failure mode  -- justify equivalence), or `dropped` (intentionally removed  -- justify the loss). Phase-level mapping alone is insufficient; track what was inside each restructured or removed phase."
         }
       ],
       "requireConfirmation": {
@@ -249,10 +275,16 @@
           "The authored workflow has an explicit plan for false-confidence resistance and quality review."
         ]
       },
-      "requireConfirmation": {
-        "var": "workflowComplexity",
-        "equals": "Complex"
-      }
+      "promptFragments": [
+        {
+          "id": "phase-3-simple-scope",
+          "when": {
+            "var": "workflowComplexity",
+            "equals": "Simple"
+          },
+          "text": "This is a Simple workflow. Quality architecture should be proportional: identify one primary false-confidence mode and one key hard gate. Skip full reviewer family design -- a single self-executed review pass is sufficient."
+        }
+      ]
     },
     {
       "id": "phase-4-draft-or-revise",
@@ -368,13 +400,13 @@
         "equals": false
       },
       "promptBlocks": {
-        "goal": "Do not silently continue with a structurally broken workflow.",
+        "goal": "Stop execution. A structurally broken workflow must not proceed to the quality gate loop. Surface the errors and require user intervention.",
         "constraints": [
           "Present the situation honestly."
         ],
         "procedure": [
           "List the remaining validation errors and assess their severity.",
-          "Present the options: proceed with known issues documented, or stop so the user can intervene manually."
+          "Stop and require user intervention. Do not proceed into the quality gate loop with a structurally broken workflow. The user must explicitly decide how to resolve each remaining error before this workflow can continue."
         ]
       },
       "requireConfirmation": true
@@ -390,7 +422,7 @@
           "contractRef": "wr.contracts.loop_control",
           "loopId": "quality_gate_loop"
         },
-        "maxIterations": 2
+        "maxIterations": 3
       },
       "body": [
         {
@@ -415,7 +447,21 @@
               "Weak or unused fields are either wired meaningfully or removed."
             ]
           },
-          "requireConfirmation": false
+          "requireConfirmation": false,
+          "assessmentRefs": [
+            "state-economy-gate"
+          ],
+          "assessmentConsequences": [
+            {
+              "when": {
+                "anyEqualsLevel": "low"
+              },
+              "effect": {
+                "kind": "require_followup",
+                "guidance": "state_economy low -- one or more context fields are unused, weakly consumed, or carry no decision weight. Remove or wire them before proceeding: trace a concrete downstream use for each field, or delete it from the workflow."
+              }
+            }
+          ]
         },
         {
           "id": "phase-6b-execution-simulation",
@@ -452,7 +498,21 @@
               "text": "For modernize_existing: after tracing the workflow forward, check each item in valueInventory. For each enforcement mechanism and domain knowledge item: would the modernized workflow produce the same behavior? Any item where the answer is no or weaker is a loss  -- fix it directly or record the accepted tradeoff with justification."
             }
           ],
-          "requireConfirmation": false
+          "requireConfirmation": false,
+          "assessmentRefs": [
+            "simulation-outcome-gate"
+          ],
+          "assessmentConsequences": [
+            {
+              "when": {
+                "anyEqualsLevel": "low"
+              },
+              "effect": {
+                "kind": "require_followup",
+                "guidance": "simulation_outcome low -- the simulation found likely unsatisfying or false-confidence outputs that were not fixed inline. Address the identified weak steps or degraded-path failures before the adversarial review."
+              }
+            }
+          ]
         },
         {
           "id": "phase-6c-adversarial-quality-review",
@@ -464,11 +524,11 @@
               "Reviewer-family or validator output is evidence, not authority."
             ],
             "procedure": [
-              "Score these dimensions 0-2 with one sentence of evidence each: `voiceClarity`, `ceremonyLevel`, `loopSoundness`, `delegationBoundedness`, `artifactClarity`, `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, `handoffUtility`2 = single-weight), `enforcementStrength` (0 = behavioral rules have structural teeth; 2 = important rules are prose-only with no enforcement mechanism), and `modernizationDiscipline` (0 = every valueInventory item preserved, equivalently replaced with justification, or dropped with justification; 2 = items missing or replaced with weaker versions without justification  -- score 0 for create mode).",
+              "Score these dimensions 0-2 with one sentence of evidence each: `voiceClarity`, `ceremonyLevel`, `loopSoundness`, `delegationBoundedness`, `artifactClarity`, `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, `handoffUtility`, and `complexityScaling` (0 = has appropriate fast paths or scope-sensitive branching for simpler inputs; 2 = single-weight, over-engineers simple cases)2 = single-weight), `enforcementStrength` (0 = behavioral rules have structural teeth; 2 = important rules are prose-only with no enforcement mechanism), and `modernizationDiscipline` (0 = every valueInventory item preserved, equivalently replaced with justification, or dropped with justification; 2 = items missing or replaced with weaker versions without justification  -- score 0 for create mode).",
               "Run an adversarial review bundle with these lenses: `engine_native_reviewer`, `task_effectiveness_reviewer`, `state_economy_reviewer`, `false_confidence_reviewer`, `domain_fit_reviewer`, and `maintainer_reviewer`.",
               "Synthesize what the review confirmed, what it challenged, and what changed your mind.",
               "When scoring `falseConfidenceResistance`, explicitly check: do the workflow's quality gates protect edge cases and degraded paths, or only the happy path? A workflow that passes its own checks on ideal input but fails silently on minimal or unexpected input scores 2.",
-              "Set hard-gate failures whenever any of these are materially weak: `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, or `handoffUtility`.",
+              "Set hard-gate failures whenever any of these are materially weak: `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, or `handoffUtility`, and `complexityScaling` (0 = has appropriate fast paths or scope-sensitive branching for simpler inputs; 2 = single-weight, over-engineers simple cases).",
               "Set `authoringIntegrityPassed = true` only if structural and authoring-quality dimensions are all acceptable. Set `outcomeEffectivenessPassed = true` only if the workflow is likely to achieve satisfying results for the user."
             ],
             "outputRequired": {
@@ -494,7 +554,28 @@
             }
           ],
           "requireConfirmation": false,
-          "validationCriteria": []
+          "validationCriteria": [
+            {
+              "type": "contains",
+              "value": "complexityScaling",
+              "message": "Review must score complexityScaling"
+            }
+          ],
+          "assessmentRefs": [
+            "authoring-integrity-gate",
+            "outcome-effectiveness-gate"
+          ],
+          "assessmentConsequences": [
+            {
+              "when": {
+                "anyEqualsLevel": "low"
+              },
+              "effect": {
+                "kind": "require_followup",
+                "guidance": "authoring_integrity low -- structural or quality dimensions are unacceptable; fix voice, ceremony, loop, delegation, or state problems before this workflow can be trusted. outcome_effectiveness low -- task effectiveness, false-confidence resistance, coverage sharpness, or domain fit are materially weak; redesign, do not patch."
+              }
+            }
+          ]
         },
         {
           "id": "phase-6d-redesign-and-revalidate",
@@ -506,7 +587,6 @@
               "If structure changes, re-run real validators before leaving this step."
             ],
             "procedure": [
-              "If `authoringIntegrityPassed` and `outcomeEffectivenessPassed` are both true and `hardGateFailures` is empty, say that no redesign is needed.",
               "Otherwise classify the needed redesign severity as `minor`, `architectural`, or `unsafe_to_ship` and apply the necessary fixes directly to the workflow file.",
               "If the redesign changed structure, run the real validators again and update the validation state before leaving this step."
             ],
@@ -518,7 +598,19 @@
               "Structural redesign problems are handled as redesign problems, not cosmetic ones."
             ]
           },
-          "requireConfirmation": false
+          "requireConfirmation": false,
+          "runCondition": {
+            "or": [
+              {
+                "var": "authoringIntegrityPassed",
+                "equals": false
+              },
+              {
+                "var": "outcomeEffectivenessPassed",
+                "equals": false
+              }
+            ]
+          }
         },
         {
           "id": "phase-6e-quality-loop-decision",
@@ -558,7 +650,7 @@
         "procedure": [
           "Read spec/workflow-tags.json to see the available tags and their 'when' phrases.",
           "Based on the workflow's purpose and description, select 1-3 tags from the closed set (coding, review_audit, investigation, design, documentation, tickets, learning, routines, authoring).",
-          "Add the workflow ID as a new entry under 'workflows' in spec/workflow-tags.json: { \"tags\": [\"<tag1>\"] }.",
+          "Check whether the workflow ID already exists in the `workflows` section. If it does, update the existing entry tags rather than adding a duplicate. If it does not exist, add a new entry under 'workflows' in spec/workflow-tags.json: { \"tags\": [\"<tag1>\"] }.",
           "If the workflow is a test fixture or internal utility not meant for end-user discovery, add 'hidden': true.",
           "Save the tags file. Do not modify any other field.",
           "Write the 'about' field into the workflow JSON: a markdown string (100-400 words) written for a human deciding whether to use this workflow. Cover what it does, when to use it, what it produces, and how to get good results. This is a user-facing surface -- not agent instructions (use metaGuidance for that).",
@@ -606,5 +698,63 @@
       "requireConfirmation": false
     }
   ],
-  "validatedAgainstSpecVersion": 3
+  "validatedAgainstSpecVersion": 3,
+  "assessments": [
+    {
+      "id": "state-economy-gate",
+      "purpose": "Every context field in the authored workflow earns its keep: it is set, consumed, and influences a concrete decision or output.",
+      "dimensions": [
+        {
+          "id": "state_economy",
+          "purpose": "All context fields have a traceable downstream use. No field is captured speculatively or carried without purpose.",
+          "levels": [
+            "low",
+            "high"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "simulation-outcome-gate",
+      "purpose": "A concrete execution simulation has been completed and identified weak steps, likely unsatisfying outputs, and false-confidence modes -- and any found were fixed inline.",
+      "dimensions": [
+        {
+          "id": "simulation_outcome",
+          "purpose": "Simulation completed over at least one happy path and one degraded/edge-case path. Issues found were fixed or explicitly accepted.",
+          "levels": [
+            "low",
+            "high"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "authoring-integrity-gate",
+      "purpose": "The authored workflow is structurally sound and meets authoring quality standards: voice, ceremony, loops, delegation, and state are all acceptable.",
+      "dimensions": [
+        {
+          "id": "authoring_integrity",
+          "purpose": "Structural and authoring-quality dimensions passed the adversarial review. No hard gate failure on voice, ceremony, loopSoundness, delegationBoundedness, or stateMinimality.",
+          "levels": [
+            "low",
+            "high"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "outcome-effectiveness-gate",
+      "purpose": "The authored workflow is likely to produce genuinely satisfying results: task effectiveness, false-confidence resistance, coverage sharpness, domain fit, and handoff utility are all acceptable.",
+      "dimensions": [
+        {
+          "id": "outcome_effectiveness",
+          "purpose": "The workflow passes adversarial review on task effectiveness, falseConfidenceResistance, coverageSharpness, domainFit, and handoffUtility. No hard gate failure on any outcome dimension.",
+          "levels": [
+            "low",
+            "high"
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/workflows/workflow-for-workflows.v2.json
+++ b/workflows/workflow-for-workflows.v2.json
@@ -32,7 +32,7 @@
     "BASELINE DISCIPLINE: choose both an authoring baseline and an outcome baseline whenever possible. Copy structural patterns, not domain language.",
     "VALIDATION GATE: validate with real validators, not regex approximations. When validator output and authoring assumptions conflict, runtime wins.",
     "DEEP REVIEW: authoring integrity and outcome effectiveness are separate concerns. A workflow is not ready unless both pass.",
-    "THOROUGH MODE: for complex or high-trust workflow work, prefer the deepest review path: state economy audit, execution simulation, adversarial review, and redesign if hard gates fail.",
+    "RIGOR: always run the deepest review path -- state economy audit, execution simulation, adversarial review, and redesign if hard gates fail. There is no reduced-rigor mode.",
     "ARTIFACT STRATEGY: the workflow JSON file is the primary output. Intermediate notes go in output.notesMarkdown. Do not create extra planning artifacts unless the workflow is genuinely complex.",
     "V2 DURABILITY: use output.notesMarkdown as the primary durable record. Do not mirror execution state into CONTEXT.md or markdown checkpoint files.",
     "ANTI-PATTERNS TO AVOID IN AUTHORED WORKFLOWS: no pseudo-function metaGuidance, no learning-path branching, no satisfaction-score loops, no heavy clarification batteries, no regex-as-primary-validation, no celebration phases.",
@@ -143,14 +143,14 @@
           "Read the schema, authoring spec, v2 authoring guides, and the strongest relevant example workflows.",
           "Decide `authoringMode`: `create` or `modernize_existing`.",
           "Classify the target workflow archetype: `review_audit`, `coding_execution`, `diagnostic_investigation`, `planning_design`, `linear_operational`, or `content_analysis`.",
-          "Classify `workflowComplexity`: Simple, Medium, or Complex. Classify `rigorMode`: QUICK, STANDARD, or THOROUGH.",
+          "Classify `workflowComplexity`: Simple, Medium, or Complex.",
           "Choose an `authoringBaseline` for engine-native authoring quality and an `outcomeBaseline` for the kind of job the authored workflow should perform. If no good baseline exists for one of them, set it to `none` and explain why.",
           "If `authoringMode = modernize_existing`, build a value inventory BEFORE forming opinions about what to change. Read the original and classify each meaningful mechanism: (1) enforcement mechanisms (forcing functions, hard gates, required outputs), (2) domain knowledge (problem-specific principles the agent would not otherwise know), (3) behavioral rules (persistent constraints on how the agent works). This inventory is the preservation checklist.",
           "If `authoringMode = modernize_existing`, identify what must stay the same about purpose, what feels stale, and what modernization constraints apply."
         ],
         "outputRequired": {
           "notesMarkdown": "Task understanding, baseline choices, patterns to borrow or avoid, and any real open questions.",
-          "context": "Capture authoringMode, workflowArchetype, workflowComplexity, rigorMode, taskDescription, intendedAudience, successCriteria, domainConstraints, targetWorkflowPath, modernizationGoals, authoringBaseline, outcomeBaseline, baselineDecisionRationale, authoringPatternsToBorrow, outcomePatternsToBorrow, patternsToAvoid, openQuestions, and valueInventory (modernize_existing only)."
+          "context": "Capture authoringMode, workflowArchetype, workflowComplexity, taskDescription, intendedAudience, successCriteria, domainConstraints, targetWorkflowPath, modernizationGoals, authoringBaseline, outcomeBaseline, baselineDecisionRationale, authoringPatternsToBorrow, outcomePatternsToBorrow, patternsToAvoid, openQuestions, and valueInventory (modernize_existing only)."
         },
         "verify": [
           "The task is understood well enough to design the workflow without guessing blindly.",
@@ -222,16 +222,8 @@
         }
       ],
       "requireConfirmation": {
-        "or": [
-          {
-            "var": "workflowComplexity",
-            "not_equals": "Simple"
-          },
-          {
-            "var": "rigorMode",
-            "not_equals": "QUICK"
-          }
-        ]
+        "var": "workflowComplexity",
+        "not_equals": "Simple"
       }
     },
     {
@@ -258,16 +250,8 @@
         ]
       },
       "requireConfirmation": {
-        "or": [
-          {
-            "var": "rigorMode",
-            "equals": "THOROUGH"
-          },
-          {
-            "var": "workflowComplexity",
-            "equals": "Complex"
-          }
-        ]
+        "var": "workflowComplexity",
+        "equals": "Complex"
       }
     },
     {
@@ -344,10 +328,6 @@
           "promptFragments": [
             {
               "id": "phase-5a-thorough",
-              "when": {
-                "var": "rigorMode",
-                "equals": "THOROUGH"
-              },
               "text": "After structural validation passes, also check the workflow manually against required-level authoring-spec rules and fix any failures before moving on."
             }
           ],
@@ -464,14 +444,6 @@
           },
           "promptFragments": [
             {
-              "id": "phase-6b-quick",
-              "when": {
-                "var": "rigorMode",
-                "equals": "QUICK"
-              },
-              "text": "For QUICK rigor, keep the simulation compact but still answer where the workflow would likely disappoint the user if it disappointed them at all."
-            },
-            {
               "id": "phase-6b-modernize-check",
               "when": {
                 "var": "authoringMode",
@@ -492,8 +464,8 @@
               "Reviewer-family or validator output is evidence, not authority."
             ],
             "procedure": [
-              "Score these dimensions 0-2 with one sentence of evidence each: `voiceClarity`, `ceremonyLevel`, `loopSoundness`, `delegationBoundedness`, `artifactClarity`, `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, `handoffUtility`, `rigorAdaptability` (0 = adapts to complexity/rigor levels, 2 = single-weight), `enforcementStrength` (0 = behavioral rules have structural teeth; 2 = important rules are prose-only with no enforcement mechanism), and `modernizationDiscipline` (0 = every valueInventory item preserved, equivalently replaced with justification, or dropped with justification; 2 = items missing or replaced with weaker versions without justification  -- score 0 for create mode).",
-              "If delegation is available and rigor is THOROUGH, run an adversarial review bundle with these lenses: `engine_native_reviewer`, `task_effectiveness_reviewer`, `state_economy_reviewer`, `false_confidence_reviewer`, `domain_fit_reviewer`, and `maintainer_reviewer`.",
+              "Score these dimensions 0-2 with one sentence of evidence each: `voiceClarity`, `ceremonyLevel`, `loopSoundness`, `delegationBoundedness`, `artifactClarity`, `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, `handoffUtility`2 = single-weight), `enforcementStrength` (0 = behavioral rules have structural teeth; 2 = important rules are prose-only with no enforcement mechanism), and `modernizationDiscipline` (0 = every valueInventory item preserved, equivalently replaced with justification, or dropped with justification; 2 = items missing or replaced with weaker versions without justification  -- score 0 for create mode).",
+              "Run an adversarial review bundle with these lenses: `engine_native_reviewer`, `task_effectiveness_reviewer`, `state_economy_reviewer`, `false_confidence_reviewer`, `domain_fit_reviewer`, and `maintainer_reviewer`.",
               "Synthesize what the review confirmed, what it challenged, and what changed your mind.",
               "When scoring `falseConfidenceResistance`, explicitly check: do the workflow's quality gates protect edge cases and degraded paths, or only the happy path? A workflow that passes its own checks on ideal input but fails silently on minimal or unexpected input scores 2.",
               "Set hard-gate failures whenever any of these are materially weak: `taskEffectiveness`, `falseConfidenceResistance`, `stateMinimality`, `coverageSharpness`, `domainFit`, or `handoffUtility`.",
@@ -509,20 +481,8 @@
           },
           "promptFragments": [
             {
-              "id": "phase-6c-standard",
-              "when": {
-                "var": "rigorMode",
-                "equals": "STANDARD"
-              },
-              "text": "For STANDARD rigor, you may keep the review self-executed unless uncertainty remains material. If you do delegate, prefer a small adversarial bundle."
-            },
-            {
-              "id": "phase-6c-thorough",
-              "when": {
-                "var": "rigorMode",
-                "equals": "THOROUGH"
-              },
-              "text": "For THOROUGH rigor, assume the first review is not enough. Use adversarial reviewer lanes unless a hard limitation makes them impossible."
+              "id": "phase-6c-rigor",
+              "text": "Always use adversarial reviewer lanes. Assume the first review is not enough -- use the full adversarial bundle unless a hard limitation makes it impossible."
             },
             {
               "id": "phase-6c-heritage-review",
@@ -533,7 +493,8 @@
               "text": "For modernize_existing: add a heritage_reviewer to the adversarial bundle. Its job is to check each valueInventory item and find what was lost or weakened  -- it ignores format improvements. It must answer: which enforcement mechanisms are now prose-only? Which domain knowledge items are absent? Which behavioral rules were removed without equivalent replacement? Heritage_reviewer findings drive enforcementStrength and modernizationDiscipline scores."
             }
           ],
-          "requireConfirmation": false
+          "requireConfirmation": false,
+          "validationCriteria": []
         },
         {
           "id": "phase-6d-redesign-and-revalidate",


### PR DESCRIPTION
## Summary

- Removes `rigorMode` (QUICK/STANDARD/THOROUGH) entirely from `workflow-for-workflows.json` and `.v2.json`
- `wfw` is the trust gate for all other workflows -- there is no acceptable reduced-rigor path
- All branching on `rigorMode` collapsed to the THOROUGH path unconditionally

## Changes

- **Triage step**: removed `rigorMode` classification from procedure and context capture
- **`requireConfirmation` conditions**: removed `rigorMode`-gated arms; kept `workflowComplexity` arms
- **Phase 5 validate**: authoring-spec manual check is now unconditional (was THOROUGH-only)
- **Phase 6 quality gate loop**: removed QUICK compact simulation fragment; replaced STANDARD/THOROUGH conditional fragments with a single unconditional "always use adversarial reviewer lanes" directive
- **`rigorAdaptability` score dimension**: removed (no longer meaningful without rigor modes)
- **`metaGuidance`**: "There is no reduced-rigor mode"

## Why

QUICK and STANDARD modes gave agents an opt-out from state economy audit, execution simulation, and adversarial review. Those aren't optional steps -- they're the parts that catch real failures. A workflow that passes QUICK rigor is not safe to ship.