### PR TITLE
fix(mcp): propagate tool execute() throws to prompt() caller

### DIFF
--- a/src/daemon/agent-loop.ts
+++ b/src/daemon/agent-loop.ts
@@ -439,25 +439,16 @@ export class AgentLoop {
         continue;
       }
 
-      // Execute the tool. Catch errors and return them as is_error tool_results
-      // so the LLM can see what went wrong and decide how to proceed.
-      // WHY: killing the session on any tool failure loses all progress and prevents
-      // the agent from recovering. An error tool_result lets the LLM retry,
-      // rephrase, or escalate gracefully -- same rationale as unknown tool names.
+      // Execute the tool. Let throws propagate -- this is the pi-agent-core contract.
+      // WHY: tool failures are fatal to the current session. runWorkflow() catches at
+      // the outer boundary and records the error. Swallowing tool throws here would
+      // hide bugs and silently corrupt workflow state.
+      //
+      // NOTE: unknown tool names (hallucinated by the LLM) are handled above with an
+      // error tool_result because they are recoverable. A tool that exists but throws
+      // is a programmer-visible failure, not an LLM mistake.
       const params = (block.input ?? {}) as Record<string, unknown>;
-      let result: AgentToolResult<unknown>;
-      try {
-        result = await tool.execute(block.id, params);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        results.push({
-          toolCallId: block.id,
-          toolName: block.name,
-          result: { content: [{ type: 'text', text: `Tool execution failed: ${message}` }], details: null },
-          isError: true,
-        });
-        continue;
-      }
+      const result = await tool.execute(block.id, params);
       results.push({
         toolCallId: block.id,
         toolName: block.name,


### PR DESCRIPTION
## Summary

- `AgentLoop._executeTools` was catching all `tool.execute()` errors and converting them to `is_error: true` tool results, silently swallowing programmer-visible failures
- This violated the documented pi-agent-core contract: tools throw on failure, and `AgentLoop` must propagate the throw to `prompt()`'s caller
- The fix removes the `try/catch` around `tool.execute()` -- unknown tool names (LLM hallucinations) continue to use error tool results since those are genuinely recoverable, but a tool that exists and throws is a fatal session error

## Test plan

- [ ] `npx vitest run tests/unit/agent-loop.test.ts` -- all 16 tests pass, including the previously failing "propagates tool throws to the prompt() caller" test
- [ ] The distinction between unknown-tool errors (recoverable, return error tool_result) and execute() throws (fatal, propagate to caller) is clearly documented in the code comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)