### PR TITLE
fix(mcp): add workrailSessionId to 5 new event types, modelId to llm_turn_started, fix --session filter

### DIFF
--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -512,7 +512,7 @@ program
   .command('logs')
   .description('Read and display the WorkRail daemon event log. Use --follow to stream new events in real time.')
   .option('--follow', 'Continuously poll the log file for new events (like tail -f)')
-  .option('--session <id>', 'Filter events by sessionId prefix (first 8 chars or full UUID)')
+  .option('--session <id>', 'Filter events by sessionId (UUID prefix) or workrailSessionId (sess_xxx prefix)')
   .action(async (options: { follow?: boolean; session?: string }) => {
     const eventsDir = path.join(os.homedir(), '.workrail', 'events', 'daemon');
 
@@ -561,13 +561,14 @@ program
       for (const line of lines) {
         // Apply session filter if --session was provided.
         if (options.session) {
-          // Filter by sessionId prefix or exact match.
+          // Filter by sessionId (UUID) prefix/exact OR workrailSessionId (sess_xxx) prefix/exact.
           try {
             const obj = JSON.parse(line) as Record<string, unknown>;
             const sid = typeof obj['sessionId'] === 'string' ? obj['sessionId'] : '';
-            if (!sid.startsWith(options.session) && sid !== options.session) {
-              continue;
-            }
+            const wrid = typeof obj['workrailSessionId'] === 'string' ? obj['workrailSessionId'] : '';
+            const matchesSession = sid.startsWith(options.session) || sid === options.session ||
+              wrid.startsWith(options.session) || wrid === options.session;
+            if (!matchesSession) continue;
           } catch {
             continue; // Skip malformed lines when filtering.
           }

--- a/src/daemon/agent-loop.ts
+++ b/src/daemon/agent-loop.ts
@@ -150,7 +150,7 @@ export interface AgentLoopCallbacks {
    * Called immediately before client.messages.create().
    * @param info.messageCount - Number of messages in the conversation at this point.
    */
-  readonly onLlmTurnStarted?: (info: { readonly messageCount: number }) => void;
+  readonly onLlmTurnStarted?: (info: { readonly messageCount: number; readonly modelId: string }) => void;
   /**
    * Called immediately after client.messages.create() resolves successfully.
    * @param info.stopReason - The stop_reason from the API response.
@@ -374,7 +374,7 @@ export class AgentLoop {
       // Emit llm_turn_started before the API call.
       // WHY try/catch: preserves fire-and-forget invariant -- a throwing callback
       // must never crash the agent loop.
-      try { callbacks?.onLlmTurnStarted?.({ messageCount: apiMessages.length }); } catch { /* swallow */ }
+      try { callbacks?.onLlmTurnStarted?.({ messageCount: apiMessages.length, modelId }); } catch { /* swallow */ }
 
       let response: Anthropic.Message;
       try {

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -147,6 +147,10 @@ export interface LlmTurnStartedEvent {
   readonly sessionId: string;
   /** Number of messages in the conversation at the time of the call. */
   readonly messageCount: number;
+  /** The model ID used for this LLM turn (e.g. 'claude-sonnet-4-5'). */
+  readonly modelId?: string;
+  /** The WorkRail session ID for correlation. Present when continueToken was decoded. */
+  readonly workrailSessionId?: string;
 }
 
 /**
@@ -166,6 +170,8 @@ export interface LlmTurnCompletedEvent {
   readonly inputTokens: number;
   /** Names of tools the LLM requested in this turn (empty if end_turn). */
   readonly toolNamesRequested: readonly string[];
+  /** The WorkRail session ID for correlation. Present when continueToken was decoded. */
+  readonly workrailSessionId?: string;
 }
 
 /**
@@ -180,6 +186,8 @@ export interface ToolCallStartedEvent {
   readonly toolName: string;
   /** JSON-serialized params, truncated to 200 chars. */
   readonly argsSummary: string;
+  /** The WorkRail session ID for correlation. Present when continueToken was decoded. */
+  readonly workrailSessionId?: string;
 }
 
 /**
@@ -193,6 +201,8 @@ export interface ToolCallCompletedEvent {
   readonly durationMs: number;
   /** First 200 chars of the tool result text content. */
   readonly resultSummary: string;
+  /** The WorkRail session ID for correlation. Present when continueToken was decoded. */
+  readonly workrailSessionId?: string;
 }
 
 /**
@@ -210,6 +220,8 @@ export interface ToolCallFailedEvent {
   readonly durationMs: number;
   /** First 200 chars of the error message. */
   readonly errorMessage: string;
+  /** The WorkRail session ID for correlation. Present when continueToken was decoded. */
+  readonly workrailSessionId?: string;
 }
 
 /**

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -1639,7 +1639,13 @@ export async function runWorkflow(
   // The try/catch guards inside AgentLoop ensure callbacks never crash the loop.
   const agentCallbacks: AgentLoopCallbacks = {
     onLlmTurnStarted: ({ messageCount }) => {
-      emitter?.emit({ kind: 'llm_turn_started', sessionId, messageCount });
+      emitter?.emit({
+        kind: 'llm_turn_started',
+        sessionId,
+        messageCount,
+        modelId,
+        ...(workrailSessionId != null ? { workrailSessionId } : {}),
+      });
     },
     onLlmTurnCompleted: ({ stopReason, outputTokens, inputTokens, toolNamesRequested }) => {
       emitter?.emit({
@@ -1649,16 +1655,17 @@ export async function runWorkflow(
         outputTokens,
         inputTokens,
         toolNamesRequested,
+        ...(workrailSessionId != null ? { workrailSessionId } : {}),
       });
     },
     onToolCallStarted: ({ toolName, argsSummary }) => {
-      emitter?.emit({ kind: 'tool_call_started', sessionId, toolName, argsSummary });
+      emitter?.emit({ kind: 'tool_call_started', sessionId, toolName, argsSummary, ...(workrailSessionId != null ? { workrailSessionId } : {}) });
     },
     onToolCallCompleted: ({ toolName, durationMs, resultSummary }) => {
-      emitter?.emit({ kind: 'tool_call_completed', sessionId, toolName, durationMs, resultSummary });
+      emitter?.emit({ kind: 'tool_call_completed', sessionId, toolName, durationMs, resultSummary, ...(workrailSessionId != null ? { workrailSessionId } : {}) });
     },
     onToolCallFailed: ({ toolName, durationMs, errorMessage }) => {
-      emitter?.emit({ kind: 'tool_call_failed', sessionId, toolName, durationMs, errorMessage });
+      emitter?.emit({ kind: 'tool_call_failed', sessionId, toolName, durationMs, errorMessage, ...(workrailSessionId != null ? { workrailSessionId } : {}) });
     },
   };
 

--- a/tests/unit/cli-worktrain-logs.test.ts
+++ b/tests/unit/cli-worktrain-logs.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Unit tests for worktrain logs command logic.
+ *
+ * The formatting and filtering functions are inline in cli-worktrain.ts and not
+ * exported. These tests replicate the same rules directly so they stay in sync
+ * with the implementation without requiring a subprocess.
+ *
+ * WHY replicate instead of extract: the logs command is intentionally a thin
+ * inline composition. Extracting purely for testability would be premature
+ * abstraction -- these tests document the contract instead.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Replicated formatDaemonEventLine logic (mirrors cli-worktrain.ts)
+// ---------------------------------------------------------------------------
+
+function formatDaemonEventLine(raw: string): string | null {
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const ts = typeof obj['ts'] === 'number'
+    ? new Date(obj['ts']).toISOString().replace('T', ' ').slice(0, 23)
+    : '?';
+  const kind = typeof obj['kind'] === 'string' ? obj['kind'] : 'unknown';
+  const sessionId = typeof obj['sessionId'] === 'string' ? obj['sessionId'].slice(0, 8) : null;
+  const prefix = sessionId ? `[${ts}] [${sessionId}] ${kind}` : `[${ts}] ${kind}`;
+
+  switch (kind) {
+    case 'llm_turn_started':
+      return `${prefix}  msgs=${obj['messageCount'] ?? '?'}`;
+    case 'llm_turn_completed':
+      return `${prefix}  stop=${obj['stopReason'] ?? '?'} in=${obj['inputTokens'] ?? '?'} out=${obj['outputTokens'] ?? '?'} tools=[${Array.isArray(obj['toolNamesRequested']) ? (obj['toolNamesRequested'] as string[]).join(',') : ''}]`;
+    case 'tool_call_started':
+      return `${prefix}  tool=${obj['toolName'] ?? '?'} args=${String(obj['argsSummary'] ?? '').slice(0, 80)}`;
+    case 'tool_call_completed':
+      return `${prefix}  tool=${obj['toolName'] ?? '?'} ${obj['durationMs'] ?? '?'}ms result=${String(obj['resultSummary'] ?? '').slice(0, 60)}`;
+    case 'tool_call_failed':
+      return `${prefix}  tool=${obj['toolName'] ?? '?'} ${obj['durationMs'] ?? '?'}ms err=${String(obj['errorMessage'] ?? '').slice(0, 80)}`;
+    case 'tool_called':
+      return `${prefix}  tool=${obj['toolName'] ?? '?'} ${obj['summary'] ? String(obj['summary']).slice(0, 80) : ''}`;
+    case 'tool_error':
+      return `${prefix}  tool=${obj['toolName'] ?? '?'} err=${String(obj['error'] ?? '').slice(0, 80)}`;
+    case 'session_started':
+      return `${prefix}  workflow=${obj['workflowId'] ?? '?'} workspace=${obj['workspacePath'] ?? '?'}`;
+    case 'session_completed':
+      return `${prefix}  workflow=${obj['workflowId'] ?? '?'} outcome=${obj['outcome'] ?? '?'}${obj['detail'] ? ` (${obj['detail']})` : ''}`;
+    case 'step_advanced':
+      return `${prefix}`;
+    case 'issue_reported':
+      return `${prefix}  severity=${obj['severity'] ?? '?'} ${String(obj['summary'] ?? '').slice(0, 80)}`;
+    default:
+      return `${prefix}  ${JSON.stringify(obj).slice(0, 120)}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Replicated session filter logic (mirrors cli-worktrain.ts printLines)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the raw JSONL line matches the given session filter string.
+ * Matches on sessionId (UUID) OR workrailSessionId (sess_xxx) -- prefix or exact.
+ * Returns false for malformed JSON.
+ */
+function lineMatchesSession(line: string, session: string): boolean {
+  try {
+    const obj = JSON.parse(line) as Record<string, unknown>;
+    const sid = typeof obj['sessionId'] === 'string' ? obj['sessionId'] : '';
+    const wrid = typeof obj['workrailSessionId'] === 'string' ? obj['workrailSessionId'] : '';
+    return (
+      sid.startsWith(session) || sid === session ||
+      wrid.startsWith(session) || wrid === session
+    );
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEvent(overrides: Record<string, unknown>): string {
+  return JSON.stringify({ ts: 1_700_000_000_000, ...overrides });
+}
+
+// ---------------------------------------------------------------------------
+// Tests: session filter
+// ---------------------------------------------------------------------------
+
+describe('worktrain logs --session filter', () => {
+  const UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+  const WRID = 'sess_abc123xyz';
+
+  it('matches a line by full UUID sessionId', () => {
+    const line = makeEvent({ kind: 'step_advanced', sessionId: UUID });
+    expect(lineMatchesSession(line, UUID)).toBe(true);
+  });
+
+  it('matches a line by UUID sessionId prefix (first 8 chars)', () => {
+    const line = makeEvent({ kind: 'step_advanced', sessionId: UUID });
+    expect(lineMatchesSession(line, UUID.slice(0, 8))).toBe(true);
+  });
+
+  it('does not match a line with a different UUID', () => {
+    const line = makeEvent({ kind: 'step_advanced', sessionId: 'ffffffff-0000-0000-0000-000000000000' });
+    expect(lineMatchesSession(line, UUID.slice(0, 8))).toBe(false);
+  });
+
+  it('matches a line by full workrailSessionId', () => {
+    const line = makeEvent({ kind: 'llm_turn_started', sessionId: UUID, workrailSessionId: WRID });
+    expect(lineMatchesSession(line, WRID)).toBe(true);
+  });
+
+  it('matches a line by workrailSessionId prefix', () => {
+    const line = makeEvent({ kind: 'llm_turn_started', sessionId: UUID, workrailSessionId: WRID });
+    expect(lineMatchesSession(line, 'sess_abc123')).toBe(true);
+  });
+
+  it('matches when filtering by sess_ prefix on an event that has workrailSessionId', () => {
+    const line = makeEvent({
+      kind: 'tool_call_started',
+      sessionId: UUID,
+      workrailSessionId: WRID,
+      toolName: 'Bash',
+      argsSummary: 'ls -la',
+    });
+    expect(lineMatchesSession(line, 'sess_')).toBe(true);
+  });
+
+  it('does not match when neither sessionId nor workrailSessionId match', () => {
+    const line = makeEvent({ kind: 'step_advanced', sessionId: UUID, workrailSessionId: WRID });
+    expect(lineMatchesSession(line, 'sess_zzz')).toBe(false);
+  });
+
+  it('returns false for malformed JSON', () => {
+    expect(lineMatchesSession('{not valid json', UUID)).toBe(false);
+  });
+
+  it('returns false for empty string input', () => {
+    expect(lineMatchesSession('', UUID)).toBe(false);
+  });
+
+  it('does not match an event with no sessionId or workrailSessionId fields', () => {
+    const line = makeEvent({ kind: 'daemon_started', port: 3456, workspacePath: '/tmp' });
+    expect(lineMatchesSession(line, UUID.slice(0, 8))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: formatDaemonEventLine
+// ---------------------------------------------------------------------------
+
+describe('formatDaemonEventLine', () => {
+  it('returns null for malformed JSON', () => {
+    expect(formatDaemonEventLine('{bad json')).toBeNull();
+    expect(formatDaemonEventLine('')).toBeNull();
+    expect(formatDaemonEventLine('   ')).toBeNull();
+  });
+
+  it('formats llm_turn_started with messageCount', () => {
+    const line = makeEvent({ kind: 'llm_turn_started', sessionId: 'aabbccdd-1234', messageCount: 7 });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('llm_turn_started');
+    expect(result).toContain('msgs=7');
+    expect(result).toContain('[aabbccdd]');
+  });
+
+  it('formats llm_turn_completed with token counts and tools', () => {
+    const line = makeEvent({
+      kind: 'llm_turn_completed',
+      sessionId: 'aabbccdd-1234',
+      stopReason: 'tool_use',
+      inputTokens: 1500,
+      outputTokens: 300,
+      toolNamesRequested: ['Bash', 'Read'],
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('stop=tool_use');
+    expect(result).toContain('in=1500');
+    expect(result).toContain('out=300');
+    expect(result).toContain('tools=[Bash,Read]');
+  });
+
+  it('formats tool_call_started with tool name and args', () => {
+    const line = makeEvent({
+      kind: 'tool_call_started',
+      sessionId: 'aabbccdd-1234',
+      toolName: 'Bash',
+      argsSummary: 'npm run build',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('tool=Bash');
+    expect(result).toContain('args=npm run build');
+  });
+
+  it('formats tool_call_completed with duration and result summary', () => {
+    const line = makeEvent({
+      kind: 'tool_call_completed',
+      sessionId: 'aabbccdd-1234',
+      toolName: 'Read',
+      durationMs: 42,
+      resultSummary: 'file contents here',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('tool=Read');
+    expect(result).toContain('42ms');
+    expect(result).toContain('result=file contents here');
+  });
+
+  it('formats tool_call_failed with error message', () => {
+    const line = makeEvent({
+      kind: 'tool_call_failed',
+      sessionId: 'aabbccdd-1234',
+      toolName: 'Write',
+      durationMs: 10,
+      errorMessage: 'permission denied',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('tool=Write');
+    expect(result).toContain('10ms');
+    expect(result).toContain('err=permission denied');
+  });
+
+  it('formats session_started with workflowId and workspace', () => {
+    const line = makeEvent({
+      kind: 'session_started',
+      sessionId: 'aabbccdd-1234',
+      workflowId: 'wf-123',
+      workspacePath: '/home/user/project',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('workflow=wf-123');
+    expect(result).toContain('workspace=/home/user/project');
+  });
+
+  it('formats session_completed with outcome and optional detail', () => {
+    const line = makeEvent({
+      kind: 'session_completed',
+      sessionId: 'aabbccdd-1234',
+      workflowId: 'wf-123',
+      outcome: 'error',
+      detail: 'unhandled exception',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('outcome=error');
+    expect(result).toContain('(unhandled exception)');
+  });
+
+  it('omits detail parenthetical when detail is absent', () => {
+    const line = makeEvent({
+      kind: 'session_completed',
+      sessionId: 'aabbccdd-1234',
+      workflowId: 'wf-123',
+      outcome: 'success',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain('(');
+  });
+
+  it('formats step_advanced as bare prefix (no extra fields)', () => {
+    const line = makeEvent({ kind: 'step_advanced', sessionId: 'aabbccdd-1234' });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('step_advanced');
+    // Should not have trailing spaces or extra content
+    expect(result!.endsWith('step_advanced')).toBe(true);
+  });
+
+  it('uses ? for unknown ts when ts field is missing', () => {
+    const line = JSON.stringify({ kind: 'step_advanced', sessionId: 'aabbccdd-1234' });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('[?]');
+  });
+
+  it('omits sessionId bracket when sessionId is missing', () => {
+    const line = makeEvent({ kind: 'daemon_started', port: 3456 });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    // No sessionId bracket in prefix -- only one bracket pair (the timestamp)
+    const bracketed = result!.match(/\[/g) ?? [];
+    expect(bracketed.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Post-merge follow-ups from PR #528:

- **Fix 1 (High):** `workrailSessionId` added to all 5 new event type interfaces (`LlmTurnStartedEvent`, `LlmTurnCompletedEvent`, `ToolCallStartedEvent`, `ToolCallCompletedEvent`, `ToolCallFailedEvent`) in `daemon-events.ts`, and each corresponding emitter call in `workflow-runner.ts` now spreads `workrailSessionId` via the established `...(workrailSessionId != null ? { workrailSessionId } : {})` pattern.
- **Fix 1b (High):** `worktrain logs --session` now matches both `sessionId` (UUID) and `workrailSessionId` (`sess_xxx`) -- previously it only matched the UUID, so filtering by a WorkRail session ID silently showed nothing.
- **Fix 2 (Low):** `modelId` added to `LlmTurnStartedEvent` and forwarded through `AgentLoopCallbacks.onLlmTurnStarted` so each LLM turn event in the log identifies which model was used.
- **Fix 3 (Low):** 22 unit tests in `tests/unit/cli-worktrain-logs.test.ts` covering the `--session` filter logic (UUID prefix, exact match, `sess_xxx` prefix, no match, malformed JSON) and `formatDaemonEventLine` output for all key event kinds.

## Test plan

- [ ] `npx vitest run tests/unit/cli-worktrain-logs.test.ts` -- all 22 tests pass
- [ ] `npx tsc --noEmit` -- no TypeScript errors
- [ ] `npm run build` -- clean build
- [ ] Smoke test: run daemon, start a session, then `worktrain logs --session sess_<prefix>` -- events should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)