### PR TITLE
feat(console): fix isLive and add liveActivity for daemon sessions

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4309,3 +4309,79 @@ worktrain console --workspace ~/git/myproject  # workspace-scoped view
 **The classify-task-workflow role:** when a task is classified, it can also output a `deduplicationKey` (e.g. `fix:trigger-store:error-kind-consistency`) that is stored with the queue item. Queue items with the same key are considered duplicates.
 
 **What makes this hard:** semantic dedup (two tasks described differently but solving the same problem) requires embedding-based similarity, not exact match. For MVP, exact `sourceId` match + approximate PR title search is sufficient. Semantic dedup is a post-knowledge-graph feature.
+
+---
+
+### Agent actions as first-class events in the session event log (Apr 18, 2026)
+
+**The vision:** the console should be able to reconstruct exactly what an agent did in a session -- every tool call, every argument, every result, every decision -- by reading the event log alone. No log files, no stdout parsing, no separate monitoring infrastructure. The session event store IS the audit trail.
+
+**What's already in the event log:**
+- `session_created`, `run_started`, `run_completed`
+- `node_created`, `edge_created`, `advance_recorded`
+- `node_output_appended` (step notes)
+- `preferences_changed`, `context_set`, `observation_recorded`
+
+**What's missing -- agent-level actions:**
+- `tool_call_started` -- which tool was called, with what arguments, at what timestamp
+- `tool_call_completed` -- result (truncated), duration, success/error
+- `llm_turn_started` -- model, token count estimate, step context
+- `llm_turn_completed` -- stop reason, output tokens, whether steer() was injected
+- `steer_injected` -- what context was injected and why (session recap, workspace context)
+- `report_issue_recorded` -- the structured issue from the `report_issue` tool
+- `worktrain_stuck` -- when WORKTRAIN_STUCK marker is emitted
+
+**Why this matters:**
+Today the `DaemonEventEmitter` writes to `~/.workrail/events/daemon/YYYY-MM-DD.jsonl` separately from the session store. That's two places to look -- and they're not correlated to specific sessions. Putting agent actions into the session event log means:
+- Console can show a session timeline: "Phase 0: called `bash` 3 times (12ms, 8ms, 45ms) → called `read` 2 times → advanced to Phase 1"
+- The proof record (verification chain spec) can link specific tool calls to assessment gate evidence
+- Crash recovery knows exactly where in the agent's execution it died
+- The knowledge graph can be updated from session events without re-reading step notes
+
+**The event schema (additions to the existing event store format):**
+
+```typescript
+// Tool call lifecycle
+{ kind: 'tool_call_started', tool: 'bash', args: { command: 'git status' }, nodeId, ts }
+{ kind: 'tool_call_completed', tool: 'bash', durationMs: 45, exitCode: 0, resultSummary: '...', nodeId, ts }
+{ kind: 'tool_call_failed', tool: 'bash', durationMs: 45, error: 'ENOENT', nodeId, ts }
+
+// LLM turn lifecycle  
+{ kind: 'llm_turn_started', model: 'claude-sonnet-4-6', inputTokens: 12000, nodeId, ts }
+{ kind: 'llm_turn_completed', stopReason: 'tool_use', outputTokens: 450, toolsRequested: ['bash'], nodeId, ts }
+
+// Steer injection
+{ kind: 'steer_injected', reason: 'session_recap', contentLength: 800, nodeId, ts }
+
+// Agent self-reporting
+{ kind: 'report_issue_recorded', severity: 'warning', summary: '...', sessionId, ts }
+```
+
+**Where to emit them:**
+- In `src/daemon/agent-loop.ts` -- before and after each `tool.execute()` call, before and after each LLM call
+- In `src/daemon/workflow-runner.ts` -- for steer injection and report_issue recording
+- Use the existing `V2ToolContext` session store to append events (same mechanism as `continue_workflow` and `start_workflow`)
+
+**Console rendering:**
+Each session detail view gets a "Timeline" tab alongside "Steps" and "Notes":
+```
+Phase 0: Understand & Classify         [2m 14s]
+  ├── llm_turn              450 tokens → 3 tool calls
+  ├── bash: git status                    45ms ✓
+  ├── bash: gh pr list                   180ms ✓  
+  ├── read: AGENTS.md                      8ms ✓
+  └── llm_turn              280 tokens → advance
+Phase 1a: State Hypothesis              [0m 38s]
+  ├── llm_turn              310 tokens → advance
+  ...
+```
+
+**Relationship to DaemonEventEmitter:**
+The existing `DaemonEventEmitter` (written in #498) writes to a separate daily log file. Once agent actions are first-class session events, the daemon event emitter can be simplified or removed -- the session event log is the canonical record. The console reads session events, not daemon event files.
+
+**Build order:**
+1. Add `tool_call_started`/`tool_call_completed` events to `agent-loop.ts` -- smallest change, highest value
+2. Add `llm_turn_started`/`llm_turn_completed` events
+3. Console Timeline tab reads and renders the new event kinds
+4. Wire `report_issue_recorded` and `steer_injected` events
+5. Deprecate `DaemonEventEmitter` once console reads from session events

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -55,6 +55,13 @@ export interface SessionStartedEvent {
   readonly sessionId: string;
   readonly workflowId: string;
   readonly workspacePath: string;
+  /**
+   * The WorkRail session ID (e.g. 'sess_abc123') decoded from the continueToken.
+   * Absent on the session_started event (emitted before executeStartWorkflow returns).
+   * Present on subsequent per-session events once the continueToken is decoded.
+   * Used by ConsoleService to correlate daemon event log entries with session store entries.
+   */
+  readonly workrailSessionId?: string;
 }
 
 /** An agent tool was called. */
@@ -64,6 +71,12 @@ export interface ToolCalledEvent {
   readonly toolName: string;
   /** First 80 chars of the primary tool parameter (e.g. bash command, file path). */
   readonly summary?: string;
+  /**
+   * The WorkRail session ID (e.g. 'sess_abc123') for this tool call.
+   * Used by ConsoleService to correlate daemon event log entries with session store entries.
+   * Present when the continueToken was successfully decoded after executeStartWorkflow.
+   */
+  readonly workrailSessionId?: string;
 }
 
 /** A tool returned an error result (isError=true). */
@@ -73,12 +86,16 @@ export interface ToolErrorEvent {
   readonly toolName: string;
   /** First 200 chars of the error message. */
   readonly error: string;
+  /** The WorkRail session ID for correlation. Present when continueToken was decoded. */
+  readonly workrailSessionId?: string;
 }
 
 /** Workflow advanced to the next step. */
 export interface StepAdvancedEvent {
   readonly kind: 'step_advanced';
   readonly sessionId: string;
+  /** The WorkRail session ID for correlation. Present when continueToken was decoded. */
+  readonly workrailSessionId?: string;
 }
 
 /** Workflow run ended (success, error, or timeout). */
@@ -89,6 +106,8 @@ export interface SessionCompletedEvent {
   readonly outcome: 'success' | 'error' | 'timeout';
   /** Human-readable reason (stopReason, error message, or timeout type). */
   readonly detail?: string;
+  /** The WorkRail session ID for correlation. Present when continueToken was decoded. */
+  readonly workrailSessionId?: string;
 }
 
 /** HTTP POST to callbackUrl was attempted. */

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -797,6 +797,7 @@ export function makeContinueWorkflowTool(
   // Optional injection point for testing -- defaults to the real implementation.
   _executeContinueWorkflowFn: typeof executeContinueWorkflow = executeContinueWorkflow,
   emitter?: DaemonEventEmitter,
+  workrailSessionId?: string | null,
 ): AgentTool {
   return {
     name: 'continue_workflow',
@@ -811,7 +812,7 @@ export function makeContinueWorkflowTool(
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
       console.log(`[WorkflowRunner] Tool: continue_workflow sessionId=${sessionId}`);
-      emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'continue_workflow', summary: (params.intent as string | undefined) ?? 'advance' });
+      emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'continue_workflow', summary: (params.intent as string | undefined) ?? 'advance', ...(workrailSessionId != null ? { workrailSessionId } : {}) });
       const result = await _executeContinueWorkflowFn(
         {
           continueToken: params.continueToken,
@@ -915,7 +916,7 @@ export function makeContinueWorkflowTool(
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function makeBashTool(workspacePath: string, schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter): AgentTool {
+export function makeBashTool(workspacePath: string, schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter, workrailSessionId?: string | null): AgentTool {
   return {
     name: 'Bash',
     description:
@@ -931,7 +932,7 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
       console.log(`[WorkflowRunner] Tool: bash "${String(params.command).slice(0, 80)}"`);
-      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Bash', summary: String(params.command).slice(0, 80) });
+      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Bash', summary: String(params.command).slice(0, 80), ...(workrailSessionId != null ? { workrailSessionId } : {}) });
       const cwd = params.cwd ?? workspacePath;
       try {
         const { stdout, stderr } = await execAsync(params.command, {
@@ -988,7 +989,7 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeReadTool(schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter): AgentTool {
+function makeReadTool(schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter, workrailSessionId?: string | null): AgentTool {
   return {
     name: 'Read',
     description: 'Read the contents of a file at the given absolute path.',
@@ -999,7 +1000,7 @@ function makeReadTool(schemas: Record<string, any>, sessionId?: string, emitter?
       _toolCallId: string,
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
-      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Read', summary: String(params.filePath).slice(0, 80) });
+      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Read', summary: String(params.filePath).slice(0, 80), ...(workrailSessionId != null ? { workrailSessionId } : {}) });
       const content = await fs.readFile(params.filePath, 'utf8');
       return {
         content: [{ type: 'text', text: content }],
@@ -1010,7 +1011,7 @@ function makeReadTool(schemas: Record<string, any>, sessionId?: string, emitter?
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeWriteTool(schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter): AgentTool {
+function makeWriteTool(schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter, workrailSessionId?: string | null): AgentTool {
   return {
     name: 'Write',
     description: 'Write content to a file at the given absolute path. Creates parent directories if needed.',
@@ -1021,7 +1022,7 @@ function makeWriteTool(schemas: Record<string, any>, sessionId?: string, emitter
       _toolCallId: string,
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
-      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Write', summary: String(params.filePath).slice(0, 80) });
+      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Write', summary: String(params.filePath).slice(0, 80), ...(workrailSessionId != null ? { workrailSessionId } : {}) });
       await fs.mkdir(path.dirname(params.filePath), { recursive: true });
       await fs.writeFile(params.filePath, params.content, 'utf8');
       return {
@@ -1385,6 +1386,9 @@ export async function runWorkflow(
   console.log(`[WorkflowRunner] Session started: sessionId=${sessionId} workflowId=${trigger.workflowId}`);
 
   // Emit session_started event immediately after session ID is assigned.
+  // WHY workrailSessionId absent here: the continueToken is not yet decoded at this
+  // point (executeStartWorkflow has not been called yet). workrailSessionId is added
+  // to subsequent per-session events after the token decode completes below.
   emitter?.emit({
     kind: 'session_started',
     sessionId,
@@ -1392,8 +1396,14 @@ export async function runWorkflow(
     workspacePath: trigger.workspacePath,
   });
 
-  // ---- DaemonRegistry: register session ----
-  daemonRegistry?.register(sessionId, trigger.workflowId);
+  // ---- WorkRail session ID (decoded from continueToken after executeStartWorkflow) ----
+  // WHY: DaemonRegistry is keyed by WorkRail session ID (not the process-local UUID).
+  // ConsoleService.loadSessionSummary() looks up the registry by WorkRail session ID,
+  // so registering with the process UUID was a bug -- isLive was always false.
+  // This let variable is set below after executeStartWorkflow returns and the continueToken
+  // is decoded. All closures that need the WorkRail session ID capture this variable by
+  // reference -- they see the correct value when they run (after it has been assigned).
+  let workrailSessionId: string | null = null;
 
   // ---- Client and model setup ----
   // Priority: agentConfig.model (trigger-specific override) > env-based detection.
@@ -1411,7 +1421,7 @@ export async function runWorkflow(
     // Parse "provider/model-id" -- split on the first slash only
     const slashIdx = trigger.agentConfig.model.indexOf('/');
     if (slashIdx === -1) {
-      daemonRegistry?.unregister(sessionId, 'failed');
+      // Registration has not happened yet at this point (happens after executeStartWorkflow + decode).
       return {
         _tag: 'error',
         workflowId: trigger.workflowId,
@@ -1448,9 +1458,12 @@ export async function runWorkflow(
   const onAdvance = (stepText: string, _continueToken: string): void => {
     pendingSteerText = stepText;
     // Heartbeat on each step advance -- the session is alive and making progress.
-    daemonRegistry?.heartbeat(sessionId);
-    // Emit step_advanced event.
-    emitter?.emit({ kind: 'step_advanced', sessionId });
+    // WHY workrailSessionId: DaemonRegistry is keyed by WorkRail session ID (not process UUID).
+    // workrailSessionId is populated after executeStartWorkflow + continueToken decode.
+    // The closure captures it by reference -- correct value is available when onAdvance fires.
+    if (workrailSessionId !== null) daemonRegistry?.heartbeat(workrailSessionId);
+    // Emit step_advanced event with workrailSessionId for liveActivity correlation.
+    emitter?.emit({ kind: 'step_advanced', sessionId, ...(workrailSessionId != null ? { workrailSessionId } : {}) });
   };
 
   const onComplete = (notes: string | undefined): void => {
@@ -1483,7 +1496,7 @@ export async function runWorkflow(
     );
 
     if (startResult.isErr()) {
-      daemonRegistry?.unregister(sessionId, 'failed');
+      // Registration has not happened yet (happens after token decode below).
       return {
         _tag: 'error',
         workflowId: trigger.workflowId,
@@ -1497,6 +1510,43 @@ export async function runWorkflow(
   const startContinueToken = firstStep.continueToken ?? '';
   const startCheckpointToken = firstStep.checkpointToken ?? null;
 
+  // ---- Decode WorkRail session ID from the continueToken ----
+  // WHY: daemonRegistry.register() and daemon event emitter both need the WorkRail
+  // session ID (e.g. 'sess_abc123') so ConsoleService can correlate them with session
+  // store entries. The process-local UUID (sessionId above) is useless for this lookup.
+  //
+  // The decode uses parseContinueTokenOrFail() -- same pattern as loadSessionNotes().
+  // On decode failure: log an error and proceed without registry/emitter correlation.
+  // The session still runs correctly; isLive and liveActivity just won't work for
+  // this session (an unusual internal error since the token just came from executeStartWorkflow).
+  //
+  // WHY assigned to the outer `workrailSessionId` let (declared before onAdvance):
+  // The onAdvance closure captures workrailSessionId by reference. By the time the
+  // agent loop calls onAdvance, this variable is already populated.
+  if (startContinueToken) {
+    const decoded = await parseContinueTokenOrFail(
+      startContinueToken,
+      ctx.v2.tokenCodecPorts,
+      ctx.v2.tokenAliasStore,
+    );
+    if (decoded.isOk()) {
+      workrailSessionId = decoded.value.sessionId;
+    } else {
+      console.error(
+        `[WorkflowRunner] Error: could not decode WorkRail session ID from continueToken -- isLive and liveActivity will not work for this session. Reason: ${decoded.error.message}`,
+      );
+    }
+  }
+
+  // ---- DaemonRegistry: register session with WorkRail session ID ----
+  // WHY: ConsoleService.loadSessionSummary() looks up the registry by WorkRail session ID
+  // (not the process-local UUID). Using the WorkRail session ID here ensures isLive works.
+  // INVARIANT: register() is called at most once per runWorkflow() call. The early-exit
+  // paths above (model validation failure, start_workflow failure) happen before this point.
+  if (workrailSessionId !== null) {
+    daemonRegistry?.register(workrailSessionId, trigger.workflowId);
+  }
+
   // Crash safety: persist tokens before starting the agent loop. A crash between
   // this point and the first continue_workflow call leaves a recoverable state file.
   if (startContinueToken) {
@@ -1507,8 +1557,8 @@ export async function runWorkflow(
   // no pending continuation). Return success without creating an Agent.
   if (firstStep.isComplete) {
     await fs.unlink(path.join(DAEMON_SESSIONS_DIR, `${sessionId}.json`)).catch(() => {});
-    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'success', detail: 'stop' });
-    daemonRegistry?.unregister(sessionId, 'completed');
+    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'success', detail: 'stop', ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+    if (workrailSessionId !== null) daemonRegistry?.unregister(workrailSessionId, 'completed');
     return { _tag: 'success', workflowId: trigger.workflowId, stopReason: 'stop' };
   }
 
@@ -1519,10 +1569,10 @@ export async function runWorkflow(
   // start_workflow is NOT in this list: the daemon calls executeStartWorkflow()
   // directly above so the LLM cannot call it again.
   const tools: AgentTool[] = [
-    makeContinueWorkflowTool(sessionId, ctx, onAdvance, onComplete, schemas, executeContinueWorkflow, emitter),
-    makeBashTool(trigger.workspacePath, schemas, sessionId, emitter),
-    makeReadTool(schemas, sessionId, emitter),
-    makeWriteTool(schemas, sessionId, emitter),
+    makeContinueWorkflowTool(sessionId, ctx, onAdvance, onComplete, schemas, executeContinueWorkflow, emitter, workrailSessionId),
+    makeBashTool(trigger.workspacePath, schemas, sessionId, emitter, workrailSessionId),
+    makeReadTool(schemas, sessionId, emitter, workrailSessionId),
+    makeWriteTool(schemas, sessionId, emitter, workrailSessionId),
     makeReportIssueTool(sessionId, emitter),
   ];
 
@@ -1645,7 +1695,7 @@ export async function runWorkflow(
     for (const toolResult of event.toolResults) {
       if (toolResult.isError) {
         const errorText = toolResult.result?.content[0]?.text ?? 'tool error';
-        emitter?.emit({ kind: 'tool_error', sessionId, toolName: toolResult.toolName, error: errorText.slice(0, 200) });
+        emitter?.emit({ kind: 'tool_error', sessionId, toolName: toolResult.toolName, error: errorText.slice(0, 200), ...(workrailSessionId != null ? { workrailSessionId } : {}) });
       }
     }
 
@@ -1729,8 +1779,8 @@ export async function runWorkflow(
   // timeoutReason is set before agent.abort() in both abort paths; by the time we
   // reach here the catch has completed and it is safe to read synchronously.
   if (timeoutReason !== null) {
-    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'timeout', detail: timeoutReason });
-    daemonRegistry?.unregister(sessionId, 'failed');
+    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'timeout', detail: timeoutReason, ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+    if (workrailSessionId !== null) daemonRegistry?.unregister(workrailSessionId, 'failed');
     const limitDescription = timeoutReason === 'wall_clock'
       ? `${trigger.agentConfig?.maxSessionMinutes ?? DEFAULT_SESSION_TIMEOUT_MINUTES} minutes`
       : `${trigger.agentConfig?.maxTurns} turns`;
@@ -1745,8 +1795,8 @@ export async function runWorkflow(
 
   if (stopReason === 'error' || errorMessage) {
     const errMsg = errorMessage ?? 'Agent stopped with error reason';
-    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'error', detail: errMsg.slice(0, 200) });
-    daemonRegistry?.unregister(sessionId, 'failed');
+    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'error', detail: errMsg.slice(0, 200), ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+    if (workrailSessionId !== null) daemonRegistry?.unregister(workrailSessionId, 'failed');
     // Append a structured stuck marker so coordinator scripts can detect and act on it.
     // WHY: parseable by worktrain coordinator scripts without LLM involvement --
     // scripts-over-agent for routing decisions.
@@ -1772,8 +1822,8 @@ export async function runWorkflow(
     // Best-effort: ignore ENOENT (session never persisted tokens) and other errors.
   });
 
-  emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'success', detail: stopReason });
-  daemonRegistry?.unregister(sessionId, 'completed');
+  emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'success', detail: stopReason, ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+  if (workrailSessionId !== null) daemonRegistry?.unregister(workrailSessionId, 'completed');
 
   return {
     _tag: 'success',

--- a/src/v2/usecases/console-service.ts
+++ b/src/v2/usecases/console-service.ts
@@ -12,6 +12,9 @@
  * loading execution snapshots (stepId) and pinned workflows (step title, workflow name).
  * Graceful degradation: if any label can't be resolved, it falls back to null.
  */
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { type ResultAsync, ResultAsync as RA } from 'neverthrow';
 import { okAsync, errAsync, err } from 'neverthrow';
 import type { DirectoryListingPortV2 } from '../ports/directory-listing.port.js';
@@ -53,6 +56,7 @@ import type {
   ConsoleAdvanceOutcomeKind,
   ConsoleNodeGap,
   ConsoleArtifact,
+  ConsoleToolActivity,
 } from './console-types.js';
 import type { DomainEventV1 } from '../durable-core/schemas/session/index.js';
 import type { LoadedSessionTruthV2 } from '../ports/session-event-log-store.port.js';
@@ -100,6 +104,93 @@ const DORMANCY_THRESHOLD_MS = (() => {
  * this in a future daemon iteration; for MVP, heartbeats fire at continue_workflow advances.
  */
 const AUTONOMOUS_HEARTBEAT_THRESHOLD_MS = 10 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Live activity (daemon event log)
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum number of tool activity entries to return in liveActivity.
+ * WHY 5: enough to show recent activity without overwhelming the console UI.
+ */
+const LIVE_ACTIVITY_MAX_ENTRIES = 5;
+
+/**
+ * Maximum bytes to read from the daemon event log file tail.
+ * WHY 100KB: at ~200 bytes/event, this covers ~500 events -- far more than
+ * LIVE_ACTIVITY_MAX_ENTRIES. Matches the tail-read pattern in console-routes.ts.
+ */
+const DAEMON_EVENT_LOG_READ_LIMIT_BYTES = 100 * 1024;
+
+/**
+ * Directory for daemon event log JSONL files.
+ * Format: YYYY-MM-DD.jsonl, one per day, rotated automatically by DaemonEventEmitter.
+ */
+const DAEMON_EVENTS_DIR = path.join(os.homedir(), '.workrail', 'events', 'daemon');
+
+/**
+ * Read the last N tool_called events from today's daemon event log for a given session.
+ *
+ * Best-effort: returns null on any error (file not found, parse error, etc.).
+ * Never throws or propagates errors -- this is observability, not correctness.
+ *
+ * @param workrailSessionId - The WorkRail session ID to filter by.
+ * @param maxEntries - Maximum number of entries to return.
+ */
+async function readLiveActivity(
+  workrailSessionId: string,
+  maxEntries: number,
+): Promise<readonly ConsoleToolActivity[] | null> {
+  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const filePath = path.join(DAEMON_EVENTS_DIR, `${date}.jsonl`);
+
+  try {
+    let raw: string;
+    const stat = await fs.stat(filePath);
+    if (stat.size > DAEMON_EVENT_LOG_READ_LIMIT_BYTES) {
+      // Tail-read: read only the last DAEMON_EVENT_LOG_READ_LIMIT_BYTES.
+      // First line in the slice may be truncated -- JSON.parse catch handles it.
+      const fd = await fs.open(filePath, 'r');
+      const offset = stat.size - DAEMON_EVENT_LOG_READ_LIMIT_BYTES;
+      const buf = Buffer.alloc(DAEMON_EVENT_LOG_READ_LIMIT_BYTES);
+      await fd.read(buf, 0, DAEMON_EVENT_LOG_READ_LIMIT_BYTES, offset);
+      await fd.close();
+      raw = buf.toString('utf8');
+    } else {
+      raw = await fs.readFile(filePath, 'utf8');
+    }
+
+    const activities: ConsoleToolActivity[] = [];
+
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const event = JSON.parse(line) as Record<string, unknown>;
+        if (
+          event['kind'] !== 'tool_called' ||
+          event['workrailSessionId'] !== workrailSessionId ||
+          typeof event['toolName'] !== 'string' ||
+          typeof event['ts'] !== 'number'
+        ) {
+          continue;
+        }
+        activities.push({
+          toolName: event['toolName'],
+          ...(typeof event['summary'] === 'string' ? { summary: event['summary'] } : {}),
+          ts: event['ts'],
+        });
+      } catch {
+        // Malformed line -- skip it
+      }
+    }
+
+    // Return last N entries (most recent activity).
+    return activities.slice(-maxEntries);
+  } catch {
+    // File not found, permission error, etc. -- return null gracefully.
+    return null;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Run completion map — keyed by runId, true when preferred tip snapshot
@@ -173,6 +264,8 @@ export class ConsoleService {
 
   getSessionDetail(sessionIdStr: string): ResultAsync<ConsoleSessionDetail, ConsoleServiceError> {
     const sessionId = asSessionId(sessionIdStr);
+    const nowMs = Date.now();
+
     return this.ports.sessionStore
       .load(sessionId)
       .mapErr((storeErr): ConsoleServiceError => ({
@@ -181,19 +274,44 @@ export class ConsoleService {
       }))
       .andThen((truth) => {
         const dagRes = projectRunDagV2(truth.events);
-        if (dagRes.isErr()) {
-          return resolveRunCompletion(truth.events, this.ports.snapshotStore)
-            .map((completionMap) => projectSessionDetail(sessionId, truth, completionMap, {}, {}));
-        }
-        const dag = dagRes.value;
 
-        return RA.combine([
-          resolveRunCompletion(truth.events, this.ports.snapshotStore),
-          resolveStepLabels(dag, this.ports.snapshotStore, this.ports.pinnedWorkflowStore),
-          resolveWorkflowNames(dag, this.ports.pinnedWorkflowStore),
-        ] as const).map(([completionMap, stepLabels, workflowNames]) =>
-          projectSessionDetail(sessionId, truth, completionMap, stepLabels, workflowNames)
+        const detailRA = (() => {
+          if (dagRes.isErr()) {
+            return resolveRunCompletion(truth.events, this.ports.snapshotStore)
+              .map((completionMap) => projectSessionDetail(sessionId, truth, completionMap, {}, {}));
+          }
+          const dag = dagRes.value;
+
+          return RA.combine([
+            resolveRunCompletion(truth.events, this.ports.snapshotStore),
+            resolveStepLabels(dag, this.ports.snapshotStore, this.ports.pinnedWorkflowStore),
+            resolveWorkflowNames(dag, this.ports.pinnedWorkflowStore),
+          ] as const).map(([completionMap, stepLabels, workflowNames]) =>
+            projectSessionDetail(sessionId, truth, completionMap, stepLabels, workflowNames)
+          );
+        })();
+
+        // Attach liveActivity when the session is currently live.
+        // isLive: the session appears in DaemonRegistry with a recent heartbeat.
+        // Best-effort: any error reading the event log returns null liveActivity.
+        const registryEntry = this.ports.daemonRegistry?.snapshot().get(sessionId);
+        const isLive = registryEntry !== undefined
+          && (nowMs - registryEntry.lastHeartbeatMs) < AUTONOMOUS_HEARTBEAT_THRESHOLD_MS;
+
+        if (!isLive) {
+          return detailRA.map((detail) => ({ ...detail, liveActivity: null }));
+        }
+
+        // Session is live -- read tool activity from daemon event log.
+        // WHY RA.fromSafePromise: readLiveActivity never throws (returns null on error).
+        const liveActivityRA = RA.fromSafePromise(
+          readLiveActivity(sessionIdStr, LIVE_ACTIVITY_MAX_ENTRIES)
         );
+
+        return RA.combine([detailRA, liveActivityRA] as const).map(([detail, liveActivity]) => ({
+          ...detail,
+          liveActivity,
+        }));
       });
   }
 

--- a/src/v2/usecases/console-service.ts
+++ b/src/v2/usecases/console-service.ts
@@ -153,8 +153,11 @@ async function readLiveActivity(
       const fd = await fs.open(filePath, 'r');
       const offset = stat.size - DAEMON_EVENT_LOG_READ_LIMIT_BYTES;
       const buf = Buffer.alloc(DAEMON_EVENT_LOG_READ_LIMIT_BYTES);
-      await fd.read(buf, 0, DAEMON_EVENT_LOG_READ_LIMIT_BYTES, offset);
-      await fd.close();
+      try {
+        await fd.read(buf, 0, DAEMON_EVENT_LOG_READ_LIMIT_BYTES, offset);
+      } finally {
+        await fd.close();
+      }
       raw = buf.toString('utf8');
     } else {
       raw = await fs.readFile(filePath, 'utf8');

--- a/src/v2/usecases/console-types.ts
+++ b/src/v2/usecases/console-types.ts
@@ -132,11 +132,32 @@ export interface ConsoleDagRun {
   readonly skippedSteps: readonly ConsoleGhostStep[];
 }
 
+/**
+ * A single tool call recorded in the daemon event log.
+ * Shown in the console as live activity for actively-running daemon sessions.
+ */
+export interface ConsoleToolActivity {
+  /** Name of the tool that was called (e.g. 'Bash', 'Read', 'Write', 'continue_workflow'). */
+  readonly toolName: string;
+  /** First 80 chars of the primary tool parameter. Absent for some tool calls. */
+  readonly summary?: string;
+  /** Unix epoch ms when the tool call was recorded. */
+  readonly ts: number;
+}
+
 export interface ConsoleSessionDetail {
   readonly sessionId: string;
   readonly sessionTitle: string | null;
   readonly health: ConsoleSessionHealth;
   readonly runs: readonly ConsoleDagRun[];
+  /**
+   * The last N tool calls recorded in the daemon event log for this session.
+   * Only present when the session is currently live (isLive=true in the session summary)
+   * and the daemon event log contains correlated tool_called events.
+   * null when the session is not live, the daemon is not running in the same process,
+   * or the event log cannot be read.
+   */
+  readonly liveActivity?: readonly ConsoleToolActivity[] | null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fix isLive bug**: `DaemonRegistry` was keyed by a process-local UUID but `ConsoleService` looked it up by WorkRail session ID (`sess_xxx`), so `isLive` was always `false`. Fixed by decoding the `continueToken` after `executeStartWorkflow` to get the WorkRail session ID and using it as the registry key.
- **Add workrailSessionId to daemon events**: Added optional `workrailSessionId` field to `ToolCalledEvent`, `StepAdvancedEvent`, `SessionCompletedEvent`, and `ToolErrorEvent` in the daemon JSONL event log. Enables offline correlation between event log entries and WorkRail session store entries.
- **Add liveActivity to session detail**: `GET /api/v2/sessions/:sessionId` now includes a `liveActivity` field (last 5 tool calls) for sessions that are currently live. Read from the daily daemon JSONL event log, correlated by `workrailSessionId`. Best-effort -- returns `null` when the session is not live, the daemon is not running, or the event log cannot be read.

Note: `isAutonomous` (Feature 1) was already fully implemented and required no changes. The running session detection (Feature 3) also already works correctly at the API level via `deriveRunStatus`.

## Test plan

- [x] TypeScript compiles clean
- [x] `tests/unit/console-service-autonomous.test.ts` -- 11/11 pass (isLive and isAutonomous)
- [x] `tests/unit/workflow-runner-bash-tool.test.ts` -- 16/16 pass
- [ ] Manual: start a daemon session, verify `GET /api/v2/sessions/:sessionId` returns `liveActivity` with recent tool calls
- [ ] Manual: verify `GET /api/v2/sessions` returns `isLive: true` for active daemon sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)