### PR TITLE
fix(mcp): add workrailSessionId to IssueReportedEvent and SIGINT to logs --follow

### DIFF
--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -596,6 +596,10 @@ program
 
     // --follow mode: print existing lines then poll for new ones.
     // Start at offset 0 to show all existing events, then track the byte position.
+    // WHY explicit SIGINT handler: makes Ctrl-C clean exit explicit rather than
+    // relying on Node's default SIGINT behavior inside the polling loop.
+    process.once('SIGINT', () => process.exit(0));
+
     let currentFilePath = filePath;
     let offset = 0;
 

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -133,6 +133,8 @@ export interface IssueReportedEvent {
   readonly summary: string;
   /** Current continueToken, if the agent provided it (enables coordinator resumption). */
   readonly continueToken?: string;
+  /** The WorkRail session ID for correlation. Present when continueToken was decoded. */
+  readonly workrailSessionId?: string;
 }
 
 /**

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -1097,11 +1097,13 @@ interface IssueRecord {
  *
  * @param sessionId - The process-local session UUID (keys the issues file).
  * @param emitter - Optional event emitter to fire an issue_reported event.
+ * @param workrailSessionId - The WorkRail session ID for event correlation (optional).
  * @param issuesDirOverride - Override the issues directory (for tests).
  */
 export function makeReportIssueTool(
   sessionId: string,
   emitter?: DaemonEventEmitter,
+  workrailSessionId?: string | null,
   issuesDirOverride?: string,
 ): AgentTool {
   const issuesDir = issuesDirOverride ?? path.join(os.homedir(), '.workrail', 'issues');
@@ -1183,6 +1185,7 @@ export function makeReportIssueTool(
         severity: record.severity,
         summary: record.summary,
         ...(record.continueToken !== undefined && { continueToken: record.continueToken }),
+        ...(workrailSessionId != null ? { workrailSessionId } : {}),
       });
 
       const isFatal = record.severity === 'fatal';
@@ -1585,7 +1588,7 @@ export async function runWorkflow(
     makeBashTool(trigger.workspacePath, schemas, sessionId, emitter, workrailSessionId),
     makeReadTool(schemas, sessionId, emitter, workrailSessionId),
     makeWriteTool(schemas, sessionId, emitter, workrailSessionId),
-    makeReportIssueTool(sessionId, emitter),
+    makeReportIssueTool(sessionId, emitter, workrailSessionId),
   ];
 
   // ---- Context loading (soul + workspace + session notes) ----

--- a/tests/unit/workflow-runner-report-issue.test.ts
+++ b/tests/unit/workflow-runner-report-issue.test.ts
@@ -66,17 +66,17 @@ describe('makeReportIssueTool()', () => {
 
   describe('tool shape', () => {
     it('returns a tool with name report_issue', () => {
-      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      const tool = makeReportIssueTool('sess-1', undefined, undefined, tmpDir);
       expect(tool.name).toBe('report_issue');
     });
 
     it('description mentions the auto-fix coordinator', () => {
-      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      const tool = makeReportIssueTool('sess-1', undefined, undefined, tmpDir);
       expect(tool.description).toContain('auto-fix coordinator');
     });
 
     it('input schema requires kind, severity, and summary', () => {
-      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      const tool = makeReportIssueTool('sess-1', undefined, undefined, tmpDir);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const schema = tool.inputSchema as any;
       expect(schema.required).toContain('kind');
@@ -87,7 +87,7 @@ describe('makeReportIssueTool()', () => {
 
   describe('return values', () => {
     it('returns non-fatal confirmation for info severity', async () => {
-      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      const tool = makeReportIssueTool('sess-1', undefined, undefined, tmpDir);
       const result = await tool.execute('call-1', {
         kind: 'tool_failure',
         severity: 'info',
@@ -98,7 +98,7 @@ describe('makeReportIssueTool()', () => {
     });
 
     it('returns non-fatal confirmation for warn severity', async () => {
-      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      const tool = makeReportIssueTool('sess-1', undefined, undefined, tmpDir);
       const result = await tool.execute('call-1', {
         kind: 'blocked',
         severity: 'warn',
@@ -108,7 +108,7 @@ describe('makeReportIssueTool()', () => {
     });
 
     it('returns non-fatal confirmation for error severity', async () => {
-      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      const tool = makeReportIssueTool('sess-1', undefined, undefined, tmpDir);
       const result = await tool.execute('call-1', {
         kind: 'unexpected_behavior',
         severity: 'error',
@@ -118,7 +118,7 @@ describe('makeReportIssueTool()', () => {
     });
 
     it('returns FATAL message for fatal severity', async () => {
-      const tool = makeReportIssueTool('sess-1', undefined, tmpDir);
+      const tool = makeReportIssueTool('sess-1', undefined, undefined, tmpDir);
       const result = await tool.execute('call-1', {
         kind: 'needs_human',
         severity: 'fatal',
@@ -131,7 +131,7 @@ describe('makeReportIssueTool()', () => {
 
   describe('JSONL write', () => {
     it('writes a JSON line to <issuesDirOverride>/<sessionId>.jsonl', async () => {
-      const tool = makeReportIssueTool('sess-abc', undefined, tmpDir);
+      const tool = makeReportIssueTool('sess-abc', undefined, undefined, tmpDir);
       await tool.execute('call-1', {
         kind: 'tool_failure',
         severity: 'error',
@@ -146,7 +146,7 @@ describe('makeReportIssueTool()', () => {
     });
 
     it('written JSON contains kind, severity, summary, sessionId, and ts', async () => {
-      const tool = makeReportIssueTool('sess-abc', undefined, tmpDir);
+      const tool = makeReportIssueTool('sess-abc', undefined, undefined, tmpDir);
       await tool.execute('call-1', {
         kind: 'blocked',
         severity: 'warn',
@@ -167,7 +167,7 @@ describe('makeReportIssueTool()', () => {
     });
 
     it('includes optional fields when provided', async () => {
-      const tool = makeReportIssueTool('sess-abc', undefined, tmpDir);
+      const tool = makeReportIssueTool('sess-abc', undefined, undefined, tmpDir);
       await tool.execute('call-1', {
         kind: 'tool_failure',
         severity: 'error',
@@ -194,7 +194,7 @@ describe('makeReportIssueTool()', () => {
 
     it('creates directory if it does not exist', async () => {
       const nestedDir = path.join(tmpDir, 'issues', 'nested');
-      const tool = makeReportIssueTool('sess-abc', undefined, nestedDir);
+      const tool = makeReportIssueTool('sess-abc', undefined, undefined, nestedDir);
       await tool.execute('call-1', {
         kind: 'self_correction',
         severity: 'info',
@@ -212,7 +212,7 @@ describe('makeReportIssueTool()', () => {
       // We simulate failure by pointing to /dev/null as the directory -- mkdir
       // on /dev/null will fail because it is not a directory.
       const badDir = '/dev/null/impossible-path';
-      const tool = makeReportIssueTool('sess-abc', undefined, badDir);
+      const tool = makeReportIssueTool('sess-abc', undefined, undefined, badDir);
 
       // Must not throw -- fire-and-forget swallows all write errors.
       await expect(
@@ -226,7 +226,7 @@ describe('makeReportIssueTool()', () => {
 
     it('truncates summary longer than 200 chars to exactly 200 chars', async () => {
       const longSummary = 'a'.repeat(201);
-      const tool = makeReportIssueTool('sess-abc', undefined, tmpDir);
+      const tool = makeReportIssueTool('sess-abc', undefined, undefined, tmpDir);
       await tool.execute('call-1', {
         kind: 'tool_failure',
         severity: 'error',
@@ -252,7 +252,7 @@ describe('makeReportIssueTool()', () => {
         origEmit(event);
       });
 
-      const tool = makeReportIssueTool('sess-abc', emitter, tmpDir);
+      const tool = makeReportIssueTool('sess-abc', emitter, undefined, tmpDir);
       await tool.execute('call-1', {
         kind: 'unexpected_behavior',
         severity: 'warn',
@@ -270,7 +270,7 @@ describe('makeReportIssueTool()', () => {
 
     it('does not emit an event when no emitter is provided', async () => {
       // If no emitter, no event -- no error should occur.
-      const tool = makeReportIssueTool('sess-abc', undefined, tmpDir);
+      const tool = makeReportIssueTool('sess-abc', undefined, undefined, tmpDir);
       await expect(
         tool.execute('call-1', {
           kind: 'self_correction',


### PR DESCRIPTION
## Summary

- Add `readonly workrailSessionId?: string` to `IssueReportedEvent` so `issue_reported` events are filterable by WorkRail session via `worktrain logs --session sess_xxx`
- Update `makeReportIssueTool` to accept `workrailSessionId` as a 3rd parameter (shifting `issuesDirOverride` to 4th) and include it in the emitted event using the same spread pattern as all other session-correlated events
- Pass `workrailSessionId` at the call site in `runTriggerSession`
- Add explicit `process.once('SIGINT', () => process.exit(0))` before the `logs --follow` polling loop for clean Ctrl-C exit

## Test plan

- [ ] All 15 tests in `tests/unit/workflow-runner-report-issue.test.ts` pass (updated call signatures for the new 4-arg form)
- [ ] Full test suite passes (`npm run build` + `npx vitest run`) -- one pre-existing flaky perf test unrelated to these changes
- [ ] `issue_reported` events emitted by the daemon now include `workrailSessionId` when the session token has been decoded, enabling `worktrain logs --session sess_xxx` filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)