### PR TITLE
fix(console): populate repoRoot on session summaries from observation events

### DIFF
--- a/src/v2/usecases/console-service.ts
+++ b/src/v2/usecases/console-service.ts
@@ -701,6 +701,25 @@ function extractGitBranch(events: readonly DomainEventV1[]): string | null {
   return null;
 }
 
+/**
+ * Extract the repo root path from observation events.
+ *
+ * The repo_root observation is written at session start by the workspace anchor
+ * (LocalWorkspaceAnchorV2). It holds the absolute path to the git repo root so
+ * the console workspace view can group sessions by repo even when no matching
+ * worktree entry exists (e.g. in standalone console mode or when the worktrees
+ * API is slow / unavailable).
+ */
+function extractRepoRoot(events: readonly DomainEventV1[]): string | null {
+  for (const e of events) {
+    if (e.kind !== EVENT_KIND.OBSERVATION_RECORDED) continue;
+    if (e.data.key === 'repo_root') {
+      return e.data.value.value;
+    }
+  }
+  return null;
+}
+
 
 function truncateTitle(text: string, maxLen = 120): string {
   if (text.length <= maxLen) return text;
@@ -747,6 +766,7 @@ function projectSessionSummary(
 
   const sessionTitle = sortedEventsRes.isOk() ? deriveSessionTitle(sortedEventsRes.value) : null;
   const gitBranch = extractGitBranch(events);
+  const repoRoot = extractRepoRoot(events);
 
   // Derive isAutonomous from context_set events. Checks all runs; true if any run has
   // is_autonomous: 'true' in its context. Gracefully degrades to false on projection error.
@@ -779,6 +799,7 @@ function projectSessionSummary(
       hasUnresolvedGaps: false,
       recapSnippet: null,
       gitBranch,
+      repoRoot,
       lastModifiedMs,
       isAutonomous,
       isLive,
@@ -833,6 +854,7 @@ function projectSessionSummary(
     hasUnresolvedGaps,
     recapSnippet,
     gitBranch,
+    repoRoot,
     lastModifiedMs,
     isAutonomous,
     isLive,

--- a/src/v2/usecases/console-types.ts
+++ b/src/v2/usecases/console-types.ts
@@ -36,6 +36,10 @@ export interface ConsoleSessionSummary {
   readonly hasUnresolvedGaps: boolean;
   readonly recapSnippet: string | null;
   readonly gitBranch: string | null;
+  /** Absolute filesystem path to the repo root, derived from the session's repo_root
+   * observation event. Used by the console workspace view to group sessions by repo
+   * when no matching worktree is available (standalone console fallback). */
+  readonly repoRoot: string | null;
   /** Filesystem mtime of the session directory (epoch ms). */
   readonly lastModifiedMs: number;
   /** True when the session was started by the WorkRail autonomous daemon.

--- a/tests/unit/console-service-repo-root.test.ts
+++ b/tests/unit/console-service-repo-root.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for repoRoot extraction in ConsoleService.getSessionList().
+ *
+ * repoRoot: derived from observation_recorded event with key === 'repo_root'.
+ * Durable -- comes from the event log (written by LocalWorkspaceAnchorV2 at
+ * session start). Null when no such observation has been recorded.
+ *
+ * This field is required by the console frontend's joinSessionsAndWorktrees()
+ * to group sessions by repo when no matching worktree is available (standalone
+ * console fallback).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { okAsync } from 'neverthrow';
+import { ConsoleService } from '../../src/v2/usecases/console-service.js';
+import {
+  InMemorySessionEventLogStore,
+  InMemorySnapshotStore,
+  InMemoryPinnedWorkflowStore,
+} from '../fakes/v2/index.js';
+import type { DirectoryListingPortV2, DirEntryWithMtime } from '../../src/v2/ports/directory-listing.port.js';
+import type { DataDirPortV2 } from '../../src/v2/ports/data-dir.port.js';
+import type { DomainEventV1 } from '../../src/v2/durable-core/schemas/session/index.js';
+import type { SessionEventLogReadonlyStorePortV2 } from '../../src/v2/ports/session-event-log-store.port.js';
+import type { SessionId } from '../../src/v2/durable-core/ids/index.js';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+function makeDirectoryListing(entries: readonly DirEntryWithMtime[]): DirectoryListingPortV2 {
+  return {
+    readdir: () => okAsync([]),
+    readdirWithMtime: () => okAsync(entries),
+  };
+}
+
+const stubDataDir = { sessionsDir: () => '/fake/sessions' } as unknown as DataDirPortV2;
+
+function makeServiceWithStore(
+  sessionId: string,
+  store: SessionEventLogReadonlyStorePortV2,
+): ConsoleService {
+  return new ConsoleService({
+    directoryListing: makeDirectoryListing([{ name: sessionId, mtimeMs: Date.now() }]),
+    dataDir: stubDataDir,
+    sessionStore: store,
+    snapshotStore: new InMemorySnapshotStore(),
+    pinnedWorkflowStore: new InMemoryPinnedWorkflowStore(),
+  });
+}
+
+function makeObservationEvent(
+  sessionId: string,
+  key: string,
+  value: string,
+  eventIndex: number,
+): DomainEventV1 {
+  return {
+    v: 1,
+    eventId: `evt_obs_${eventIndex}`,
+    eventIndex,
+    sessionId: sessionId as SessionId,
+    kind: 'observation_recorded',
+    dedupeKey: `observation_recorded:${sessionId}:${key}`,
+    data: {
+      confidence: 'high',
+      key,
+      value: { type: 'short_string', value },
+    },
+  } as DomainEventV1;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ConsoleService repoRoot', () => {
+  it('is null when no observation_recorded events are present', async () => {
+    const sessionId = 'sess_repo001aaaaaaaaaaaaaaa';
+    const store: SessionEventLogReadonlyStorePortV2 = {
+      load: (_id) => okAsync({ events: [], manifest: [] }),
+      loadValidatedPrefix: (_id) => okAsync({ kind: 'complete', truth: { events: [], manifest: [] } }),
+    };
+
+    const service = makeServiceWithStore(sessionId, store);
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.repoRoot).toBeNull();
+  });
+
+  it('is null when observation events exist but none have key repo_root', async () => {
+    const sessionId = 'sess_repo002aaaaaaaaaaaaaaa';
+    const events: DomainEventV1[] = [
+      makeObservationEvent(sessionId, 'git_branch', 'main', 0),
+      makeObservationEvent(sessionId, 'git_head_sha', 'abc123', 1),
+    ];
+    const store: SessionEventLogReadonlyStorePortV2 = {
+      load: (_id) => okAsync({ events, manifest: [] }),
+      loadValidatedPrefix: (_id) => okAsync({ kind: 'complete', truth: { events, manifest: [] } }),
+    };
+
+    const service = makeServiceWithStore(sessionId, store);
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions[0]!.repoRoot).toBeNull();
+  });
+
+  it('returns the repo_root value from observation_recorded event', async () => {
+    const sessionId = 'sess_repo003aaaaaaaaaaaaaaa';
+    const repoRootPath = '/Users/user/git/myproject';
+    const events: DomainEventV1[] = [
+      makeObservationEvent(sessionId, 'repo_root_hash', 'sha256:abc', 0),
+      makeObservationEvent(sessionId, 'repo_root', repoRootPath, 1),
+      makeObservationEvent(sessionId, 'git_branch', 'feature/my-branch', 2),
+    ];
+    const store: SessionEventLogReadonlyStorePortV2 = {
+      load: (_id) => okAsync({ events, manifest: [] }),
+      loadValidatedPrefix: (_id) => okAsync({ kind: 'complete', truth: { events, manifest: [] } }),
+    };
+
+    const service = makeServiceWithStore(sessionId, store);
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+
+    const sessions = result._unsafeUnwrap().sessions;
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.repoRoot).toBe(repoRootPath);
+  });
+
+  it('returns the first repo_root observation when multiple exist', async () => {
+    const sessionId = 'sess_repo004aaaaaaaaaaaaaaa';
+    const firstPath = '/Users/user/git/first';
+    const secondPath = '/Users/user/git/second';
+    const events: DomainEventV1[] = [
+      makeObservationEvent(sessionId, 'repo_root', firstPath, 0),
+      makeObservationEvent(sessionId, 'repo_root', secondPath, 1),
+    ];
+    const store: SessionEventLogReadonlyStorePortV2 = {
+      load: (_id) => okAsync({ events, manifest: [] }),
+      loadValidatedPrefix: (_id) => okAsync({ kind: 'complete', truth: { events, manifest: [] } }),
+    };
+
+    const service = makeServiceWithStore(sessionId, store);
+    const result = await service.getSessionList();
+    expect(result.isOk()).toBe(true);
+
+    const sessions = result._unsafeUnwrap().sessions;
+    // First occurrence wins -- consistent with extractGitBranch behavior
+    expect(sessions[0]!.repoRoot).toBe(firstPath);
+  });
+});


### PR DESCRIPTION
## Summary

- The standalone console's `/api/v2/sessions` response was missing `repoRoot` on each `ConsoleSessionSummary`, causing sessions to be invisible in the workspace view
- The frontend's `joinSessionsAndWorktrees()` uses `session.repoRoot` as a fallback grouping key when no matching worktree exists -- without it, any session whose git branch doesn't match a known worktree is silently excluded
- The `repo_root` observation event is written at session start by the workspace anchor but `extractRepoRoot()` was never implemented in `console-service.ts`, unlike the parallel `extractGitBranch()` for `git_branch`

**Root cause:** structural omission -- `repoRoot` was declared in the frontend DTO (`console/src/api/types.ts`) but never populated by the backend projection.

**Fix:**
- Add `extractRepoRoot()` to `src/v2/usecases/console-service.ts` -- reads `observation_recorded` events with `key === 'repo_root'` (mirrors `extractGitBranch()`)
- Add `readonly repoRoot: string | null` to `ConsoleSessionSummary` in `src/v2/usecases/console-types.ts`
- Populate `repoRoot` in both return paths of `projectSessionSummary()`

No frontend changes needed -- the frontend type already declares this field correctly.

## Test plan

- [x] All 335 test files, 4773 tests pass (`npx vitest run`)
- [x] New test file `tests/unit/console-service-repo-root.test.ts` with 4 tests covering:
  - null when no observation events
  - null when observations exist but no `repo_root` key
  - returns the path when `repo_root` observation is present
  - first occurrence wins when multiple `repo_root` observations exist
- [x] TypeScript compiles with no errors (`npx tsc --noEmit`)
- [ ] Manual: start `worktrain console`, confirm sessions appear under correct repo/branch grouping in the workspace view

🤖 Generated with [Claude Code](https://claude.com/claude-code)