### PR TITLE
feat(mcp): add structured conversation logging for daemon

### DIFF
--- a/docs/design/daemon-conversation-logging-plan.md
+++ b/docs/design/daemon-conversation-logging-plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan: Daemon Conversation Logging
+
+## Problem Statement
+
+The WorkRail daemon runs workflows autonomously but provides minimal visibility into what the agent is actually doing. Today you can see `session_started`, `tool_called`, and `session_completed` in the JSONL event log - but you cannot see what the LLM decided, which tools it requested, how long each tool took, or whether a tool succeeded. Adding `llm_turn_started`, `llm_turn_completed`, `tool_call_started`, `tool_call_completed`, and `tool_call_failed` events - plus a `worktrain logs` CLI command - turns the event file into a real-time audit trail of agent behavior.
+
+## Acceptance Criteria
+
+1. After an LLM API call in `_runLoop()`, `llm_turn_started` is written before the call and `llm_turn_completed` after the response.
+2. For every tool execution via `_executeTools()`, `tool_call_started` is written before `tool.execute()`, and either `tool_call_completed` or `tool_call_failed` is written after.
+3. `tool_call_started` args are truncated to max 200 chars. `tool_call_completed` result summary truncated to max 200 chars.
+4. All new events appear in the same daily JSONL file as existing events.
+5. `worktrain logs` reads today's log file and prints each event formatted for humans.
+6. `worktrain logs --follow` polls the file every 500ms and prints new events as they arrive.
+7. `worktrain logs --session <id>` filters events to those with matching `sessionId`.
+8. `worktrain logs --follow` handles midnight file rotation (switches to new date file).
+9. If the log file doesn't exist, `worktrain logs` prints a helpful message; `--follow` waits for the file.
+10. TypeScript compiles without errors. Existing tests pass.
+
+## Non-Goals
+
+- NOT putting events in the v2 session event store
+- NOT adding a Console Timeline tab
+- NOT deprecating `tool_called` events (backward compat)
+- NOT implementing accurate pre-call token counting (message count proxy is sufficient)
+- NOT searching across multiple day files for `--session` filter
+
+## Philosophy-Driven Constraints
+
+- **Fire-and-forget invariant**: All callbacks in AgentLoop are wrapped in try/catch that swallow errors.
+- **DI for boundaries**: AgentLoop receives callbacks, not DaemonEventEmitter itself.
+- **Make illegal states unrepresentable**: New event kinds added to `DaemonEvent` discriminated union.
+- **YAGNI**: Only the specified event kinds and fields.
+
+## Invariants
+
+1. `tool_call_started` is always followed by either `tool_call_completed` or `tool_call_failed`.
+2. `llm_turn_started` may have no matching `llm_turn_completed` on API error - this is intentional signal.
+3. Callbacks in AgentLoop never propagate exceptions to the caller.
+4. `DaemonEvent` union remains exhaustive.
+
+## Selected Approach
+
+AgentLoopOptions callbacks: 5 optional callback properties on `AgentLoopOptions` called in `_runLoop()` and `_executeTools()`. workflow-runner.ts wires them to `emitter?.emit()`.
+
+## Vertical Slices
+
+### Slice 1: New event types in daemon-events.ts
+- Add interfaces: `LlmTurnStartedEvent`, `LlmTurnCompletedEvent`, `ToolCallStartedEvent`, `ToolCallCompletedEvent`, `ToolCallFailedEvent`
+- Extend `DaemonEvent` union with all 5
+
+### Slice 2: AgentLoopOptions callbacks + emission in agent-loop.ts
+- Add 5 optional callbacks to `AgentLoopOptions`
+- Call with try/catch in `_runLoop()` before/after `client.messages.create()`
+- Call with try/catch in `_executeTools()` before/after `tool.execute()`
+- Add `Date.now()` timing for tool calls
+
+### Slice 3: Wire callbacks in workflow-runner.ts
+- In `runWorkflow()`, pass `AgentLoop` constructor the 5 callbacks
+- Each callback calls `emitter?.emit()` with the appropriate new event kind
+
+### Slice 4: `worktrain logs` CLI command
+- Add `program.command('logs')` with `--follow` and `--session <id>` options
+- Read daily JSONL, format each line, handle ENOENT
+- Polling loop with midnight rotation
+
+### Slice 5: Tests
+- `daemon-events.test.ts`: Add 5 new event kinds to exhaustiveness test
+- `agent-loop.test.ts`: Add tests for callback timing, completion, failure, and try/catch guards
+
+## Test Design
+
+- onToolCallStarted fires before tool execute (verified via call order recording)
+- onToolCallCompleted fires after successful execute (verified with durationMs > 0)
+- onToolCallFailed fires when tool throws (loop continues normally)
+- onLlmTurnStarted fires with correct messageCount before API call
+- onLlmTurnCompleted fires with actual token counts from API response
+- Callbacks that throw do not crash the loop
+
+## Risk Register
+
+| Risk | Mitigation |
+|---|---|
+| Callback throws crash the session | try/catch on all 5 callback invocations |
+| --follow misses events at midnight | Date-check on each poll iteration |
+
+## PR Strategy
+
+Single PR: `feat/daemon-conversation-logging`
+
+## Philosophy Alignment
+
+- DI for boundaries: Satisfied (callbacks, not DaemonEventEmitter in AgentLoop)
+- Make illegal states unrepresentable: Satisfied (discriminated union)
+- Errors are data: Satisfied (tool throws -> tool_call_failed, not propagated)
+- Fire-and-forget: Satisfied (try/catch guards)
+- YAGNI: Satisfied
+- Exhaustiveness: Satisfied (union extended + test updated)

--- a/docs/design/daemon-conversation-logging-review.md
+++ b/docs/design/daemon-conversation-logging-review.md
@@ -1,0 +1,55 @@
+# Daemon Conversation Logging: Design Review Findings
+
+## Tradeoff Review
+
+| Tradeoff | Assessment | Conditions for failure |
+|---|---|---|
+| AgentLoopOptions gains 5 optional callbacks | Acceptable - all optional, zero cost when absent | Would matter if AgentLoop were a versioned public library |
+| Dual `tool_called` + `tool_call_started` events in log | Minor duplication, harmless - different fields, different consumers | If a consumer enforced "one event per tool execution" |
+| `llm_turn_started` uses message count (proxy) | Spec-compliant - user explicitly said "estimate from message count" | If accurate pre-call token counts were needed for routing |
+| `--follow` polls at 500ms interval | Acceptable for human-readable monitoring | If sub-100ms stream was required |
+
+## Failure Mode Review
+
+| Failure mode | Status | Mitigation |
+|---|---|---|
+| Callback throws, propagates into agent loop | **UNMITIGATED - REQUIRES FIX** | Add try/catch around all 5 callback invocations in agent-loop.ts |
+| `tool_call_started` without matching `tool_call_completed` | Handled - catch block emits `tool_call_failed` | No action needed |
+| `llm_turn_started` without matching `llm_turn_completed` (API error) | Acceptable - unmatched started = API error signal | No action needed |
+| `--follow` misses events at midnight file rotation | **REQUIRES FIX** | Check `new Date()` on each poll; switch to new file when date changes |
+| Log file doesn't exist (daemon not started) | Handled - ENOENT returns graceful message | No action needed |
+
+## Runner-Up / Simpler Alternative Review
+
+- **Runner-up (Candidate B, per-tool factories)**: No elements worth borrowing. Centralizing in `_executeTools()` is strictly better.
+- **Simpler alternative (no AgentLoop changes + `turn_end` subscriber for LLM events)**: Fails spec - `turn_end` fires after tool results, not after API response. Not a valid simplification.
+- **Hybrid (callbacks for LLM, per-factory for tools)**: Two patterns for the same concern. Worse than either pure approach.
+
+## Philosophy Alignment
+
+**Satisfied**: DI for boundaries, immutability, make illegal states unrepresentable, errors as data, determinism, YAGNI, validate at boundaries.
+
+**Under tension (acceptable)**:
+- Type safety: `argsSummary` is deliberately a truncated string - this is spec-required (max 200 chars) and appropriate for JSONL serialization.
+- Exhaustiveness: DaemonEvent union grows by 5; no switch consumers exist so this is theoretical only.
+
+## Findings
+
+### Red (blocking)
+None.
+
+### Orange (should fix before implementation)
+1. **Missing try/catch around callbacks in agent-loop.ts**: A buggy callback passed to `AgentLoop` would propagate a throw into the agent loop and crash the session. This violates the fire-and-forget invariant that all observability in the daemon upholds. Fix: wrap each of the 5 callback invocations with `try { callback(info); } catch { /* swallow */ }`.
+
+### Yellow (fix during implementation)
+2. **Midnight file rotation in `--follow`**: The polling loop should check `new Date().toISOString().slice(0, 10)` on each iteration and switch to the new file when the date changes. 3-line fix in the polling loop.
+
+## Recommended Revisions
+
+1. Add try/catch guards around all callback invocations in `_runLoop()` and `_executeTools()` in `agent-loop.ts`.
+2. Add date-aware file switching in the `--follow` polling loop in `cli-worktrain.ts`.
+
+## Residual Concerns
+
+- The `tool_called` + `tool_call_started` dual events: a future cleanup task could deprecate `tool_called` once all consumers migrate to `tool_call_started`. Not in scope for this PR.
+- The `worktrain logs` command reads from the daily JSONL file directly. If sessions span multiple days, `--session <id>` would only find events in the current day's file. A future improvement could search across all files. Not in scope.

--- a/docs/design/daemon-conversation-logging.md
+++ b/docs/design/daemon-conversation-logging.md
@@ -1,0 +1,129 @@
+# Daemon Conversation Logging: Design Candidates
+
+## Problem Understanding
+
+### Core tensions
+
+1. **AgentLoop decoupling vs. LLM turn visibility**: AgentLoop is intentionally decoupled from all observability infrastructure (no DaemonEventEmitter import). To emit LLM turn events FROM inside `_runLoop()`, we need to bridge this gap without coupling AgentLoop to daemon-specific types. Options: inject callbacks, use the existing AgentEvent subscriber system, or violate the boundary. The subscriber system fires at `turn_end` (after tool results), which is not the right boundary for `llm_turn_started` / `llm_turn_completed`. Callbacks are the right choice.
+
+2. **Single-source vs. dual-source tool events**: Today each tool factory (`makeBashTool`, `makeReadTool`, etc.) emits `tool_called` directly. Adding `tool_call_started/completed/failed` in `_executeTools()` creates a single centralized emission point. The existing `tool_called` events remain for backward compatibility; new event kinds are additive.
+
+3. **Input token estimation**: True token counts require a tokenizer (tiktoken or the API's usage field). The API returns `response.usage.input_tokens` and `response.usage.output_tokens` in the response. For `llm_turn_started`, emit message count as proxy. For `llm_turn_completed`, emit actual token counts from the API response.
+
+4. **`worktrain logs --follow` streaming**: Node.js file watching is noisy; polling every 500ms is reliable and simple for MVP.
+
+### What makes this hard
+
+Nothing is architecturally hard. The tricky parts are:
+- Getting tool event timing exactly right (started before execute, completed/failed after)
+- For `worktrain logs --follow`: handling the case where the log file doesn't exist yet
+- TypeScript type checking: callback signatures must be precise for ts-strict
+
+### Likely seam
+
+The real seam for tool events is `_executeTools()` in `agent-loop.ts` - it's the single place all tools execute. The real seam for LLM turn events is the `client.messages.create()` call in `_runLoop()`. Both are in `agent-loop.ts`.
+
+## Philosophy Constraints
+
+From `CLAUDE.md` (system-wide):
+- **DI for boundaries**: inject external effects (observability) to keep core logic testable
+- **YAGNI with discipline**: no speculative fields beyond what's in the spec
+- **Exhaustiveness everywhere**: new event kinds extend the `DaemonEvent` discriminated union
+- **Fire-and-forget invariant**: `emit()` is void, errors swallowed - observability never affects correctness
+- **Prefer fakes over mocks**: FakeAnthropicClient pattern in agent-loop tests
+
+No philosophy conflicts found between stated principles and existing repo patterns.
+
+## Impact Surface
+
+- `runWorkflow()` in `workflow-runner.ts`: constructs AgentLoop, must pass new callbacks
+- `AgentLoopOptions` interface: extended with optional callbacks (non-breaking)
+- `DaemonEvent` union: extended with new members (exhaustiveness tests must update)
+- `tests/unit/daemon-events.test.ts`: the exhaustiveness test at line 169 must list new event kinds
+- `tests/unit/agent-loop.test.ts`: needs tests for callback invocation timing
+- No public API changes - all daemon-internal
+
+## Candidates
+
+### Candidate A: AgentLoopOptions callbacks (recommended)
+
+**Summary**: Add 5 optional callback properties to `AgentLoopOptions` in `agent-loop.ts`. Call them synchronously in `_runLoop()` and `_executeTools()`. Wire in `workflow-runner.ts` to call `emitter?.emit()`.
+
+**New properties on AgentLoopOptions**:
+```typescript
+onLlmTurnStarted?: (info: { messageCount: number }) => void
+onLlmTurnCompleted?: (info: {
+  stopReason: string;
+  outputTokens: number;
+  inputTokens: number;
+  toolNamesRequested: string[];
+}) => void
+onToolCallStarted?: (info: { toolName: string; argsSummary: string }) => void
+onToolCallCompleted?: (info: { toolName: string; durationMs: number; resultSummary: string }) => void
+onToolCallFailed?: (info: { toolName: string; durationMs: number; errorMessage: string }) => void
+```
+
+**Tensions resolved**: AgentLoop stays decoupled from DaemonEventEmitter. Single source of truth for tool event timing.
+
+**Boundary**: AgentLoop / workflow-runner.ts interface. Correct seam - AgentLoop is a reusable primitive; workflow-runner.ts is the daemon-specific orchestrator.
+
+**Failure mode**: If a callback throws, it propagates into the agent loop. Mitigated by: callbacks call `emitter?.emit()` which is fire-and-forget and never throws.
+
+**Follows existing pattern**: `DaemonRegistry` uses the same inject-as-optional pattern. `toolExecution: 'sequential'` is already a strategy parameter on `AgentLoopOptions`.
+
+**Gains**: Central timing; no changes to individual tool factories; clean separation; new tools get events automatically.
+**Gives up**: `AgentLoopOptions` interface is slightly heavier (5 optional callbacks). Callbacks are less discoverable than per-tool pattern.
+
+**Scope**: best-fit.
+
+**Philosophy**: honors DI-for-boundaries, YAGNI, exhaustiveness. No conflicts.
+
+---
+
+### Candidate B: Extend per-tool factory pattern (adapt existing)
+
+**Summary**: Keep the existing per-tool `emitter?.emit({ kind: 'tool_called' })` approach. Add `tool_call_started` emit before `tool.execute()` and `tool_call_completed`/`tool_call_failed` after, inside each of the 5 tool factory closures. Add LLM turn callbacks to `AgentLoopOptions` only for the LLM-specific events.
+
+**Tensions resolved**: Minimizes changes to AgentLoop (only 2 callbacks instead of 5). Follows the exact existing pattern.
+
+**Boundary**: Each tool factory is the emission point.
+
+**Failure mode**: 5 tool factories x 3 events each = 15 new emit calls. Duplication risk. New tools added later won't automatically get events.
+
+**Follows existing pattern**: Pure adaptation of the existing `tool_called` pattern.
+
+**Gains**: No callbacks for tool events in AgentLoopOptions; no risk of propagated errors.
+**Gives up**: DRY principle - timing logic duplicated 5x. Maintenance trap.
+
+**Scope**: best-fit for existing tools, but creates technical debt.
+
+**Philosophy**: conflicts with "compose with small, pure functions" (duplication). Honors DI-for-boundaries.
+
+## Comparison and Recommendation
+
+**Recommendation: Candidate A**
+
+Candidate A wins on every meaningful dimension:
+- **Best-fit boundary**: `_executeTools()` is the single canonical execution point for all tools.
+- **Most manageable failure mode**: callbacks call `emitter?.emit()` which can never throw.
+- **Best philosophy fit**: "Compose with small, pure functions" and "DI for boundaries" both point to A.
+- **Easiest to evolve**: Adding a 6th tool gets events automatically.
+- **Consistent with repo patterns**: Same pattern as `DaemonRegistry` injection.
+
+## Self-Critique
+
+**Strongest argument against**: Candidate A adds 5 callback properties to `AgentLoopOptions`. If `AgentLoop` is used in tests without an emitter, the interface is heavier. Counter: all 5 are optional (`?`), zero cost when absent.
+
+**Narrower option that was considered**: Only add LLM turn callbacks (skip `tool_call_started/completed/failed`). Doesn't satisfy the spec.
+
+**Broader option**: Put the emitter directly in `AgentLoopOptions`. Would require `AgentLoop` to import `DaemonEventEmitter`, coupling the modules. Unjustified.
+
+**Invalidating assumption**: None. `_executeTools()` is the only tool execution path in `AgentLoop`.
+
+## Open Questions for Implementation
+
+1. The existing `tool_called` events in per-tool factories (`makeBashTool`, `makeReadTool`, `makeWriteTool`, `makeContinueWorkflowTool`) - keep them as-is for backward compat, or remove them now that `tool_call_started` supersedes them? Decision: keep for backward compat since consumers may depend on them.
+
+2. For the `worktrain logs --follow` command, should it print historical lines first then follow? Yes - show existing entries then poll for new ones.
+
+3. Should `worktrain logs --session <id>` filter by exact sessionId match? Yes.

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -456,6 +456,181 @@ program
   });
 
 // ═══════════════════════════════════════════════════════════════════════════
+// LOGS COMMAND
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Format a single DaemonEvent JSONL line for human-readable output.
+ *
+ * WHY inline: the logs command is the only consumer of this formatting.
+ * Keeping it here avoids creating a module for a single 30-line function.
+ */
+function formatDaemonEventLine(raw: string): string | null {
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null; // Skip malformed lines silently.
+  }
+
+  const ts = typeof obj['ts'] === 'number'
+    ? new Date(obj['ts']).toISOString().replace('T', ' ').slice(0, 23)
+    : '?';
+  const kind = typeof obj['kind'] === 'string' ? obj['kind'] : 'unknown';
+  const sessionId = typeof obj['sessionId'] === 'string' ? obj['sessionId'].slice(0, 8) : null;
+  const prefix = sessionId ? `[${ts}] [${sessionId}] ${kind}` : `[${ts}] ${kind}`;
+
+  switch (kind) {
+    case 'llm_turn_started':
+      return `${prefix}  msgs=${obj['messageCount'] ?? '?'}`;
+    case 'llm_turn_completed':
+      return `${prefix}  stop=${obj['stopReason'] ?? '?'} in=${obj['inputTokens'] ?? '?'} out=${obj['outputTokens'] ?? '?'} tools=[${Array.isArray(obj['toolNamesRequested']) ? (obj['toolNamesRequested'] as string[]).join(',') : ''}]`;
+    case 'tool_call_started':
+      return `${prefix}  tool=${obj['toolName'] ?? '?'} args=${String(obj['argsSummary'] ?? '').slice(0, 80)}`;
+    case 'tool_call_completed':
+      return `${prefix}  tool=${obj['toolName'] ?? '?'} ${obj['durationMs'] ?? '?'}ms result=${String(obj['resultSummary'] ?? '').slice(0, 60)}`;
+    case 'tool_call_failed':
+      return `${prefix}  tool=${obj['toolName'] ?? '?'} ${obj['durationMs'] ?? '?'}ms err=${String(obj['errorMessage'] ?? '').slice(0, 80)}`;
+    case 'tool_called':
+      return `${prefix}  tool=${obj['toolName'] ?? '?'} ${obj['summary'] ? String(obj['summary']).slice(0, 80) : ''}`;
+    case 'tool_error':
+      return `${prefix}  tool=${obj['toolName'] ?? '?'} err=${String(obj['error'] ?? '').slice(0, 80)}`;
+    case 'session_started':
+      return `${prefix}  workflow=${obj['workflowId'] ?? '?'} workspace=${obj['workspacePath'] ?? '?'}`;
+    case 'session_completed':
+      return `${prefix}  workflow=${obj['workflowId'] ?? '?'} outcome=${obj['outcome'] ?? '?'}${obj['detail'] ? ` (${obj['detail']})` : ''}`;
+    case 'step_advanced':
+      return `${prefix}`;
+    case 'issue_reported':
+      return `${prefix}  severity=${obj['severity'] ?? '?'} ${String(obj['summary'] ?? '').slice(0, 80)}`;
+    default:
+      return `${prefix}  ${JSON.stringify(obj).slice(0, 120)}`;
+  }
+}
+
+program
+  .command('logs')
+  .description('Read and display the WorkRail daemon event log. Use --follow to stream new events in real time.')
+  .option('--follow', 'Continuously poll the log file for new events (like tail -f)')
+  .option('--session <id>', 'Filter events by sessionId prefix (first 8 chars or full UUID)')
+  .action(async (options: { follow?: boolean; session?: string }) => {
+    const eventsDir = path.join(os.homedir(), '.workrail', 'events', 'daemon');
+
+    /**
+     * Compute today's log file path.
+     * Recomputed on each poll iteration so --follow handles midnight rotation.
+     */
+    function todayFilePath(): string {
+      const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+      return path.join(eventsDir, `${date}.jsonl`);
+    }
+
+    /**
+     * Read lines from a file starting at byte offset, return lines and new offset.
+     * Returns null if the file does not exist.
+     */
+    function readNewLines(filePath: string, fromOffset: number): { lines: string[]; newOffset: number } | null {
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(filePath);
+      } catch {
+        return null; // File doesn't exist yet.
+      }
+
+      if (stat.size <= fromOffset) {
+        return { lines: [], newOffset: fromOffset }; // No new bytes.
+      }
+
+      const fd = fs.openSync(filePath, 'r');
+      try {
+        const len = stat.size - fromOffset;
+        const buf = Buffer.alloc(len);
+        fs.readSync(fd, buf, 0, len, fromOffset);
+        const text = buf.toString('utf8');
+        const lines = text.split('\n').filter((l) => l.trim().length > 0);
+        return { lines, newOffset: stat.size };
+      } finally {
+        fs.closeSync(fd);
+      }
+    }
+
+    /**
+     * Print a set of raw JSONL lines, applying the session filter if set.
+     */
+    function printLines(lines: string[]): void {
+      for (const line of lines) {
+        // Apply session filter if --session was provided.
+        if (options.session) {
+          // Filter by sessionId prefix or exact match.
+          try {
+            const obj = JSON.parse(line) as Record<string, unknown>;
+            const sid = typeof obj['sessionId'] === 'string' ? obj['sessionId'] : '';
+            if (!sid.startsWith(options.session) && sid !== options.session) {
+              continue;
+            }
+          } catch {
+            continue; // Skip malformed lines when filtering.
+          }
+        }
+
+        const formatted = formatDaemonEventLine(line);
+        if (formatted !== null) {
+          process.stdout.write(formatted + '\n');
+        }
+      }
+    }
+
+    const filePath = todayFilePath();
+
+    if (!options.follow) {
+      // One-shot: read the file and exit.
+      const result = readNewLines(filePath, 0);
+      if (result === null) {
+        process.stdout.write(`No events yet. Is the daemon running? (Expected: ${filePath})\n`);
+        return;
+      }
+      printLines(result.lines);
+      return;
+    }
+
+    // --follow mode: print existing lines then poll for new ones.
+    // Start at offset 0 to show all existing events, then track the byte position.
+    let currentFilePath = filePath;
+    let offset = 0;
+
+    // Print all existing lines first.
+    const initial = readNewLines(currentFilePath, 0);
+    if (initial !== null) {
+      printLines(initial.lines);
+      offset = initial.newOffset;
+    } else {
+      process.stdout.write(`Waiting for events... (${currentFilePath})\n`);
+    }
+
+    // Poll every 500ms for new lines.
+    // Handles midnight rotation: recompute file path on each iteration.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 500));
+
+      const newFilePath = todayFilePath();
+      if (newFilePath !== currentFilePath) {
+        // Day rolled over -- switch to the new file from the beginning.
+        currentFilePath = newFilePath;
+        offset = 0;
+      }
+
+      const result = readNewLines(currentFilePath, offset);
+      if (result !== null && result.lines.length > 0) {
+        printLines(result.lines);
+        offset = result.newOffset;
+      } else if (result !== null) {
+        offset = result.newOffset; // Update offset even if no new lines.
+      }
+    }
+  });
+
+// ═══════════════════════════════════════════════════════════════════════════
 // ENTRY POINT
 // ═══════════════════════════════════════════════════════════════════════════
 

--- a/src/daemon/agent-loop.ts
+++ b/src/daemon/agent-loop.ts
@@ -134,6 +134,58 @@ export interface AgentInternalToolResultMessage {
   readonly content: ReadonlyArray<Anthropic.ToolResultBlockParam>;
 }
 
+/**
+ * Observability callbacks for AgentLoop.
+ *
+ * All callbacks are optional and fire synchronously at specific lifecycle points.
+ * Each is wrapped in try/catch inside AgentLoop to preserve the fire-and-forget
+ * invariant: a throwing callback must never crash the agent loop.
+ *
+ * WHY callbacks instead of event emitter: AgentLoop is decoupled from
+ * DaemonEventEmitter. Callbacks are the DI boundary that keeps AgentLoop
+ * reusable outside the daemon without pulling in observability infrastructure.
+ */
+export interface AgentLoopCallbacks {
+  /**
+   * Called immediately before client.messages.create().
+   * @param info.messageCount - Number of messages in the conversation at this point.
+   */
+  readonly onLlmTurnStarted?: (info: { readonly messageCount: number }) => void;
+  /**
+   * Called immediately after client.messages.create() resolves successfully.
+   * @param info.stopReason - The stop_reason from the API response.
+   * @param info.outputTokens - Actual output token count from the API response.
+   * @param info.inputTokens - Actual input token count from the API response.
+   * @param info.toolNamesRequested - Names of tools the LLM requested (empty for end_turn).
+   */
+  readonly onLlmTurnCompleted?: (info: {
+    readonly stopReason: string;
+    readonly outputTokens: number;
+    readonly inputTokens: number;
+    readonly toolNamesRequested: readonly string[];
+  }) => void;
+  /**
+   * Called immediately before tool.execute().
+   * @param info.toolName - The tool's name.
+   * @param info.argsSummary - JSON-serialized params, truncated to 200 chars.
+   */
+  readonly onToolCallStarted?: (info: { readonly toolName: string; readonly argsSummary: string }) => void;
+  /**
+   * Called immediately after a successful tool.execute().
+   * @param info.toolName - The tool's name.
+   * @param info.durationMs - Wall-clock duration of the tool execution in milliseconds.
+   * @param info.resultSummary - First 200 chars of the tool result text content.
+   */
+  readonly onToolCallCompleted?: (info: { readonly toolName: string; readonly durationMs: number; readonly resultSummary: string }) => void;
+  /**
+   * Called when tool.execute() throws.
+   * @param info.toolName - The tool's name.
+   * @param info.durationMs - Wall-clock duration up to the point of failure.
+   * @param info.errorMessage - First 200 chars of the error message.
+   */
+  readonly onToolCallFailed?: (info: { readonly toolName: string; readonly durationMs: number; readonly errorMessage: string }) => void;
+}
+
 /** Options for constructing an AgentLoop. */
 export interface AgentLoopOptions {
   /** System prompt sent with every LLM request. */
@@ -154,6 +206,18 @@ export interface AgentLoopOptions {
    * Only 'sequential' is needed for WorkRail (tools have ordering requirements).
    */
   readonly toolExecution?: 'sequential';
+  /**
+   * Optional observability callbacks for structured event emission.
+   *
+   * Each callback fires at a specific lifecycle point (before/after LLM call,
+   * before/after tool execute). All are wrapped in try/catch -- a throwing callback
+   * never crashes the agent loop. Callers that do not provide callbacks pay zero cost.
+   *
+   * WHY optional on the options object: keeps AgentLoopOptions self-contained and
+   * follows the existing strategy-param pattern (toolExecution is already a strategy
+   * field on options).
+   */
+  readonly callbacks?: AgentLoopCallbacks;
 }
 
 // ---------------------------------------------------------------------------
@@ -284,7 +348,7 @@ export class AgentLoop {
   // ---------------------------------------------------------------------------
 
   private async _runLoop(): Promise<void> {
-    const { client, modelId, systemPrompt, tools, maxTokens = 8192 } = this._options;
+    const { client, modelId, systemPrompt, tools, maxTokens = 8192, callbacks } = this._options;
 
     while (true) {
       // Check abort before each LLM call.
@@ -307,6 +371,11 @@ export class AgentLoop {
         input_schema: t.inputSchema as Anthropic.Tool.InputSchema,
       }));
 
+      // Emit llm_turn_started before the API call.
+      // WHY try/catch: preserves fire-and-forget invariant -- a throwing callback
+      // must never crash the agent loop.
+      try { callbacks?.onLlmTurnStarted?.({ messageCount: apiMessages.length }); } catch { /* swallow */ }
+
       let response: Anthropic.Message;
       try {
         response = await client.messages.create(
@@ -328,6 +397,23 @@ export class AgentLoop {
         this._appendErrorMessage(isAbort ? 'aborted' : message);
         await this._emitEvent({ type: 'agent_end' });
         return;
+      }
+
+      // Emit llm_turn_completed after the API response.
+      // WHY try/catch: preserves fire-and-forget invariant.
+      // WHY inline block: scopes toolNamesRequested to avoid polluting the outer loop.
+      {
+        const toolNamesRequested = response.content
+          .filter((block): block is Anthropic.ToolUseBlock => block.type === 'tool_use')
+          .map((block) => block.name);
+        try {
+          callbacks?.onLlmTurnCompleted?.({
+            stopReason: response.stop_reason ?? 'unknown',
+            outputTokens: response.usage.output_tokens,
+            inputTokens: response.usage.input_tokens,
+            toolNamesRequested,
+          });
+        } catch { /* swallow */ }
       }
 
       // Append the assistant response to messages.
@@ -415,6 +501,7 @@ export class AgentLoop {
   private async _executeTools(
     toolUseBlocks: readonly Anthropic.ToolUseBlock[],
   ): Promise<AgentToolCallResult[]> {
+    const { callbacks } = this._options;
     const results: AgentToolCallResult[] = [];
 
     for (const block of toolUseBlocks) {
@@ -452,11 +539,22 @@ export class AgentLoop {
       // error -- the LLM must see stderr and decide whether to retry, rephrase, or
       // escalate. Same rationale as unknown tool names above.
       const params = (block.input ?? {}) as Record<string, unknown>;
+
+      // Emit tool_call_started before execute().
+      // WHY try/catch: preserves fire-and-forget invariant -- a throwing callback
+      // must never crash the agent loop.
+      const argsSummary = JSON.stringify(params).slice(0, 200);
+      try { callbacks?.onToolCallStarted?.({ toolName: block.name, argsSummary }); } catch { /* swallow */ }
+
+      const toolStartMs = Date.now();
       let result: AgentToolResult<unknown>;
       try {
         result = await tool.execute(block.id, params);
       } catch (err: unknown) {
+        const durationMs = Date.now() - toolStartMs;
         const message = err instanceof Error ? err.message : String(err);
+        // Emit tool_call_failed for the throwing path.
+        try { callbacks?.onToolCallFailed?.({ toolName: block.name, durationMs, errorMessage: message.slice(0, 200) }); } catch { /* swallow */ }
         results.push({
           toolCallId: block.id,
           toolName: block.name,
@@ -465,6 +563,14 @@ export class AgentLoop {
         });
         continue;
       }
+
+      // Emit tool_call_completed for the success path.
+      {
+        const durationMs = Date.now() - toolStartMs;
+        const resultSummary = (result.content[0]?.text ?? '(no output)').slice(0, 200);
+        try { callbacks?.onToolCallCompleted?.({ toolName: block.name, durationMs, resultSummary }); } catch { /* swallow */ }
+      }
+
       results.push({
         toolCallId: block.id,
         toolName: block.name,

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -117,6 +117,83 @@ export interface IssueReportedEvent {
 }
 
 /**
+ * LLM turn starting: the agent is about to call the LLM API.
+ *
+ * Emitted in agent-loop.ts immediately before client.messages.create().
+ * WHY messageCount: the number of messages in the conversation is a proxy for
+ * input token usage. Actual input tokens are not available until the API responds.
+ */
+export interface LlmTurnStartedEvent {
+  readonly kind: 'llm_turn_started';
+  readonly sessionId: string;
+  /** Number of messages in the conversation at the time of the call. */
+  readonly messageCount: number;
+}
+
+/**
+ * LLM turn completed: the LLM API returned a response.
+ *
+ * Emitted in agent-loop.ts immediately after client.messages.create() resolves.
+ * WHY actual tokens: response.usage contains the exact counts from the API.
+ */
+export interface LlmTurnCompletedEvent {
+  readonly kind: 'llm_turn_completed';
+  readonly sessionId: string;
+  /** The stop_reason from the API response ('tool_use', 'end_turn', etc.). */
+  readonly stopReason: string;
+  /** Actual output token count from the API response. */
+  readonly outputTokens: number;
+  /** Actual input token count from the API response. */
+  readonly inputTokens: number;
+  /** Names of tools the LLM requested in this turn (empty if end_turn). */
+  readonly toolNamesRequested: readonly string[];
+}
+
+/**
+ * A tool call is starting. Emitted in agent-loop.ts before tool.execute().
+ *
+ * WHY argsSummary: raw params may be large (e.g. file contents in Write tool).
+ * Truncating to 200 chars gives observability without bloating the event log.
+ */
+export interface ToolCallStartedEvent {
+  readonly kind: 'tool_call_started';
+  readonly sessionId: string;
+  readonly toolName: string;
+  /** JSON-serialized params, truncated to 200 chars. */
+  readonly argsSummary: string;
+}
+
+/**
+ * A tool call completed successfully. Emitted in agent-loop.ts after tool.execute().
+ */
+export interface ToolCallCompletedEvent {
+  readonly kind: 'tool_call_completed';
+  readonly sessionId: string;
+  readonly toolName: string;
+  /** Wall-clock duration of the tool execution in milliseconds. */
+  readonly durationMs: number;
+  /** First 200 chars of the tool result text content. */
+  readonly resultSummary: string;
+}
+
+/**
+ * A tool call failed (tool.execute() threw). Emitted in agent-loop.ts in the catch block.
+ *
+ * WHY separate from tool_error: tool_error is emitted by the turn_end subscriber in
+ * workflow-runner.ts for isError tool_results. tool_call_failed is emitted by the
+ * agent-loop.ts catch block when execute() throws -- finer-grained timing.
+ */
+export interface ToolCallFailedEvent {
+  readonly kind: 'tool_call_failed';
+  readonly sessionId: string;
+  readonly toolName: string;
+  /** Wall-clock duration up to the point of failure in milliseconds. */
+  readonly durationMs: number;
+  /** First 200 chars of the error message. */
+  readonly errorMessage: string;
+}
+
+/**
  * Union of all daemon lifecycle events.
  *
  * Each member has a `kind` discriminant so switch exhaustiveness is enforced
@@ -132,7 +209,12 @@ export type DaemonEvent =
   | StepAdvancedEvent
   | SessionCompletedEvent
   | DeliveryAttemptedEvent
-  | IssueReportedEvent;
+  | IssueReportedEvent
+  | LlmTurnStartedEvent
+  | LlmTurnCompletedEvent
+  | ToolCallStartedEvent
+  | ToolCallCompletedEvent
+  | ToolCallFailedEvent;
 
 // ---------------------------------------------------------------------------
 // DaemonEventEmitter

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -31,7 +31,7 @@ import { randomUUID } from 'node:crypto';
 import Anthropic from '@anthropic-ai/sdk';
 import { AnthropicBedrock } from '@anthropic-ai/bedrock-sdk';
 import { AgentLoop } from "./agent-loop.js";
-import type { AgentTool, AgentToolResult, AgentEvent } from "./agent-loop.js";
+import type { AgentTool, AgentToolResult, AgentEvent, AgentLoopCallbacks } from "./agent-loop.js";
 import type { V2ToolContext } from '../mcp/types.js';
 import { executeStartWorkflow } from '../mcp/handlers/v2-execution/start.js';
 import { executeContinueWorkflow } from '../mcp/handlers/v2-execution/index.js';
@@ -1570,6 +1570,36 @@ export async function runWorkflow(
     contextJson +
     '\n\nComplete all step work, then call continue_workflow with your notes to begin.';
 
+  // ---- Observability callbacks for AgentLoop ----
+  // Wire structured event emission for LLM turns and tool calls.
+  // WHY callbacks not direct emitter: AgentLoop is decoupled from DaemonEventEmitter.
+  // Each callback calls emitter?.emit() which is fire-and-forget (void, errors swallowed).
+  // The try/catch guards inside AgentLoop ensure callbacks never crash the loop.
+  const agentCallbacks: AgentLoopCallbacks = {
+    onLlmTurnStarted: ({ messageCount }) => {
+      emitter?.emit({ kind: 'llm_turn_started', sessionId, messageCount });
+    },
+    onLlmTurnCompleted: ({ stopReason, outputTokens, inputTokens, toolNamesRequested }) => {
+      emitter?.emit({
+        kind: 'llm_turn_completed',
+        sessionId,
+        stopReason,
+        outputTokens,
+        inputTokens,
+        toolNamesRequested,
+      });
+    },
+    onToolCallStarted: ({ toolName, argsSummary }) => {
+      emitter?.emit({ kind: 'tool_call_started', sessionId, toolName, argsSummary });
+    },
+    onToolCallCompleted: ({ toolName, durationMs, resultSummary }) => {
+      emitter?.emit({ kind: 'tool_call_completed', sessionId, toolName, durationMs, resultSummary });
+    },
+    onToolCallFailed: ({ toolName, durationMs, errorMessage }) => {
+      emitter?.emit({ kind: 'tool_call_failed', sessionId, toolName, durationMs, errorMessage });
+    },
+  };
+
   // ---- AgentLoop (one per runWorkflow() call, not reused) ----
   // WHY AgentLoop instead of pi-agent-core's Agent: AgentLoop is the first-party
   // replacement that uses @anthropic-ai/sdk directly, eliminating the private npm
@@ -1583,6 +1613,7 @@ export async function runWorkflow(
     // Sequential execution: continue_workflow must complete before Bash begins
     // on the next step. Workflow tools have ordering requirements.
     toolExecution: 'sequential',
+    callbacks: agentCallbacks,
   });
 
   // ---- Session limits (wall-clock timeout + max-turn limit) ----

--- a/tests/unit/agent-loop.test.ts
+++ b/tests/unit/agent-loop.test.ts
@@ -564,3 +564,208 @@ describe('AgentLoop', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// AgentLoopCallbacks tests
+// ---------------------------------------------------------------------------
+
+describe('AgentLoop callbacks', () => {
+  it('onLlmTurnStarted fires before the API call with correct messageCount', async () => {
+    const client = new FakeAnthropicClient([makeEndTurnMessage()]);
+    const startedCalls: Array<{ messageCount: number }> = [];
+
+    const agent = new AgentLoop({
+      systemPrompt: 'test',
+      tools: [],
+      client,
+      modelId: 'test-model',
+      callbacks: {
+        onLlmTurnStarted: (info) => { startedCalls.push(info); },
+      },
+    });
+
+    await agent.prompt(USER_MSG);
+
+    // One LLM call was made. onLlmTurnStarted should have fired once.
+    expect(startedCalls).toHaveLength(1);
+    // The initial user message is 1 message in the conversation.
+    expect(startedCalls[0]!.messageCount).toBe(1);
+  });
+
+  it('onLlmTurnCompleted fires after the API call with token counts and stop reason', async () => {
+    const client = new FakeAnthropicClient([makeEndTurnMessage()]);
+    const completedCalls: Array<{ stopReason: string; outputTokens: number; inputTokens: number; toolNamesRequested: readonly string[] }> = [];
+
+    const agent = new AgentLoop({
+      systemPrompt: 'test',
+      tools: [],
+      client,
+      modelId: 'test-model',
+      callbacks: {
+        onLlmTurnCompleted: (info) => { completedCalls.push(info); },
+      },
+    });
+
+    await agent.prompt(USER_MSG);
+
+    expect(completedCalls).toHaveLength(1);
+    // makeEndTurnMessage returns usage: { input_tokens: 10, output_tokens: 5 }.
+    expect(completedCalls[0]!.inputTokens).toBe(10);
+    expect(completedCalls[0]!.outputTokens).toBe(5);
+    expect(completedCalls[0]!.stopReason).toBe('end_turn');
+    expect(completedCalls[0]!.toolNamesRequested).toEqual([]);
+  });
+
+  it('onLlmTurnCompleted reports tool names when LLM requests tool calls', async () => {
+    const tool = makeTool('Bash', '(bash output)');
+    const client = new FakeAnthropicClient([
+      makeToolUseMessage('Bash', 'call-1', { command: 'echo hi' }),
+      makeEndTurnMessage(),
+    ]);
+    const completedCalls: Array<{ toolNamesRequested: readonly string[] }> = [];
+
+    const agent = new AgentLoop({
+      systemPrompt: 'test',
+      tools: [tool],
+      client,
+      modelId: 'test-model',
+      callbacks: {
+        onLlmTurnCompleted: (info) => { completedCalls.push(info); },
+      },
+    });
+
+    await agent.prompt(USER_MSG);
+
+    // First turn: tool_use. Second turn: end_turn.
+    expect(completedCalls).toHaveLength(2);
+    expect(completedCalls[0]!.toolNamesRequested).toEqual(['Bash']);
+    expect(completedCalls[1]!.toolNamesRequested).toEqual([]);
+  });
+
+  it('onToolCallStarted fires before tool execute with truncated argsSummary', async () => {
+    const tool = makeTool('Bash', '(output)');
+    const client = new FakeAnthropicClient([
+      makeToolUseMessage('Bash', 'call-1', { command: 'git status' }),
+      makeEndTurnMessage(),
+    ]);
+    const startedCalls: Array<{ toolName: string; argsSummary: string }> = [];
+    const executionOrder: string[] = [];
+
+    // Intercept execute() to record ordering.
+    const wrappedTool = {
+      ...tool,
+      async execute(toolCallId: string, params: Record<string, unknown>) {
+        executionOrder.push('execute');
+        return tool.execute(toolCallId, params);
+      },
+    };
+
+    const agent = new AgentLoop({
+      systemPrompt: 'test',
+      tools: [wrappedTool],
+      client,
+      modelId: 'test-model',
+      callbacks: {
+        onToolCallStarted: (info) => {
+          executionOrder.push('onToolCallStarted');
+          startedCalls.push(info);
+        },
+      },
+    });
+
+    await agent.prompt(USER_MSG);
+
+    expect(startedCalls).toHaveLength(1);
+    expect(startedCalls[0]!.toolName).toBe('Bash');
+    expect(startedCalls[0]!.argsSummary).toContain('git status');
+    // onToolCallStarted must fire BEFORE execute().
+    expect(executionOrder[0]).toBe('onToolCallStarted');
+    expect(executionOrder[1]).toBe('execute');
+  });
+
+  it('onToolCallCompleted fires after successful execute with durationMs and resultSummary', async () => {
+    const tool = makeTool('Read', 'file contents here');
+    const client = new FakeAnthropicClient([
+      makeToolUseMessage('Read', 'call-1', { filePath: '/tmp/test.txt' }),
+      makeEndTurnMessage(),
+    ]);
+    const completedCalls: Array<{ toolName: string; durationMs: number; resultSummary: string }> = [];
+
+    const agent = new AgentLoop({
+      systemPrompt: 'test',
+      tools: [tool],
+      client,
+      modelId: 'test-model',
+      callbacks: {
+        onToolCallCompleted: (info) => { completedCalls.push(info); },
+      },
+    });
+
+    await agent.prompt(USER_MSG);
+
+    expect(completedCalls).toHaveLength(1);
+    expect(completedCalls[0]!.toolName).toBe('Read');
+    expect(typeof completedCalls[0]!.durationMs).toBe('number');
+    expect(completedCalls[0]!.durationMs).toBeGreaterThanOrEqual(0);
+    expect(completedCalls[0]!.resultSummary).toBe('file contents here');
+  });
+
+  it('onToolCallFailed fires when tool.execute() throws, loop continues', async () => {
+    // A tool that always throws.
+    const throwingTool: AgentTool = {
+      name: 'BadTool',
+      description: 'always throws',
+      inputSchema: { type: 'object', properties: {} },
+      label: 'BadTool',
+      async execute(): Promise<AgentToolResult<unknown>> {
+        throw new Error('intentional failure');
+      },
+    };
+
+    const client = new FakeAnthropicClient([
+      makeToolUseMessage('BadTool', 'call-1'),
+      makeEndTurnMessage(), // Loop continues after the tool failure.
+    ]);
+    const failedCalls: Array<{ toolName: string; durationMs: number; errorMessage: string }> = [];
+
+    const agent = new AgentLoop({
+      systemPrompt: 'test',
+      tools: [throwingTool],
+      client,
+      modelId: 'test-model',
+      callbacks: {
+        onToolCallFailed: (info) => { failedCalls.push(info); },
+      },
+    });
+
+    await agent.prompt(USER_MSG);
+
+    expect(failedCalls).toHaveLength(1);
+    expect(failedCalls[0]!.toolName).toBe('BadTool');
+    expect(failedCalls[0]!.errorMessage).toContain('intentional failure');
+    expect(typeof failedCalls[0]!.durationMs).toBe('number');
+  });
+
+  it('a throwing callback does not crash the agent loop', async () => {
+    const client = new FakeAnthropicClient([makeEndTurnMessage()]);
+
+    const agent = new AgentLoop({
+      systemPrompt: 'test',
+      tools: [],
+      client,
+      modelId: 'test-model',
+      callbacks: {
+        // All callbacks throw -- the loop must still complete normally.
+        onLlmTurnStarted: () => { throw new Error('callback error'); },
+        onLlmTurnCompleted: () => { throw new Error('callback error'); },
+      },
+    });
+
+    // Must not throw. Loop completes normally despite throwing callbacks.
+    await expect(agent.prompt(USER_MSG)).resolves.toBeUndefined();
+
+    const messages = agent.state.messages;
+    const lastMsg = messages[messages.length - 1];
+    expect(lastMsg?.role).toBe('assistant');
+  });
+});

--- a/tests/unit/daemon-events.test.ts
+++ b/tests/unit/daemon-events.test.ts
@@ -180,6 +180,12 @@ describe('DaemonEventEmitter', () => {
       { kind: 'session_completed', sessionId: 's1', workflowId: 'w1', outcome: 'success' },
       { kind: 'delivery_attempted', callbackUrl: 'https://example.com', outcome: 'success' },
       { kind: 'issue_reported', sessionId: 's1', issueKind: 'tool_failure', severity: 'warn', summary: 'test' },
+      // New conversation logging events (Slice 1).
+      { kind: 'llm_turn_started', sessionId: 's1', messageCount: 3 },
+      { kind: 'llm_turn_completed', sessionId: 's1', stopReason: 'tool_use', outputTokens: 150, inputTokens: 1200, toolNamesRequested: ['Bash'] },
+      { kind: 'tool_call_started', sessionId: 's1', toolName: 'Bash', argsSummary: '{"command":"git status"}' },
+      { kind: 'tool_call_completed', sessionId: 's1', toolName: 'Bash', durationMs: 45, resultSummary: 'On branch main' },
+      { kind: 'tool_call_failed', sessionId: 's1', toolName: 'Bash', durationMs: 12, errorMessage: 'Command failed' },
     ];
 
     for (const event of events) {


### PR DESCRIPTION
## Summary

- Adds 5 new event kinds to `DaemonEventEmitter`: `llm_turn_started`, `llm_turn_completed`, `tool_call_started`, `tool_call_completed`, `tool_call_failed`
- Adds `AgentLoopCallbacks` interface to `agent-loop.ts` with optional callbacks that fire around LLM API calls and tool executions, wired via `runWorkflow()` in `workflow-runner.ts`
- Adds `worktrain logs [--follow] [--session <id>]` CLI command that reads the daily JSONL event file and formats events for human reading (like `tail -f` but pretty-printed)

## Design

New events are emitted from `AgentLoop._runLoop()` (LLM turns) and `AgentLoop._executeTools()` (tool calls) via injected callbacks, keeping `AgentLoop` decoupled from `DaemonEventEmitter`. All callbacks are wrapped in `try/catch` to preserve the fire-and-forget invariant -- a throwing callback never crashes the agent loop. Existing `tool_called` events are unchanged for backward compatibility.

## Test plan

- [ ] `npx vitest run tests/unit/agent-loop.test.ts` -- 23 tests including 7 new callback timing tests
- [ ] `npx vitest run tests/unit/daemon-events.test.ts` -- 6 tests including updated exhaustiveness test
- [ ] `npx vitest run tests/unit/` -- full unit suite (283 files, 3526 tests)
- [ ] `worktrain logs --help` -- shows correct usage
- [ ] `worktrain logs` -- reads today's JSONL and formats events nicely
- [ ] `worktrain logs --session <id>` -- filters by session ID prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)