### PR TITLE
fix(daemon): use /bin/bash for Bash tool to support process substitution and bash syntax

### DIFF
--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -937,6 +937,7 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
         const { stdout, stderr } = await execAsync(params.command, {
           cwd,
           timeout: BASH_TIMEOUT_MS,
+          shell: '/bin/bash',
         });
         const output = [stdout, stderr].filter(Boolean).join('\n');
         return {


### PR DESCRIPTION
The Bash tool was using the default shell (/bin/sh) which doesn't support bash-specific syntax like process substitution `<(...)`. Agents commonly use these when comparing files or diffing output. Daemon now runs commands with `/bin/bash` explicitly.