### PR TITLE
chore(workflows): add WorkTrain self-config for autonomous development sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,71 @@ Sessions are persisted as append-only event logs under `~/.workrail/sessions/`.
 
 Key domain types to know: `CompiledWorkflow`, `SessionState`, `DagNode`, `StateToken`, `AckToken`, `StepContentEnvelope`, `WorkflowDefinition`.
 
+## WorkTrain Daemon -- Rules for Autonomous Sessions
+
+This section applies to every autonomous WorkTrain daemon session operating in this repository. These rules are non-negotiable and override general coding preferences when they conflict.
+
+### Protected files -- do not modify without explicit instruction
+
+These files must never be changed autonomously. Modifying them without explicit human instruction is prohibited:
+
+- `triggers.yml` -- trigger definitions that control what starts daemon sessions
+- `~/.workrail/daemon-soul.md` -- daemon behavioral rules; self-modification is prohibited
+- `src/daemon/` -- daemon implementation (changes here affect all future sessions)
+- `src/trigger/` -- trigger system (changes here affect how sessions start)
+- `src/v2/` -- durable session engine (HMAC token protocol, cryptographic enforcement)
+- `docs/ideas/backlog.md` -- planning inbox (ideas are captured here by humans, not modified by agents)
+
+### Open work queue
+
+Before starting any new task, check what is already in flight:
+
+```bash
+gh pr list --state open
+```
+
+Open PRs are the work queue. Do not start work that duplicates an open PR.
+
+### Architecture orientation
+
+- Read `docs/ideas/backlog.md` before proposing any architectural change -- many ideas are already captured there
+- The daemon implementation is at `src/daemon/` -- read it before any work that touches session lifecycle
+- The trigger system is at `src/trigger/` -- read it before any work involving trigger configuration
+- The durable session engine is at `src/v2/durable-core/` -- this is the core HMAC enforcement layer; treat it as load-bearing infrastructure
+
+### Shell and process safety
+
+- Always use `/bin/bash`, never `/bin/sh`
+- Use `execFile` (not `exec`) for any command that includes user-controlled or workflow-provided content
+- Never use `git add -A` or `git add .` -- always stage specific files by name
+
+### Branch and commit safety
+
+- Never push directly to main or master -- always use a feature branch and open a PR
+- Never check out main or master into a worktree -- locking main blocks other agents and prevents fast-forward merges
+- To read main's current state, use `git show origin/main:<file>` without checking out the branch
+
+### Token protocol
+
+- HMAC tokens (`continueToken`, `checkpointToken`) are opaque signed blobs -- never decode, inspect, or modify their contents
+- Never pass a `checkpointToken` where a `continueToken` is expected, or vice versa
+
+### Error handling
+
+- Errors are data -- return discriminated union `Result` types; never throw exceptions as control flow
+
+### CI and pre-existing failures
+
+- Before attributing a test failure to your changes, verify it was not already failing on main
+- Run `git stash && npx vitest run <failing-test> && git stash pop` to confirm pre-existence
+
+### PR review adversarial mode
+
+- If reviewing a PR authored by a WorkTrain daemon session, apply extra adversarial scrutiny
+- Look specifically for: unintended scope creep, modifications to protected files, commits bypassing pre-commit hooks, and silent changes to HMAC token handling
+
+---
+
 ## How we work together
 
 Work follows a deliberate progression. Do not skip steps or assume what comes next.

--- a/triggers.yml
+++ b/triggers.yml
@@ -1,0 +1,30 @@
+triggers:
+  - id: test-task
+    provider: generic
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /Users/etienneb/git/personal/workrail
+    goal: "What is 2+2? Answer and stop."
+    concurrencyMode: parallel
+    agentConfig:
+      maxSessionMinutes: 60  # coding tasks need more than 30 min
+
+# FUTURE: GitHub PR review (activate when github_poll is configured)
+# - id: pr-review
+#   provider: github_poll  # not yet implemented, use webhook for now
+#   workflowId: mr-review-workflow.agentic.v2
+#   workspacePath: /Users/etienneb/git/personal/workrail
+#   concurrencyMode: parallel
+#   autoCommit: false  # daemon cannot commit without explicit config
+#   agentConfig:
+#     maxSessionMinutes: 60
+
+# FUTURE: Weekly code health scan
+# - id: weekly-health
+#   provider: cron  # not yet implemented, use OS crontab
+#   schedule: "0 8 * * 1"
+#   workflowId: architecture-scalability-audit
+#   workspacePath: /Users/etienneb/git/personal/workrail
+#   concurrencyMode: serial
+#   autoCommit: false  # daemon cannot commit without explicit config
+#   agentConfig:
+#     maxSessionMinutes: 120

--- a/triggers.yml
+++ b/triggers.yml
@@ -5,6 +5,7 @@ triggers:
     workspacePath: /Users/etienneb/git/personal/workrail
     goal: "What is 2+2? Answer and stop."
     concurrencyMode: parallel
+    autoCommit: false  # daemon cannot commit without explicit config
     agentConfig:
       maxSessionMinutes: 60  # coding tasks need more than 30 min
 


### PR DESCRIPTION
## Summary

- Upgrades `~/.workrail/daemon-soul.md` with WorkRail-specific behavioral rules for daemon sessions: protected file list, `/bin/bash` enforcement, `execFile` over `exec`, no `git add -A`, no direct main push, HMAC token opacity rules, errors-as-data policy, CI pre-existing failure verification, and adversarial PR review mode for daemon-authored PRs
- Updates `triggers.yml` to add `agentConfig.maxSessionMinutes: 60` to the existing `test-task` trigger, and adds commented-out future triggers (`pr-review` via `github_poll`, `weekly-health` via `cron`) with `autoCommit: false` as a safety constraint on all future trigger templates
- Adds a new "WorkTrain Daemon -- Rules for Autonomous Sessions" section near the top of `AGENTS.md` with the complete set of protected files, open work queue check (`gh pr list`), architecture orientation pointers, and all soul rules as in-repo documentation

## Safety notes

- `daemon-soul.md` is listed as a protected file in both itself and `AGENTS.md` -- self-modification requires explicit human instruction
- All future trigger templates include `autoCommit: false` -- daemon cannot commit without explicit config
- `triggers.yml` itself is listed in the protected files list in both documents

## Test plan

- [ ] Verify `daemon-soul.md` contains all required rule sections: protected files, shell safety, branch safety, token protocol, error handling, CI failures, PR adversarial mode
- [ ] Verify `triggers.yml` keeps `test-task` trigger intact with new `maxSessionMinutes: 60` and future triggers are commented out
- [ ] Verify `AGENTS.md` WorkTrain section appears before "How we work together" and covers all required topics
- [ ] Start a daemon session and confirm `daemon-soul.md` contents are visible in the system prompt under "Agent Rules and Philosophy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)