### PR TITLE
feat(mcp): add DaemonEventEmitter for structured daemon lifecycle events

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -3925,3 +3925,48 @@ More critically: if a session is restarted by the daemon but then stalls (Bedroc
 3. **Orphaned session cleanup should be user-facing.** `worktrain cleanup` or `worktrain status` should surface orphaned sessions with their age and offer to clear them. Right now they silently accumulate.
 
 4. **Better logging when runWorkflow() swallows errors.** The `void runWorkflow(...)` pattern in `console-routes.ts` and `trigger-router.ts` drops errors silently. Every path that ends in silence (no log, no session advance, no error) should at minimum log `[WorkflowRunner] Session died silently` with the session ID.
+
+---
+
+### Observability and logging as first-class citizens (Apr 17, 2026)
+
+**The principle:** WorkTrain should never be a black box. Every action, decision, failure, and state transition should be traceable after the fact -- by a human, by another agent, or by a coordinator script. Logging and observability are not afterthoughts; they are core infrastructure.
+
+**What "first-class" means:**
+
+1. **Structured, not prose.** Every log line should be machine-parseable. Use consistent prefixes (`[WorkflowRunner]`, `[TriggerRouter]`, `[DaemonConsole]`), consistent key=value pairs, and structured JSON for rich payloads. No freeform strings that require regex to parse.
+
+2. **Levels matter.** INFO for normal operations, WARN for recoverable anomalies, ERROR for failures that need attention. Silence = actively working, not unknown. A session that produces no logs for 5+ minutes should emit a heartbeat.
+
+3. **Every state transition logged.** Session start, step advance, tool call, tool result (including errors), session end (success/timeout/error). No silent gaps. The daemon observability logs (#442) are a start -- extend this everywhere.
+
+4. **Errors always include context.** Not just the message -- which session, which tool, which step, which trigger, how long it had been running, what the last successful action was. Enough to diagnose without re-running.
+
+5. **Correlation IDs.** Every session has a `sessionId`. Every tool call has a `toolCallId`. Log entries should include the relevant ID so you can filter across a full session's history. Today the daemon logs include `sessionId` -- extend this to trigger IDs, workflow IDs, and step IDs.
+
+6. **Log destinations are configurable.** Today: stdout → daemon.log file via redirect. Long-term: structured JSON to a log aggregator (Datadog, CloudWatch, file), separate log files per workspace, log rotation. The daemon should accept a `--log-level` flag and a `--log-format json|human` flag.
+
+7. **The session store IS the audit log.** Every `advance_recorded`, `node_output_appended`, `validation_performed` event is a durable structured record. The session store should be queryable as a post-mortem tool. `worktrain session logs <id>` should reconstruct the full story of what happened.
+
+**Specific gaps to close:**
+
+- `continue_workflow` tool: log the step ID and notes length being submitted, not just "continue_workflow called"
+- `makeBashTool`: log exit code and output length in addition to the command
+- `makeReadTool` / `makeWriteTool`: log file path and bytes
+- `AgentLoop`: log each LLM turn (turn number, stop reason, tool count) -- today nothing is logged between tool calls
+- `TriggerRouter`: log when a session is queued (semaphore at capacity) and when it dequeues
+- `PollingScheduler`: log each poll cycle result (N events found, N new, N dispatched)
+- `DeliveryClient`: log delivery attempt, HTTP status, response time
+- `DaemonConsole`: log when the console HTTP server starts, stops, or fails a request
+
+**The `worktrain logs` command:**
+```bash
+worktrain logs                          # tail daemon.log
+worktrain logs --session sess_abc123    # replay full session from event store
+worktrain logs --trigger test-task      # all sessions for this trigger
+worktrain logs --level error            # only errors across all sources
+worktrain logs --since 1h               # last hour
+worktrain logs --format json            # machine-readable output
+```
+
+**Self-healing dependency:** The automatic gap detection, WORKTRAIN_STUCK routing, and coordinator self-healing patterns all depend on logs being structured and complete. You can't auto-fix what you can't observe. Logging quality is a prerequisite for autonomous operation at scale.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -3970,3 +3970,62 @@ worktrain logs --format json            # machine-readable output
 ```
 
 **Self-healing dependency:** The automatic gap detection, WORKTRAIN_STUCK routing, and coordinator self-healing patterns all depend on logs being structured and complete. You can't auto-fix what you can't observe. Logging quality is a prerequisite for autonomous operation at scale.
+
+---
+
+### Event sourcing for orchestration: extend the session store to daemon and coordinator events (Apr 17, 2026)
+
+**The decision:** extend the existing WorkRail event store infrastructure to cover orchestration-level events, not build a separate system. The session store is already append-only, crash-safe, content-addressed, and queryable -- rebuilding those properties would be wasteful.
+
+**The model: multiple event streams, same infrastructure**
+
+```
+~/.workrail/events/
+  sessions/          ← already exists (per-session workflow events)
+  daemon/            ← new: lifecycle, triggers, delivery, errors
+  triggers/          ← new: per-trigger poll history and outcomes
+  coordinator/       ← future: coordinator script decisions and routing
+```
+
+Each stream is append-only JSONL with the same segment/manifest pattern as the session store. The `worktrain logs` command queries across streams. Watchdog and coordinator scripts subscribe to streams.
+
+**Daemon event stream: what gets recorded**
+
+Every significant daemon action becomes a structured event:
+
+```jsonl
+{"ts":"2026-04-17T...","kind":"daemon_started","port":3200,"workspacePath":"...","version":"3.31.0"}
+{"ts":"...","kind":"trigger_fired","triggerId":"test-task","workflowId":"coding-task-workflow-agentic"}
+{"ts":"...","kind":"session_queued","sessionId":"sess_abc","triggerId":"test-task","queueDepth":0}
+{"ts":"...","kind":"session_started","sessionId":"sess_abc","workflowId":"coding-task-workflow-agentic","modelId":"..."}
+{"ts":"...","kind":"tool_called","sessionId":"sess_abc","tool":"Bash","command":"ls docs/ | grep trigger"}
+{"ts":"...","kind":"tool_error","sessionId":"sess_abc","tool":"Bash","error":"exit 1","isError":true}
+{"ts":"...","kind":"step_advanced","sessionId":"sess_abc","stepId":"phase-0-triage-and-mode","advance":1}
+{"ts":"...","kind":"session_completed","sessionId":"sess_abc","stopReason":"stop","durationMs":1847000}
+{"ts":"...","kind":"delivery_attempted","sessionId":"sess_abc","callbackUrl":"https://...","status":200}
+{"ts":"...","kind":"poll_cycle","triggerId":"pr-review","eventsFound":3,"newEvents":1,"dispatched":1}
+```
+
+**`DaemonEventEmitter`:** thin wrapper around the event store, called from TriggerRouter, workflow-runner, delivery-client, and polling-scheduler. Each call appends one event to `~/.workrail/events/daemon/YYYY-MM-DD.jsonl`. Zero overhead when nothing is listening.
+
+**`worktrain logs` CLI:** reads from both session store and daemon event stream, correlates by `sessionId`, presents a unified timeline:
+
+```
+worktrain logs                          # tail current daemon events
+worktrain logs --session sess_abc123    # full timeline: trigger → steps → delivery
+worktrain logs --trigger test-task      # all sessions for this trigger  
+worktrain logs --level error            # only errors across all streams
+worktrain logs --since 1h               # last hour of activity
+worktrain logs --format json            # machine-readable for scripts
+```
+
+**SSE extension:** the console already streams session events via SSE. Extend to also stream daemon events so the console live feed shows everything: trigger fires, tool calls, delivery attempts, errors -- not just step advances. This is the "more than just the DAG" console improvement.
+
+**Why this matters for self-healing:** The coordinator self-healing pattern requires the coordinator to observe what happened. Today it reads `lastStepNotes` and session store snapshots -- both batch reads after the fact. With a subscribable daemon event stream, the coordinator can react in real time: "tool_error event for session X → spawn diagnostic sub-session now" rather than "check for WORKTRAIN_STUCK markers after the fact."
+
+**Build order:**
+1. `DaemonEventEmitter` + daemon event stream file (append-only JSONL, no fancy infra needed to start)
+2. Wire emitter calls into TriggerRouter, workflow-runner, delivery-client
+3. `worktrain logs` CLI commands (reads files, correlates by sessionId)
+4. SSE extension in DaemonConsole for live event streaming
+5. Coordinator script subscription to event streams (replaces polling session store)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -239,6 +239,7 @@ program
   .action(async (options: { workspace?: string }) => {
     const { startTriggerListener } = await import('./trigger/trigger-listener.js');
     const { startDaemonConsole } = await import('./trigger/daemon-console.js');
+    const { DaemonEventEmitter } = await import('./daemon/daemon-events.js');
 
     await initializeContainer({ runtimeMode: { kind: 'cli' } });
     const { createToolContext } = await import('./mcp/server.js');
@@ -274,10 +275,16 @@ program
       process.exit(1);
     }
 
+    // Create the daemon event emitter singleton.
+    // WHY here (before startTriggerListener): the emitter must exist before any
+    // daemon_started event can be emitted inside the listener's server.listen callback.
+    const emitter = new DaemonEventEmitter();
+
     const handle = await startTriggerListener(ctx, {
       workspacePath,
       apiKey: apiKey,
       env: process.env,
+      emitter,
     });
 
     if (handle === null) {

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -1,0 +1,177 @@
+/**
+ * WorkRail Daemon: Structured Event Stream
+ *
+ * Appends structured JSON events to a daily JSONL file at
+ * ~/.workrail/events/daemon/YYYY-MM-DD.jsonl.
+ *
+ * Design decisions:
+ * - emit() is fire-and-forget (returns void synchronously). All async work runs
+ *   in a detached Promise that swallows errors unconditionally. Observability
+ *   must never affect correctness -- a failed append is always silent.
+ * - File path is computed fresh from new Date() on each emit() call, so daily
+ *   rotation happens automatically with zero state.
+ * - Directory is created lazily on the first write (recursive mkdir is idempotent).
+ * - DaemonEventEmitter is injected as an optional parameter wherever events are
+ *   emitted (pattern mirrors DaemonRegistry in workflow-runner.ts). Callers that
+ *   do not inject an emitter pay zero overhead.
+ * - DaemonEvent is a discriminated union so invalid event shapes are impossible
+ *   to construct at compile time.
+ * - dirOverride is provided for testing: pass a temp directory to capture events
+ *   without touching ~/.workrail.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+// ---------------------------------------------------------------------------
+// DaemonEvent: discriminated union of all event kinds
+// ---------------------------------------------------------------------------
+
+/** Daemon process started and webhook server is listening. */
+export interface DaemonStartedEvent {
+  readonly kind: 'daemon_started';
+  readonly port: number;
+  readonly workspacePath: string;
+}
+
+/** Incoming webhook accepted and validated. */
+export interface TriggerFiredEvent {
+  readonly kind: 'trigger_fired';
+  readonly triggerId: string;
+  readonly workflowId: string;
+}
+
+/** Workflow run entered the KeyedAsyncQueue (may wait for a slot). */
+export interface SessionQueuedEvent {
+  readonly kind: 'session_queued';
+  readonly triggerId: string;
+  readonly workflowId: string;
+}
+
+/** Workflow run started (session ID assigned, agent loop about to start). */
+export interface SessionStartedEvent {
+  readonly kind: 'session_started';
+  readonly sessionId: string;
+  readonly workflowId: string;
+  readonly workspacePath: string;
+}
+
+/** An agent tool was called. */
+export interface ToolCalledEvent {
+  readonly kind: 'tool_called';
+  readonly sessionId: string;
+  readonly toolName: string;
+  /** First 80 chars of the primary tool parameter (e.g. bash command, file path). */
+  readonly summary?: string;
+}
+
+/** A tool returned an error result (isError=true). */
+export interface ToolErrorEvent {
+  readonly kind: 'tool_error';
+  readonly sessionId: string;
+  readonly toolName: string;
+  /** First 200 chars of the error message. */
+  readonly error: string;
+}
+
+/** Workflow advanced to the next step. */
+export interface StepAdvancedEvent {
+  readonly kind: 'step_advanced';
+  readonly sessionId: string;
+}
+
+/** Workflow run ended (success, error, or timeout). */
+export interface SessionCompletedEvent {
+  readonly kind: 'session_completed';
+  readonly sessionId: string;
+  readonly workflowId: string;
+  readonly outcome: 'success' | 'error' | 'timeout';
+  /** Human-readable reason (stopReason, error message, or timeout type). */
+  readonly detail?: string;
+}
+
+/** HTTP POST to callbackUrl was attempted. */
+export interface DeliveryAttemptedEvent {
+  readonly kind: 'delivery_attempted';
+  readonly callbackUrl: string;
+  readonly outcome: 'success' | 'http_error' | 'network_error';
+  readonly statusCode?: number;
+}
+
+/**
+ * Union of all daemon lifecycle events.
+ *
+ * Each member has a `kind` discriminant so switch exhaustiveness is enforced
+ * by the TypeScript compiler.
+ */
+export type DaemonEvent =
+  | DaemonStartedEvent
+  | TriggerFiredEvent
+  | SessionQueuedEvent
+  | SessionStartedEvent
+  | ToolCalledEvent
+  | ToolErrorEvent
+  | StepAdvancedEvent
+  | SessionCompletedEvent
+  | DeliveryAttemptedEvent;
+
+// ---------------------------------------------------------------------------
+// DaemonEventEmitter
+// ---------------------------------------------------------------------------
+
+/**
+ * Append-only event emitter for the WorkRail daemon.
+ *
+ * Each call to emit() writes one JSON line to the daily file:
+ *   ~/.workrail/events/daemon/YYYY-MM-DD.jsonl
+ * (or dirOverride/YYYY-MM-DD.jsonl in tests).
+ *
+ * The emitter is injected as an optional parameter wherever events are emitted.
+ * Callers that do not inject an instance pay zero cost.
+ */
+export class DaemonEventEmitter {
+  private readonly _dir: string;
+
+  /**
+   * @param dirOverride - Override the output directory. Used in tests to
+   *   capture events in a temp directory without touching ~/.workrail.
+   *   Production code omits this parameter.
+   */
+  constructor(dirOverride?: string) {
+    this._dir = dirOverride ?? path.join(os.homedir(), '.workrail', 'events', 'daemon');
+  }
+
+  /**
+   * Append a structured event to the daily JSONL file.
+   *
+   * Fire-and-forget: returns void synchronously. The underlying append runs
+   * in a detached Promise. All errors are swallowed -- observability must
+   * never affect correctness.
+   *
+   * WHY void + catch: the event append is diagnostic only. A failed write
+   * (disk full, permission denied) must not propagate to the caller or
+   * interrupt the workflow session.
+   */
+  emit(event: DaemonEvent): void {
+    void this._append(event).catch(() => {
+      // Intentionally empty: errors are silently swallowed.
+    });
+  }
+
+  /**
+   * Internal async append implementation.
+   *
+   * WHY separated from emit(): keeps emit() synchronous and the async I/O
+   * path unit-testable in isolation.
+   */
+  private async _append(event: DaemonEvent): Promise<void> {
+    const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+    const filePath = path.join(this._dir, `${date}.jsonl`);
+
+    await fs.mkdir(this._dir, { recursive: true });
+
+    const line = JSON.stringify({ ts: Date.now(), ...event }) + '\n';
+    await fs.appendFile(filePath, line, 'utf8');
+  }
+}

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -171,7 +171,7 @@ export class DaemonEventEmitter {
 
     await fs.mkdir(this._dir, { recursive: true });
 
-    const line = JSON.stringify({ ts: Date.now(), ...event }) + '\n';
+    const line = JSON.stringify({ ...event, ts: Date.now() }) + '\n';
     await fs.appendFile(filePath, line, 'utf8');
   }
 }

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -1304,6 +1304,7 @@ export async function runWorkflow(
   // no pending continuation). Return success without creating an Agent.
   if (firstStep.isComplete) {
     await fs.unlink(path.join(DAEMON_SESSIONS_DIR, `${sessionId}.json`)).catch(() => {});
+    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'success', detail: 'stop' });
     daemonRegistry?.unregister(sessionId, 'completed');
     return { _tag: 'success', workflowId: trigger.workflowId, stopReason: 'stop' };
   }

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -40,6 +40,7 @@ import type { V2StartWorkflowOutputSchema } from '../mcp/output-schemas.js';
 import { parseContinueTokenOrFail } from '../mcp/handlers/v2-token-ops.js';
 import { asSessionId } from '../v2/durable-core/ids/index.js';
 import { projectNodeOutputsV2 } from '../v2/projections/node-outputs.js';
+import type { DaemonEventEmitter } from './daemon-events.js';
 
 const execAsync = promisify(exec);
 
@@ -795,6 +796,7 @@ export function makeContinueWorkflowTool(
   schemas: Record<string, any>,
   // Optional injection point for testing -- defaults to the real implementation.
   _executeContinueWorkflowFn: typeof executeContinueWorkflow = executeContinueWorkflow,
+  emitter?: DaemonEventEmitter,
 ): AgentTool {
   return {
     name: 'continue_workflow',
@@ -809,6 +811,7 @@ export function makeContinueWorkflowTool(
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
       console.log(`[WorkflowRunner] Tool: continue_workflow sessionId=${sessionId}`);
+      emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'continue_workflow', summary: (params.intent as string | undefined) ?? 'advance' });
       const result = await _executeContinueWorkflowFn(
         {
           continueToken: params.continueToken,
@@ -912,7 +915,7 @@ export function makeContinueWorkflowTool(
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function makeBashTool(workspacePath: string, schemas: Record<string, any>): AgentTool {
+export function makeBashTool(workspacePath: string, schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter): AgentTool {
   return {
     name: 'Bash',
     description:
@@ -928,6 +931,7 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
       console.log(`[WorkflowRunner] Tool: bash "${String(params.command).slice(0, 80)}"`);
+      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Bash', summary: String(params.command).slice(0, 80) });
       const cwd = params.cwd ?? workspacePath;
       try {
         const { stdout, stderr } = await execAsync(params.command, {
@@ -983,7 +987,7 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeReadTool(schemas: Record<string, any>): AgentTool {
+function makeReadTool(schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter): AgentTool {
   return {
     name: 'Read',
     description: 'Read the contents of a file at the given absolute path.',
@@ -994,6 +998,7 @@ function makeReadTool(schemas: Record<string, any>): AgentTool {
       _toolCallId: string,
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
+      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Read', summary: String(params.filePath).slice(0, 80) });
       const content = await fs.readFile(params.filePath, 'utf8');
       return {
         content: [{ type: 'text', text: content }],
@@ -1004,7 +1009,7 @@ function makeReadTool(schemas: Record<string, any>): AgentTool {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeWriteTool(schemas: Record<string, any>): AgentTool {
+function makeWriteTool(schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter): AgentTool {
   return {
     name: 'Write',
     description: 'Write content to a file at the given absolute path. Creates parent directories if needed.',
@@ -1015,6 +1020,7 @@ function makeWriteTool(schemas: Record<string, any>): AgentTool {
       _toolCallId: string,
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
+      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Write', summary: String(params.filePath).slice(0, 80) });
       await fs.mkdir(path.dirname(params.filePath), { recursive: true });
       await fs.writeFile(params.filePath, params.content, 'utf8');
       return {
@@ -1157,6 +1163,9 @@ function buildUserMessage(text: string): { role: 'user'; content: string; timest
  * @param daemonRegistry - Optional registry for tracking live daemon sessions.
  *   When provided, register/heartbeat/unregister are called at the appropriate
  *   lifecycle points. When omitted, registry operations are skipped.
+ * @param emitter - Optional event emitter for structured lifecycle events.
+ *   When provided, emits session_started, tool_called, tool_error, step_advanced,
+ *   and session_completed events. When omitted, no events are emitted (zero overhead).
  * @returns WorkflowRunResult discriminated union. Never throws.
  */
 export async function runWorkflow(
@@ -1164,6 +1173,7 @@ export async function runWorkflow(
   ctx: V2ToolContext,
   apiKey: string,
   daemonRegistry?: DaemonRegistry,
+  emitter?: DaemonEventEmitter,
 ): Promise<WorkflowRunResult> {
   // ---- Session ID (process-local, crash safety) ----
   // Each runWorkflow() call generates a unique UUID that keys the per-session
@@ -1172,6 +1182,14 @@ export async function runWorkflow(
   // is stored as a value inside the file, so crash-resume can retrieve it.
   const sessionId = randomUUID();
   console.log(`[WorkflowRunner] Session started: sessionId=${sessionId} workflowId=${trigger.workflowId}`);
+
+  // Emit session_started event immediately after session ID is assigned.
+  emitter?.emit({
+    kind: 'session_started',
+    sessionId,
+    workflowId: trigger.workflowId,
+    workspacePath: trigger.workspacePath,
+  });
 
   // ---- DaemonRegistry: register session ----
   daemonRegistry?.register(sessionId, trigger.workflowId);
@@ -1230,6 +1248,8 @@ export async function runWorkflow(
     pendingSteerText = stepText;
     // Heartbeat on each step advance -- the session is alive and making progress.
     daemonRegistry?.heartbeat(sessionId);
+    // Emit step_advanced event.
+    emitter?.emit({ kind: 'step_advanced', sessionId });
   };
 
   const onComplete = (notes: string | undefined): void => {
@@ -1295,10 +1315,10 @@ export async function runWorkflow(
   // start_workflow is NOT in this list: the daemon calls executeStartWorkflow()
   // directly above so the LLM cannot call it again.
   const tools: AgentTool[] = [
-    makeContinueWorkflowTool(sessionId, ctx, onAdvance, onComplete, schemas),
-    makeBashTool(trigger.workspacePath, schemas),
-    makeReadTool(schemas),
-    makeWriteTool(schemas),
+    makeContinueWorkflowTool(sessionId, ctx, onAdvance, onComplete, schemas, executeContinueWorkflow, emitter),
+    makeBashTool(trigger.workspacePath, schemas, sessionId, emitter),
+    makeReadTool(schemas, sessionId, emitter),
+    makeWriteTool(schemas, sessionId, emitter),
   ];
 
   // ---- Context loading (soul + workspace + session notes) ----
@@ -1385,6 +1405,14 @@ export async function runWorkflow(
   const unsubscribe = agent.subscribe(async (event: AgentEvent) => {
     if (event.type !== 'turn_end') return;
 
+    // Emit tool_error events for any tool results that reported isError=true.
+    for (const toolResult of event.toolResults) {
+      if (toolResult.isError) {
+        const errorText = toolResult.result?.content[0]?.text ?? 'tool error';
+        emitter?.emit({ kind: 'tool_error', sessionId, toolName: toolResult.toolName, error: errorText.slice(0, 200) });
+      }
+    }
+
     // Track turns for the max-turn limit.
     turnCount++;
 
@@ -1465,6 +1493,7 @@ export async function runWorkflow(
   // timeoutReason is set before agent.abort() in both abort paths; by the time we
   // reach here the catch has completed and it is safe to read synchronously.
   if (timeoutReason !== null) {
+    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'timeout', detail: timeoutReason });
     daemonRegistry?.unregister(sessionId, 'failed');
     const limitDescription = timeoutReason === 'wall_clock'
       ? `${trigger.agentConfig?.maxSessionMinutes ?? DEFAULT_SESSION_TIMEOUT_MINUTES} minutes`
@@ -1479,8 +1508,9 @@ export async function runWorkflow(
   }
 
   if (stopReason === 'error' || errorMessage) {
-    daemonRegistry?.unregister(sessionId, 'failed');
     const errMsg = errorMessage ?? 'Agent stopped with error reason';
+    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'error', detail: errMsg.slice(0, 200) });
+    daemonRegistry?.unregister(sessionId, 'failed');
     // Append a structured stuck marker so coordinator scripts can detect and act on it.
     // WHY: parseable by worktrain coordinator scripts without LLM involvement --
     // scripts-over-agent for routing decisions.
@@ -1506,6 +1536,7 @@ export async function runWorkflow(
     // Best-effort: ignore ENOENT (session never persisted tokens) and other errors.
   });
 
+  emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'success', detail: stopReason });
   daemonRegistry?.unregister(sessionId, 'completed');
 
   return {

--- a/src/trigger/delivery-client.ts
+++ b/src/trigger/delivery-client.ts
@@ -20,6 +20,7 @@
 import type { Result } from '../runtime/result.js';
 import { ok, err } from '../runtime/result.js';
 import type { WorkflowRunResult } from '../daemon/workflow-runner.js';
+import type { DaemonEventEmitter } from '../daemon/daemon-events.js';
 
 // ---------------------------------------------------------------------------
 // DeliveryError: discriminated union for POST failure modes
@@ -41,11 +42,14 @@ export type DeliveryError =
  * @param callbackUrl - The delivery target URL (must be http:// or https://).
  *   Validated at load time by trigger-store.ts; trusted here.
  * @param result - The WorkflowRunResult to deliver.
+ * @param emitter - Optional event emitter. When provided, emits delivery_attempted
+ *   after the HTTP POST resolves (success or failure). When absent, no event is emitted.
  * @returns Result<void, DeliveryError>. Never throws.
  */
 export async function post(
   callbackUrl: string,
   result: WorkflowRunResult,
+  emitter?: DaemonEventEmitter,
 ): Promise<Result<void, DeliveryError>> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 30_000);
@@ -58,10 +62,13 @@ export async function post(
     });
     if (!res.ok) {
       const body = await res.text().catch(() => '');
+      emitter?.emit({ kind: 'delivery_attempted', callbackUrl, outcome: 'http_error', statusCode: res.status });
       return err({ kind: 'http_error', status: res.status, body });
     }
+    emitter?.emit({ kind: 'delivery_attempted', callbackUrl, outcome: 'success', statusCode: res.status });
     return ok(undefined);
   } catch (e: unknown) {
+    emitter?.emit({ kind: 'delivery_attempted', callbackUrl, outcome: 'network_error' });
     return err({ kind: 'network_error', message: String(e) });
   } finally {
     clearTimeout(timer);

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -30,6 +30,7 @@ import { loadWorkrailConfigFile, loadWorkspacesFromConfigFile } from '../config/
 import { runWorkflow, runStartupRecovery } from '../daemon/workflow-runner.js';
 import type { WebhookEvent, WorkspaceConfig } from './types.js';
 import { asTriggerId } from './types.js';
+import type { DaemonEventEmitter } from '../daemon/daemon-events.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -76,6 +77,12 @@ export interface StartTriggerListenerOptions {
    * Pass {} to explicitly disable workspace namespacing (e.g. in tests).
    */
   readonly workspaces?: Readonly<Record<string, WorkspaceConfig>>;
+  /**
+   * Optional event emitter for structured daemon lifecycle events.
+   * When provided, emits daemon_started after the server starts listening.
+   * When absent, no events are emitted (zero overhead).
+   */
+  readonly emitter?: DaemonEventEmitter;
 }
 
 // ---------------------------------------------------------------------------
@@ -240,7 +247,7 @@ export async function startTriggerListener(
 
   // Create router and Express app
   const runWorkflowFn: RunWorkflowFn = options.runWorkflowFn ?? runWorkflow;
-  const router = new TriggerRouter(triggerIndex, ctx, apiKey, runWorkflowFn, undefined, maxConcurrentSessions);
+  const router = new TriggerRouter(triggerIndex, ctx, apiKey, runWorkflowFn, undefined, maxConcurrentSessions, options.emitter);
   const app = createTriggerApp(router);
 
   // Startup crash recovery: detect and clear any orphaned session files left by a
@@ -277,6 +284,14 @@ export async function startTriggerListener(
       const addr = server.address();
       const actualPort = (addr && typeof addr === 'object') ? addr.port : port;
       console.log(`[TriggerListener] Webhook server listening on port ${actualPort}`);
+
+      // Emit daemon_started event after the server is confirmed listening.
+      options.emitter?.emit({
+        kind: 'daemon_started',
+        port: actualPort,
+        workspacePath: options.workspacePath,
+      });
+
       resolve({
         port: actualPort,
         router,

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -36,6 +36,7 @@ import type {
 } from './types.js';
 import { parseHandoffArtifact, runDelivery } from './delivery-action.js';
 import type { ExecFn } from './delivery-action.js';
+import type { DaemonEventEmitter } from '../daemon/daemon-events.js';
 
 /**
  * Default production exec function: promisify(execFile).
@@ -67,6 +68,8 @@ export type RunWorkflowFn = (
   trigger: WorkflowTrigger,
   ctx: V2ToolContext,
   apiKey: string,
+  daemonRegistry?: import('../v2/infra/in-memory/daemon-registry/index.js').DaemonRegistry,
+  emitter?: DaemonEventEmitter,
 ) => Promise<WorkflowRunResult>;
 
 // ---------------------------------------------------------------------------
@@ -404,6 +407,7 @@ export class TriggerRouter {
   private readonly execFn: ExecFn;
   private readonly semaphore: Semaphore;
   private readonly _maxConcurrentSessions: number;
+  private readonly emitter: DaemonEventEmitter | undefined;
 
   constructor(
     private readonly index: ReadonlyMap<string, TriggerDefinition>,
@@ -417,8 +421,15 @@ export class TriggerRouter {
      */
     execFn?: ExecFn,
     maxConcurrentSessions?: number,
+    /**
+     * Optional event emitter for structured daemon lifecycle events.
+     * When provided, emits trigger_fired and session_queued events.
+     * When absent, no events are emitted (zero overhead).
+     */
+    emitter?: DaemonEventEmitter,
   ) {
     this.execFn = execFn ?? execFileAsync;
+    this.emitter = emitter;
     // Validate and clamp: maxConcurrentSessions must be >= 1.
     // A value of 0 or negative would deadlock all dispatches -- make it impossible.
     const requested = maxConcurrentSessions ?? DEFAULT_MAX_CONCURRENT_SESSIONS;
@@ -501,6 +512,9 @@ export class TriggerRouter {
       ...(trigger.soulFile !== undefined ? { soulFile: trigger.soulFile } : {}),
     };
 
+    // Emit trigger_fired: the webhook was accepted and validated.
+    this.emitter?.emit({ kind: 'trigger_fired', triggerId: trigger.id, workflowId: trigger.workflowId });
+
     // Enqueue asynchronously.
     // Queue key strategy:
     // - 'serial' (default): use trigger.id as the key so concurrent webhook fires for
@@ -514,6 +528,9 @@ export class TriggerRouter {
       ? `${trigger.id}:${crypto.randomUUID()}`
       : trigger.id;
     void this.queue.enqueue(queueKey, async () => {
+      // Emit session_queued: the run entered the queue (may wait for a semaphore slot).
+      this.emitter?.emit({ kind: 'session_queued', triggerId: trigger.id, workflowId: trigger.workflowId });
+
       // Acquire the global semaphore before starting runWorkflowFn().
       // WHY inside the callback (not before enqueue): route() must return immediately.
       // Blocking here is safe; blocking before enqueue() would break the 202 contract.
@@ -527,7 +544,7 @@ export class TriggerRouter {
       await this.semaphore.acquire();
       let result: WorkflowRunResult;
       try {
-        result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey);
+        result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey, undefined, this.emitter);
       } finally {
         this.semaphore.release();
       }
@@ -544,7 +561,7 @@ export class TriggerRouter {
       const originalTag = result._tag;
       const originalResult = result;
       if (trigger.callbackUrl) {
-        const deliveryResult = await deliveryPost(trigger.callbackUrl, result);
+        const deliveryResult = await deliveryPost(trigger.callbackUrl, result, this.emitter);
         if (deliveryResult.kind === 'err') {
           const deliveryError =
             deliveryResult.error.kind === 'http_error'
@@ -630,7 +647,7 @@ export class TriggerRouter {
       await this.semaphore.acquire();
       let result: WorkflowRunResult;
       try {
-        result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey);
+        result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey, undefined, this.emitter);
       } finally {
         this.semaphore.release();
       }

--- a/tests/unit/daemon-events.test.ts
+++ b/tests/unit/daemon-events.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for src/daemon/daemon-events.ts
+ *
+ * Covers:
+ * - Events written to a temp directory (not ~/.workrail)
+ * - Each event appends a valid JSON line with ts and kind
+ * - Daily rotation: different date strings produce different files
+ * - Errors are swallowed: fs failures do not propagate from emit()
+ * - Directory is created lazily on first write
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DaemonEventEmitter } from '../../src/daemon/daemon-events.js';
+import type { DaemonEvent } from '../../src/daemon/daemon-events.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a unique temp directory for each test. */
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'workrail-daemon-events-test-'));
+}
+
+/**
+ * Read all JSONL lines from a file, parsed as objects.
+ * Returns an empty array if the file does not exist.
+ */
+async function readJsonlLines(filePath: string): Promise<Record<string, unknown>[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf8');
+  } catch {
+    return [];
+  }
+  return raw
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+/** Wait for all pending async I/O to flush. */
+async function flushAsync(): Promise<void> {
+  // emit() fires a detached Promise. The underlying fs.appendFile is async I/O.
+  // We poll until the file appears or a reasonable number of ticks pass.
+  // Using multiple setTimeout(0) + setImmediate rounds ensures both microtasks
+  // and I/O callbacks complete before we inspect the result.
+  for (let i = 0; i < 20; i++) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DaemonEventEmitter', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    // Clean up temp dir after each test.
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates the daily JSONL file and writes a valid JSON line', async () => {
+    const emitter = new DaemonEventEmitter(tmpDir);
+
+    emitter.emit({ kind: 'daemon_started', port: 3200, workspacePath: '/workspace' });
+
+    await flushAsync();
+
+    const files = await fs.readdir(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}\.jsonl$/);
+
+    const lines = await readJsonlLines(path.join(tmpDir, files[0]!));
+    expect(lines).toHaveLength(1);
+
+    const line = lines[0]!;
+    expect(typeof line['ts']).toBe('number');
+    expect(line['kind']).toBe('daemon_started');
+    expect(line['port']).toBe(3200);
+    expect(line['workspacePath']).toBe('/workspace');
+  });
+
+  it('appends multiple events as separate lines', async () => {
+    const emitter = new DaemonEventEmitter(tmpDir);
+
+    emitter.emit({ kind: 'trigger_fired', triggerId: 'trig-1', workflowId: 'wf-1' });
+    emitter.emit({ kind: 'session_queued', triggerId: 'trig-1', workflowId: 'wf-1' });
+    emitter.emit({ kind: 'session_started', sessionId: 'sess-1', workflowId: 'wf-1', workspacePath: '/ws' });
+
+    await flushAsync();
+
+    const files = await fs.readdir(tmpDir);
+    const lines = await readJsonlLines(path.join(tmpDir, files[0]!));
+    expect(lines).toHaveLength(3);
+    // Ordering is not guaranteed for concurrent fire-and-forget appends.
+    // Verify all 3 kinds are present.
+    const kinds = lines.map((l) => l['kind']);
+    expect(kinds).toContain('trigger_fired');
+    expect(kinds).toContain('session_queued');
+    expect(kinds).toContain('session_started');
+  });
+
+  it('creates directory lazily on first write', async () => {
+    // Use a nested path that does not exist yet.
+    const nestedDir = path.join(tmpDir, 'sub', 'dir');
+    const emitter = new DaemonEventEmitter(nestedDir);
+
+    emitter.emit({ kind: 'step_advanced', sessionId: 'sess-1' });
+    await flushAsync();
+
+    const files = await fs.readdir(nestedDir);
+    expect(files).toHaveLength(1);
+  });
+
+  it('daily rotation: different date strings produce different files', async () => {
+    const emitter = new DaemonEventEmitter(tmpDir);
+
+    // Spy on Date.prototype.toISOString to return two different dates.
+    const originalToISOString = Date.prototype.toISOString;
+
+    // First emit on "day 1"
+    Date.prototype.toISOString = () => '2026-01-01T12:00:00.000Z';
+    emitter.emit({ kind: 'tool_called', sessionId: 's1', toolName: 'Bash' });
+    await flushAsync();
+
+    // Second emit on "day 2"
+    Date.prototype.toISOString = () => '2026-01-02T12:00:00.000Z';
+    emitter.emit({ kind: 'tool_called', sessionId: 's1', toolName: 'Read' });
+    await flushAsync();
+
+    // Restore original
+    Date.prototype.toISOString = originalToISOString;
+
+    const files = (await fs.readdir(tmpDir)).sort();
+    expect(files).toHaveLength(2);
+    expect(files[0]).toBe('2026-01-01.jsonl');
+    expect(files[1]).toBe('2026-01-02.jsonl');
+  });
+
+  it('swallows errors when appendFile throws -- emit() returns void without throwing', async () => {
+    // Use a path that is actually a file (not a directory) so mkdir/appendFile will fail.
+    const blockingFile = path.join(tmpDir, 'blocker');
+    await fs.writeFile(blockingFile, 'occupied', 'utf8');
+
+    // The emitter's dir is the path of a regular file -- appendFile will fail.
+    const emitter = new DaemonEventEmitter(blockingFile);
+
+    // Must not throw synchronously or asynchronously.
+    expect(() => {
+      emitter.emit({ kind: 'session_completed', sessionId: 's1', workflowId: 'wf-1', outcome: 'error' });
+    }).not.toThrow();
+
+    // Wait for the detached Promise to settle (error swallowed).
+    await flushAsync();
+
+    // No crash, no unhandled rejection -- test passes.
+  });
+
+  it('each event kind has the correct discriminant field', async () => {
+    const emitter = new DaemonEventEmitter(tmpDir);
+
+    const events: DaemonEvent[] = [
+      { kind: 'daemon_started', port: 3200, workspacePath: '/ws' },
+      { kind: 'trigger_fired', triggerId: 't1', workflowId: 'w1' },
+      { kind: 'session_queued', triggerId: 't1', workflowId: 'w1' },
+      { kind: 'session_started', sessionId: 's1', workflowId: 'w1', workspacePath: '/ws' },
+      { kind: 'tool_called', sessionId: 's1', toolName: 'Bash' },
+      { kind: 'tool_error', sessionId: 's1', toolName: 'Bash', error: 'fail' },
+      { kind: 'step_advanced', sessionId: 's1' },
+      { kind: 'session_completed', sessionId: 's1', workflowId: 'w1', outcome: 'success' },
+      { kind: 'delivery_attempted', callbackUrl: 'https://example.com', outcome: 'success' },
+    ];
+
+    for (const event of events) {
+      emitter.emit(event);
+    }
+    await flushAsync();
+
+    const files = await fs.readdir(tmpDir);
+    const lines = await readJsonlLines(path.join(tmpDir, files[0]!));
+    expect(lines).toHaveLength(events.length);
+
+    // Ordering is not guaranteed for concurrent fire-and-forget appends.
+    // Verify all event kinds are present and each line has a numeric ts.
+    const kinds = lines.map((l) => l['kind']);
+    for (const event of events) {
+      expect(kinds).toContain(event.kind);
+    }
+    for (const line of lines) {
+      expect(typeof line['ts']).toBe('number');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- New `src/daemon/daemon-events.ts` with `DaemonEventEmitter` class and `DaemonEvent` discriminated union (9 event kinds)
- Wires 9 emission sites: `daemon_started`, `trigger_fired`, `session_queued`, `session_started`, `tool_called` (4 tools), `tool_error`, `step_advanced`, `session_completed`, `delivery_attempted`
- Each event appends a JSON line to `~/.workrail/events/daemon/YYYY-MM-DD.jsonl` (daily rotation, lazy dir creation)
- Emitter injected as optional param everywhere -- zero overhead when absent, never throws

## Test plan

- [ ] `npx vitest run tests/unit/daemon-events.test.ts` -- 6 new tests pass (temp dir injection, rotation, error swallowing, all 9 event kinds)
- [ ] `npx vitest run tests/unit/` -- 3349/3350 passing (1 pre-existing failure in agent-loop.test.ts unrelated to this PR)
- [ ] `npx tsc --noEmit` -- compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)