### PR TITLE
feat(docs): enforce authoring-spec coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,15 @@ jobs:
       - name: Validate workflow discovery (workflow_list/workflow_get)
         run: npm run validate:workflow-discovery
 
+      - name: Validate authoring spec (structure and sourceRefs)
+        run: npm run validate:authoring-spec
+
+      - name: Validate authoring docs (generated docs match spec)
+        run: npm run validate:authoring-docs
+
+      - name: Validate feature coverage (all wr.features.* documented in authoring-spec)
+        run: npm run validate:feature-coverage
+
       - name: Summary
         if: success()
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,22 @@ npm run dev:mcp
 
 **Config note:** The project `.mcp.json` `workrail` entry should shadow the global `~/.claude/settings.json` entry when Claude Code is started from this repo. Verify via `/mcp` on first use -- if two `workrail` entries appear, rename the `.mcp.json` entry to `workrail-dev`.
 
+## When adding a new engine feature
+
+A "new engine feature" means any of:
+- A new `wr.features.*` entry in `src/application/services/compiler/feature-registry.ts`
+- A new field or behavior in `spec/workflow.schema.json`
+- A new runtime behavior in `src/v2/durable-core/` or `src/mcp/` that workflow authors need to declare, reference, or avoid
+
+**All items required before the PR can merge:**
+
+- [ ] `spec/authoring-spec.json`: add or update a rule covering the new feature. The rule's `checks` or rule text must mention the full feature ID string (e.g. `wr.features.capabilities`) or the schema field name. The rule's `sourceRefs` must include the implementing file.
+- [ ] `spec/authoring-spec.json` `lastReviewed`: update to today's date.
+- [ ] Run `npm run validate:authoring-spec` -- must pass.
+- [ ] Run `npm run validate:feature-coverage` -- must pass.
+- [ ] `docs/authoring-v2.md`: add or update the section explaining when and how to use the feature.
+- [ ] Run `npm run validate:authoring-docs` -- must pass (regenerates `docs/authoring.md` from spec).
+
 ## Release policy
 
 - Releases are automated via semantic-release on merge to main

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -269,6 +269,7 @@ Canonical current rules for authoring good WorkRail workflows. workflow.schema.j
 
 **Checks**
 - If the workflow delegates work to subagents, declare `wr.features.subagent_guidance`.
+- If the workflow uses optional capabilities (delegation, web, code execution), declare `wr.features.capabilities`.
 - If the workflow uses Memory MCP for context recall or persistence, declare `wr.features.memory_context`.
 - Do not duplicate feature-injected guidance in metaGuidance or step prompts. Let the compiler handle it.
 
@@ -299,6 +300,26 @@ Canonical current rules for authoring good WorkRail workflows. workflow.schema.j
 
 **Source refs**
 - `src/application/services/compiler/feature-registry.ts` (runtime) — The registry rejects unknown feature IDs at compile time.
+
+### declare-capabilities-for-optional-tool-use
+- **Level**: recommended
+- **Status**: active
+- **Scope**: workflow.features
+- **Rule**: Declare `wr.features.capabilities` when the workflow depends on optional capabilities (delegation, web access, code execution, etc.) that may not be available in every environment.
+- **Why**: The capabilities feature injects constraint and graceful-degradation guidance at every step. Without it, agents silently assume optional capabilities are available and produce brittle workflows that fail in restricted environments.
+- **Enforced by**: advisory
+
+**Checks**
+- If the workflow uses delegation, web access, code execution, or any other capability that may be unavailable, declare `wr.features.capabilities`.
+- If delegation is also used, declare both `wr.features.capabilities` and `wr.features.subagent_guidance` -- they inject different guidance.
+- Do not declare `wr.features.capabilities` for workflows that only use standard file/tool access available in all environments.
+
+**Anti-patterns**
+- Skipping `wr.features.capabilities` for a workflow that delegates to subagents or fetches from the web, leaving agents with no degradation guidance when the capability is absent
+- Declaring `wr.features.capabilities` for a workflow that only uses universally-available tools like Read, Write, and Bash
+
+**Source refs**
+- `src/application/services/compiler/feature-registry.ts` (runtime) — Canonical feature definition for wr.features.capabilities, including injected constraints and procedure steps.
 
 
 ## Workflow references
@@ -452,7 +473,7 @@ Canonical current rules for authoring good WorkRail workflows. workflow.schema.j
 ### assessment-use-for-bounded-judgment
 - **Level**: recommended
 - **Status**: active
-- **Scope**: workflow.assessments, step.assessmentRefs, step.assessmentConsequences
+- **Scope**: workflow.assessments, step.assessment-refs, step.assessment-consequences
 - **Rule**: Use assessment gates when a step needs the agent to submit a bounded, durable judgment before the workflow can safely advance -- not for generic scoring or ceremony.
 - **Why**: Assessment gates force explicit structured reasoning at a decision point and durably record the result. Generic scoring that never affects routing adds noise without value.
 - **Enforced by**: advisory
@@ -491,10 +512,10 @@ Canonical current rules for authoring good WorkRail workflows. workflow.schema.j
 ### assessment-v1-constraints
 - **Level**: required
 - **Status**: active
-- **Scope**: step.assessmentRefs, step.assessmentConsequences
+- **Scope**: step.assessment-refs, step.assessment-consequences
 - **Rule**: A step may declare one or more assessmentRefs and at most one assessmentConsequences entry. When assessmentConsequences is present, at least one ref is required. Use anyEqualsLevel as the trigger -- the engine checks all submitted dimensions across all referenced assessments and fires if any equals that level.
 - **Why**: Multiple refs allow composing separate orthogonal assessment definitions (e.g. quality-gate + coverage-gate) behind a single blocking consequence, without forcing unrelated dimensions into one monolithic definition.
-- **Enforced by**: schema
+- **Enforced by**: validator
 
 **Checks**
 - At least one assessmentRefs entry when assessmentConsequences is present.
@@ -845,4 +866,8 @@ Canonical current rules for authoring good WorkRail workflows. workflow.schema.j
 - `delegation.context-packet`: Structured context passed to subagents
 - `delegation.result-envelope`: Structured result shape returned by subagents
 - `legacy.patterns`: Older authoring patterns that should now be discouraged or avoided
+- `workflow.references`: The workflow-level references array declaring external documents surfaced at start time.
+- `workflow.assessments`: The workflow-level assessments array declaring reusable assessment gate definitions.
+- `step.assessment-refs`: The step-level assessmentRefs array referencing declared assessment gate definitions.
+- `step.assessment-consequences`: The step-level assessmentConsequences array declaring blocking consequences when gate dimension levels are met.
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "validate:authoring-spec": "node scripts/validate-authoring-spec.js",
     "validate:authoring-docs": "node scripts/generate-authoring-docs.js --check",
     "validate:workflow-discovery": "node scripts/validate-workflow-discovery.js",
+    "validate:feature-coverage": "node scripts/validate-feature-coverage.js",
     "precommit": "npm run validate:registry",
     "preinstall": "node -e \"const v=parseInt(process.versions.node.split('.')[0],10); if(v<20){console.error('WorkRail requires Node.js >=20. Current: '+process.versions.node+'\\nPlease upgrade: https://nodejs.org/'); process.exit(1);}\"",
     "dev:mcp": "pkill -f \"$(pwd)/dist/mcp-server.js\" 2>/dev/null; sleep 0.5; WORKRAIL_TRANSPORT=http WORKRAIL_ENABLE_SESSION_TOOLS=true node dist/mcp-server.js",

--- a/scripts/validate-feature-coverage.js
+++ b/scripts/validate-feature-coverage.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Validates that every `wr.features.*` ID in the feature registry is documented
+ * in spec/authoring-spec.json.
+ *
+ * Run: node scripts/validate-feature-coverage.js
+ * CI:  npm run validate:feature-coverage
+ *
+ * Hard-fails with a named list of uncovered IDs. Zero false positives by design:
+ * the check only fires when a feature exists in the registry but is absent from
+ * the spec entirely. It does not check rule quality -- only presence.
+ *
+ * When a new feature is added to feature-registry.ts, this script will fail until
+ * a rule referencing that feature ID is added to authoring-spec.json.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const REGISTRY_PATH = path.join(repoRoot, 'src/application/services/compiler/feature-registry.ts');
+const SPEC_PATH = path.join(repoRoot, 'spec/authoring-spec.json');
+
+function extractFeatureIds(source) {
+  // Match id: 'wr.features.*' or id: "wr.features.*"
+  const matches = [...source.matchAll(/id:\s*['"]([^'"]+)['"]/g)];
+  const ids = matches.map((m) => m[1]).filter((id) => id.startsWith('wr.features.'));
+  if (ids.length === 0) {
+    throw new Error(
+      'Extracted 0 feature IDs from feature-registry.ts -- regex may be broken or the file moved.\n' +
+      `Looked in: ${REGISTRY_PATH}`
+    );
+  }
+  return ids;
+}
+
+function collectSpecText(spec) {
+  const texts = [];
+  const visitRule = (rule) => {
+    texts.push(
+      rule.id ?? '',
+      rule.rule ?? '',
+      ...(rule.checks ?? []),
+      ...(rule.antiPatterns ?? []),
+      ...(rule.sourceRefs ?? []).map((r) => `${r.path ?? ''} ${r.note ?? ''}`)
+    );
+  };
+  for (const topic of [...(spec.topics ?? []), ...(spec.plannedTopics ?? [])]) {
+    for (const rule of topic.rules ?? []) visitRule(rule);
+  }
+  for (const rule of spec.plannedRules ?? []) visitRule(rule);
+  return texts.join('\n');
+}
+
+function main() {
+  if (!fs.existsSync(REGISTRY_PATH)) {
+    console.error(`[feature-coverage] SKIP: feature registry not found at ${REGISTRY_PATH}`);
+    console.error('  This check requires the TypeScript source tree. Skipping in package-only environments.');
+    process.exit(0);
+  }
+
+  const registrySource = fs.readFileSync(REGISTRY_PATH, 'utf8');
+  const spec = JSON.parse(fs.readFileSync(SPEC_PATH, 'utf8'));
+
+  const featureIds = extractFeatureIds(registrySource);
+  const specText = collectSpecText(spec);
+
+  const uncovered = featureIds.filter((id) => !specText.includes(id));
+
+  if (uncovered.length > 0) {
+    console.error('[feature-coverage] FAIL: feature IDs with no authoring-spec.json coverage:');
+    for (const id of uncovered) {
+      console.error(`  - ${id}`);
+    }
+    console.error('');
+    console.error('Fix: add a rule to spec/authoring-spec.json (topics or plannedTopics) whose');
+    console.error('  checks, rule text, or sourceRefs mentions the full feature ID string.');
+    console.error('  See the "features" topic in authoring-spec.json for the existing pattern.');
+    process.exit(1);
+  }
+
+  console.log(`[feature-coverage] OK: all ${featureIds.length} feature(s) covered in authoring-spec.json`);
+  console.log(`  Features: ${featureIds.join(', ')}`);
+}
+
+main();

--- a/spec/authoring-spec.json
+++ b/spec/authoring-spec.json
@@ -3,7 +3,7 @@
   "version": 3,
   "title": "WorkRail Authoring Rules",
   "purpose": "Canonical current rules for authoring good WorkRail workflows. workflow.schema.json remains the source of truth for legal structure.",
-  "lastReviewed": "2026-04-04",
+  "lastReviewed": "2026-04-16",
   "principles": [
     "Schema defines what is valid. These rules define what is good.",
     "Prefer current authoring rules over design rationale or historical notes.",
@@ -200,6 +200,22 @@
     {
       "id": "legacy.patterns",
       "description": "Older authoring patterns that should now be discouraged or avoided"
+    },
+    {
+      "id": "workflow.references",
+      "description": "The workflow-level references array declaring external documents surfaced at start time."
+    },
+    {
+      "id": "workflow.assessments",
+      "description": "The workflow-level assessments array declaring reusable assessment gate definitions."
+    },
+    {
+      "id": "step.assessment-refs",
+      "description": "The step-level assessmentRefs array referencing declared assessment gate definitions."
+    },
+    {
+      "id": "step.assessment-consequences",
+      "description": "The step-level assessmentConsequences array declaring blocking consequences when gate dimension levels are met."
     }
   ],
   "topics": [
@@ -647,6 +663,7 @@
           ],
           "checks": [
             "If the workflow delegates work to subagents, declare `wr.features.subagent_guidance`.",
+            "If the workflow uses optional capabilities (delegation, web, code execution), declare `wr.features.capabilities`.",
             "If the workflow uses Memory MCP for context recall or persistence, declare `wr.features.memory_context`.",
             "Do not duplicate feature-injected guidance in metaGuidance or step prompts. Let the compiler handle it."
           ],
@@ -683,6 +700,35 @@
           ],
           "antiPatterns": [
             "Inventing feature IDs like `wr.features.my_custom_thing`"
+          ]
+        },
+        {
+          "id": "declare-capabilities-for-optional-tool-use",
+          "status": "active",
+          "level": "recommended",
+          "scope": [
+            "workflow.features"
+          ],
+          "rule": "Declare `wr.features.capabilities` when the workflow depends on optional capabilities (delegation, web access, code execution, etc.) that may not be available in every environment.",
+          "why": "The capabilities feature injects constraint and graceful-degradation guidance at every step. Without it, agents silently assume optional capabilities are available and produce brittle workflows that fail in restricted environments.",
+          "enforcement": [
+            "advisory"
+          ],
+          "sourceRefs": [
+            {
+              "kind": "runtime",
+              "path": "src/application/services/compiler/feature-registry.ts",
+              "note": "Canonical feature definition for wr.features.capabilities, including injected constraints and procedure steps."
+            }
+          ],
+          "checks": [
+            "If the workflow uses delegation, web access, code execution, or any other capability that may be unavailable, declare `wr.features.capabilities`.",
+            "If delegation is also used, declare both `wr.features.capabilities` and `wr.features.subagent_guidance` -- they inject different guidance.",
+            "Do not declare `wr.features.capabilities` for workflows that only use standard file/tool access available in all environments."
+          ],
+          "antiPatterns": [
+            "Skipping `wr.features.capabilities` for a workflow that delegates to subagents or fetches from the web, leaving agents with no degradation guidance when the capability is absent",
+            "Declaring `wr.features.capabilities` for a workflow that only uses universally-available tools like Read, Write, and Bash"
           ]
         }
       ]
@@ -941,12 +987,14 @@
           "level": "recommended",
           "scope": [
             "workflow.assessments",
-            "step.assessmentRefs",
-            "step.assessmentConsequences"
+            "step.assessment-refs",
+            "step.assessment-consequences"
           ],
           "rule": "Use assessment gates when a step needs the agent to submit a bounded, durable judgment before the workflow can safely advance -- not for generic scoring or ceremony.",
           "why": "Assessment gates force explicit structured reasoning at a decision point and durably record the result. Generic scoring that never affects routing adds noise without value.",
-          "enforcement": ["advisory"],
+          "enforcement": [
+            "advisory"
+          ],
           "sourceRefs": [
             {
               "kind": "example",
@@ -978,7 +1026,9 @@
           ],
           "rule": "Each dimension in an assessment must capture a distinct failure mode that the other dimensions cannot catch. A dimension that restates existing workflow state (such as a generic 'confidence' dimension that mirrors the workflow's confidence band) adds ceremony without structure.",
           "why": "The value of multiple dimensions is that each one independently blocks advancement for a different reason. Correlated or vague dimensions collapse to a single gate with extra steps.",
-          "enforcement": ["advisory"],
+          "enforcement": [
+            "advisory"
+          ],
           "checks": [
             "Each dimension is independently checkable without needing to know the result of the others.",
             "No dimension restates a context variable the workflow already computes (e.g. recommendationConfidenceBand).",
@@ -995,12 +1045,14 @@
           "status": "active",
           "level": "required",
           "scope": [
-            "step.assessmentRefs",
-            "step.assessmentConsequences"
+            "step.assessment-refs",
+            "step.assessment-consequences"
           ],
           "rule": "A step may declare one or more assessmentRefs and at most one assessmentConsequences entry. When assessmentConsequences is present, at least one ref is required. Use anyEqualsLevel as the trigger -- the engine checks all submitted dimensions across all referenced assessments and fires if any equals that level.",
           "why": "Multiple refs allow composing separate orthogonal assessment definitions (e.g. quality-gate + coverage-gate) behind a single blocking consequence, without forcing unrelated dimensions into one monolithic definition.",
-          "enforcement": ["schema"],
+          "enforcement": [
+            "validator"
+          ],
           "checks": [
             "At least one assessmentRefs entry when assessmentConsequences is present.",
             "No more than one assessmentConsequences entry per step.",
@@ -1484,12 +1536,5 @@
       ]
     }
   ],
-  "plannedRules": [],
-  "changelog": [
-    {
-      "version": 3,
-      "date": "2026-03-21",
-      "summary": "Baseline version at staleness feature introduction."
-    }
-  ]
+  "plannedRules": []
 }


### PR DESCRIPTION
## Summary

Mechanical enforcement for authoring docs staying current with engine features. Three scripts that were advisory-only are now CI gates. A new script catches undocumented features on every PR.

## Changes

**`scripts/validate-feature-coverage.js` (new)**
- Reads `feature-registry.ts`, extracts all `wr.features.*` IDs, asserts each appears somewhere in `authoring-spec.json`
- Hard-fails with a named list of uncovered IDs
- Day-1 catch: `wr.features.capabilities` was completely undocumented

**`ci.yml` -- three steps added to the `validate-workflows` job**
- `validate:authoring-spec` -- spec structure and sourceRefs validity (was package-only before)
- `validate:authoring-docs` -- generated docs match spec (was package-only before)
- `validate:feature-coverage` -- all `wr.features.*` IDs covered (new)

**`spec/authoring-spec.json`**
- New rule: `declare-capabilities-for-optional-tool-use` covering `wr.features.capabilities`
- New scope catalog entries: `workflow.references`, `workflow.assessments`, `step.assessment-refs`, `step.assessment-consequences`
- Rename `step.assessmentRefs` → `step.assessment-refs` (schema compliance -- kebab-case required)
- Fix `assessment-v1-constraints` enforcement: `schema` → `validator` (valid enum value)
- Remove stale `changelog` property (additionalProperties: false)
- `lastReviewed` updated

**`AGENTS.md`**
- New "When adding a new engine feature" section with a 6-item required checklist
- Specific, actionable, not a principle

## What this prevents

Previously: a PR could ship a new `wr.features.*` entry, update the schema, and merge without any authoring doc update -- and CI would never notice. Now: the PR fails `validate:feature-coverage` until a rule is added to the spec.

## What this doesn't cover (follow-on)

- Schema field coverage (new workflow.schema.json fields without spec rules) -- planned as `validate:authoring-coverage.js`
- sourceRefs staleness check (spec rules whose implementation files changed after `lastReviewed`) -- planned as `--check-staleness` flag