### PR TITLE
feat(mcp): richer daemon system prompt and report_issue tool

### DIFF
--- a/docs/design/implementation_plan.md
+++ b/docs/design/implementation_plan.md
@@ -1,0 +1,192 @@
+# Implementation Plan: WorkTrain System Prompt Preamble + report_issue Tool
+
+## Problem Statement
+
+The WorkTrain daemon's system prompt preamble is thin (15 lines) and relies on the soul file for behavioral guidance. This leaves unattended agents without explicit direction on self-directed reasoning, the oracle hierarchy, or what to do when things go wrong. Additionally, there is no structured way for agents to record issues/errors for a future auto-fix coordinator -- failures either go unrecorded or end up buried in step notes.
+
+---
+
+## Acceptance Criteria
+
+1. `buildSystemPrompt()` output contains a richer preamble (~55 lines) that:
+   - Opens with "You are WorkRail Auto, an autonomous agent..." (existing test assertion preserved)
+   - Includes `## Your tools` section listing all 5 tools (existing test assertion)
+   - Includes `## Execution contract` section (existing test assertion)
+   - Adds `## What you are`, `## Your oracle`, `## Self-directed reasoning`, `## The workflow is the contract`, `## Silent failure is the worst outcome`, `## Tools are your hands not your voice`, `## You don't have a user` sections
+   - All existing `workflow-runner-system-prompt.test.ts` tests pass without modification
+
+2. `makeReportIssueTool(sessionId, emitter?, issuesDirOverride?)` is exported from `workflow-runner.ts`:
+   - Tool name: `report_issue`
+   - Input schema accepts: `kind` (5-value literal enum), `severity` (4-value literal enum), `summary` (string, required), `context` (string, optional), `toolName` (string, optional), `command` (string, optional), `suggestedFix` (string, optional), `continueToken` (string, optional)
+   - `execute()` appends one JSON line to `~/.workrail/issues/<sessionId>.jsonl` (or `issuesDirOverride/<sessionId>.jsonl` in tests) -- fire-and-forget (void+catch)
+   - `execute()` emits a `DaemonEventEmitter` event with `kind: 'issue_reported'`
+   - For non-fatal severity: returns `"Issue recorded (severity=<severity>). Continue with your work unless this is fatal."`
+   - For fatal severity: returns `"FATAL issue recorded. Call continue_workflow with notes explaining the blocker, then the session will end."`
+   - Wired into `runWorkflow()` tools array
+
+3. `IssueReportedEvent` is added to `DaemonEvent` union in `daemon-events.ts`:
+   - `kind: 'issue_reported'`, `sessionId: string`, `issueKind` (5-value literal union), `severity` (4-value literal union), `summary: string`, `continueToken?: string`
+
+4. `npm run build` succeeds (no TS errors)
+5. `npx vitest run` passes (all existing tests + new tests)
+
+---
+
+## Non-Goals
+
+- No auto-fix coordinator implementation
+- No IssueStore class (YAGNI -- extract when coordinator needs it)
+- No changes to `soul-template.ts`, `triggers.yml`, or `src/v2/`
+- No changes to the soul file template/default
+- No changes to AgentLoop behavior (fatal severity does not abort the loop)
+- No async changes to `buildSystemPrompt()` (must remain synchronous and pure)
+
+---
+
+## Philosophy-Driven Constraints
+
+- `buildSystemPrompt()` must remain a pure, synchronous function (no I/O, no side effects)
+- All `DaemonEvent` variants must use `readonly` fields only
+- `IssueReportedEvent.issueKind` and `.severity` must be literal union types (not `string`)
+- JSONL write must be fire-and-forget: `void appendIssueAsync().catch(() => {})`
+- `mkdir({ recursive: true })` before every appendFile (handles missing dir silently)
+- `issuesDirOverride` parameter for test isolation (mirrors DaemonEventEmitter constructor)
+
+---
+
+## Invariants
+
+1. `buildSystemPrompt()` is pure and synchronous -- verified by existing tests calling it directly
+2. `'You are WorkRail Auto'` is present in `buildSystemPrompt()` output -- verified by test L29
+3. `'## Your tools'` is present in `buildSystemPrompt()` output -- verified by test L30
+4. `'## Execution contract'` is present in `buildSystemPrompt()` output -- verified by test L32
+5. All `DaemonEvent` variants use `readonly` fields -- verified by TS compiler
+6. `DaemonEvent` union is exhaustive -- TS compiler enforces at every switch site
+7. `report_issue.execute()` never throws -- returns `AgentToolResult` always
+8. JSONL write never blocks `execute()` return -- `void` Promise
+
+---
+
+## Selected Approach + Rationale
+
+**Part 1:** Module-private `BASE_SYSTEM_PROMPT` string constant defined above `buildSystemPrompt()`. The function uses it as the start of the lines array. Rationale: named constant is readable as a document; testable via `buildSystemPrompt()` output; follows `soul-template.ts` precedent for stable-content constants.
+
+**Part 2:** `makeReportIssueTool(sessionId, emitter?, issuesDirOverride?)` inline tool factory following the exact shape of `makeReadTool`/`makeWriteTool`. Private `appendIssueAsync()` helper for JSONL write. `issuesDirOverride` for test isolation (hybrid of inline factory + runner-up's dirOverride). Rationale: YAGNI -- no IssueStore class until coordinator exists; hybrid resolves testability without over-engineering.
+
+**Runner-up:** IssueStore class (Candidate B). Lost to YAGNI -- one caller, no coordinator yet.
+
+---
+
+## Vertical Slices
+
+### Slice 1: Create feature branch
+- Create `feat/worktrain-system-prompt-and-report-issue` from current main
+- Verify clean state
+
+### Slice 2: Add IssueReportedEvent to daemon-events.ts
+- Add `IssueReportedEvent` interface
+- Add to `DaemonEvent` union
+- Verify TS compiles
+
+### Slice 3: Replace buildSystemPrompt() preamble
+- Define `BASE_SYSTEM_PROMPT` constant above `buildSystemPrompt()`
+- Replace lines 1087-1108 to use the constant
+- Verify all existing system-prompt tests pass
+
+### Slice 4: Implement makeReportIssueTool
+- Add private `appendIssueAsync()` helper
+- Add `makeReportIssueTool()` factory
+- Wire into `runWorkflow()` tools array
+
+### Slice 5: Tests
+- Add tests for `makeReportIssueTool` -- verify JSONL write with temp dir, verify event emitted, verify return strings, verify fatal vs non-fatal
+- Verify all existing tests still pass
+
+### Slice 6: Build + full test run
+- `npm run build` -- zero errors
+- `npx vitest run` -- all pass
+
+### Slice 7: PR
+- Commit with conventional commit message
+- Open PR to main
+
+---
+
+## Test Design
+
+### Existing tests (must pass unchanged)
+- `tests/unit/workflow-runner-system-prompt.test.ts` -- all 11 tests
+- `tests/unit/daemon-events.test.ts` -- all existing tests
+
+### New tests to add
+File: `tests/unit/workflow-runner-report-issue.test.ts`
+
+Test cases:
+1. `makeReportIssueTool` -- returns correct tool name and description
+2. `execute()` with non-fatal severity -- returns confirmation string with severity
+3. `execute()` with fatal severity -- returns FATAL message
+4. `execute()` -- writes JSON line to issuesDirOverride/<sessionId>.jsonl
+5. `execute()` -- written JSON contains kind, severity, summary, ts, sessionId
+6. `execute()` -- creates dir if it doesn't exist (mkdir recursive)
+7. `execute()` -- emits `issue_reported` event via emitter
+8. `execute()` -- optional fields (context, toolName, command, suggestedFix, continueToken) present in JSON when provided
+9. `execute()` -- does not throw when write fails (fire-and-forget)
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| BASE_SYSTEM_PROMPT missing required test strings | Low | High (CI break) | Include `'You are WorkRail Auto'`, `'## Your tools'`, `'## Execution contract'` explicitly; tests catch immediately |
+| IssueReportedEvent `issueKind` vs tool input `kind` confusion | Low | Medium (runtime behavior ok, TS shape wrong) | Use `issueKind` in event interface; keep `kind` in input schema |
+| Silent JSONL write failure not caught in tests | Low | Low (fire-and-forget is intentional) | issuesDirOverride isolates write path; test case #9 verifies no throw |
+| Agent ignores fatal severity | Medium | Medium (tokens wasted) | Out of scope; coordinator detects post-hoc |
+
+---
+
+## PR Packaging Strategy
+
+Single PR: `feat/worktrain-system-prompt-and-report-issue`
+- All 3 files changed: `src/daemon/workflow-runner.ts`, `src/daemon/daemon-events.ts`, `tests/unit/workflow-runner-report-issue.test.ts`
+- Commit message: `feat(console): richer daemon system prompt and report_issue tool`
+
+Wait -- scope is `daemon`, not `console`. Correct commit message:
+`feat(mcp): richer daemon system prompt and report_issue tool for auto-fix coordinator`
+
+Actually these are daemon changes. The allowed scopes from CLAUDE.md are: `console`, `mcp`, `workflows`, `engine`, `schema`, `docs`. The daemon lives under `mcp` in this codebase (daemon is part of the WorkRail server). Use scope `mcp`.
+
+---
+
+## Philosophy Alignment Per Slice
+
+### Slice 2 (daemon-events.ts)
+- Exhaustiveness everywhere -> satisfied (new union variant, TS enforces handling)
+- Make illegal states unrepresentable -> satisfied (literal unions for issueKind/severity)
+- Immutability by default -> satisfied (readonly fields)
+
+### Slice 3 (BASE_SYSTEM_PROMPT)
+- Functional core, imperative shell -> satisfied (buildSystemPrompt remains pure)
+- Immutability by default -> satisfied (const)
+- Document why not what -> satisfied (JSDoc on constant)
+- YAGNI with discipline -> satisfied (no speculative additions)
+
+### Slice 4 (makeReportIssueTool)
+- Observability as a constraint -> satisfied (fire-and-forget, never blocks)
+- Errors are data -> satisfied (execute() returns AgentToolResult, never throws)
+- Prefer fakes over mocks -> satisfied (issuesDirOverride for tests)
+- YAGNI with discipline -> satisfied (no IssueStore class)
+- Exhaustiveness everywhere -> satisfied (return value handles all severity levels)
+
+### Slice 5 (tests)
+- Prefer fakes over mocks -> satisfied (temp dir, no fs mocking)
+- Determinism -> satisfied (all test writes go to unique temp dirs)
+
+---
+
+## Summary
+
+- `estimatedPRCount`: 1
+- `planConfidenceBand`: High
+- `unresolvedUnknownCount`: 0
+- `followUpTickets`: Extract IssueStore class when auto-fix coordinator is built

--- a/docs/design/worktrain-system-prompt-report-issue-candidates.md
+++ b/docs/design/worktrain-system-prompt-report-issue-candidates.md
@@ -1,0 +1,135 @@
+# WorkTrain: System Prompt Preamble + report_issue Tool -- Design Candidates
+
+## Problem Understanding
+
+### Core Tensions
+
+1. **Preamble richness vs. existing test assertions** -- The current `buildSystemPrompt()` preamble is ~15 lines (identity, tools, execution contract, session state). The new spec replaces it with ~55 lines covering oracle hierarchy, self-directed reasoning, workflow-as-contract, silent failure, and tools-as-hands. The existing tests assert specific strings (`'You are WorkRail Auto'`, `'## Your tools'`, `'## Execution contract'`) must be present. The new content must include those strings or the tests break.
+
+2. **report_issue write durability vs. fire-and-forget contract** -- The JSONL file must be written reliably enough for a future coordinator to read it, but a disk-full or permission error must never interrupt the agent session. Resolution: same void+catch pattern as `DaemonEventEmitter`.
+
+3. **Purity of buildSystemPrompt vs. tool name references in prose** -- The new preamble mentions `report_issue` by name in the "silent failure" section. If the tool name ever changes, the system prompt text becomes stale. This is an accepted documentation-drift risk; tool names are stable identifiers.
+
+4. **YAGNI (no coordinator yet) vs. extractability (coordinator coming soon)** -- The auto-fix coordinator that will read the issue JSONL doesn't exist. Building a dedicated `IssueStore` class now is speculative. However, the file write must still work for the coordinator when it arrives.
+
+### Likely Seam
+
+- **Preamble:** `buildSystemPrompt()` lines 1086-1108 in `src/daemon/workflow-runner.ts`. This is the correct seam -- pure function, all callers go through it.
+- **report_issue tool:** The tools array in `runWorkflow()` at lines 1318-1323. New tool factory `makeReportIssueTool()` slots in here.
+- **DaemonEvent union:** `src/daemon/daemon-events.ts` -- add `IssueReportedEvent` + extend union.
+
+### What Makes This Hard
+
+- Existing test assertions constrain the new preamble content -- `'## Your tools'` and `'## Execution contract'` must survive the rewrite.
+- `report_issue.execute()` must be fire-and-forget for the JSONL write. Junior devs would `await` it directly and let I/O errors propagate.
+- `IssueReportedEvent` fields must be typed as literal union strings (not `string`), otherwise illegal kind/severity values are representable at compile time.
+
+---
+
+## Philosophy Constraints
+
+From `/Users/etienneb/CLAUDE.md` and `~/.workrail/daemon-soul.md`:
+
+- **Exhaustiveness everywhere** -- `DaemonEvent` must remain a discriminated union; new variant must follow the pattern
+- **Make illegal states unrepresentable** -- `kind` and `severity` on IssueReportedEvent must be literal unions, not strings
+- **YAGNI with discipline** -- don't build IssueStore class until the coordinator needs it
+- **Observability as a constraint** -- fire-and-forget writes must never block correctness
+- **Document 'why' not 'what'** -- JSDoc on BASE_SYSTEM_PROMPT explaining why it's a constant
+- **Immutability by default** -- all DaemonEvent interfaces use `readonly` fields
+- **Functional core, imperative shell** -- buildSystemPrompt is pure; JSONL write is at the shell boundary
+
+---
+
+## Impact Surface
+
+- `tests/unit/workflow-runner-system-prompt.test.ts` -- 3 assertions on preamble content that must pass after rewrite
+- `tests/unit/daemon-events.test.ts` -- existing event tests; adding a new event kind must not break exhaustiveness checks
+- Any future TypeScript code that does `switch (event.kind)` on `DaemonEvent` -- must handle `'issue_reported'` or get a compile error (desired)
+- `runWorkflow()` tools array -- adding `makeReportIssueTool` here; `sessionId` and `emitter` are already in scope
+- The `BASE_SYSTEM_PROMPT` constant mentions the tool by name -- documentation drift if tool is renamed later
+
+---
+
+## Candidates
+
+### Part 1: New Preamble
+
+#### Candidate A -- Inline replacement (no constant)
+- **Summary:** Replace the 4-item preamble lines directly in the `lines` array inside `buildSystemPrompt()`.
+- **Tensions resolved:** Existing tests still pass (required strings included). **Accepted:** Preamble not readable in isolation; harder to document with JSDoc.
+- **Boundary:** Inside `buildSystemPrompt()`, same as today.
+- **Failure mode:** If session state tag position shifts, tests break. Manageable.
+- **Repo pattern:** Departs -- existing code has no named constant but the soul-template.ts extraction is a precedent.
+- **Gains:** No indirection. **Losses:** Not visible as a document; can't be verified without calling buildSystemPrompt.
+- **Scope:** Too narrow.
+
+#### Candidate B -- Named `BASE_SYSTEM_PROMPT` constant (recommended)
+- **Summary:** Extract the static preamble into `export const BASE_SYSTEM_PROMPT: string` defined above `buildSystemPrompt()`. The function uses it as the first element of the lines array. JSDoc explains why it's a constant vs inline.
+- **Tensions resolved:** Preamble visible as a document; existing test assertions pass; honors 'Document why not what'.
+- **Accepted:** Slight indirection; tool name drift risk (prose mentions `report_issue`).
+- **Boundary:** Module-scoped constant, not exported (callers use `buildSystemPrompt`). Dynamic content (session state, soul, workspace) remains in the function.
+- **Failure mode:** If a future author edits `BASE_SYSTEM_PROMPT` and removes `'## Your tools'` or `'## Execution contract'`, tests catch it immediately.
+- **Repo pattern:** Follows soul-template.ts precedent (constant for stable content, function for dynamic assembly).
+- **Gains:** Readable, documentable, testable in isolation. **Losses:** None significant.
+- **Scope:** Best-fit.
+- **Philosophy:** Honors 'Immutability by default' (const), 'Document why not what' (JSDoc), 'Determinism' (pure function unchanged).
+
+---
+
+### Part 2: report_issue Tool
+
+#### Candidate A -- Inline tool factory with private async helper (recommended)
+- **Summary:** `makeReportIssueTool(sessionId: string, emitter?: DaemonEventEmitter): AgentTool` -- custom inline JSON schema (no schemas param), `execute()` fires a void Promise for the JSONL write (same pattern as DaemonEventEmitter), emits `issue_reported` event, returns string confirmation. A module-level private `appendIssueAsync()` function handles the actual fs writes to keep execute() clean.
+- **Tensions resolved:** Fire-and-forget (never blocks), type-safe kind/severity, YAGNI (no IssueStore class), natural tool-factory shape.
+- **Accepted:** Less isolated unit-testability for the JSONL write path (no dirOverride). Extractable later.
+- **Boundary:** Tool factory in `workflow-runner.ts` alongside make*Tool siblings. Private helper in same file.
+- **Failure mode:** JSONL write fails silently. Accepted -- same contract as DaemonEventEmitter.
+- **Repo pattern:** Follows tool factory pattern exactly (name, description, inputSchema, label, execute).
+- **Gains:** Simple, correct, consistent with existing code. **Losses:** JSONL write not unit-testable in isolation today.
+- **Scope:** Best-fit.
+- **Philosophy:** Honors 'YAGNI with discipline', 'Exhaustiveness everywhere' (literal unions), 'Make illegal states unrepresentable', 'Observability as a constraint'.
+
+#### Candidate B -- Dedicated `IssueStore` class (parallel to DaemonEventEmitter)
+- **Summary:** Extract a class `IssueStore` with `append(sessionId, issue)` and `dirOverride` for tests. Injected into `makeReportIssueTool`. Separate file or same file.
+- **Tensions resolved:** Full unit-testability with dirOverride, separation of concerns.
+- **Accepted:** Over-engineering for current scope (coordinator doesn't exist). YAGNI violated.
+- **Boundary:** New abstraction layer. Only one caller today.
+- **Failure mode:** Premature abstraction; adds complexity with no current benefit.
+- **Repo pattern:** Matches DaemonEventEmitter exactly -- but DaemonEventEmitter was built when multiple callers needed it immediately.
+- **Gains:** Testable in isolation, clean interface for future coordinator. **Losses:** Speculative complexity today.
+- **Scope:** Too broad (no coordinator in this PR).
+- **Philosophy:** Conflicts with 'YAGNI with discipline'. Honors 'Prefer fakes over mocks'.
+
+---
+
+## Comparison and Recommendation
+
+### Part 1
+Candidate B (BASE_SYSTEM_PROMPT constant) dominates on every axis. Not a close call.
+
+### Part 2
+Candidate A (inline tool factory) wins on YAGNI. The only real loss is JSONL write isolation in tests -- acceptable since the write is purely observational (fire-and-forget), not correctness-affecting.
+
+**If the auto-fix coordinator were being built in this PR**, Candidate B would be justified. It isn't.
+
+---
+
+## Self-Critique
+
+### Part 1 strongest counter-argument
+'The constant is 55 lines and clutters the file.' Counter: it's in a clearly labeled `## System prompt` section. A 55-line constant is readable. The alternative (55 lines of array items with string literals) is worse. Not a real objection.
+
+### Part 2 strongest counter-argument
+'DaemonEventEmitter is a class -- to be consistent, IssueStore should also be a class.' True in the abstract. But DaemonEventEmitter was built when the event stream was a first-class concern. Issue recording is secondary observability for a future feature. The consistency argument applies when there are multiple callers, not one.
+
+### Pivot conditions
+- **Part 2:** If the coordinator PR is planned for this sprint, extract IssueStore now to save rework later.
+- **Part 1:** If the BASE_SYSTEM_PROMPT constant is exported and used in tests directly, add it to the test file's import.
+
+---
+
+## Open Questions for the Main Agent
+
+1. Should `BASE_SYSTEM_PROMPT` be exported (for tests to import directly) or left module-private? Current test assertions only check the output of `buildSystemPrompt()`, so private is sufficient.
+2. Should `IssueReportedEvent` include `continueToken` (for coordinator to resume)? The spec says optional -- include it as `readonly continueToken?: string`.
+3. The new preamble's `## Your tools` section should list `report_issue` -- does it also list `Bash`, `Read`, `Write`, `continue_workflow`? Yes, for completeness.

--- a/docs/design/worktrain-system-prompt-report-issue-design-review.md
+++ b/docs/design/worktrain-system-prompt-report-issue-design-review.md
@@ -1,0 +1,73 @@
+# WorkTrain: System Prompt Preamble + report_issue Tool -- Design Review Findings
+
+## Tradeoff Review
+
+| Tradeoff | Assessment |
+|---|---|
+| Tool name drift: preamble prose mentions `report_issue` | Acceptable. Prose is guidance, not tool registration. Agent uses the tools array. |
+| JSONL write not unit-testable in isolation | **Resolved** by adding `issuesDirOverride?: string` to `makeReportIssueTool`. |
+| No IssueStore class (YAGNI) | Acceptable. Coordinator doesn't exist in this PR. Extractable later. |
+| Fatal severity doesn't abort the loop | Accepted limitation. Tool returns instructional text. Agent is told to stop. Recording the issue is the priority. |
+
+---
+
+## Failure Mode Review
+
+| Failure Mode | Handling | Risk |
+|---|---|---|
+| Missing issues dir | `mkdir recursive` before appendFile (DaemonEventEmitter pattern) | Low |
+| Preamble loses required test strings | Caught immediately by existing vitest assertions | Low (self-healing) |
+| Agent ignores fatal severity and continues | Instructional return value. Can't force stop from inside tool without violating 'errors are data'. | Medium (accepted) |
+| sessionId is process-local UUID not server ID | Consistent with all other tools in this file. Coordinator correlates via sessionId. | Low |
+
+---
+
+## Runner-Up / Simpler Alternative Review
+
+**Part 1:** Inline preamble (runner-up) offers no advantages over the named constant. Candidate B dominates.
+
+**Part 2:** IssueStore class (runner-up) offers `dirOverride` for isolated testing. A hybrid was adopted: add `issuesDirOverride?: string` parameter to `makeReportIssueTool` without extracting a full class. This resolves the testability weakness at negligible complexity cost.
+
+**Simpler alternative (no dirOverride):** Technically satisfies acceptance criteria. Rejected because it violates 'prefer fakes over mocks' and departs from the established DaemonEventEmitter precedent for no benefit.
+
+---
+
+## Philosophy Alignment
+
+| Principle | Status |
+|---|---|
+| Immutability by default | Satisfied: `const BASE_SYSTEM_PROMPT`; readonly IssueReportedEvent fields |
+| Make illegal states unrepresentable | Satisfied: `kind` and `severity` are literal union types |
+| Exhaustiveness everywhere | Satisfied: new DaemonEvent variant triggers TS compile error on unhandled switch |
+| Errors are data | Satisfied: report_issue returns string confirmation, never throws |
+| YAGNI with discipline | Satisfied: no IssueStore class |
+| Observability as a constraint | Satisfied: fire-and-forget, never blocks correctness |
+| Prefer fakes over mocks | Satisfied (after hybrid): issuesDirOverride allows temp-dir testing |
+| Document why not what | Satisfied: JSDoc on BASE_SYSTEM_PROMPT constant; WHY comments on void+catch |
+
+---
+
+## Findings
+
+### Yellow (low-risk, note for implementer)
+
+**Y1:** `BASE_SYSTEM_PROMPT` must include `'You are WorkRail Auto'`, `'## Your tools'`, and `'## Execution contract'` to preserve existing test assertions. The implementer must verify these strings survive the rewrite verbatim.
+
+**Y2:** The new preamble's `## Your tools` section should list all 5 tools: `continue_workflow`, `Bash`, `Read`, `Write`, `report_issue`. If any tool is added/removed in the future, the preamble prose becomes stale. Accepted documentation-drift risk.
+
+**Y3:** The `issuesDirOverride` parameter changes the signature of `makeReportIssueTool`. Wire it through `runWorkflow()` with `undefined` (production path). A test for the file write path should be added to `tests/unit/`.
+
+---
+
+## Recommended Revisions
+
+1. **Add `issuesDirOverride?: string` to `makeReportIssueTool`** -- adopt the hybrid over inline-only. (Already decided above.)
+2. **Use `void appendIssueAsync(...).catch(() => {})` idiom** -- identical to DaemonEventEmitter._append; don't await.
+3. **IssueReportedEvent fields:** Use `readonly` on all fields; `issueKind` not `kind` for the payload (since `kind` is the discriminant `'issue_reported'`). Wait -- looking at the spec: the tool's input schema field is `kind` (the issue type), but the event discriminant is also `kind: 'issue_reported'`. Rename the payload field to `issueKind` in `IssueReportedEvent` to avoid shadowing, while keeping the JSON input schema field as `kind` (per spec).
+
+---
+
+## Residual Concerns
+
+- **Fatal severity + agent continuation:** The design cannot enforce stopping. This is a known limitation of the instruction-based approach. The coordinator will need to detect "fatal issue recorded, then agent continued for N more steps" and flag it. Out of scope for this PR.
+- **Issue file format:** The spec says 'JSON line' but doesn't specify the schema. The implementer should include all input fields plus `ts: Date.now()` and `sessionId` for correlation -- consistent with how daemon events are written.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4117,3 +4117,62 @@ Different tasks need different cognitive profiles. A subagent type bundles: syst
 The type determines the system prompt variant, not just the tools. A `challenger` gets a system prompt that explicitly says "your job is to find problems, not solve them -- do not offer solutions." A `verifier` gets "do not trust claims without running the commands yourself."
 
 This is the WorkTrain equivalent of cognitive specialization -- different agents for different modes of thought, not just different tasks. The workflow step can specify which subagent type to spawn: `spawn_session({ type: 'challenger', goal: '...' })`.
+
+---
+
+### Workflow-scoped system prompts for subagents (Apr 17, 2026)
+
+**The idea:** Workflows (and individual steps within them) can declare a `systemPrompt` field that gets injected into subagent sessions spawned by that workflow step. The workflow author encodes the cognitive mode directly rather than describing it in step prose that the agent has to interpret.
+
+**Why this is the right layer:**
+The workflow already controls: what steps run, what tools are available, what the output contract is, what assessments are required. The cognitive mode -- how the agent should think -- is a natural extension of that. A workflow that says "run as adversarial challenger" should be able to enforce that at the platform level, not just suggest it in a prompt.
+
+**Two levels:**
+
+**1. Workflow-level `systemPrompt`** -- applies to all subagents spawned by this workflow:
+```json
+{
+  "id": "mr-review-workflow.agentic.v2",
+  "systemPrompt": "You are an adversarial code reviewer. Your job is to find problems, not validate the approach. Do not offer solutions -- only surface issues with evidence. Treat every claim as unproven until you verify it yourself.",
+  "steps": [...]
+}
+```
+
+**2. Step-level `systemPrompt`** -- overrides the workflow-level prompt for a specific step:
+```json
+{
+  "id": "phase-hypothesis-challenge",
+  "systemPrompt": "You are a devil's advocate. For every assumption in the hypothesis, find the strongest counterargument. Do not be balanced -- be adversarial.",
+  "prompt": "Challenge the leading hypothesis..."
+}
+```
+
+**How it composes with the base system prompt:**
+The final subagent system prompt is assembled in layers:
+1. WorkTrain base prompt (execution contract, oracle priority, tools)
+2. Workflow-level `systemPrompt` (cognitive mode for this workflow)
+3. Step-level `systemPrompt` (cognitive override for this step)
+4. Soul file (operator behavioral rules)
+5. AGENTS.md / workspace context
+6. Session knowledge log (inherited context, if `context: 'inherit'`)
+7. Step prompt (the actual work instruction)
+
+The workflow author controls layers 2-3. The operator controls layer 4. The platform assembles 1 and 5-7 automatically. Clear separation of concerns.
+
+**This also enables the subagent type system** (from the previous backlog entry) to be workflow-driven rather than call-site-driven. Instead of `spawn_session({ type: 'challenger' })`, the workflow step that spawns a challenger simply declares `systemPrompt: "you are adversarial..."` -- the cognitive mode travels with the workflow definition, not the spawn call.
+
+**Schema addition:**
+```typescript
+interface WorkflowDefinition {
+  systemPrompt?: string;  // workflow-level, injected into all subagent sessions
+  steps: WorkflowStep[];
+}
+
+interface WorkflowStep {
+  systemPrompt?: string;  // step-level, overrides workflow-level for this step
+  prompt: string;
+  // ...existing fields
+}
+```
+
+**Authoring implication:** The `workflow-for-workflows` meta-workflow should guide authors to write cognitive mode as `systemPrompt` rather than embedding it in `prompt` prose. "What mode should the agent be in?" is a structural question, not a content question.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4029,3 +4029,51 @@ worktrain logs --format json            # machine-readable for scripts
 3. `worktrain logs` CLI commands (reads files, correlates by sessionId)
 4. SSE extension in DaemonConsole for live event streaming
 5. Coordinator script subscription to event streams (replaces polling session store)
+
+---
+
+### Subagent context packaging: the main agent assumes too much (Apr 17, 2026)
+
+**The problem:** When a main agent spawns a subagent, the work package it creates is usually too thin. The main agent has rich context from the full conversation -- why this task matters, what was already tried, what constraints were discovered -- but it packages the subagent task as if that context is shared. The subagent gets a one-liner and has to rediscover everything from scratch.
+
+This is the same problem as a developer handing a junior a vague JIRA ticket instead of a proper brief. The subagent wastes tokens re-deriving what the main agent already knows, or worse, makes wrong assumptions.
+
+**Where this manifests:**
+- Coding task subagents that don't know why a specific approach was chosen
+- MR review subagents that don't know what invariants matter for this codebase
+- Discovery subagents that re-read files the main agent just read
+- Fix subagents that don't know what was already tried and failed
+
+**Three solution directions:**
+
+**Option A: Better instructions to the main agent (prompt engineering)**
+Add explicit guidance to the WorkTrain system prompt: "When spawning a subagent, include: (1) what you already know that the subagent won't, (2) what was already tried, (3) why this specific approach was chosen, (4) what constraints or invariants matter, (5) what 'done' looks like." This is the cheapest fix but depends on the main agent reliably following it.
+
+**Option B: Platform-assisted package creation (structured)**
+The `worktrain spawn` command (or the `spawn_session` tool) takes a structured work package:
+```typescript
+spawnSession({
+  workflowId: 'coding-task-workflow-agentic',
+  goal: '...',
+  context: {
+    whyThisApproach: '...',        // what the main agent knows about the decision
+    alreadyTried: [...],           // what failed
+    knownConstraints: [...],       // invariants the subagent must respect
+    relevantFiles: [...],          // files the main agent already read
+    completionCriteria: '...'      // what done actually looks like
+  }
+})
+```
+The platform validates that the package is complete before spawning -- missing fields emit a warning or block the spawn. The subagent's system prompt is enriched with this context automatically, without the main agent having to think about how to format it.
+
+**Option C: Platform-mediated context transfer (autonomous)**
+The platform automatically packages context from the spawning session into the child session. When the main agent calls `spawn_session`, the platform reads the current session's step notes and recent advances, synthesizes a context bundle, and injects it into the child's system prompt. No explicit packaging required from the main agent.
+
+This is the most powerful but also the most complex -- requires the platform to understand what's relevant, not just what's recent.
+
+**Recommended approach: B + A**
+Option B (structured work package with validation) as the primary mechanism. Option A (better main agent instructions) as a fallback. Option C as a long-term goal once the knowledge graph and session event stream are queryable enough to synthesize context automatically.
+
+**The `context` field in the structured package is the key addition.** Today `worktrain spawn` takes `goal`, `workflowId`, `workspacePath`. Adding a structured `context` object that the platform validates and injects gives subagents the brief they need without depending on the main agent to remember to include it.
+
+**Connection to knowledge graph:** Once the structural knowledge graph is built, `relevantFiles` can be auto-populated from a graph query rather than requiring the main agent to list them. The platform asks "what files are relevant to this goal?" and includes them automatically. This is how the context packaging problem gets solved at scale -- the platform knows what the subagent needs without the main agent having to enumerate it.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4077,3 +4077,43 @@ Option B (structured work package with validation) as the primary mechanism. Opt
 **The `context` field in the structured package is the key addition.** Today `worktrain spawn` takes `goal`, `workflowId`, `workspacePath`. Adding a structured `context` object that the platform validates and injects gives subagents the brief they need without depending on the main agent to remember to include it.
 
 **Connection to knowledge graph:** Once the structural knowledge graph is built, `relevantFiles` can be auto-populated from a graph query rather than requiring the main agent to list them. The platform asks "what files are relevant to this goal?" and includes them automatically. This is how the context packaging problem gets solved at scale -- the platform knows what the subagent needs without the main agent having to enumerate it.
+
+**Session knowledge log (extends Option B):**
+As the main agent progresses, it continuously appends to a structured `session-knowledge.jsonl` for the session. Not step notes (those are workflow artifacts) -- this is a running record of things that would matter to any agent picking up this work:
+
+```jsonl
+{"kind":"decision","summary":"Using execFile not exec for all subprocess calls","reason":"Shell injection risk with user-controlled content","ts":1234567890}
+{"kind":"user_pushback","summary":"User rejected the polling approach","detail":"Wants webhook-based solution instead","ts":...}
+{"kind":"relevant_file","path":"src/trigger/trigger-router.ts","why":"Core routing logic, all trigger changes flow through here","ts":...}
+{"kind":"constraint","summary":"Never modify triggers.yml autonomously","source":"daemon-soul.md","ts":...}
+{"kind":"tried_and_failed","summary":"Tried npx approach, got version mismatch","detail":"Local build is different from installed package","ts":...}
+{"kind":"external_ref","url":"https://github.com/...","why":"Design doc for the delivery pattern","ts":...}
+{"kind":"plan","path":"implementation_plan.md","summary":"3-slice plan for the feature","ts":...}
+```
+
+When spawning a subagent, the platform automatically includes the session knowledge log in the work package. The subagent gets the full brief without the main agent having to reconstruct it.
+
+**Blank subagents (intentionally uncontextualized):**
+Sometimes you explicitly DON'T want context from the main session -- fresh eyes are the point. A hypothesis challenge subagent should challenge the leading hypothesis, not be anchored to it. An adversarial reviewer should find problems without knowing the main agent thinks the approach is sound.
+
+The `spawn_session` call should have an explicit `context: 'inherit' | 'blank' | 'custom'` field:
+- `inherit` -- auto-package from session knowledge log (default for most tasks)
+- `blank` -- no session context injected, subagent starts fresh (for adversarial roles)
+- `custom` -- explicit structured package (for precise control)
+
+**Subagent types with specialized system prompts and tools:**
+
+Different tasks need different cognitive profiles. A subagent type bundles: system prompt, available tools, and context mode:
+
+| Type | System prompt focus | Tools | Context |
+|------|---------------------|-------|---------|
+| `researcher` | Thorough, neutral, evidence-first | Read, Bash (read-only), Glob, Grep | inherit |
+| `challenger` | Adversarial, finds holes, challenges assumptions | Read, Bash | blank (intentionally unanchored) |
+| `implementer` | Precise, follows plans, no improvisation | Read, Write, Bash, continue_workflow | inherit |
+| `reviewer` | Finds bugs, security issues, philosophy violations | Read, Bash | blank |
+| `verifier` | Confirms claims with evidence, runs commands | Read, Bash | inherit |
+| `coordinator` | Routes work, reads event streams, dispatches | worktrain_spawn, worktrain_await | inherit |
+
+The type determines the system prompt variant, not just the tools. A `challenger` gets a system prompt that explicitly says "your job is to find problems, not solve them -- do not offer solutions." A `verifier` gets "do not trust claims without running the commands yourself."
+
+This is the WorkTrain equivalent of cognitive specialization -- different agents for different modes of thought, not just different tasks. The workflow step can specify which subagent type to spawn: `spawn_session({ type: 'challenger', goal: '...' })`.

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -100,6 +100,23 @@ export interface DeliveryAttemptedEvent {
 }
 
 /**
+ * An agent called report_issue to record a structured issue for the auto-fix coordinator.
+ *
+ * WHY issueKind not kind: `kind` is the union discriminant ('issue_reported'); the
+ * payload field that describes the category of the reported issue is named `issueKind`
+ * to avoid shadowing the discriminant in the interface.
+ */
+export interface IssueReportedEvent {
+  readonly kind: 'issue_reported';
+  readonly sessionId: string;
+  readonly issueKind: 'tool_failure' | 'blocked' | 'unexpected_behavior' | 'needs_human' | 'self_correction';
+  readonly severity: 'info' | 'warn' | 'error' | 'fatal';
+  readonly summary: string;
+  /** Current continueToken, if the agent provided it (enables coordinator resumption). */
+  readonly continueToken?: string;
+}
+
+/**
  * Union of all daemon lifecycle events.
  *
  * Each member has a `kind` discriminant so switch exhaustiveness is enforced
@@ -114,7 +131,8 @@ export type DaemonEvent =
   | ToolErrorEvent
   | StepAdvancedEvent
   | SessionCompletedEvent
-  | DeliveryAttemptedEvent;
+  | DeliveryAttemptedEvent
+  | IssueReportedEvent;
 
 // ---------------------------------------------------------------------------
 // DaemonEventEmitter

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -1032,8 +1032,221 @@ function makeWriteTool(schemas: Record<string, any>, sessionId?: string, emitter
 }
 
 // ---------------------------------------------------------------------------
+// report_issue tool
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a single JSON issue record to the per-session JSONL file.
+ *
+ * WHY void + catch: issue recording is purely observational. A failed write
+ * (disk full, permission denied) must not propagate to the caller or interrupt
+ * the workflow session. Same fire-and-forget contract as DaemonEventEmitter.
+ *
+ * WHY separate helper: keeps execute() synchronous from the caller's perspective
+ * and makes the async write path independently testable via issuesDirOverride.
+ *
+ * @param issuesDir - Directory for issue files (override in tests; production uses ~/.workrail/issues).
+ * @param sessionId - Session identifier used as the filename.
+ * @param record - The issue payload to serialize as a JSON line.
+ */
+async function appendIssueAsync(
+  issuesDir: string,
+  sessionId: string,
+  record: IssueRecord,
+): Promise<void> {
+  await fs.mkdir(issuesDir, { recursive: true });
+  const filePath = path.join(issuesDir, `${sessionId}.jsonl`);
+  const line = JSON.stringify({ ...record, ts: Date.now() }) + '\n';
+  await fs.appendFile(filePath, line, 'utf8');
+}
+
+/** Input record shape for a report_issue call (before ts is appended). */
+interface IssueRecord {
+  sessionId: string;
+  kind: 'tool_failure' | 'blocked' | 'unexpected_behavior' | 'needs_human' | 'self_correction';
+  severity: 'info' | 'warn' | 'error' | 'fatal';
+  summary: string;
+  context?: string;
+  toolName?: string;
+  command?: string;
+  suggestedFix?: string;
+  continueToken?: string;
+}
+
+/**
+ * Build the report_issue tool.
+ *
+ * Agents call this to record a structured issue for the auto-fix coordinator.
+ * The tool does NOT stop the session -- it creates a record and returns a
+ * confirmation. For fatal severity, the return value instructs the agent to call
+ * continue_workflow with a blocker note, after which the session ends.
+ *
+ * @param sessionId - The process-local session UUID (keys the issues file).
+ * @param emitter - Optional event emitter to fire an issue_reported event.
+ * @param issuesDirOverride - Override the issues directory (for tests).
+ */
+export function makeReportIssueTool(
+  sessionId: string,
+  emitter?: DaemonEventEmitter,
+  issuesDirOverride?: string,
+): AgentTool {
+  const issuesDir = issuesDirOverride ?? path.join(os.homedir(), '.workrail', 'issues');
+
+  return {
+    name: 'report_issue',
+    description:
+      "Record a structured issue, error, or unexpected behavior. Call this AND continue_workflow (unless fatal). " +
+      "Does not stop the session -- it creates a record for the auto-fix coordinator.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        kind: {
+          type: 'string',
+          enum: ['tool_failure', 'blocked', 'unexpected_behavior', 'needs_human', 'self_correction'],
+          description: 'Category of issue being reported.',
+        },
+        severity: {
+          type: 'string',
+          enum: ['info', 'warn', 'error', 'fatal'],
+          description: 'Severity level. Fatal means the session cannot continue productively.',
+        },
+        summary: {
+          type: 'string',
+          description: 'One-line summary of the issue. Max 200 chars.',
+          maxLength: 200,
+        },
+        context: {
+          type: 'string',
+          description: 'What you were trying to do when this issue occurred.',
+        },
+        toolName: {
+          type: 'string',
+          description: 'Name of the tool that failed or behaved unexpectedly, if applicable.',
+        },
+        command: {
+          type: 'string',
+          description: 'The shell command or expression that caused the issue, if applicable.',
+        },
+        suggestedFix: {
+          type: 'string',
+          description: 'A suggested fix or recovery action for the auto-fix coordinator.',
+        },
+        continueToken: {
+          type: 'string',
+          description: 'The current continueToken, so the coordinator can resume this session.',
+        },
+      },
+      required: ['kind', 'severity', 'summary'],
+      additionalProperties: false,
+    },
+    label: 'report_issue',
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    execute: async (_toolCallId: string, params: any): Promise<AgentToolResult<unknown>> => {
+      const record: IssueRecord = {
+        sessionId,
+        kind: params.kind as IssueRecord['kind'],
+        severity: params.severity as IssueRecord['severity'],
+        summary: String(params.summary ?? '').slice(0, 200),
+        ...(params.context !== undefined && { context: String(params.context) }),
+        ...(params.toolName !== undefined && { toolName: String(params.toolName) }),
+        ...(params.command !== undefined && { command: String(params.command) }),
+        ...(params.suggestedFix !== undefined && { suggestedFix: String(params.suggestedFix) }),
+        ...(params.continueToken !== undefined && { continueToken: String(params.continueToken) }),
+      };
+
+      // Fire-and-forget: write must never block execute() or propagate errors.
+      // WHY void + catch: observability must not affect correctness.
+      void appendIssueAsync(issuesDir, sessionId, record).catch(() => {
+        // Intentionally empty: write failures are silently swallowed.
+      });
+
+      // Emit structured event for console/SSE stream visibility.
+      emitter?.emit({
+        kind: 'issue_reported',
+        sessionId,
+        issueKind: record.kind,
+        severity: record.severity,
+        summary: record.summary,
+        ...(record.continueToken !== undefined && { continueToken: record.continueToken }),
+      });
+
+      const isFatal = record.severity === 'fatal';
+      const message = isFatal
+        ? `FATAL issue recorded. Call continue_workflow with notes explaining the blocker, then the session will end.`
+        : `Issue recorded (severity=${record.severity}). Continue with your work unless this is fatal.`;
+
+      return {
+        content: [{ type: 'text', text: message }],
+        details: { sessionId, kind: record.kind, severity: record.severity },
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // System prompt
 // ---------------------------------------------------------------------------
+
+/**
+ * Static preamble for the daemon agent system prompt.
+ *
+ * WHY a named constant: extracting the preamble makes it readable as a document,
+ * gives it a stable identity for tests, and follows the soul-template.ts precedent
+ * of separating stable content from dynamic assembly. The dynamic parts (session
+ * state, soul, workspace context) are injected by buildSystemPrompt() below.
+ *
+ * WHY these sections: daemon sessions run unattended. The agent has no user to ask.
+ * The preamble replaces that missing human with: an oracle hierarchy, a reasoning
+ * protocol, and explicit contracts for the two failure modes that matter most --
+ * skipping steps and silent failure.
+ */
+const BASE_SYSTEM_PROMPT = `\
+You are WorkRail Auto, an autonomous agent that executes workflows step by step. You are running unattended -- there is no user watching. Your entire job is to faithfully complete the current workflow.
+
+## What you are
+You are highly capable. You handle ambitious, multi-step tasks that require real codebase understanding. You don't hedge, ask for permission, or stop to check in. You work.
+
+## Your oracle (consult in this order when uncertain)
+1. The daemon soul rules (## Agent Rules and Philosophy below)
+2. AGENTS.md / CLAUDE.md in the workspace (injected below under Workspace Context)
+3. The current workflow step's prompt and guidance
+4. Local code patterns in the relevant module (grep the directory, not the whole repo)
+5. Industry best practices -- only when nothing above applies
+
+## Self-directed reasoning
+Ask yourself questions to clarify your approach, then answer them yourself using tools before acting. Never wait for a human to answer -- you are the oracle.
+
+Bad pattern: "I'll analyze both layers." (no justification)
+Good pattern: "Question: Should I check the middleware? Answer: The workflow step says 'trace the full call chain', and the AGENTS.md says the entry point is in the middleware layer. Yes, start there."
+
+## Your tools
+- \`continue_workflow\`: Advance to the next step. Call this after completing each step's work. Always include your notes in notesMarkdown and round-trip the continueToken exactly.
+- \`Bash\`: Run shell commands. Use for building, testing, running scripts.
+- \`Read\`: Read files.
+- \`Write\`: Write files.
+- \`report_issue\`: Record a structured issue, error, or unexpected behavior. Call this AND continue_workflow (unless fatal). Does not stop the session -- it creates a record for the auto-fix coordinator.
+
+## Execution contract
+1. Read the step carefully. Do ALL the work the step asks for.
+2. Call \`continue_workflow\` with your notes. Include the continueToken exactly.
+3. Repeat until the workflow reports it is complete.
+4. Do NOT skip steps. Do NOT call \`continue_workflow\` without completing the step's work.
+
+## The workflow is the contract
+Every step must be fully completed before you call continue_workflow. The workflow step prompt is the specification of what 'done' means -- not a suggestion. Don't advance until the work is actually done.
+
+Your cognitive mode changes per step: some steps make you a researcher, others a reviewer, others an implementer. Adopt the mode the step describes. Don't bring your own agenda.
+
+## Silent failure is the worst outcome
+If something goes wrong: call report_issue, then continue unless severity is 'fatal'. Do NOT silently retry forever, work around failures without noting them, or pretend things worked. The issue record is how the system learns and self-heals.
+
+## Tools are your hands, not your voice
+Don't narrate what you're about to do. Use the tool and report what you found. Token efficiency matters -- you have a wall-clock timeout.
+
+## You don't have a user. You have a workflow and a soul.
+If you're unsure, consult the oracle above. If nothing answers the question, make a reasoned decision, call report_issue with kind='self_correction' to document it, and continue.\
+`;
 
 /**
  * Format prior step notes into a concise session state recap string.
@@ -1084,20 +1297,7 @@ export function buildSystemPrompt(
   workspaceContext: string | null,
 ): string {
   const lines = [
-    'You are WorkRail Auto, an autonomous agent that executes workflows step by step.',
-    '',
-    '## Your tools',
-    '- `continue_workflow`: Advance to the next step. Call this after completing each step\'s work.',
-    '  Always include your notes in notesMarkdown and round-trip the continueToken exactly.',
-    '- `Bash`: Run shell commands. Use for building, testing, running scripts.',
-    '- `Read`: Read files.',
-    '- `Write`: Write files.',
-    '',
-    '## Execution contract',
-    '1. Read the step carefully. Do ALL the work the step asks for.',
-    '2. Call `continue_workflow` with your notes. Include the continueToken exactly.',
-    '3. Repeat until the workflow reports it is complete.',
-    '4. Do NOT skip steps. Do NOT call `continue_workflow` without completing the step\'s work.',
+    BASE_SYSTEM_PROMPT,
     '',
     `<workrail_session_state>${sessionState}</workrail_session_state>`,
     '',
@@ -1320,6 +1520,7 @@ export async function runWorkflow(
     makeBashTool(trigger.workspacePath, schemas, sessionId, emitter),
     makeReadTool(schemas, sessionId, emitter),
     makeWriteTool(schemas, sessionId, emitter),
+    makeReportIssueTool(sessionId, emitter),
   ];
 
   // ---- Context loading (soul + workspace + session notes) ----

--- a/tests/unit/daemon-events.test.ts
+++ b/tests/unit/daemon-events.test.ts
@@ -179,6 +179,7 @@ describe('DaemonEventEmitter', () => {
       { kind: 'step_advanced', sessionId: 's1' },
       { kind: 'session_completed', sessionId: 's1', workflowId: 'w1', outcome: 'success' },
       { kind: 'delivery_attempted', callbackUrl: 'https://example.com', outcome: 'success' },
+      { kind: 'issue_reported', sessionId: 's1', issueKind: 'tool_failure', severity: 'warn', summary: 'test' },
     ];
 
     for (const event of events) {

--- a/tests/unit/workflow-runner-report-issue.test.ts
+++ b/tests/unit/workflow-runner-report-issue.test.ts
@@ -223,6 +223,22 @@ describe('makeReportIssueTool()', () => {
         }),
       ).resolves.not.toThrow();
     });
+
+    it('truncates summary longer than 200 chars to exactly 200 chars', async () => {
+      const longSummary = 'a'.repeat(201);
+      const tool = makeReportIssueTool('sess-abc', undefined, tmpDir);
+      await tool.execute('call-1', {
+        kind: 'tool_failure',
+        severity: 'error',
+        summary: longSummary,
+      });
+
+      await flushAsync();
+
+      const filePath = path.join(tmpDir, 'sess-abc.jsonl');
+      const lines = await readJsonlLines(filePath);
+      expect(lines[0]!['summary']).toBe('a'.repeat(200));
+    });
   });
 
   describe('event emission', () => {

--- a/tests/unit/workflow-runner-report-issue.test.ts
+++ b/tests/unit/workflow-runner-report-issue.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Unit tests for makeReportIssueTool() in workflow-runner.ts.
+ *
+ * Strategy: use issuesDirOverride to write to a temp directory, avoiding any
+ * writes to ~/.workrail. The appendIssueAsync fire-and-forget write is tested
+ * via flushAsync() -- same approach as daemon-events.test.ts.
+ *
+ * WHY no fs mocking: the issuesDirOverride parameter makes the test hermetic
+ * without requiring mocks. This follows the "prefer fakes over mocks" principle.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeReportIssueTool } from '../../src/daemon/workflow-runner.js';
+import { DaemonEventEmitter } from '../../src/daemon/daemon-events.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a unique temp directory for each test. */
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'workrail-report-issue-test-'));
+}
+
+/**
+ * Read all JSONL lines from a file, parsed as objects.
+ * Returns an empty array if the file does not exist.
+ */
+async function readJsonlLines(filePath: string): Promise<Record<string, unknown>[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf8');
+  } catch {
+    return [];
+  }
+  return raw
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+/** Wait for all pending async I/O to flush (same pattern as daemon-events.test.ts). */
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('makeReportIssueTool()', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('tool shape', () => {
+    it('returns a tool with name report_issue', () => {
+      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      expect(tool.name).toBe('report_issue');
+    });
+
+    it('description mentions the auto-fix coordinator', () => {
+      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      expect(tool.description).toContain('auto-fix coordinator');
+    });
+
+    it('input schema requires kind, severity, and summary', () => {
+      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const schema = tool.inputSchema as any;
+      expect(schema.required).toContain('kind');
+      expect(schema.required).toContain('severity');
+      expect(schema.required).toContain('summary');
+    });
+  });
+
+  describe('return values', () => {
+    it('returns non-fatal confirmation for info severity', async () => {
+      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      const result = await tool.execute('call-1', {
+        kind: 'tool_failure',
+        severity: 'info',
+        summary: 'Bash exit code 1 with empty stderr',
+      });
+      expect(result.content[0]?.text).toContain('Issue recorded (severity=info)');
+      expect(result.content[0]?.text).not.toContain('FATAL');
+    });
+
+    it('returns non-fatal confirmation for warn severity', async () => {
+      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      const result = await tool.execute('call-1', {
+        kind: 'blocked',
+        severity: 'warn',
+        summary: 'Could not find expected file',
+      });
+      expect(result.content[0]?.text).toContain('severity=warn');
+    });
+
+    it('returns non-fatal confirmation for error severity', async () => {
+      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      const result = await tool.execute('call-1', {
+        kind: 'unexpected_behavior',
+        severity: 'error',
+        summary: 'Test suite returned exit code 2',
+      });
+      expect(result.content[0]?.text).toContain('severity=error');
+    });
+
+    it('returns FATAL message for fatal severity', async () => {
+      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      const result = await tool.execute('call-1', {
+        kind: 'needs_human',
+        severity: 'fatal',
+        summary: 'Cannot proceed without human decision',
+      });
+      expect(result.content[0]?.text).toContain('FATAL issue recorded');
+      expect(result.content[0]?.text).toContain('continue_workflow');
+    });
+  });
+
+  describe('JSONL write', () => {
+    it('writes a JSON line to <issuesDirOverride>/<sessionId>.jsonl', async () => {
+      const tool = makeReportIssueTool('sess-abc', undefined, tmpDir);
+      await tool.execute('call-1', {
+        kind: 'tool_failure',
+        severity: 'error',
+        summary: 'npm run build failed',
+      });
+
+      await flushAsync();
+
+      const filePath = path.join(tmpDir, 'sess-abc.jsonl');
+      const lines = await readJsonlLines(filePath);
+      expect(lines).toHaveLength(1);
+    });
+
+    it('written JSON contains kind, severity, summary, sessionId, and ts', async () => {
+      const tool = makeReportIssueTool('sess-abc', undefined, tmpDir);
+      await tool.execute('call-1', {
+        kind: 'blocked',
+        severity: 'warn',
+        summary: 'Could not clone repo',
+      });
+
+      await flushAsync();
+
+      const filePath = path.join(tmpDir, 'sess-abc.jsonl');
+      const lines = await readJsonlLines(filePath);
+      const record = lines[0]!;
+
+      expect(record['kind']).toBe('blocked');
+      expect(record['severity']).toBe('warn');
+      expect(record['summary']).toBe('Could not clone repo');
+      expect(record['sessionId']).toBe('sess-abc');
+      expect(typeof record['ts']).toBe('number');
+    });
+
+    it('includes optional fields when provided', async () => {
+      const tool = makeReportIssueTool('sess-abc', undefined, tmpDir);
+      await tool.execute('call-1', {
+        kind: 'tool_failure',
+        severity: 'error',
+        summary: 'Bash failed',
+        context: 'Running npm run test',
+        toolName: 'Bash',
+        command: 'npm run test',
+        suggestedFix: 'Check if node_modules is installed',
+        continueToken: 'ct_abc123',
+      });
+
+      await flushAsync();
+
+      const filePath = path.join(tmpDir, 'sess-abc.jsonl');
+      const lines = await readJsonlLines(filePath);
+      const record = lines[0]!;
+
+      expect(record['context']).toBe('Running npm run test');
+      expect(record['toolName']).toBe('Bash');
+      expect(record['command']).toBe('npm run test');
+      expect(record['suggestedFix']).toBe('Check if node_modules is installed');
+      expect(record['continueToken']).toBe('ct_abc123');
+    });
+
+    it('creates directory if it does not exist', async () => {
+      const nestedDir = path.join(tmpDir, 'issues', 'nested');
+      const tool = makeReportIssueTool('sess-abc', undefined, nestedDir);
+      await tool.execute('call-1', {
+        kind: 'self_correction',
+        severity: 'info',
+        summary: 'Made a reasoned decision without oracle guidance',
+      });
+
+      await flushAsync();
+
+      const files = await fs.readdir(nestedDir);
+      expect(files).toContain('sess-abc.jsonl');
+    });
+
+    it('does not throw when the write fails (fire-and-forget)', async () => {
+      // Use a path where writes will fail: a non-writable location.
+      // We simulate failure by pointing to /dev/null as the directory -- mkdir
+      // on /dev/null will fail because it is not a directory.
+      const badDir = '/dev/null/impossible-path';
+      const tool = makeReportIssueTool('sess-abc', undefined, badDir);
+
+      // Must not throw -- fire-and-forget swallows all write errors.
+      await expect(
+        tool.execute('call-1', {
+          kind: 'tool_failure',
+          severity: 'error',
+          summary: 'Test error',
+        }),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('event emission', () => {
+    it('emits an issue_reported event via the emitter', async () => {
+      const emitter = new DaemonEventEmitter(tmpDir);
+      const emittedEvents: unknown[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const origEmit = emitter.emit.bind(emitter);
+      vi.spyOn(emitter, 'emit').mockImplementation((event) => {
+        emittedEvents.push(event);
+        origEmit(event);
+      });
+
+      const tool = makeReportIssueTool('sess-abc', emitter, tmpDir);
+      await tool.execute('call-1', {
+        kind: 'unexpected_behavior',
+        severity: 'warn',
+        summary: 'Unexpected output from git status',
+      });
+
+      expect(emittedEvents).toHaveLength(1);
+      const event = emittedEvents[0] as Record<string, unknown>;
+      expect(event['kind']).toBe('issue_reported');
+      expect(event['sessionId']).toBe('sess-abc');
+      expect(event['issueKind']).toBe('unexpected_behavior');
+      expect(event['severity']).toBe('warn');
+      expect(event['summary']).toBe('Unexpected output from git status');
+    });
+
+    it('does not emit an event when no emitter is provided', async () => {
+      // If no emitter, no event -- no error should occur.
+      const tool = makeReportIssueTool('sess-abc', undefined, tmpDir);
+      await expect(
+        tool.execute('call-1', {
+          kind: 'self_correction',
+          severity: 'info',
+          summary: 'Made a decision',
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the thin 15-line daemon system prompt preamble with a `BASE_SYSTEM_PROMPT` constant (~55 lines) that bakes in: oracle hierarchy (soul -> workspace context -> step -> local patterns -> best practices), self-directed reasoning protocol, workflow-as-contract rules, and silent-failure guidance
- Adds `makeReportIssueTool()` so daemon agents can record structured issues to `~/.workrail/issues/<sessionId>.jsonl` for a future auto-fix coordinator; emits `issue_reported` event via `DaemonEventEmitter`; fire-and-forget write never blocks session correctness
- Adds `IssueReportedEvent` to the `DaemonEvent` discriminated union with typed `issueKind` and `severity` fields
- 14 new unit tests for `makeReportIssueTool` using temp-dir isolation (no `~/.workrail` writes in tests)

## Test plan

- [ ] `npm run build` passes with zero errors
- [ ] All 16 existing `workflow-runner-system-prompt.test.ts` tests pass (preamble assertions preserved)
- [ ] All 6 `daemon-events.test.ts` tests pass
- [ ] All 14 new `workflow-runner-report-issue.test.ts` tests pass
- [ ] Pre-existing failures in `agent-loop.test.ts` and `perf-fixes.test.ts` confirmed pre-existing (not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)