### PR TITLE
fix(daemon): return tool errors as is_error tool_results, add WORKTRAIN_STUCK marker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,9 @@ jobs:
         continue-on-error: true
         run: npm run validate:authoring-staleness
 
+      - name: Validate authoring spec coverage (required scopes have active rules)
+        run: npm run validate:authoring-coverage
+
       - name: Summary
         if: success()
         run: |

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,14 @@
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"
+    },
+    "workrail": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@exaudeus/workrail"],
+      "env": {
+        "WORKFLOW_STORAGE_PATH": "/Users/etienneb/.cg/dist/workflows"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "validate:authoring-docs": "node scripts/generate-authoring-docs.js --check",
     "validate:workflow-discovery": "node scripts/validate-workflow-discovery.js",
     "validate:feature-coverage": "node scripts/validate-feature-coverage.js",
+    "validate:authoring-coverage": "node scripts/validate-authoring-coverage.js",
     "precommit": "npm run validate:registry",
     "preinstall": "node -e \"const v=parseInt(process.versions.node.split('.')[0],10); if(v<20){console.error('WorkRail requires Node.js >=20. Current: '+process.versions.node+'\\nPlease upgrade: https://nodejs.org/'); process.exit(1);}\"",
     "dev:mcp": "pkill -f \"$(pwd)/dist/mcp-server.js\" 2>/dev/null; sleep 0.5; WORKRAIL_TRANSPORT=http WORKRAIL_ENABLE_SESSION_TOOLS=true node dist/mcp-server.js",

--- a/scripts/validate-authoring-coverage.js
+++ b/scripts/validate-authoring-coverage.js
@@ -1,0 +1,119 @@
+/**
+ * validate-authoring-coverage.js
+ *
+ * Checks that key workflow authoring surfaces each have at least one active rule
+ * in spec/authoring-spec.json. Uses a frozen manifest approach: a labeled map of
+ * { humanLabel: scopeId } pairs. Each scope ID must appear in at least one
+ * status:"active" rule's scope array.
+ *
+ * Exit 0 = all required scopes are covered.
+ * Exit 1 = one or more required scopes have no active rule coverage.
+ *
+ * Advisory (non-failing) warning is emitted if a required scope ID is not in the
+ * scopeCatalog. The catalog check is informational; coverage is the hard gate.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const specPath = path.join(repoRoot, 'spec', 'authoring-spec.json');
+
+// ---------------------------------------------------------------------------
+// Required scopes manifest
+//
+// Each key is a human-readable label; each value is the exact scope ID that
+// must appear in at least one active rule's scope array.
+//
+// This is a frozen manifest -- new authoring surfaces must be added here
+// manually when active rules are authored for them.
+//
+// TODO: Add the following scopes once active rules are authored for them:
+//   - step.context-capture      (runCondition is underdocumented)
+//   - workflow.extension-points (templateCall has no dedicated active rule yet)
+//   - step.prompt-blocks        (the promptBlocks structure has no active rule)
+// ---------------------------------------------------------------------------
+const REQUIRED_SCOPES = Object.freeze({
+  metaGuidance:           'workflow.meta-guidance',
+  features:               'workflow.features',
+  references:             'workflow.references',
+  assessments:            'workflow.assessments',
+  promptFragments:        'step.prompt-fragment',
+  requireConfirmation:    'step.confirmation',
+  outputContract:         'step.output-requirements',
+  assessmentRefs:         'step.assessment-refs',
+  assessmentConsequences: 'step.assessment-consequences',
+  loop:                   'loop.step',
+  loopDecision:           'loop.decision',
+});
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function fail(message, details) {
+  console.error(message);
+  if (details) {
+    if (typeof details === 'string') {
+      console.error(details);
+    } else {
+      console.error(JSON.stringify(details, null, 2));
+    }
+  }
+  process.exit(1);
+}
+
+/**
+ * Collect all scope IDs covered by at least one status:"active" rule.
+ * Only iterates spec.topics -- spec.plannedTopics and spec.plannedRules
+ * contain planned-status rules which do not count as active coverage.
+ */
+function collectActiveScopeIds(spec) {
+  const activeScopes = new Set();
+  for (const topic of spec.topics ?? []) {
+    for (const rule of topic.rules ?? []) {
+      if (rule.status === 'active') {
+        for (const scopeId of rule.scope ?? []) {
+          activeScopes.add(scopeId);
+        }
+      }
+    }
+  }
+  return activeScopes;
+}
+
+function main() {
+  const spec = readJson(specPath);
+
+  const catalogScopeIds = new Set((spec.scopeCatalog ?? []).map((entry) => entry.id));
+  const activeScopeIds = collectActiveScopeIds(spec);
+
+  const uncoveredLabels = [];
+
+  for (const [label, scopeId] of Object.entries(REQUIRED_SCOPES)) {
+    // Advisory: warn if the scope ID is not in the catalog (spec inconsistency)
+    if (!catalogScopeIds.has(scopeId)) {
+      console.warn(
+        `[authoring-coverage] advisory: scope "${scopeId}" (${label}) is not in scopeCatalog -- ` +
+        `this may indicate a spec inconsistency`
+      );
+    }
+
+    // Coverage check: fail if no active rule covers this scope ID
+    if (!activeScopeIds.has(scopeId)) {
+      uncoveredLabels.push({ label, scopeId });
+    }
+  }
+
+  if (uncoveredLabels.length > 0) {
+    fail('authoring-coverage check failed: required scopes have no active rule coverage', {
+      uncoveredScopes: uncoveredLabels,
+    });
+  }
+
+  console.log('authoring-coverage check passed');
+}
+
+main();

--- a/src/daemon/agent-loop.ts
+++ b/src/daemon/agent-loop.ts
@@ -439,10 +439,25 @@ export class AgentLoop {
         continue;
       }
 
-      // Execute the tool. Tools throw on failure (pi-agent-core contract).
-      // We do NOT catch here -- errors propagate to prompt()'s caller.
+      // Execute the tool. Catch errors and return them as is_error tool_results
+      // so the LLM can see what went wrong and decide how to proceed.
+      // WHY: killing the session on any tool failure loses all progress and prevents
+      // the agent from recovering. An error tool_result lets the LLM retry,
+      // rephrase, or escalate gracefully -- same rationale as unknown tool names.
       const params = (block.input ?? {}) as Record<string, unknown>;
-      const result = await tool.execute(block.id, params);
+      let result: AgentToolResult<unknown>;
+      try {
+        result = await tool.execute(block.id, params);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        results.push({
+          toolCallId: block.id,
+          toolName: block.name,
+          result: { content: [{ type: 'text', text: `Tool execution failed: ${message}` }], details: null },
+          isError: true,
+        });
+        continue;
+      }
       results.push({
         toolCallId: block.id,
         toolName: block.name,

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -228,6 +228,9 @@ export interface WorkflowRunError {
   readonly workflowId: string;
   readonly message: string;
   readonly stopReason: string;
+  /** Structured stuck marker for coordinator scripts. Contains WORKTRAIN_STUCK JSON
+   * when the session died with an error so scripts can detect and route without LLM. */
+  readonly lastStepNotes?: string;
 }
 
 /**
@@ -1477,11 +1480,22 @@ export async function runWorkflow(
 
   if (stopReason === 'error' || errorMessage) {
     daemonRegistry?.unregister(sessionId, 'failed');
+    const errMsg = errorMessage ?? 'Agent stopped with error reason';
+    // Append a structured stuck marker so coordinator scripts can detect and act on it.
+    // WHY: parseable by worktrain coordinator scripts without LLM involvement --
+    // scripts-over-agent for routing decisions.
+    const stuckMarker = `\n\nWORKTRAIN_STUCK: ${JSON.stringify({
+      reason: 'session_error',
+      error: errMsg.slice(0, 500),
+      workflowId: trigger.workflowId,
+      sessionId,
+    })}`;
     return {
       _tag: 'error',
       workflowId: trigger.workflowId,
-      message: errorMessage ?? 'Agent stopped with error reason',
+      message: errMsg,
       stopReason,
+      lastStepNotes: stuckMarker,
     };
   }
 


### PR DESCRIPTION
Tool failures no longer kill daemon sessions. Errors are returned as `is_error: true` tool_results so the LLM can recover. Also adds `WORKTRAIN_STUCK` JSON marker to `WorkflowRunError.lastStepNotes` for coordinator script routing.