### PR TITLE
fix(daemon): arch audit fixes -- withWorkrailSession helper, dual-stream doc, timeout message, liveActivity both streams

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4416,3 +4416,31 @@ The blanket try/catch in AgentLoop._executeTools() converts ALL tool throws to i
 **Mitigation already in place:** `--isolation worktree` creates branches named `worktree-agent-<id>` -- these are identifiable and bulk-deletable. The daemon's `runStartupRecovery()` could also prune them.
 
 **Build order:** startup pruning (trivial, high value) → automatic cleanup on session end → `worktrain worktree` CLI commands.
+
+---
+
+### Simplify MCP server: remove primary election, bridge, and HTTP serving (architectural cleanup)
+
+**The core insight:** the bridge/primary-election system exists solely to solve "only one process should serve the console UI on port 3456." Now that `worktrain console` is a standalone file-watching binary (PR #512), that problem is already solved. The entire bridge/election system can be removed.
+
+**What "allow multiple MCP processes" means in practice:**
+- Each Claude Code window gets its own MCP server -- no port contention, no primary election, no bridge reconnect cycles
+- MCP server becomes pure stdio: starts, handles tools, exits. Nothing async needs to write after the pipe closes -- EPIPE is irrelevant.
+- Session store is append-only JSONL per-session -- multiple processes writing different sessions cannot corrupt each other
+- `worktrain console` aggregates all sessions from the file store regardless of how many MCP servers ran
+
+**What to remove:**
+- `DashboardLock` / `tryBecomePrimary()` / `bindWithPortFallback()` -- the entire primary election system
+- `bridge-entry.ts` -- the bridge, spawn storm, and reconnect drama are gone
+- `HttpServer` starting as part of the MCP server -- console owns HTTP, not MCP
+
+**What remains for the MCP server:** pure stdio MCP protocol + session engine. No HTTP, no port binding, no lock files. Starts instantly, exits cleanly.
+
+**Why this is safe:**
+- Tokens are session-scoped UUIDs -- two servers cannot share a session
+- Append-only JSONL has no exclusive file locks
+- ~50MB per process × 3 Claude Code windows = 150MB -- acceptable
+
+**The bridge complexity was always a band-aid.** It was the right solution when the MCP server also owned the console UI. With the standalone console, the band-aid can come off and the system becomes dramatically simpler and more reliable.
+
+**Build order:** extract `worktrain console` fully (done) → remove HttpServer from MCP startup → remove bridge → remove DashboardLock/primary election → MCP server is pure stdio.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4390,3 +4390,29 @@ The existing `DaemonEventEmitter` (written in #498) writes to a separate daily l
 ### FatalToolError: distinguish recoverable from non-recoverable tool failures (follow-up from PR #523)
 The blanket try/catch in AgentLoop._executeTools() converts ALL tool throws to isError tool_results. This is correct for Bash/Read/Write (LLM can see and retry), but potentially wrong for continue_workflow failures (LLM retrying with a broken token loops). The discovery agent proposed a FatalToolError subclass: tools throw FatalToolError for non-recoverable errors (session corruption, bad tokens), plain Error for recoverable failures. _executeTools catches plain Error and returns isError; FatalToolError propagates and kills the session. Combined with the DEFAULT_MAX_TURNS cap (PR followup), this provides defense-in-depth.
 5. Deprecate `DaemonEventEmitter` once console reads from session events
+
+---
+
+### Worktree lifecycle management: automatic cleanup and inventory (Apr 18, 2026)
+
+**The problem:** every WorkTrain agent that uses `--isolation worktree` leaves a worktree on disk after completion. With 10 concurrent agents running all day, this accumulated to 69 worktrees in `.claude/worktrees/`, triggering hundreds of simultaneous `git status` processes that saturated the CPU.
+
+**What's needed:**
+
+1. **Automatic cleanup on session end** -- when a WorkTrain session completes (success or failure), the daemon automatically runs `git worktree remove <path> --force` for the session's worktree. If the branch is already merged to main, also delete the local branch ref.
+
+2. **Startup pruning** -- `workrail daemon` startup runs `git worktree prune` in each configured workspace before starting the trigger listener.
+
+3. **`worktrain worktree list`** -- shows all WorkTrain-managed worktrees: path, branch, session ID, age, whether the branch is merged.
+
+4. **`worktrain worktree clean`** -- removes all worktrees whose branches are merged to main, or older than N days. Dry-run mode by default.
+
+5. **`worktrain worktree status`** -- summary: how many worktrees, total disk usage, any stale ones.
+
+6. **Never use main as a worktree** (already in backlog) -- enforced at worktree creation time, not just as a rule.
+
+**Root cause of the CPU spike:** 69 worktrees × repeated `git status --short` from tools/IDE plugins = hundreds of concurrent git processes. Each `git status` on a large repo with many untracked files is CPU-intensive.
+
+**Mitigation already in place:** `--isolation worktree` creates branches named `worktree-agent-<id>` -- these are identifiable and bulk-deletable. The daemon's `runStartupRecovery()` could also prune them.
+
+**Build order:** startup pruning (trivial, high value) → automatic cleanup on session end → `worktrain worktree` CLI commands.

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -177,6 +177,24 @@ export interface LlmTurnCompletedEvent {
 /**
  * A tool call is starting. Emitted in agent-loop.ts before tool.execute().
  *
+ * NOTE -- dual-stream model:
+ * Two parallel tool event streams exist in the daemon JSONL log:
+ *
+ * 1. COARSE stream (legacy): `tool_called` events emitted from inside each
+ *    tool's execute() body in workflow-runner.ts. Includes a tool-specific
+ *    `summary` field (truncated command/path). Consumed by `readLiveActivity()`
+ *    in console-service.ts for the live session panel.
+ *
+ * 2. FINE-GRAINED stream (new): `tool_call_started`, `tool_call_completed`,
+ *    `tool_call_failed` events emitted via AgentLoopCallbacks in agent-loop.ts.
+ *    Includes `durationMs` and `resultSummary`. Intended for timing analysis,
+ *    `worktrain logs --follow`, and future analytics features.
+ *
+ * WHY two streams: `tool_called` predates AgentLoopCallbacks and is emitted
+ * from inside each tool -- it has tool-specific context (the Bash command, the
+ * file path) that AgentLoop cannot see. The fine-grained stream adds timing
+ * and lifecycle without replacing the coarse stream.
+ *
  * WHY argsSummary: raw params may be large (e.g. file contents in Write tool).
  * Truncating to 200 chars gives observability without bloating the event log.
  */

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -92,6 +92,18 @@ const DEFAULT_SESSION_TIMEOUT_MINUTES = 30;
 const DEFAULT_MAX_TURNS = 50;
 
 /**
+ * Conditionally spreads workrailSessionId into a daemon event object.
+ *
+ * WHY: workrailSessionId (the WorkRail sess_xxx ID) is unavailable at session_started
+ * time -- it can only be decoded from the continueToken after executeStartWorkflow()
+ * returns. All subsequent events include it when available, via this helper.
+ * Returns an empty object when sid is null so callers can spread unconditionally.
+ */
+function withWorkrailSession(sid: string | null | undefined): { workrailSessionId?: string } {
+  return sid != null ? { workrailSessionId: sid } : {};
+}
+
+/**
  * Directory that holds per-session crash-recovery state files.
  * Each concurrent runWorkflow() call writes to its own <sessionId>.json file,
  * so concurrent sessions never clobber each other.
@@ -824,7 +836,7 @@ export function makeContinueWorkflowTool(
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
       console.log(`[WorkflowRunner] Tool: continue_workflow sessionId=${sessionId}`);
-      emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'continue_workflow', summary: (params.intent as string | undefined) ?? 'advance', ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+      emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'continue_workflow', summary: (params.intent as string | undefined) ?? 'advance', ...withWorkrailSession(workrailSessionId) });
       const result = await _executeContinueWorkflowFn(
         {
           continueToken: params.continueToken,
@@ -944,7 +956,7 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
       console.log(`[WorkflowRunner] Tool: bash "${String(params.command).slice(0, 80)}"`);
-      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Bash', summary: String(params.command).slice(0, 80), ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Bash', summary: String(params.command).slice(0, 80), ...withWorkrailSession(workrailSessionId) });
       const cwd = params.cwd ?? workspacePath;
       try {
         const { stdout, stderr } = await execAsync(params.command, {
@@ -1012,7 +1024,7 @@ function makeReadTool(schemas: Record<string, any>, sessionId?: string, emitter?
       _toolCallId: string,
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
-      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Read', summary: String(params.filePath).slice(0, 80), ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Read', summary: String(params.filePath).slice(0, 80), ...withWorkrailSession(workrailSessionId) });
       const content = await fs.readFile(params.filePath, 'utf8');
       return {
         content: [{ type: 'text', text: content }],
@@ -1034,7 +1046,7 @@ function makeWriteTool(schemas: Record<string, any>, sessionId?: string, emitter
       _toolCallId: string,
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
-      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Write', summary: String(params.filePath).slice(0, 80), ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+      if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Write', summary: String(params.filePath).slice(0, 80), ...withWorkrailSession(workrailSessionId) });
       await fs.mkdir(path.dirname(params.filePath), { recursive: true });
       await fs.writeFile(params.filePath, params.content, 'utf8');
       return {
@@ -1475,7 +1487,7 @@ export async function runWorkflow(
     // The closure captures it by reference -- correct value is available when onAdvance fires.
     if (workrailSessionId !== null) daemonRegistry?.heartbeat(workrailSessionId);
     // Emit step_advanced event with workrailSessionId for liveActivity correlation.
-    emitter?.emit({ kind: 'step_advanced', sessionId, ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+    emitter?.emit({ kind: 'step_advanced', sessionId, ...withWorkrailSession(workrailSessionId) });
   };
 
   const onComplete = (notes: string | undefined): void => {
@@ -1569,7 +1581,7 @@ export async function runWorkflow(
   // no pending continuation). Return success without creating an Agent.
   if (firstStep.isComplete) {
     await fs.unlink(path.join(DAEMON_SESSIONS_DIR, `${sessionId}.json`)).catch(() => {});
-    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'success', detail: 'stop', ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'success', detail: 'stop', ...withWorkrailSession(workrailSessionId) });
     if (workrailSessionId !== null) daemonRegistry?.unregister(workrailSessionId, 'completed');
     return { _tag: 'success', workflowId: trigger.workflowId, stopReason: 'stop' };
   }
@@ -1644,7 +1656,7 @@ export async function runWorkflow(
         sessionId,
         messageCount,
         modelId,
-        ...(workrailSessionId != null ? { workrailSessionId } : {}),
+        ...withWorkrailSession(workrailSessionId),
       });
     },
     onLlmTurnCompleted: ({ stopReason, outputTokens, inputTokens, toolNamesRequested }) => {
@@ -1655,17 +1667,17 @@ export async function runWorkflow(
         outputTokens,
         inputTokens,
         toolNamesRequested,
-        ...(workrailSessionId != null ? { workrailSessionId } : {}),
+        ...withWorkrailSession(workrailSessionId),
       });
     },
     onToolCallStarted: ({ toolName, argsSummary }) => {
-      emitter?.emit({ kind: 'tool_call_started', sessionId, toolName, argsSummary, ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+      emitter?.emit({ kind: 'tool_call_started', sessionId, toolName, argsSummary, ...withWorkrailSession(workrailSessionId) });
     },
     onToolCallCompleted: ({ toolName, durationMs, resultSummary }) => {
-      emitter?.emit({ kind: 'tool_call_completed', sessionId, toolName, durationMs, resultSummary, ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+      emitter?.emit({ kind: 'tool_call_completed', sessionId, toolName, durationMs, resultSummary, ...withWorkrailSession(workrailSessionId) });
     },
     onToolCallFailed: ({ toolName, durationMs, errorMessage }) => {
-      emitter?.emit({ kind: 'tool_call_failed', sessionId, toolName, durationMs, errorMessage, ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+      emitter?.emit({ kind: 'tool_call_failed', sessionId, toolName, durationMs, errorMessage, ...withWorkrailSession(workrailSessionId) });
     },
   };
 
@@ -1714,7 +1726,7 @@ export async function runWorkflow(
     for (const toolResult of event.toolResults) {
       if (toolResult.isError) {
         const errorText = toolResult.result?.content[0]?.text ?? 'tool error';
-        emitter?.emit({ kind: 'tool_error', sessionId, toolName: toolResult.toolName, error: errorText.slice(0, 200), ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+        emitter?.emit({ kind: 'tool_error', sessionId, toolName: toolResult.toolName, error: errorText.slice(0, 200), ...withWorkrailSession(workrailSessionId) });
       }
     }
 
@@ -1798,11 +1810,11 @@ export async function runWorkflow(
   // timeoutReason is set before agent.abort() in both abort paths; by the time we
   // reach here the catch has completed and it is safe to read synchronously.
   if (timeoutReason !== null) {
-    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'timeout', detail: timeoutReason, ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'timeout', detail: timeoutReason, ...withWorkrailSession(workrailSessionId) });
     if (workrailSessionId !== null) daemonRegistry?.unregister(workrailSessionId, 'failed');
     const limitDescription = timeoutReason === 'wall_clock'
       ? `${trigger.agentConfig?.maxSessionMinutes ?? DEFAULT_SESSION_TIMEOUT_MINUTES} minutes`
-      : `${trigger.agentConfig?.maxTurns} turns`;
+      : `${trigger.agentConfig?.maxTurns ?? DEFAULT_MAX_TURNS} turns`;
     return {
       _tag: 'timeout',
       workflowId: trigger.workflowId,
@@ -1814,7 +1826,7 @@ export async function runWorkflow(
 
   if (stopReason === 'error' || errorMessage) {
     const errMsg = errorMessage ?? 'Agent stopped with error reason';
-    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'error', detail: errMsg.slice(0, 200), ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+    emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'error', detail: errMsg.slice(0, 200), ...withWorkrailSession(workrailSessionId) });
     if (workrailSessionId !== null) daemonRegistry?.unregister(workrailSessionId, 'failed');
     // Append a structured stuck marker so coordinator scripts can detect and act on it.
     // WHY: parseable by worktrain coordinator scripts without LLM involvement --
@@ -1841,7 +1853,7 @@ export async function runWorkflow(
     // Best-effort: ignore ENOENT (session never persisted tokens) and other errors.
   });
 
-  emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'success', detail: stopReason, ...(workrailSessionId != null ? { workrailSessionId } : {}) });
+  emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'success', detail: stopReason, ...withWorkrailSession(workrailSessionId) });
   if (workrailSessionId !== null) daemonRegistry?.unregister(workrailSessionId, 'completed');
 
   return {

--- a/src/v2/usecases/console-service.ts
+++ b/src/v2/usecases/console-service.ts
@@ -129,10 +129,15 @@ const DAEMON_EVENT_LOG_READ_LIMIT_BYTES = 100 * 1024;
 const DAEMON_EVENTS_DIR = path.join(os.homedir(), '.workrail', 'events', 'daemon');
 
 /**
- * Read the last N tool_called events from today's daemon event log for a given session.
+ * Read the last N tool activity events from today's daemon event log for a given session.
+ *
+ * Reads from BOTH the coarse stream (tool_called) and fine-grained stream (tool_call_started)
+ * to show all tool activity regardless of which stream emitted it. See ToolCallStartedEvent
+ * in daemon-events.ts for documentation of the dual-stream model.
  *
  * Best-effort: returns null on any error (file not found, parse error, etc.).
  * Never throws or propagates errors -- this is observability, not correctness.
+ * Returns [] when no matching events found (log readable but empty for this session).
  *
  * @param workrailSessionId - The WorkRail session ID to filter by.
  * @param maxEntries - Maximum number of entries to return.
@@ -170,8 +175,12 @@ async function readLiveActivity(
       if (!line.trim()) continue;
       try {
         const event = JSON.parse(line) as Record<string, unknown>;
+        // Accept both coarse stream (tool_called) and fine-grained stream (tool_call_started).
+        // See dual-stream model docs in ToolCallStartedEvent in daemon-events.ts.
+        const isToolEvent =
+          event['kind'] === 'tool_called' || event['kind'] === 'tool_call_started';
         if (
-          event['kind'] !== 'tool_called' ||
+          !isToolEvent ||
           event['workrailSessionId'] !== workrailSessionId ||
           typeof event['toolName'] !== 'string' ||
           typeof event['ts'] !== 'number'


### PR DESCRIPTION
## Summary

Fixes three findings from architecture audit of PRs #523-539:

- **HIGH**: Add `withWorkrailSession()` helper to eliminate 14 manual conditional spreads in workflow-runner.ts -- single type-enforced pattern, documented WHY
- **HIGH**: Document dual tool-event stream model in daemon-events.ts + update `readLiveActivity()` to consume both `tool_called` (coarse) and `tool_call_started` (fine-grained) events
- **LOW**: Fix timeout message "exceeded turn limit after undefined turns" -- was missing `?? DEFAULT_MAX_TURNS` fallback
- **docs**: Add MCP server simplification spec to backlog -- remove primary election/bridge now that `worktrain console` is standalone

## Test plan
- [ ] Build passes
- [ ] Timeout message correctly shows turn count when `agentConfig.maxTurns` is not set
- [ ] `liveActivity` in session detail includes both `tool_called` and `tool_call_started` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)