### PR TITLE
feat(docs): add --check-staleness flag to validate-authoring-spec.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,12 @@ jobs:
       - name: Validate feature coverage (all wr.features.* documented in authoring-spec)
         run: npm run validate:feature-coverage
 
+      - name: Check authoring spec staleness (advisory)
+        # Informational only -- warns when .ts/.js sourceRef files are newer than lastReviewed.
+        # Not a hard gate; set WORKRAIL_STRICT_STALENESS=1 to make it fail.
+        continue-on-error: true
+        run: npm run validate:authoring-staleness
+
       - name: Summary
         if: success()
         run: |

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "validate:registry": "node --experimental-strip-types scripts/validate-workflows-registry.ts",
     "stamp-workflow": "node scripts/stamp-workflow.ts",
     "validate:authoring-spec": "node scripts/validate-authoring-spec.js",
+    "validate:authoring-staleness": "node scripts/validate-authoring-spec.js --check-staleness",
     "validate:authoring-docs": "node scripts/generate-authoring-docs.js --check",
     "validate:workflow-discovery": "node scripts/validate-workflow-discovery.js",
     "validate:feature-coverage": "node scripts/validate-feature-coverage.js",

--- a/scripts/validate-authoring-spec.js
+++ b/scripts/validate-authoring-spec.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 const Ajv = require('ajv');
 
 const repoRoot = path.resolve(__dirname, '..');
@@ -132,6 +133,75 @@ function validateRuleIdsAndScopes(spec) {
   }
 }
 
+// Checks whether .ts/.js sourceRef files have been modified more recently than the
+// review date recorded in the spec (rule.lastReviewed ?? spec.lastReviewed).
+//
+// Advisory by default: warns but exits 0 so authors can see the gap without being blocked.
+// Set WORKRAIL_STRICT_STALENESS=1 to hard-fail (useful once review discipline is established).
+//
+// Note: shallow git clones may produce false negatives -- files with history before the
+// shallow boundary appear up-to-date. Advisory mode is the safe default for this reason.
+function checkStaleness(spec) {
+  const strictMode = process.env.WORKRAIL_STRICT_STALENESS === '1';
+  const staleEntries = [];
+
+  // Verify we are inside a git repository before running any git commands.
+  try {
+    execSync('git rev-parse --git-dir', { cwd: repoRoot, stdio: 'ignore' });
+  } catch {
+    console.warn('[staleness] Skipping: not in a git repo or git unavailable.');
+    return;
+  }
+
+  for (const topic of spec.topics) {
+    for (const rule of topic.rules) {
+      for (const ref of rule.sourceRefs ?? []) {
+        if (!ref.path.endsWith('.ts') && !ref.path.endsWith('.js')) continue;
+
+        const fullPath = path.join(repoRoot, ref.path);
+        if (!fs.existsSync(fullPath)) continue;
+
+        // Per-rule date takes precedence when present; fall back to spec-level date.
+        const reviewDate = rule.lastReviewed ?? spec.lastReviewed;
+        if (!reviewDate) {
+          console.warn(`[staleness] No review date for rule "${rule.id}", skipping ${ref.path}`);
+          continue;
+        }
+
+        let gitDate = '';
+        try {
+          gitDate = execSync(`git log -1 --format="%as" -- ${ref.path}`, {
+            cwd: repoRoot,
+            encoding: 'utf8'
+          }).trim();
+        } catch {
+          // git error on this specific file; skip it rather than crashing.
+          continue;
+        }
+
+        if (gitDate && gitDate > reviewDate) {
+          staleEntries.push({ ruleId: rule.id, path: ref.path, gitDate, reviewDate });
+        }
+      }
+    }
+  }
+
+  if (staleEntries.length === 0) {
+    console.log('[staleness] All sourceRefs are up to date.');
+    return;
+  }
+
+  console.warn(`[staleness] ${staleEntries.length} stale sourceRef(s) detected (modified after ${spec.lastReviewed}):`);
+  for (const entry of staleEntries) {
+    console.warn(`  rule "${entry.ruleId}": ${entry.path} (modified ${entry.gitDate}, reviewed ${entry.reviewDate})`);
+  }
+
+  if (strictMode) {
+    console.error('[staleness] WORKRAIL_STRICT_STALENESS=1: failing due to stale sourceRefs.');
+    process.exit(1);
+  }
+}
+
 function main() {
   const schema = readJson(schemaPath);
   const spec = readJson(specPath);
@@ -140,6 +210,10 @@ function main() {
   validateRuleIdsAndScopes(spec);
 
   console.log('authoring-spec validation passed');
+
+  if (process.argv.includes('--check-staleness')) {
+    checkStaleness(spec);
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary

- Adds `checkStaleness(spec)` function to `scripts/validate-authoring-spec.js` that checks each `.ts`/`.js` sourceRef against `rule.lastReviewed ?? spec.lastReviewed` using `git log -1 --format="%as"`
- Advisory by default (warns, exits 0); hard-fails when `WORKRAIL_STRICT_STALENESS=1`
- Adds `validate:authoring-staleness` npm script
- Adds CI step in `validate-workflows` job with `continue-on-error: true` -- informational only, never blocks merge

## Design decisions

- **Advisory by default**: the spec currently has only a top-level `lastReviewed` date; forcing failures would fire immediately. `WORKRAIL_STRICT_STALENESS=1` is the escape hatch for future tightening.
- **`rule.lastReviewed ?? spec.lastReviewed`** fallback so per-rule dates can be added organically later.
- **Separate `checkStaleness` function** rather than merging into `validateRuleIdsAndScopes` -- staleness is a different concern with different error semantics.
- **Graceful degradation**: try/catch on `git rev-parse --git-dir` handles non-git environments; `fs.existsSync` guard before each git call.

## Test plan

- [ ] `npm run validate:authoring-spec` still passes (no flag, existing behavior unchanged)
- [ ] `npm run validate:authoring-staleness` runs and reports `[staleness] All sourceRefs are up to date.` (current spec.lastReviewed is 2026-04-16 -- all source files are behind that date)
- [ ] Manually simulate old review date confirms 3 stale files are detected correctly
- [ ] `WORKRAIL_STRICT_STALENESS=1 npm run validate:authoring-staleness` exits 0 when no stale files, exits 1 when stale files present
- [ ] CI YAML parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)