### PR TITLE
fix(mcp): use path type for repo_root observations and cap maxTurns at 50

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4384,4 +4384,9 @@ The existing `DaemonEventEmitter` (written in #498) writes to a separate daily l
 2. Add `llm_turn_started`/`llm_turn_completed` events
 3. Console Timeline tab reads and renders the new event kinds
 4. Wire `report_issue_recorded` and `steer_injected` events
+
+---
+
+### FatalToolError: distinguish recoverable from non-recoverable tool failures (follow-up from PR #523)
+The blanket try/catch in AgentLoop._executeTools() converts ALL tool throws to isError tool_results. This is correct for Bash/Read/Write (LLM can see and retry), but potentially wrong for continue_workflow failures (LLM retrying with a broken token loops). The discovery agent proposed a FatalToolError subclass: tools throw FatalToolError for non-recoverable errors (session corruption, bad tokens), plain Error for recoverable failures. _executeTools catches plain Error and returns isError; FatalToolError propagates and kills the session. Combined with the DEFAULT_MAX_TURNS cap (PR followup), this provides defense-in-depth.
 5. Deprecate `DaemonEventEmitter` once console reads from session events

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -80,6 +80,18 @@ const MAX_SESSION_NOTE_CHARS = 800;
 const DEFAULT_SESSION_TIMEOUT_MINUTES = 30;
 
 /**
+ * Default maximum number of LLM turns per agent session.
+ *
+ * This default is used when no agentConfig.maxTurns is configured.
+ * Per-trigger overrides are set via triggers.yml agentConfig.maxTurns.
+ * WHY: prevents infinite retry loops when the LLM keeps calling continue_workflow
+ * with a broken token -- without a cap, each isError tool_result is visible to the
+ * LLM and it will simply retry, looping forever. 50 turns is generous enough for
+ * long coding tasks while still being a hard safety net.
+ */
+const DEFAULT_MAX_TURNS = 50;
+
+/**
  * Directory that holds per-session crash-recovery state files.
  * Each concurrent runWorkflow() call writes to its own <sessionId>.json file,
  * so concurrent sessions never clobber each other.
@@ -1672,7 +1684,7 @@ export async function runWorkflow(
   // (e.g. a fast code-review trigger vs. a slow coding-task trigger).
   const sessionTimeoutMs =
     (trigger.agentConfig?.maxSessionMinutes ?? DEFAULT_SESSION_TIMEOUT_MINUTES) * 60 * 1000;
-  const maxTurns = trigger.agentConfig?.maxTurns ?? 0; // 0 = no limit
+  const maxTurns = trigger.agentConfig?.maxTurns ?? DEFAULT_MAX_TURNS;
 
   // ---- Timeout reason flag ----
   // Tracks which limit fired first. Set synchronously before agent.abort() so the

--- a/src/v2/durable-core/domain/observation-builder.ts
+++ b/src/v2/durable-core/domain/observation-builder.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceAnchor } from '../../ports/workspace-anchor.port.js';
-import { MAX_OBSERVATION_SHORT_STRING_LENGTH } from '../constants.js';
+import { MAX_OBSERVATION_SHORT_STRING_LENGTH, MAX_OBSERVATION_PATH_LENGTH } from '../constants.js';
 
 /**
  * Observation event data shape (matches DomainEventV1 observation_recorded payload).
@@ -11,7 +11,8 @@ export interface ObservationEventData {
   readonly value:
     | { readonly type: 'short_string'; readonly value: string }
     | { readonly type: 'git_sha1'; readonly value: string }
-    | { readonly type: 'sha256'; readonly value: string };
+    | { readonly type: 'sha256'; readonly value: string }
+    | { readonly type: 'path'; readonly value: string };
   readonly confidence: 'low' | 'med' | 'high';
 }
 
@@ -25,6 +26,7 @@ export interface ObservationEventData {
  * - git_branch     → short_string (bounded to 80 chars)
  * - git_head_sha   → git_sha1 (40 hex chars)
  * - repo_root_hash → sha256 (sha256:<64 hex chars>)
+ * - repo_root      → path (bounded to 512 chars; short_string would silently drop paths > 80 chars)
  *
  * Returns empty array for empty input (graceful: no observations is valid).
  */
@@ -64,11 +66,12 @@ export function anchorsToObservations(anchors: readonly WorkspaceAnchor[]): read
         break;
 
       case 'repo_root':
-        // Lock: short_string max -- paths exceeding the limit are silently skipped (no observation emitted)
-        if (anchor.value.length > MAX_OBSERVATION_SHORT_STRING_LENGTH) break;
+        // Lock: path max 512 chars -- realistic filesystem paths can exceed short_string's 80-char limit.
+        // Using type 'path' prevents silently dropping valid repo roots on deeply nested directories.
+        if (anchor.value.length > MAX_OBSERVATION_PATH_LENGTH) break;
         observations.push({
           key: 'repo_root',
-          value: { type: 'short_string', value: anchor.value },
+          value: { type: 'path', value: anchor.value },
           confidence: 'high',
         });
         break;

--- a/tests/unit/v2/observation-builder.test.ts
+++ b/tests/unit/v2/observation-builder.test.ts
@@ -124,20 +124,34 @@ describe('anchorsToObservations', () => {
     expect(result[1]!.key).toBe('repo_root_hash');
   });
 
-  it('maps repo_root within 80 chars to short_string', () => {
+  it('maps repo_root to path type with high confidence', () => {
     const anchors: readonly WorkspaceAnchor[] = [
       { key: 'repo_root', value: '/Users/user/git/my-project' },
     ];
     const result = anchorsToObservations(anchors);
     expect(result).toHaveLength(1);
     expect(result[0]!.key).toBe('repo_root');
-    expect(result[0]!.value).toEqual({ type: 'short_string', value: '/Users/user/git/my-project' });
+    expect(result[0]!.value).toEqual({ type: 'path', value: '/Users/user/git/my-project' });
     expect(result[0]!.confidence).toBe('high');
   });
 
-  it('skips repo_root exceeding 80 chars (no observation emitted)', () => {
+  it('maps repo_root longer than 80 chars (path type, not silently dropped)', () => {
+    // Regression: short_string type would silently drop paths > 80 chars.
+    // path type supports up to 512 chars so deeply nested repos are not lost.
+    const longPath = '/Users/user/' + 'deeply-nested-directory/'.repeat(3) + 'my-project';
+    expect(longPath.length).toBeGreaterThan(80);
     const anchors: readonly WorkspaceAnchor[] = [
-      { key: 'repo_root', value: '/Users/user/' + 'a'.repeat(80) },
+      { key: 'repo_root', value: longPath },
+    ];
+    const result = anchorsToObservations(anchors);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.key).toBe('repo_root');
+    expect(result[0]!.value).toEqual({ type: 'path', value: longPath });
+  });
+
+  it('skips repo_root exceeding 512 chars (MAX_OBSERVATION_PATH_LENGTH)', () => {
+    const anchors: readonly WorkspaceAnchor[] = [
+      { key: 'repo_root', value: '/Users/user/' + 'a'.repeat(512) },
     ];
     const result = anchorsToObservations(anchors);
     expect(result).toHaveLength(0);


### PR DESCRIPTION
## Summary

- **F1 (Major):** `repo_root` observations were silently dropped for paths longer than 80 chars because the `repo_root` case in `observation-builder.ts` used `type: 'short_string'` (80-char limit). Changed to `type: 'path'` (512-char limit via `MAX_OBSERVATION_PATH_LENGTH`). Added three new tests: one confirming the path type is emitted, one regression test verifying paths >80 chars are NOT dropped, and one confirming the 512-char cap still applies.
- **F2 (Medium):** Added `DEFAULT_MAX_TURNS = 50` constant to `workflow-runner.ts`. Previously `maxTurns` defaulted to `0` (no limit), allowing infinite continue_workflow retry loops when the LLM received isError tool_results for a broken token.
- **F5 (Minor):** Appended `FatalToolError` backlog entry to `docs/ideas/backlog.md` as a follow-up to PR #523's blanket try/catch in `_executeTools()`.

## Test plan

- [x] `npx vitest run tests/unit/v2/observation-builder.test.ts` -- 14 tests pass (3 new)
- [x] `npm run build` -- clean build, no type errors
- [x] Full test suite: 4780 passed, 4 skipped; 1 pre-existing perf flake unrelated to these changes

## Files changed

- `src/v2/durable-core/domain/observation-builder.ts` -- repo_root: short_string -> path, import MAX_OBSERVATION_PATH_LENGTH, update interface and JSDoc
- `tests/unit/v2/observation-builder.test.ts` -- updated existing repo_root test + 2 new tests
- `src/daemon/workflow-runner.ts` -- add DEFAULT_MAX_TURNS = 50, use it as fallback for maxTurns
- `docs/ideas/backlog.md` -- append FatalToolError backlog item

🤖 Generated with [Claude Code](https://claude.com/claude-code)