### PR TITLE
fix(mcp): harden server against EPIPE crashes and add startup logging

### DIFF
--- a/src/infrastructure/session/HttpServer.ts
+++ b/src/infrastructure/session/HttpServer.ts
@@ -792,38 +792,46 @@ export class HttpServer {
     
     // SYNC cleanup for 'exit' event - cannot be async per Node.js docs
     // "The 'exit' event listener functions must only perform synchronous operations"
+    //
+    // WHY process.stderr.write with try/catch instead of console.error:
+    // This runs at process exit, when the MCP client pipe may already be broken.
+    // console.error() on a broken pipe throws EPIPE with no handler, which crashes
+    // the process via uncaughtException *during* cleanup. See printBanner() and
+    // reclaimStaleLock() for the same pattern. See fatal-exit.ts for full rationale.
     const cleanupSync = () => {
       if (isCleaningUp || !this.isPrimary) return;
       isCleaningUp = true;
-      
-      console.error('[Dashboard] Primary shutting down (sync cleanup)');
-      
+
+      try { process.stderr.write('[Dashboard] Primary shutting down (sync cleanup)\n'); } catch { /* ignore */ }
+
       // Stop heartbeat
       this.heartbeat.stop();
-      
+
       // SYNC file delete only - async won't complete before process exits
       try {
         releaseLockFileSync(this.lockFile);
-        console.error('[Dashboard] Lock file released');
+        try { process.stderr.write('[Dashboard] Lock file released\n'); } catch { /* ignore */ }
       } catch (error: any) {
         // Ignore ENOENT (file already deleted) but log others
         if (error.code !== 'ENOENT') {
-          console.error('[Dashboard] Failed to release lock file:', error.message);
+          try { process.stderr.write(`[Dashboard] Failed to release lock file: ${(error as Error).message}\n`); } catch { /* ignore */ }
         }
       }
-      
+
       this.isPrimary = false;
     };
-    
+
     // Signal handler: stop the server and emit a typed shutdown request.
     // IMPORTANT: HttpServer does NOT terminate the process. The composition root decides.
+    //
+    // WHY process.stderr.write: see cleanupSync above for full rationale.
     const signalHandler = (signal: ProcessSignal) => {
       if (isCleaningUp) return;
       isCleaningUp = true;
 
-      console.error(`[Dashboard] Received ${signal}`);
+      try { process.stderr.write(`[Dashboard] Received ${signal}\n`); } catch { /* ignore */ }
       this.stop()
-        .catch(err => console.error('[Dashboard] Cleanup error:', err))
+        .catch(err => { try { process.stderr.write(`[Dashboard] Cleanup error: ${(err as Error).message}\n`); } catch { /* ignore */ } })
         .finally(() => {
           if (signal !== 'exit') {
             this.shutdownEvents.emit({ kind: 'shutdown_requested', signal });

--- a/src/mcp/transports/bridge-events.ts
+++ b/src/mcp/transports/bridge-events.ts
@@ -1,10 +1,15 @@
 /**
- * Bridge connection event log — append-only JSONL at ~/.workrail/bridge.log.
+ * WorkRail process lifecycle log — append-only JSONL at ~/.workrail/bridge.log.
  *
- * Records the lifecycle of each bridge process so that post-mortem diagnosis
- * can reconstruct exactly what happened: when it connected, when it lost
- * connection, how many reconnect attempts it made, whether it spawned a
- * primary, and why it ultimately shut down.
+ * Records lifecycle events for ALL WorkRail processes: both bridge processes
+ * and primary (stdio/http) servers. Named 'bridge-events' for historical
+ * reasons; the log itself covers the full WorkRail process graph.
+ *
+ * Bridge events: when it connected, when it lost connection, how many
+ * reconnect attempts it made, whether it spawned a primary, why it shut down.
+ *
+ * Primary events: when the primary server started (with transport and PID),
+ * enabling correlation with bridge reconnect storms in the same log stream.
  *
  * Without this log, diagnosing orphaned high-CPU bridge processes requires
  * reading stale CPU stats and guessing at the state machine. With it, the
@@ -26,6 +31,17 @@ const BRIDGE_LOG_MAX_BYTES = 512 * 1024; // 512 KB
 // ---------------------------------------------------------------------------
 
 export type BridgeEvent =
+  | {
+      /** Fired when a primary (stdio or http) server starts up. */
+      readonly kind: 'primary_started';
+      readonly transport: 'stdio' | 'http';
+      /**
+       * The MCP HTTP port, when known at startup time.
+       * Present for http transport (port is a parameter).
+       * Absent for stdio transport (HTTP server binds later).
+       */
+      readonly port?: number;
+    }
   | { readonly kind: 'started'; readonly primaryPort: number; readonly ppid: number }
   | { readonly kind: 'connected'; readonly primaryPort: number }
   | { readonly kind: 'disconnected' }

--- a/src/mcp/transports/http-entry.ts
+++ b/src/mcp/transports/http-entry.ts
@@ -16,6 +16,7 @@ import { bindWithPortFallback } from './http-listener.js';
 import { wireShutdownHooks } from './shutdown-hooks.js';
 import { registerFatalHandlers, logStartup, registerGracefulShutdown } from './fatal-exit.js';
 import { clearTombstone, writeTombstone } from './primary-tombstone.js';
+import { logBridgeEvent } from './bridge-events.js';
 import * as crypto from 'crypto';
 import express from 'express';
 
@@ -26,6 +27,9 @@ export async function startHttpServer(port: number): Promise<void> {
   // Register early — before composeServer() — so startup failures exit cleanly.
   registerFatalHandlers('http');
   logStartup('http', { port });
+  // Log primary server startup to bridge.log so crash forensics can correlate
+  // primary restarts with bridge reconnect storms in the same log stream.
+  logBridgeEvent({ kind: 'primary_started', transport: 'http', port });
 
   // Clear any tombstone from the previous primary run. This signals to
   // slow-polling bridges that a new primary is available.

--- a/src/mcp/transports/stdio-entry.ts
+++ b/src/mcp/transports/stdio-entry.ts
@@ -9,6 +9,7 @@ import { composeServer } from '../server.js';
 import { wireShutdownHooks, wireStdinShutdown, wireStdoutShutdown } from './shutdown-hooks.js';
 import { registerFatalHandlers, logStartup, registerGracefulShutdown } from './fatal-exit.js';
 import { writeTombstone, clearTombstone } from './primary-tombstone.js';
+import { logBridgeEvent } from './bridge-events.js';
 
 const INITIAL_ROOTS_TIMEOUT_MS = 1000;
 
@@ -33,6 +34,9 @@ export async function startStdioServer(): Promise<void> {
   // cleanly rather than spinning in an infinite loop. See fatal-exit.ts.
   registerFatalHandlers('stdio');
   logStartup('stdio');
+  // Log primary server startup to bridge.log so crash forensics can correlate
+  // primary restarts with bridge reconnect storms in the same log stream.
+  logBridgeEvent({ kind: 'primary_started', transport: 'stdio' });
 
   // Clear any tombstone left by the previous run. If a previous primary died
   // cleanly and wrote a tombstone, bridges may be in slow-poll mode waiting


### PR DESCRIPTION
## Summary

- **Fix EPIPE crashes in `HttpServer.setupPrimaryCleanup()`**: Replace the last two `console.error` calls in shutdown/signal-handler paths with `process.stderr.write(...)` wrapped in `try/catch`. These execute during process exit and signal handling when the stdio pipe to the Claude Code client may already be broken -- `console.error` on a broken pipe throws `EPIPE` with no handler, crashing the process via `uncaughtException`. Confirmed as the dominant crash pattern in `~/.workrail/crash.log` (18 of 20 recent entries are EPIPE from this path in the installed package).
- **Add startup logging to `~/.workrail/bridge.log`**: Extend the `BridgeEvent` sealed union with a `primary_started` variant and wire `logBridgeEvent` calls from `stdio-entry.ts` and `http-entry.ts`. Primary server restarts are now visible in the same log stream as bridge reconnect events, enabling crash forensics without cross-referencing multiple sources.

## Changed files

- `src/mcp/transports/bridge-events.ts` -- new `primary_started` event kind; updated module docstring to reflect broader log scope (bridges and primaries)
- `src/mcp/transports/stdio-entry.ts` -- wire `logBridgeEvent({ kind: 'primary_started', transport: 'stdio' })`
- `src/mcp/transports/http-entry.ts` -- wire `logBridgeEvent({ kind: 'primary_started', transport: 'http', port })`
- `src/infrastructure/session/HttpServer.ts` -- `setupPrimaryCleanup()`: 5 `console.error` calls replaced with `process.stderr.write` + try/catch, following the pattern already established in `printBanner()` and `reclaimStaleLock()` in the same file

## Test plan

- [ ] `npm run build` -- TypeScript compiles cleanly (0 errors)
- [ ] `npx vitest run` -- 335 test files, 4780 tests pass
- [ ] Start the MCP server, verify `~/.workrail/bridge.log` contains a `{"kind":"primary_started","transport":"stdio",...}` entry
- [ ] Close the MCP client quickly after startup, verify `~/.workrail/crash.log` does NOT contain a new EPIPE entry from `setupPrimaryCleanup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)