### PR TITLE
fix(console): write workspacePath to daemon session context for workspace grouping

### DIFF
--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -1477,7 +1477,9 @@ export async function runWorkflow(
       { workflowId: trigger.workflowId, workspacePath: trigger.workspacePath, goal: trigger.goal },
       ctx,
       // Mark this session as autonomous so isAutonomous is derivable from the event log.
-      { is_autonomous: 'true' },
+      // workspacePath is written into the context_set event so the console can group daemon
+      // sessions by workspace even when workspace anchor resolution produces empty observations.
+      { is_autonomous: 'true', workspacePath: trigger.workspacePath },
     );
 
     if (startResult.isErr()) {

--- a/src/v2/usecases/console-routes.ts
+++ b/src/v2/usecases/console-routes.ts
@@ -574,7 +574,9 @@ export function mountConsoleRoutes(
       { workflowId, workspacePath, goal },
       v2ToolContext,
       // Mark as autonomous so isAutonomous is derivable from the event log.
-      { is_autonomous: 'true' },
+      // workspacePath is written into the context_set event so the console can group sessions
+      // by workspace even when workspace anchor resolution produces empty observations.
+      { is_autonomous: 'true', workspacePath },
     );
 
     if (startResult.isErr()) {

--- a/src/v2/usecases/console-service.ts
+++ b/src/v2/usecases/console-service.ts
@@ -702,22 +702,45 @@ function extractGitBranch(events: readonly DomainEventV1[]): string | null {
 }
 
 /**
- * Extract the repo root path from observation events.
+ * Extract the repo root path from session events.
  *
- * The repo_root observation is written at session start by the workspace anchor
- * (LocalWorkspaceAnchorV2). It holds the absolute path to the git repo root so
- * the console workspace view can group sessions by repo even when no matching
- * worktree entry exists (e.g. in standalone console mode or when the worktrees
- * API is slow / unavailable).
+ * Priority:
+ * 1. repo_root observation event -- written by the workspace anchor (LocalWorkspaceAnchorV2)
+ *    at session start. Holds the actual git repo root, which may differ from workspacePath
+ *    when the session was started from a subdirectory.
+ * 2. workspacePath from an initial context_set event -- written by the daemon and dispatch
+ *    handler as a fallback for sessions where workspace anchor resolution produced no anchors
+ *    (e.g. non-git directories, git binary unavailable, or daemon using an older engine context
+ *    without workspaceResolver). Close enough for workspace grouping in the console.
+ *
+ * Returns null only when neither source is available.
  */
 function extractRepoRoot(events: readonly DomainEventV1[]): string | null {
+  let workspacePathFallback: string | null = null;
+
   for (const e of events) {
-    if (e.kind !== EVENT_KIND.OBSERVATION_RECORDED) continue;
-    if (e.data.key === 'repo_root') {
+    if (e.kind === EVENT_KIND.OBSERVATION_RECORDED && e.data.key === 'repo_root') {
       return e.data.value.value;
     }
+    // Capture workspacePath from the initial context_set as a fallback.
+    // Only 'initial' source context is used -- agent_delta context_set events may not
+    // include workspacePath and would overwrite it with a different key set.
+    if (
+      e.kind === EVENT_KIND.CONTEXT_SET &&
+      e.data.source === 'initial' &&
+      workspacePathFallback === null
+    ) {
+      const ctx = e.data.context;
+      if (ctx && typeof ctx === 'object' && !Array.isArray(ctx)) {
+        const wp = (ctx as Record<string, unknown>)['workspacePath'];
+        if (typeof wp === 'string' && wp.length > 0) {
+          workspacePathFallback = wp;
+        }
+      }
+    }
   }
-  return null;
+
+  return workspacePathFallback;
 }
 
 


### PR DESCRIPTION
## Summary

- Daemon sessions showed `repoRoot=none` in the console because `workspacePath` was never written to the session event log. The MCP server path injects `repo_root` via `resolveWorkspaceAnchors`, but that only works when the workspace is a git repo with the binary available.
- Added `workspacePath` to the `internalContext` passed to `executeStartWorkflow` in both the trigger-based daemon path (`workflow-runner.ts`) and the auto-dispatch pre-allocated path (`console-routes.ts`). This writes `workspacePath` into the initial `context_set` event, making it durable in the session event log.
- Updated `extractRepoRoot` in `console-service.ts` to fall back to `workspacePath` from the initial `context_set` event when no `repo_root` observation is present, so daemon sessions group correctly in the workspace view.

## Test plan

- [ ] Existing unit tests pass (1359 tests, verified locally)
- [ ] Start a daemon session and verify the console shows a non-null `repoRoot` for it
- [ ] Verify that sessions with a valid git `repo_root` observation still use the observation (it takes priority over the `workspacePath` fallback in `extractRepoRoot`)
- [ ] Verify that `auto/dispatch` sessions also show correct workspace grouping in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)