### PR TITLE
fix: ship docs/ in npm package and fix wfw workspace refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "dist",
+    "docs",
     "spec",
     "workflows",
     "web"

--- a/workflows/workflow-for-workflows.json
+++ b/workflows/workflow-for-workflows.json
@@ -70,7 +70,7 @@
       "id": "authoring-guide-v2",
       "title": "Workflow Authoring Guide (v2)",
       "source": "docs/authoring-v2.md",
-      "resolveFrom": "workspace",
+      "resolveFrom": "package",
       "purpose": "Current v2 authoring principles, references guidance, and durable execution patterns.",
       "authoritative": true
     },
@@ -78,7 +78,7 @@
       "id": "workflow-authoring-reference",
       "title": "Workflow Authoring Reference",
       "source": "docs/design/workflow-authoring-v2.md",
-      "resolveFrom": "workspace",
+      "resolveFrom": "package",
       "purpose": "Detailed v2 workflow authoring patterns for loops, conditions, references, and workflow structure.",
       "authoritative": true
     },
@@ -86,7 +86,7 @@
       "id": "routines-guide",
       "title": "Routines Guide",
       "source": "docs/design/routines-guide.md",
-      "resolveFrom": "workspace",
+      "resolveFrom": "package",
       "purpose": "Current guide for deciding when to use delegation, direct execution, or template injection in authored workflows.",
       "authoritative": false
     },

--- a/workflows/workflow-for-workflows.v2.json
+++ b/workflows/workflow-for-workflows.v2.json
@@ -70,7 +70,7 @@
       "id": "authoring-guide-v2",
       "title": "Workflow Authoring Guide (v2)",
       "source": "docs/authoring-v2.md",
-      "resolveFrom": "workspace",
+      "resolveFrom": "package",
       "purpose": "Current v2 authoring principles, references guidance, and durable execution patterns.",
       "authoritative": true
     },
@@ -78,7 +78,7 @@
       "id": "workflow-authoring-reference",
       "title": "Workflow Authoring Reference",
       "source": "docs/design/workflow-authoring-v2.md",
-      "resolveFrom": "workspace",
+      "resolveFrom": "package",
       "purpose": "Detailed v2 workflow authoring patterns for loops, conditions, references, and workflow structure.",
       "authoritative": true
     },
@@ -86,7 +86,7 @@
       "id": "routines-guide",
       "title": "Routines Guide",
       "source": "docs/design/routines-guide.md",
-      "resolveFrom": "workspace",
+      "resolveFrom": "package",
       "purpose": "Current guide for deciding when to use delegation, direct execution, or template injection in authored workflows.",
       "authoritative": false
     },


### PR DESCRIPTION
## Summary

- Add `docs` to `package.json files[]` so the docs directory ships with the npm package
- Change `authoring-guide-v2`, `workflow-authoring-reference`, and `routines-guide` references in both `workflow-for-workflows` variants from `resolveFrom: 'workspace'` to `resolveFrom: 'package'`

## Why

The three docs/ references in `workflow-for-workflows` were declared as `resolveFrom: 'workspace'`, which means they resolved against the user's `workspacePath` (whatever project they ran the workflow from). Since `docs/authoring-v2.md` and friends don't exist in a user's project, the resolver silently marked them `[unresolved]` for every npm user.

The agent would see:
```
- **Workflow Authoring Guide (v2)** [unresolved]
  Path: docs/authoring-v2.md
```

These are WorkRail package docs, not user-workspace files. They should resolve from the package root with `resolveFrom: 'package'`. And since `docs/` wasn't in `package.json files[]`, even the package-relative path would have failed for anyone installing via npm.

Both fixes together make these references actually readable.