### PR TITLE
fix(daemon): expose artifacts param in continue_workflow tool for assessment gates

### DIFF
--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -772,6 +772,14 @@ function getSchemas(): Record<string, any> {
           type: 'string',
           description: 'Notes on what you did in this step (10-30 lines, markdown).',
         },
+        artifacts: {
+          type: 'array',
+          items: {},
+          description:
+            'Optional structured artifacts to attach to this step. ' +
+            'Include wr.assessment objects here when the step requires an assessment gate. ' +
+            'Example: [{ "kind": "wr.assessment", "assessmentId": "<id>", "dimensions": { "<dimensionId>": "high" } }]',
+        },
         context: {
           type: 'object',
           additionalProperties: true,
@@ -827,7 +835,8 @@ export function makeContinueWorkflowTool(
     name: 'continue_workflow',
     description:
       'Advance the WorkRail workflow to the next step. Call this after completing all work ' +
-      'required by the current step. Include your notes in notesMarkdown.',
+      'required by the current step. Include your notes in notesMarkdown. ' +
+      'When the step requires an assessment gate, include wr.assessment objects in artifacts.',
     inputSchema: schemas['ContinueWorkflowParams'],
     label: 'Continue Workflow',
 
@@ -841,8 +850,15 @@ export function makeContinueWorkflowTool(
         {
           continueToken: params.continueToken,
           intent: (params.intent ?? 'advance') as 'advance' | 'rehydrate',
-          output: params.notesMarkdown
-            ? { notesMarkdown: params.notesMarkdown }
+          // WHY: output is constructed when either notesMarkdown or artifacts is present.
+          // Agents may need to submit assessment artifacts without notes (e.g. when the
+          // step's only requirement is an assessment gate). Using `?.length` prevents an
+          // empty artifacts array from constructing a spurious output object.
+          output: (params.notesMarkdown || (params.artifacts as unknown[] | undefined)?.length)
+            ? {
+                ...(params.notesMarkdown ? { notesMarkdown: params.notesMarkdown } : {}),
+                ...(params.artifacts ? { artifacts: params.artifacts } : {}),
+              }
             : undefined,
           context: params.context,
         },

--- a/tests/unit/workflow-runner-artifacts.test.ts
+++ b/tests/unit/workflow-runner-artifacts.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for artifacts pass-through in makeContinueWorkflowTool().
+ *
+ * Verifies that:
+ * - artifacts are forwarded to executeContinueWorkflow when present
+ * - artifacts-only case (no notesMarkdown) constructs output correctly
+ * - empty artifacts array does NOT construct output
+ * - both artifacts and notesMarkdown present are both forwarded
+ * - neither present -> output is undefined (regression guard)
+ *
+ * WHY fake injection over mocking: follows the "prefer fakes over mocks"
+ * principle from CLAUDE.md. The optional `_executeContinueWorkflowFn`
+ * parameter accepts a real fake, keeping tests deterministic and realistic.
+ *
+ * Note: persistTokens() writes to ~/.workrail/daemon-sessions/<sessionId>.json.
+ * Each test uses a unique UUID session ID so files never collide. Files are
+ * cleaned up in afterEach.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, afterEach } from 'vitest';
+import { okAsync } from 'neverthrow';
+import type { V2ToolContext } from '../../src/mcp/types.js';
+import { makeContinueWorkflowTool } from '../../src/daemon/workflow-runner.js';
+import { DAEMON_SESSIONS_DIR } from '../../src/daemon/workflow-runner.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/** Minimal ok response for a successful advance. */
+function makeOkResponse() {
+  return {
+    kind: 'ok' as const,
+    continueToken: 'ct_nexttoken12345678901234567890',
+    checkpointToken: undefined,
+    isComplete: false,
+    pending: {
+      stepId: 'step-2',
+      title: 'Step 2',
+      prompt: 'Do the next work.',
+    },
+    preferences: {
+      autonomy: 'full_auto_never_stop' as const,
+      riskPolicy: 'balanced' as const,
+    },
+    nextIntent: 'perform_pending_then_continue' as const,
+    nextCall: {
+      tool: 'continue_workflow' as const,
+      params: { continueToken: 'ct_nexttoken12345678901234567890' },
+    },
+  };
+}
+
+/**
+ * Fake executeContinueWorkflow that captures the input for inspection and
+ * returns a successful ok response.
+ *
+ * WHY a mutable container object: destructuring `captured` from the returned
+ * object would snapshot its value at destructure time (null). Using a container
+ * object lets tests read `container.captured` after the async call completes
+ * and see the updated value.
+ */
+function makeFakeCapturingExec(): {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  container: { captured: any | null };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fake: (input: any, _ctx: any) => ReturnType<typeof okAsync>;
+} {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const container: { captured: any | null } = { captured: null };
+  return {
+    container,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fake: (input: any, _ctx: any) => {
+      container.captured = input;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return okAsync({ response: makeOkResponse() as any });
+    },
+  };
+}
+
+/** Null V2ToolContext -- not used by the fake. */
+const NULL_CTX = {} as unknown as V2ToolContext;
+
+/** Stub schemas -- ContinueWorkflowParams not used in tests. */
+const STUB_SCHEMAS = { ContinueWorkflowParams: {} };
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+const sessionIdsToClean: string[] = [];
+
+afterEach(async () => {
+  for (const sessionId of sessionIdsToClean) {
+    const filePath = path.join(DAEMON_SESSIONS_DIR, `${sessionId}.json`);
+    await fs.unlink(filePath).catch(() => { /* ignore if not created */ });
+  }
+  sessionIdsToClean.length = 0;
+});
+
+function makeSessionId(): string {
+  const id = randomUUID();
+  sessionIdsToClean.push(id);
+  return id;
+}
+
+/** A sample wr.assessment artifact. */
+const SAMPLE_ASSESSMENT = {
+  kind: 'wr.assessment',
+  assessmentId: 'some-gate',
+  dimensions: { some_dimension: 'high' },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('makeContinueWorkflowTool() -- artifacts pass-through', () => {
+  describe('TC1: artifacts present, notesMarkdown absent', () => {
+    it('forwards artifacts in output.artifacts and omits notesMarkdown', async () => {
+      const sessionId = makeSessionId();
+      const { container, fake } = makeFakeCapturingExec();
+      const tool = makeContinueWorkflowTool(
+        sessionId, NULL_CTX, () => {}, () => {}, STUB_SCHEMAS, fake,
+      );
+
+      await tool.execute('call-1', {
+        continueToken: 'ct_agenttoken12345678901234567',
+        artifacts: [SAMPLE_ASSESSMENT],
+      });
+
+      expect(container.captured?.output).toBeDefined();
+      expect(container.captured?.output?.artifacts).toEqual([SAMPLE_ASSESSMENT]);
+      expect(container.captured?.output?.notesMarkdown).toBeUndefined();
+    });
+  });
+
+  describe('TC2: empty artifacts array', () => {
+    it('does NOT construct output when artifacts is empty and notesMarkdown is absent', async () => {
+      const sessionId = makeSessionId();
+      const { container, fake } = makeFakeCapturingExec();
+      const tool = makeContinueWorkflowTool(
+        sessionId, NULL_CTX, () => {}, () => {}, STUB_SCHEMAS, fake,
+      );
+
+      await tool.execute('call-1', {
+        continueToken: 'ct_agenttoken12345678901234567',
+        artifacts: [],
+      });
+
+      expect(container.captured?.output).toBeUndefined();
+    });
+  });
+
+  describe('TC3: both artifacts and notesMarkdown present', () => {
+    it('forwards both notesMarkdown and artifacts in output', async () => {
+      const sessionId = makeSessionId();
+      const { container, fake } = makeFakeCapturingExec();
+      const tool = makeContinueWorkflowTool(
+        sessionId, NULL_CTX, () => {}, () => {}, STUB_SCHEMAS, fake,
+      );
+
+      await tool.execute('call-1', {
+        continueToken: 'ct_agenttoken12345678901234567',
+        notesMarkdown: 'My detailed notes',
+        artifacts: [SAMPLE_ASSESSMENT],
+      });
+
+      expect(container.captured?.output?.notesMarkdown).toBe('My detailed notes');
+      expect(container.captured?.output?.artifacts).toEqual([SAMPLE_ASSESSMENT]);
+    });
+  });
+
+  describe('TC4: neither artifacts nor notesMarkdown present (regression guard)', () => {
+    it('passes output as undefined when neither artifacts nor notesMarkdown are present', async () => {
+      const sessionId = makeSessionId();
+      const { container, fake } = makeFakeCapturingExec();
+      const tool = makeContinueWorkflowTool(
+        sessionId, NULL_CTX, () => {}, () => {}, STUB_SCHEMAS, fake,
+      );
+
+      await tool.execute('call-1', {
+        continueToken: 'ct_agenttoken12345678901234567',
+      });
+
+      expect(container.captured?.output).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- The daemon's `continue_workflow` tool in `makeContinueWorkflowTool()` only forwarded `notesMarkdown` to `executeContinueWorkflow`, silently dropping any `artifacts` the agent provided
- Autonomous agents running inside the daemon could not pass `wr.assessment` artifacts required by assessment-gate steps, making it impossible to advance past any step with an assessment gate
- This adds `artifacts` as a top-level param in the daemon tool schema (mirroring the flatten pattern already used for `notesMarkdown` and `context`)

## Changes

**`src/daemon/workflow-runner.ts`:**
- Added `artifacts?: unknown[]` to `ContinueWorkflowParams` JSON Schema in `getSchemas()`, with description explaining `wr.assessment` usage for assessment gates
- Updated output construction condition from `params.notesMarkdown ? ...` to `(params.notesMarkdown || params.artifacts?.length) ? ...` so artifacts-only submissions (no notes) correctly construct the output object
- Updated tool description to mention assessment gate artifacts

**`tests/unit/workflow-runner-artifacts.test.ts`** (new file):
- TC1: artifacts present, notesMarkdown absent -- verifies artifacts forwarded, notesMarkdown absent from output
- TC2: empty artifacts array -- verifies output is not constructed
- TC3: both present -- verifies both forwarded
- TC4: neither present -- regression guard, output is undefined

## Test plan

- [x] `npm run build` -- 0 errors
- [x] `npx vitest run tests/unit/workflow-runner-artifacts.test.ts` -- 4/4 passing (new)
- [x] All workflow-runner tests -- 76/76 passing
- [x] No changes to `executeContinueWorkflow` or MCP server schema

Note: `workspacePath` was deliberately NOT added to the daemon schema -- the daemon does not use rehydrate mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)