### PR TITLE
fix(console): include isLive field in ConsoleSessionDetail response

### DIFF
--- a/src/v2/usecases/console-service.ts
+++ b/src/v2/usecases/console-service.ts
@@ -380,7 +380,7 @@ export class ConsoleService {
 
         return RA.combine([detailRA, isLiveRA] as const).andThen(([detail, isLive]) => {
           if (!isLive) {
-            return okAsync({ ...detail, liveActivity: null });
+            return okAsync({ ...detail, isLive: false, liveActivity: null });
           }
 
           // Session is live -- read tool activity from daemon event log.
@@ -390,7 +390,7 @@ export class ConsoleService {
           );
 
           // Returns [] when no tool_called events found yet (log readable but empty); null means the log file could not be read.
-          return liveActivityRA.map((liveActivity) => ({ ...detail, liveActivity }));
+          return liveActivityRA.map((liveActivity) => ({ ...detail, isLive: true, liveActivity }));
         });
       });
   }

--- a/src/v2/usecases/console-types.ts
+++ b/src/v2/usecases/console-types.ts
@@ -151,11 +151,16 @@ export interface ConsoleSessionDetail {
   readonly health: ConsoleSessionHealth;
   readonly runs: readonly ConsoleDagRun[];
   /**
+   * Whether the session is currently running.
+   * Derived from the daemon event log: true when any correlated event exists
+   * and no session_completed event has been seen.
+   */
+  readonly isLive?: boolean;
+  /**
    * The last N tool calls recorded in the daemon event log for this session.
-   * Only present when the session is currently live (isLive=true in the session summary)
-   * and the daemon event log contains correlated tool_called events.
-   * null when the session is not live, the daemon is not running in the same process,
-   * or the event log cannot be read.
+   * Only present when the session is currently live (isLive=true).
+   * null when the session is not live or the event log cannot be read.
+   * Returns [] when live but no tool events recorded yet.
    */
   readonly liveActivity?: readonly ConsoleToolActivity[] | null;
 }


### PR DESCRIPTION
isLive was computed correctly from the event log but never included in the JSON response body. Add it to ConsoleSessionDetail type and both return paths (true and false branches).