### PR TITLE
chore(ci): refs/heads/main prevents detached HEAD in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: main
+          ref: refs/heads/main
           fetch-depth: 0
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
refs/heads/main forces git to track the branch, preventing detached HEAD which causes semantic-release to skip with 'local branch is behind remote'.