### PR TITLE
feat(workflows): improve wr.discovery goal reframing to uncover real needs

### DIFF
--- a/docs/discovery/design-candidates.md
+++ b/docs/discovery/design-candidates.md
@@ -1,0 +1,180 @@
+# Design Candidates: wr.discovery Goal Reframing
+
+**Status:** Candidate generation complete -- for main agent review  
+**Date:** 2026-04-18  
+**Session:** wr.discovery (improving goal reframing)
+
+---
+
+## Problem Understanding
+
+### Core tensions
+
+**T1: Early interrogation vs late-discovered context**  
+Goal interrogation in Phase 0 happens before any landscape work. Some hidden assumptions only become visible after reading the codebase. An early interrogation catches structural goal-type issues (solution-framed vs problem-framed) but misses context-dependent assumptions. Phase 1g retriage catches these later -- but only if the agent explicitly sets `retriageNeeded = true`.
+
+**T2: Non-interactive constraint vs interrogation quality**  
+The best reframing comes from dialogue. Daemon sessions have no human. Non-interactive interrogation means the agent interrogates itself, which risks circular reasoning (surfacing expected assumptions rather than genuinely hidden ones).
+
+**T3: Overhead for well-framed goals**  
+Any mandatory goal-challenge step adds overhead to every session, including correctly-framed ones. The mechanism must be lightweight for good goals, substantial for misframed ones.
+
+**T4: Workflow enforcement vs agent judgment**  
+The workflow can instruct the agent to classify a goal, but the classification itself is still LLM output. A `runCondition` on `goalType = solution_framed` is structural, but the `goalType` value is agent judgment. There is no escape from this.
+
+### Likely seam
+
+Phase 0's `procedure` block -- specifically the `Capture` step that lists context variables and the path selection logic. This is where goal misframing has the highest downstream impact (wrong `pathRecommendation` propagates through all subsequent steps).
+
+### What makes this hard
+
+1. The agent interrogates itself -- self-adversarial reasoning is weaker than adversarial reasoning against a well-defined artifact
+2. Solution-framed goals can look like problem-framed goals ('improve discovery' looks like a problem frame but contains hidden assumptions)
+3. Adding required output fields to Phase 0 means sessions starting mid-workflow (without Phase 0 context) need graceful fallback
+
+---
+
+## Philosophy Constraints
+
+| Principle | Constraint |
+|---|---|
+| Validate at boundaries, trust inside | Phase 0 is the input boundary; it must validate goal framing |
+| Make illegal states unrepresentable | Solution-framed goal processed without interrogation should not be a valid state |
+| YAGNI with discipline | The mechanism must add near-zero cost for well-framed goals |
+| Architectural fixes over patches | The fix should change structural invariants, not add 'be careful' reminders |
+| Determinism over cleverness | Same goalType -> same downstream path bias |
+
+**Philosophy conflict:** 'Make illegal states unrepresentable' conflicts with 'YAGNI with discipline' when it comes to adding a mandatory interrogation step. A mandatory step is more enforceable but adds overhead for every session.
+
+---
+
+## Impact Surface
+
+| Surface | Must stay consistent |
+|---|---|
+| `pathRecommendation` context variable | Set by Phase 0; used by all phase-1 `runCondition` gates |
+| `problemStatement` context variable | Should reflect the actual problem, not the stated solution |
+| `designDocPath` content | Problem framing section becomes misleading if it reflects a solution-framed goal verbatim |
+| Phase 1g `retriageNeeded` trigger | If retriage condition changes, existing sessions may behave differently |
+| Daemon sessions | Cannot be blocked on interactive responses |
+
+---
+
+## Candidates
+
+### Candidate 1: Minimal -- Extend Phase 0 `Capture` with `goalType` and `impliedProblem`
+
+**Summary:** Add `goalType` (4-value closed enum: `solution_framed | problem_framed | opportunity_framed | decision_framed`) and `impliedProblem` to the Phase 0 `Capture` step. Add a procedure instruction: classify first, derive `impliedProblem` when `solution_framed`, then select path with `goalType` awareness.
+
+**Tensions resolved:** T3 (near-zero overhead for well-framed goals -- classification is lightweight), T4 partially (structural variable exists)  
+**Tensions accepted:** T1 (pre-context), T2 (self-interrogation), T4 fully (goalType is still agent judgment)
+
+**Boundary:** Phase 0 `Capture` list and `procedure` text
+
+**Why best fit:** Phase 0 already captures 12+ context variables. Adding `goalType` and `impliedProblem` follows the established pattern. No new step IDs, no new `runCondition` chains, fully backward compatible.
+
+**Failure mode:** Agent classifies a solution-framed goal as `opportunity_framed`, skipping `impliedProblem` derivation. No structural enforcement prevents this.
+
+**Repo pattern:** Follows the existing 'Phase 0 captures context variables for downstream use' pattern.
+
+**Gains:** Zero new steps. Backward compatible. `goalType` available for all downstream phases.  
+**Gives up:** No enforcement that classification happens before path selection. Still relies on procedure text instructions, not structural ordering.
+
+**Scope judgment: best-fit as a minimal change.** Not too narrow (introduces the structural signal). Not too broad (no new steps).
+
+**Philosophy:** Honors 'YAGNI', 'Determinism'. Conflicts with 'Make illegal states unrepresentable' (misframings are still structurally possible).
+
+---
+
+### Candidate 2: Structural -- New mandatory Phase 0a before current Phase 0
+
+**Summary:** Add a new step `phase-0a-goal-interrogation` that runs before the current Phase 0. Always runs. Required outputs: `goalType` (4-value enum), `impliedProblem` (string, required when `solution_framed`), `hiddenAssumptions` (array, min 1 when `goalType != problem_framed`), `alternativeFraming` (string, optional). Phase 0 then reads `goalType` from context rather than deriving it.
+
+**Tensions resolved:** T3 partially (well-framed goals produce trivial Phase 0a output fast), T4 (structural enforcement -- path selection cannot happen without Phase 0a having run)  
+**Tensions accepted:** T1 (still pre-landscape), T2 (self-interrogation)
+
+**Boundary:** A new step with ID `phase-0a-goal-interrogation`, inserted as the first step of the workflow. Phase 0 becomes a consumer of `goalType` rather than its producer.
+
+**Why best fit:** True structural enforcement. Phase 0a is a required step. The interrogation runs before path selection by design, not by instruction. Mirrors the existing `phase-0b-capability-setup` pattern (a pre-phase setup step before the main classification phase).
+
+**Failure mode:** For well-framed goals, Phase 0a adds overhead. More importantly: Phase 0a and Phase 0 can produce contradictory conclusions if the agent reconsiders its interpretation between steps.
+
+**Repo pattern:** Adapts the `phase-0b-capability-setup` pattern. Departs in that Phase 0a runs before Phase 0 (changes existing step order).
+
+**Gains:** True enforcement. `hiddenAssumptions` and `alternativeFraming` become required outputs with engine validation. Sets a seam for a future reusable `routine-goal-interrogation`.  
+**Gives up:** Adds a step to every session (overhead for well-framed goals). Changes step order (Phase 0 is no longer the first step).
+
+**Scope judgment: best-fit for structural correctness, slightly overbroad for immediate need.** The structural separation is the correct long-term architecture.
+
+**Philosophy:** Honors 'Architectural fixes over patches', 'Make illegal states unrepresentable', 'Validate at boundaries'. Conflicts with 'YAGNI with discipline'.
+
+---
+
+### Candidate 3: Distributed -- Three targeted strengthening changes to existing steps
+
+**Summary:** No new steps. Three changes: (1) add `goalType` classification + `impliedProblem` to Phase 0 procedure (same as C1). (2) Make `problemFrameTemplate`'s 'What would make this framing wrong' field a required non-empty output contract in Phase 1e/1f steps. (3) Change Phase 1g `runCondition` from `retriageNeeded = true` to `pathRecommendation == design_first || pathRecommendation == full_spectrum` (retriage always runs for these paths).
+
+**Tensions resolved:** T1 (distributed checkpoints catch both pre-context issues at Phase 0 and post-landscape issues at Phase 1g), T3 (no new steps)  
+**Tensions accepted:** T2 (self-interrogation at all checkpoints), T4 partially
+
+**Boundary:** Three existing steps: Phase 0 (procedure text), Phase 1e/1f (output contract), Phase 1g (runCondition).
+
+**Why best fit:** Fixes the three specific weak points in the existing design without adding new steps. Distributed checkpoints catch more than a single-point interrogation.
+
+**Failure mode:** An agent anchored to the original framing can produce weak 'what would make this wrong' answers -- required non-empty output enforces form but not quality. Phase 1g always-on for `design_first` runs a (potentially unnecessary) retriage step for sessions where the path was correct from the start.
+
+**Repo pattern:** Adapts existing `outputRequired` contract pattern. Adapts `runCondition` pattern. Follows (not departs from) established mechanisms.
+
+**Gains:** No new steps. Reinforces three existing weak mechanisms. Catches both early and late misframings.  
+**Gives up:** No single strong enforcement point. Effect is diffuse. Does not fix path-selection bias (wrong path can still be chosen in Phase 0 before Phase 1g runs).
+
+**Scope judgment: too narrow as standalone, best-fit as complement to C1 or C2.**
+
+**Philosophy:** Honors 'YAGNI with discipline', 'Architectural fixes over patches'. Conflicts with 'Make illegal states unrepresentable' (path selection still uses raw stated goal).
+
+---
+
+## Comparison and Recommendation
+
+### Tension resolution matrix
+
+| Tension | C1 (Phase 0 extension) | C2 (new Phase 0a) | C3 (distributed) |
+|---|---|---|---|
+| T1: pre-context interrogation | Accepts | Accepts | Resolves (Phase 1g post-landscape) |
+| T2: self-interrogation quality | Accepts (same for all) | Accepts | Accepts |
+| T3: overhead for well-framed goals | **Resolves** (lightweight) | Accepts (adds step) | **Resolves** (absorbed) |
+| T4: structural enforcement | Partial | **Resolves** (mandatory step) | Partial |
+
+### Recommendation: C1 + C3 hybrid, with C2 as future evolution
+
+**Primary (immediate):** C1 extended with procedural strength: add `goalType`, `impliedProblem`, `hiddenAssumptions` to Phase 0 Capture as required context variables. Add explicit procedure: classify goal type first, derive implied problem before path selection, let goalType influence path bias toward `design_first` for `solution_framed` goals.
+
+**Secondary (no new steps):** Three C3 changes: (a) `goalType` in Phase 0 (same as C1), (b) make 'What would make this framing wrong' a required non-empty output in Phase 1e/1f, (c) change Phase 1g `runCondition` to always run for `design_first` and `full_spectrum` paths.
+
+**Future evolution:** If the C1+C3 hybrid proves insufficient for daemon sessions, extract Phase 0a as a mandatory pre-step (C2).
+
+---
+
+## Self-Critique
+
+**Strongest argument against this recommendation:** C1's enforcement is procedural (instructions), not structural (step ordering). A capable LLM running in QUICK mode or under context pressure can skip the classification step and proceed to path selection. C2's mandatory separate step is the only way to structurally guarantee the interrogation happened.
+
+**Counter:** Both approaches ultimately rely on the LLM following instructions. The difference is in how much structural scaffolding supports following those instructions. C2 enforces 'the step ran' not 'the step ran well.'
+
+**Narrower option:** Just add `goalType` to the Capture list with no procedure change. Too narrow -- introduces the variable without the interrogation mechanism.
+
+**Broader option:** Extract a reusable `routine-goal-interrogation` callable from any workflow. Justified if pattern proves valuable in other workflows. Not warranted now.
+
+**Assumption that would invalidate this:** Claude Sonnet already implicitly reframes solution-framed goals. Counter-evidence: two real examples (MCP simplification, structured output session) show this is not reliably true.
+
+---
+
+## Open Questions for the Main Agent
+
+1. **Should `goalType` influence path selection automatically** (e.g., `solution_framed` -> force `design_first`) or **only as a soft bias**? Automatic enforcement is stronger but may override user intent for cases where the solution IS the right framing.
+
+2. **How should `impliedProblem` flow to the design doc?** Should Phase 0 write it as the `problemStatement` in the design doc (replacing the stated goal), or record it as a separate field ('stated goal' vs 'implied problem')?
+
+3. **Phase 1g runCondition change:** Making Phase 1g always run for `design_first` and `full_spectrum` is a behavior change for existing sessions. Is this backward compatible enough?
+
+4. **`hiddenAssumptions` format:** Should this be a free-text field or a structured array? Free-text is easier to author; structured allows downstream steps to reference specific assumptions.

--- a/docs/discovery/design-review-findings.md
+++ b/docs/discovery/design-review-findings.md
@@ -1,0 +1,110 @@
+# Design Review Findings: wr.discovery Goal Reframing
+
+*Concise, actionable findings for main-agent synthesis. Not a final decision.*
+**Date:** 2026-04-18
+
+---
+
+## Tradeoff Review
+
+**Tradeoff 1: goalType classification remains agent judgment**
+
+- Acceptable: this pattern is established in the workflow (rigorMode, pathRecommendation are all agent-derived)
+- Classification examples in the procedure reduce misclassification probability
+- **Finding: YELLOW.** Add goalType classification examples to procedure text to reduce ambiguity at the problem_framed / opportunity_framed boundary.
+
+**Tradeoff 2: overhead for well-framed goals is nonzero**
+
+- A few additional context variable captures and procedure lines in Phase 0
+- Well-framed goals produce minimal output ('goalType = problem_framed, no impliedProblem needed')
+- **Finding: NON-ISSUE.** Overhead is trivial.
+
+**Tradeoff 3: Phase 1g always-on for design_first/full_spectrum**
+
+- One additional advance per session for these paths
+- Produces trivially short output for well-framed sessions ('pathChangedAfterContext = false')
+- **CRITICAL CORRECTION NEEDED:** Phase 1g runCondition must be an OR (`retriageNeeded = true OR pathRecommendation in [design_first, full_spectrum]`) not a replacement. Otherwise landscape_first sessions that explicitly need retriage will not trigger it.
+- **Finding: YELLOW.** Runnable as-designed if the OR condition is used correctly.
+
+---
+
+## Failure Mode Review
+
+**Failure mode 1: Agent misclassifies solution-framed goal as opportunity_framed**
+- Status: **Partially mitigated.** C3's Phase 1e/1f required 'what would make this framing wrong' output provides a downstream catch. Classification examples in Phase 0 reduce probability.
+- Missing mitigation: examples in procedure (address in revisions)
+- **Finding: MEDIUM risk, mitigated.**
+
+**Failure mode 2: 'What would make this framing wrong' output is formulaic**
+- Status: **Partially mitigated.** Making it required non-empty enforces form but not quality.
+- Missing mitigation: specificity instruction ('name ONE concrete condition, not a general caveat')
+- **Finding: LOW-MEDIUM risk.**
+
+**Failure mode 3: Phase 1g doesn't surface new insights for well-framed sessions**
+- Status: **Non-issue by design.** For well-framed sessions, Phase 1g is a graceful no-op that confirms the path is still correct. One advance wasted, nothing more.
+- **Finding: LOW risk, acceptable.**
+
+---
+
+## Runner-Up / Simpler Alternative Review
+
+**C2 (mandatory Phase 0a):** The structural enforcement advantage is real but comes at the cost of a mandatory overhead step for all sessions. The C1+C3 hybrid achieves most of C2's value via procedure-level enforcement plus structural runCondition changes. C2 is the right escalation if the hybrid proves insufficient.
+
+**Simpler variant:** Just one sentence added to Phase 0: 'If the goal is solution-framed, derive the underlying problem.' Too narrow -- no context variables means no downstream reference to the reframing.
+
+**`alternativeFraming` addition from C2:** Borrowing C2's `alternativeFraming` requirement (one reframe even when the original goal seems correct) is high-value, low-cost. Add to Phase 0 design doc entry, not as a context variable.
+
+**Finding: C1+C3 hybrid with two refinements (examples, alternativeFraming) stands. No direction change needed.**
+
+---
+
+## Philosophy Alignment
+
+| Principle | Status |
+|---|---|
+| Validate at boundaries, trust inside | SATISFIED -- Phase 0 becomes an active validator |
+| Make illegal states unrepresentable | PARTIALLY SATISFIED -- C3 structural changes help; C2 would fully satisfy |
+| YAGNI with discipline | SATISFIED -- no new steps, minimal additions |
+| Architectural fixes over patches | SATISFIED -- runCondition changes and required output contracts are structural |
+| Determinism over cleverness | SATISFIED -- same goalType input produces same path behavior |
+
+**One explicit philosophy tension:** 'Make illegal states unrepresentable' vs 'YAGNI with discipline' -- deliberately accepted, C2 is escalation path.
+
+---
+
+## Findings
+
+### Yellow findings
+
+**Y1: goalType classification boundary ambiguity**
+The boundary between `problem_framed` and `opportunity_framed` is unclear without examples. Add classification examples to Phase 0 procedure to reduce misclassification at this boundary.
+
+**Y2: Phase 1g runCondition must be OR, not replacement**
+The retriage step runCondition must be: `retriageNeeded = true OR pathRecommendation == design_first OR pathRecommendation == full_spectrum`. A straight replacement would break landscape_first sessions that legitimately need retriage.
+
+**Y3: 'What would make this framing wrong' needs specificity instruction**
+The required output field should specify 'name ONE concrete falsification condition, not a general caveat.' Without this, the field can be satisfied by formulaic responses.
+
+### No Red or Orange findings
+
+The selected C1+C3 direction has no material structural weaknesses.
+
+---
+
+## Recommended Revisions
+
+1. **Add goalType classification examples** to Phase 0 procedure (solution_framed: 'add X', 'implement Y', 'build X'; problem_framed: 'reduce X', 'fix Y'; opportunity_framed: 'explore X', 'decide whether Y'; decision_framed: 'choose between A and B')
+
+2. **Add `alternativeFraming`** as a required design doc entry in Phase 0: 'Before selecting a path, generate one alternative framing -- if the stated goal is wrong, what would a better goal be?'
+
+3. **Use OR condition for Phase 1g runCondition:** `retriageNeeded = true OR pathRecommendation in [design_first, full_spectrum]`
+
+4. **Add specificity instruction** to Phase 1e/1f 'what would make this framing wrong' field: require naming one concrete falsification condition.
+
+---
+
+## Residual Concerns
+
+1. The goalType classification is LLM-dependent. Without empirical testing on real sessions, we cannot confirm the classification is reliable. This is an inherent limitation of the approach.
+
+2. The C1+C3 hybrid does not prevent path-selection bias for the window between Phase 0 path selection and Phase 1g retriage. A session that selects the wrong path in Phase 0 runs several steps in the wrong direction before Phase 1g can correct it. Acceptable for STANDARD rigor; C2 is the correct escalation if this proves problematic.

--- a/docs/discovery/wr-discovery-goal-reframing.md
+++ b/docs/discovery/wr-discovery-goal-reframing.md
@@ -1,0 +1,303 @@
+# Discovery: Improving wr.discovery Goal Reframing
+
+**Status:** Discovery in progress
+**Session:** wr.discovery (Phase 1 -- diagnosis)
+**Date:** 2026-04-18
+
+**Artifact strategy:** This document is for human reading. Execution truth (context variables, step notes) lives in WorkRail session state. This doc is updated at each phase.
+
+---
+
+## Context / Ask
+
+The `wr.discovery` workflow (v3.1.0) takes the stated goal at face value. Users often state solutions instead of problems, carry faulty assumptions into the brief, or do not actually know what they want. The goal of this discovery is to diagnose what is specifically weak about the current workflow and identify improvement directions -- not to design the final solution.
+
+---
+
+## Path Recommendation
+
+**Path:** `design_first`
+
+**Rationale:** The dominant risk here is solving the wrong problem. "Make discovery better" is ambiguous. The brief itself suggests one diagnosis (takes requests at face value) but that framing may itself be incomplete -- the problem could be about *when* reframing happens, *how* it happens, *what triggers* it, or something else entirely (e.g., the problem is that the workflow is too sequential rather than too credulous). `design_first` is the right path because the framing is genuinely uncertain and jumping to "add a reframe step" risks solving a surface symptom. A `landscape_first` path would just survey other discovery frameworks -- interesting but not the center of gravity. `full_spectrum` would work but would diffuse effort equally on landscape and framing when framing is the real bottleneck.
+
+**Why not landscape_first:** The landscape (design thinking, Jobs-to-be-Done, 5 Whys, pre-mortem, etc.) is well-known and would mostly confirm what we already know. The interesting question is not "what frameworks exist" but "what structural change to this specific workflow would make it genuinely better."
+
+---
+
+## Constraints / Anti-goals
+
+**Constraints:**
+- The improved workflow must remain usable in automated (daemon) contexts where no human is present to answer follow-up questions
+- Changes to `wr.discovery.json` must follow the v2 workflow authoring format
+- The workflow already has a path-selection mechanism (phase-0); any improvement should integrate with or extend this, not duplicate it
+- Must not break existing sessions mid-flight
+
+**Anti-goals:**
+- Do not add interactive Q&A that assumes a human will respond (daemon contexts have no human)
+- Do not make the workflow so heavy that it becomes a therapy session before doing any actual work
+- Do not import external frameworks wholesale -- extract principles, do not copy playbooks
+- Do not redesign the full workflow structure -- focus on the goal-reframing problem specifically
+
+---
+
+## Landscape Packet
+
+### Current state summary
+
+`wr.discovery` v3.1.0 has a Phase 0 that:
+1. Captures `problemStatement`, `desiredOutcome`, `coreConstraints`, `antiGoals`, `primaryUncertainty`, `knownApproaches`
+2. Selects a path: `landscape_first`, `full_spectrum`, `design_first`
+3. Creates a design doc
+
+**What Phase 0 does NOT do:**
+- It does not challenge or probe the stated goal
+- It does not distinguish between "user stated a problem" vs "user stated a solution"
+- It does not surface faulty assumptions in the goal itself
+- It does not ask "is this the real problem or is it a symptom?"
+- The path selection criteria are about *emphasis* (landscape vs framing), not about *goal validity*
+
+The workflow does have a `design_first` path choice and a "what would make this framing wrong" element in the problemFrameTemplate -- but these apply after the goal is accepted, not before.
+
+### Existing approaches / precedents
+
+**1. Design Thinking (IDEO/Stanford d.school):** "Empathize" phase is explicitly about setting aside your solution hypothesis and observing real user behavior. Pre-work question: "Are we solving the right problem?" The structural insight: problem reframing is not a step *in* the process -- it is a prerequisite to starting the process.
+
+**2. Jobs-to-be-Done (Christensen):** When a user states "I want a faster horse," the JTBD practitioner asks "What job are you trying to get done?" The goal is to surface the functional, emotional, and social dimensions of the actual outcome -- not the solution form. Structured probe: "What were you doing before? What did you try? What would success look like even if our solution didn't exist?"
+
+**3. 5 Whys (Toyota):** Sequential causal probing. "Why do you want X?" -> "Because Y." "Why Y?" -> "Because Z." Three to five levels of probing reveals whether the stated goal is a root cause or a symptom. Works well for problem goals; less well for opportunity goals.
+
+**4. Pre-mortem (Gary Klein):** "Imagine we did exactly what you asked and it failed. What went wrong?" Forces the requester to articulate hidden assumptions. Particularly effective at surfacing: wrong success criteria, ignored stakeholders, underestimated constraints.
+
+**5. AI-specific: Prompt interrogation patterns:** The "goal elicitation" pattern in agentic AI systems (e.g., AutoGPT system prompts, OpenAI alignment research) distinguishes between *stated objectives* and *intended objectives*. The typical mechanism: present a synthetic interpretation back to the user and ask for confirmation or correction.
+
+**6. Consulting intake (McKinsey, IDEO, etc.):** A structured discovery brief usually has: "What decision do you need to make?" + "What would change if you had the answer?" + "Who else has thought about this?" + "What have you already tried?" The intake is not about validating the solution -- it is about understanding the decision context.
+
+### Option categories
+
+1. **Pre-step interrogation:** Add a Phase -1 (before path selection) that explicitly challenges the goal statement
+2. **Integrated reframing in Phase 0:** Extend Phase 0 to include goal challenge as part of classification
+3. **Adversarial dual-track:** Run two interpretations in parallel -- "take it literally" vs "reframe it" -- and let synthesis surface the gap
+4. **Progressive commitment:** Start with minimal goal acceptance, revisit the framing after each major phase, make reframing explicit at retriage points
+5. **Structural annotation:** Add a `goalType` classification (solution-framed, problem-framed, opportunity-framed, decision-framed) that changes how Phase 0 proceeds
+
+### Contradictions / disagreements
+
+- The workflow already has `design_first` as a path and says "Choose `design_first` when the dominant risk is solving the wrong problem" -- but the path selection itself uses the stated goal as input. If the goal is wrong, the path selection can still be wrong.
+- Phase 1g (re-triage) exists for course correction after landscape and framing work -- but it triggers on `retriageNeeded` being explicitly set, which assumes the agent identifies the need. A goal stated as a solution could pass through path selection and Phase 1 without triggering retriage.
+- The metaGuidance says "Anti-anchoring: do not let the first framing or favorite option dominate the work" -- but this applies to *candidate generation*, not to goal framing. The stated goal is not challenged by this guidance.
+
+### Evidence gaps
+
+- No direct data on how often real discovery sessions start with solution-framed goals vs problem-framed goals
+- No post-hoc analysis of sessions where the stated goal turned out to be wrong
+- The two specific examples from the brief (MCP simplification, structured output) are known anecdotally but not documented
+
+### Why this matters for path selection
+
+The current workflow's structure means the *path selection step* inherits any misframing in the goal. A solution-framed goal can be classified as `landscape_first` when it should be `design_first`. The goal challenge needs to happen *before* path selection, or path selection needs to be goal-type-aware.
+
+---
+
+## Problem Frame Packet
+
+### Users / stakeholders
+
+- **Primary:** User (human or daemon) submitting a goal to `wr.discovery`
+- **Secondary:** Etienne (workflow author) -- wants the workflow to produce genuinely surprising insights, not just organize what was already stated
+- **Tertiary:** Downstream consumers of the design document
+
+### Jobs / goals / outcomes
+
+- **Actual job:** "Help me think through this problem so I reach the best decision, even if I described the problem wrong"
+- **Stated job:** "Help me with [stated goal]"
+- **The gap:** These are often not the same. The user often does not know the gap exists.
+
+### Pains / tensions / constraints
+
+- **T1: Goal credulous processing:** Phase 0 processes the stated goal as if it is valid. A solution-framed goal ("build X") is treated as if "X is the right solution" is not an assumption.
+- **T2: Daemon context constraint:** A daemon session has no human to answer follow-up questions. Any interactive "is this really what you want?" loop requires a human. Daemon sessions must use a non-interactive reframing strategy.
+- **T3: Overhead vs signal ratio:** Heavy interrogation adds steps. If the goal is correctly framed (which it often is), the extra steps are pure overhead. The mechanism must be lightweight and skip gracefully when the goal is already well-framed.
+- **T4: Reframing is hard to automate:** The AI cannot know what the user "really" wants -- it can only identify structural signals of a poorly-framed goal (solution-framing, missing success criteria, absent alternatives, hidden assumptions).
+
+### Success criteria
+
+1. The workflow identifies solution-framed goals and surfaces the implicit problem before generating candidates
+2. The workflow works in daemon contexts (no interactive questioning required)
+3. The overhead for a well-framed goal is minimal (a few structural notes, not a full reframing ceremony)
+4. The output of a reframed session differs meaningfully from the output of a non-reframed session for the same goal
+
+### Assumptions
+
+- The goal text itself contains structural signals that distinguish "stated solution" from "stated problem" (e.g., "implement X" vs "improve Y" vs "decide between A and B")
+- Surfacing the implicit problem does not require user confirmation -- it can be done by the agent itself as a reasoning step
+- The most important case is solution-framed goals -- a user who says "add a reframe step to wr.discovery" is actually asking about "how to make discovery better" (this very brief is an example)
+
+### Reframes / HMW questions
+
+- HMW: How might we detect when a stated goal is a solution hypothesis rather than a problem statement -- without requiring human confirmation?
+- HMW: How might we ensure the workflow explores the problem space *before* accepting the stated goal's framing?
+- HMW: How might we make goal reframing something the agent does *for itself* rather than a ceremony it performs *for the user*?
+
+### What would make this framing wrong
+
+- If the agent model is already good enough at implicit reframing (without explicit prompting), the structural change adds ceremony without value
+- If daemon sessions are a small minority of `wr.discovery` uses, an interactive probe could work for the majority case
+- If the real problem is not "goal acceptance" but "insufficient candidate diversity" -- i.e., the workflow accepts the goal but generates too-narrow candidates -- then the fix belongs in Phase 3, not Phase 0
+
+---
+
+## Candidate Generation Expectations (design_first)
+
+Because this is a `design_first` pass:
+- At least one direction must meaningfully reframe the problem, not just add a "challenge" step
+- The candidate set must address the daemon constraint directly -- solutions that require human interaction are non-starters
+- Include the simplest change that could work alongside more structural alternatives
+
+---
+
+## Candidate Directions
+
+### Direction A: Goal-type classification in Phase 0 (minimal change)
+
+**Summary:** Extend Phase 0 to classify the stated goal into one of four structural types: `solution_framed` ("build/add/implement X"), `problem_framed` ("improve/fix/reduce Y"), `opportunity_framed` ("explore/understand Z"), `decision_framed` ("choose between A and B"). When the goal is `solution_framed`, Phase 0 must explicitly surface the implicit problem statement before proceeding.
+
+**Mechanism:** Add a `goalType` context variable and a procedure step: "Before selecting a path, classify the goal as `solution_framed`, `problem_framed`, `opportunity_framed`, or `decision_framed`. If `solution_framed`, produce an explicit `impliedProblem` statement: 'The stated goal implies this underlying problem: [X]. Confirm this is correct or surface a different problem frame before proceeding.'"
+
+**Why it fits:** Minimal change. Works in daemon context (no human confirmation needed -- the agent surfaces the implication and continues). Does not add steps; extends Phase 0. The goalType classification is cheap and structural.
+
+**Strongest evidence for it:** The brief itself is a perfect example: "improve wr.discovery goal reframing" is opportunity-framed, but the actual problem statement needs to be made explicit ("the workflow accepts stated goals uncritically"). Phase 0 in the current workflow would process this as landscape/full_spectrum without ever articulating the underlying mechanism.
+
+**Strongest risk against it:** The four-category taxonomy may be too rigid. Many goals are mixed (e.g., "decide whether to build X or Y" is both decision-framed and solution-framed). Also, the agent may classify incorrectly, and without human confirmation in daemon mode, the wrong classification goes uncorrected.
+
+**When it should win:** When the change must be minimal, backward-compatible, and immediately implementable without restructuring the workflow.
+
+---
+
+### Direction B: Adversarial goal interrogation as a distinct Phase 0b step
+
+**Summary:** Add a new Phase 0b (between goal capture and path selection) that runs a structured adversarial interrogation of the stated goal. The step always runs and produces: the `impliedProblem`, the `hiddenAssumptions`, and at least one `alternativeFraming`. Path selection happens *after* this step, using the enriched understanding rather than the raw goal.
+
+**Mechanism:** Phase 0b procedure: "(1) Restate the goal as a problem: what must be true for this goal to be the right thing to do? (2) List the 2-3 hidden assumptions the goal takes for granted. (3) Generate one alternative framing: if the stated goal is wrong, what would a better goal be? (4) Decide: is the original framing correct as-stated, or does the workflow proceed under the reframed problem? Set `goalValidated`, `impliedProblem`, `hiddenAssumptions`, `alternativeFraming` in context."
+
+**Why it fits:** Makes reframing structural and always-on rather than path-dependent. The adversarial lens is familiar in WorkRail (adversarial challenge is already used in Phase 3d). This is the same discipline applied earlier in the process. Works in daemon context -- no human response needed, the agent conducts the interrogation with itself.
+
+**Strongest evidence for it:** The two examples in the brief: (1) MCP simplification -- the discovery produced design candidates but missed that the immediate fix was just `artifacts` -- this is a case where the stated goal ("how do we simplify?") was accepted when the real problem was narrower ("what's the cheapest fix right now?"). (2) Structured output -- started with the wrong assumption about mixing `response_format + tools`, which Phase 0 would have surfaced if it asked "what assumptions does this goal take for granted?"
+
+**Strongest risk against it:** Adds a mandatory step. For well-framed goals, the step is overhead with no signal. Also, the agent interrogating its own goal with itself may produce circular reasoning -- it surfaces the assumptions it already expects, not genuinely hidden ones.
+
+**When it should win:** When the problem of goal acceptance is systematic and the overhead of an extra step is acceptable. This is the more thorough solution.
+
+---
+
+### Direction C: Progressive commitment -- reframing woven across phases
+
+**Summary:** Instead of a single upfront interrogation, weave explicit "is the framing still correct?" moments at multiple points in the workflow: after landscape (Phase 1b/1c), after problem framing (Phase 1e/1f), and explicitly in re-triage (Phase 1g). The mechanism: add a `framingChallenge` requirement at each of these steps -- a single structured question ("what would have to be true for the original goal to be wrong?") rather than a separate step.
+
+**Mechanism:** At Phase 1b (landscape), after summarizing the current state, add: "Before continuing, ask: does the landscape evidence support or challenge the original goal? If it challenges, update `retriageNeeded = true` and note the specific challenge." At Phase 1e/1f (problem framing), the existing `problemFrameTemplate` already has "What would make this framing wrong" -- make this a required non-empty output, not a soft guideline. In Phase 1g (re-triage), add explicit procedure: "Revisit the original goal statement. Is the goal still correct as-stated given what you now know?"
+
+**Why it fits:** Does not add steps. Upgrades existing checkpoints. The re-triage step already exists for this purpose but currently triggers on a set variable rather than mandating goal challenge. Most importantly: distributed reframing is more likely to catch late-arriving information than a single upfront interrogation.
+
+**Strongest evidence for it:** The workflow already has `anti-anchoring` guidance in metaGuidance -- "do not let the first framing or favorite option dominate." This direction makes the same principle apply to the *goal*, not just the *candidates*. It is consistent with the workflow's existing philosophy.
+
+**Strongest risk against it:** If the original goal is wrong in a way that affects path selection itself (e.g., choosing `landscape_first` when `design_first` was needed), distributed reframing happens too late. The path is already chosen; the work is already done in the wrong direction.
+
+**When it should win:** When the problem is primarily about insufficient rigor late in the workflow, not about path selection being skewed by a bad goal.
+
+---
+
+## Challenge Notes
+
+**Against Direction A (goal-type classification):**
+The four-category taxonomy solves the symptom (goal is solution-framed) but not the underlying mechanism. A goal classified as `problem_framed` ("improve Y") can still contain hidden assumptions. The classification alone is not sufficient -- it needs to be paired with explicit assumption surfacing.
+
+**Against Direction B (adversarial Phase 0b):**
+Phase 0b interrogates the goal before the agent has any landscape knowledge. This limits the quality of assumption surfacing -- the agent can only use its prior knowledge, not what it discovers in the codebase. The most surprising hidden assumptions are often ones that only become visible after seeing the actual state of the system.
+
+**Against Direction C (progressive commitment):**
+Distributed reframing is weaker than upfront reframing for the specific problem of path selection bias. If the original goal causes the wrong path to be selected, later reframing stages run within the wrong path's constraints. Retriage exists but only triggers when `retriageNeeded` is set -- and an agent anchored to the original framing may not set it.
+
+**Synthesis:** The strongest design would combine A and B: goal-type classification *plus* an adversarial interrogation step. Direction C should also be incorporated -- make the "what would make this framing wrong" field in problemFrameTemplate mandatory and non-empty. But a minimal viable change is Direction B alone.
+
+---
+
+## Resolution Notes
+
+**Primary diagnosis:**
+The core weakness is that Phase 0 has no mechanism to distinguish "user stated a real problem" from "user stated a solution hypothesis." The path selection, framing, and candidate generation all downstream from this -- if the goal is wrong, the entire workflow is scaffolded on the wrong foundation.
+
+**Secondary diagnosis:**
+Even when the path is correct, the workflow has weak *mandatory* goal challenge. The `anti-anchoring` guidance in metaGuidance is for candidates, not for the original goal. The `problemFrameTemplate`'s "what would make this framing wrong" section is a soft guideline, not a required output.
+
+**Tertiary diagnosis:**
+The re-triage step (Phase 1g) is underused. It only runs when `retriageNeeded = true`, and the agent sets this variable. An anchored agent will not set it.
+
+**Improvement directions (in priority order):**
+
+1. **Highest priority -- Phase 0 goal interrogation:** Add a structured adversarial examination of the stated goal to Phase 0 (or as a small new step before path selection). The key outputs: `goalType`, `impliedProblem`, `hiddenAssumptions`, `alternativeFraming`. This is the primary fix.
+
+2. **Medium priority -- Make "what would make this wrong" mandatory:** In the problemFrameTemplate, change the "What would make this framing wrong" from an optional field to a required output with at least one specific, concrete falsification condition.
+
+3. **Medium priority -- Make re-triage always run for full_spectrum and design_first paths:** Remove the `retriageNeeded = true` condition gate on Phase 1g for these paths. For `landscape_first`, keep the gate.
+
+4. **Lower priority -- Goal type affects path selection:** When `goalType = solution_framed`, bias toward `design_first` path selection rather than accepting the default, unless the user has explicitly confirmed that the stated solution is the correct framing.
+
+---
+
+## Decision Log
+
+| Decision | Rationale |
+|----------|-----------|
+| `design_first` path chosen | The framing of "what's wrong with wr.discovery" is itself uncertain; dominant risk is solving the wrong problem |
+| Diagnosis focused on Phase 0 | Phase 0 is where goal acceptance happens; this is the root cause |
+| Daemon context preserved as hard constraint | Daemon sessions are real use cases; interactive questioning is not viable |
+| C1+C3 hybrid selected (not C2) | C1 extends Phase 0 with goalType/impliedProblem/hiddenAssumptions; C3 strengthens existing checkpoints. C2 (mandatory Phase 0a) is structurally stronger but adds mandatory overhead for every session. YAGNI and graceful-no-op criteria favor C1+C3. |
+| 4 refinements added from review | (1) goalType examples in procedure, (2) alternativeFraming in design doc, (3) Phase 1g OR runCondition, (4) specificity instruction for framing-risk required output |
+| C2 named as escalation path | If C1+C3 hybrid proves insufficient for daemon sessions, extract Phase 0a as mandatory pre-step |
+| direct_recommendation resolution | Remaining gap (goalType classification reliability) is a runtime testability question, not a design gap |
+
+---
+
+## Final Summary
+
+### Selected direction: C1+C3 hybrid with 4 refinements
+
+**Confidence band: MEDIUM-HIGH**
+
+### What changes in the workflow
+
+**Phase 0 (phase-0-select-path):**
+1. Add to `Capture` list: `goalType` (4-value enum: `solution_framed | problem_framed | opportunity_framed | decision_framed`), `impliedProblem` (required when solution_framed), `hiddenAssumptions` (min 1 when goalType != problem_framed)
+2. Add to procedure: "Before selecting a path, classify the goal type using these examples: solution_framed ('add X', 'implement Y', 'build X'), problem_framed ('reduce X', 'fix Y', 'understand why Z'), opportunity_framed ('explore X', 'decide whether Y'), decision_framed ('choose between A and B'). If solution_framed, derive the implied problem and record at least 1 hidden assumption. Generate one alternative framing ('if this goal is wrong, what would a better goal be?') and record it in the design doc."
+3. Add to procedure: "Let goalType influence path selection: when goalType = solution_framed, bias toward design_first unless the stated solution is clearly the correct framing."
+
+**Phase 1e and 1f (problem framing steps):**
+4. Make 'What would make this framing wrong' a required non-empty output with specificity: "Name ONE concrete falsification condition -- a specific thing that, if discovered to be true, would change the path or direction."
+
+**Phase 1g (retriage):**
+5. Change `runCondition` from `{ var: "retriageNeeded", equals: true }` to an OR: `{ or: [{ var: "retriageNeeded", equals: true }, { var: "pathRecommendation", equals: "design_first" }, { var: "pathRecommendation", equals: "full_spectrum" }] }` so retriage always runs for design_first and full_spectrum paths.
+
+### Why this direction wins
+
+- Addresses path-selection bias (the root cause) by making goalType available before path selection
+- Works non-interactively (daemon compatible)
+- Adds near-zero overhead for correctly-framed goals
+- Strengthens three existing weak mechanisms rather than adding ceremony
+- Fully backward compatible (new context variables default to unset in existing sessions)
+
+### Strongest alternative: C2 (mandatory Phase 0a)
+
+C2 is more structurally correct -- a mandatory separate step enforces that goal interrogation happens before path selection at the step-execution level. If the C1+C3 hybrid proves insufficient (tested by running a session with a known solution-framed goal), the correct escalation is to extract `phase-0a-goal-interrogation` as a mandatory pre-step before Phase 0.
+
+### Residual risks
+
+1. **goalType misclassification** (MEDIUM): a solution-framed goal classified as opportunity_framed bypasses the impliedProblem derivation. Mitigated by examples in procedure and Phase 1e/1f backstop. C2 is the escalation.
+2. **Quality of 'what would make this framing wrong' output** (LOW-MEDIUM): required non-empty enforces form but not quality. Specificity instruction reduces formulaic responses.
+3. **Phase 1g produces trivial output for well-framed sessions** (LOW): acceptable graceful no-op.
+
+### Next actions
+
+These findings are the input to Phase 2: the `workflow-for-workflows` workflow will design the implementation based on this diagnosis.
+
+1. The wfw workflow should receive: the full diagnosis (Phase 0 is the root cause), the specific changes needed (5 changes listed above), the priority order (Phase 0 goalType classification is highest priority), and the decision to implement the C1+C3 hybrid, not C2.
+2. After wfw produces the improved workflow, write it to `workflows/wr.discovery.json`.
+3. Create PR on branch `feat/discovery-workflow-improve-goal-reframing`.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4444,3 +4444,67 @@ The blanket try/catch in AgentLoop._executeTools() converts ALL tool throws to i
 **The bridge complexity was always a band-aid.** It was the right solution when the MCP server also owned the console UI. With the standalone console, the band-aid can come off and the system becomes dramatically simpler and more reliable.
 
 **Build order:** extract `worktrain console` fully (done) → remove HttpServer from MCP startup → remove bridge → remove DashboardLock/primary election → MCP server is pure stdio.
+
+---
+
+### Agent-engine communication: first principles design (Apr 18, 2026)
+
+**The setup for this conversation:**
+
+Three discovery agents investigated whether the daemon should continue using MCP-style tool calls for workflow control (`continue_workflow`). Their findings:
+
+- **Discovery 1**: Tool calls are fine; enrich `continue_workflow` with `artifacts` now, explore structured output hybrid later pending Bedrock verification. ~225 tokens/request saved with hybrid.
+- **Discovery 2**: `complete_step` tool -- daemon owns transitions, continueToken hidden from LLM, notes required at type level. Cleaner DX without paradigm shift.
+- **Discovery 3**: The field has converged on tool calls. OpenAI Agents SDK, LangGraph, Temporal, Vercel AI SDK all use tool calls for workflow control. WorkRail's `continue_workflow` with HMAC tokens is already field-standard or better.
+
+**User's response to "the field has converged on tool calls":**
+
+> "Right, but do we want industry standards? Aren't we trying to build something special? What if there is better?"
+
+This is the right question. "Field convergence" is a description of where everyone ended up starting from the MCP/function-calling paradigm -- not proof that it's optimal. Every system surveyed treats the workflow engine as external infrastructure the agent calls into. WorkRail is different: **the daemon IS the workflow engine**. The agent loop and the step sequencer run in the same process, sharing the same DI container. Tool calls are a network-origin concept -- they exist because there's an LLM over there and an executor over here. WorkRail doesn't have that constraint.
+
+---
+
+#### First-principles alternatives (unexplored territory)
+
+These were not in any of the discovery agents' outputs -- they emerge from the insight that WorkRail owns both sides of the conversation:
+
+**1. Structured response parsing (no tool call for workflow control)**
+The agent outputs a structured response at the end of each turn. The daemon parses it. The LLM never "calls a tool" to advance -- it produces a well-structured output and the daemon acts on it. The continueToken and workflow machinery are completely invisible to the LLM. Example: agent outputs `{"step_complete": true, "notes": "...", "artifacts": [...]}` as its final text, daemon detects this and advances.
+
+**2. Implicit advancement (criteria-based)**
+The daemon watches what the agent produces (file writes, bash outcomes, notes) and decides when to advance -- the agent never explicitly signals "I'm done." The workflow step has completion criteria, and the daemon evaluates them against the agent's cumulative output. More like a CI pipeline (tests pass = done) than an API call. The agent just works; the daemon decides when the step is complete.
+
+**3. Declarative intent + daemon execution**
+The agent outputs what it *wants* to happen: "I want to commit these files with this message and advance to the next step." The daemon executes. Same as the scripts-over-agent principle applied to the agent's own workflow control -- the agent declares intent, scripts execute. No tool call for the mechanical parts.
+
+**4. Streaming judgment**
+The daemon reads the agent's streaming response in real-time, extracts notes and artifacts as they appear, and makes the advance decision before the agent "finishes." No explicit signal from the agent. The daemon monitors and decides.
+
+**5. Separation of concerns: tools for world, declaration for workflow**
+Keep tool calls for external actions (Bash, Read, Write) -- these genuinely need interleaved execution and result reasoning. But workflow control (advance, submit artifacts, set context) uses a different mechanism entirely: structured response, implicit detection, or a single lightweight declaration. The protocol distinction: tools are for I/O, declarations are for state.
+
+---
+
+#### What makes this hard
+
+These alternatives trade off in important ways:
+- **Structured response parsing**: requires reliable structured output from the LLM, which can fail without explicit enforcement
+- **Implicit advancement**: requires the daemon to correctly evaluate completion criteria -- complex for open-ended steps
+- **Declarative intent**: still needs some kind of output format; essentially moves the "tool call" into the response text
+- **Streaming judgment**: hardest to implement correctly; requires the daemon to parse partial responses reliably
+
+The current tool-call approach works precisely because it's explicit: the agent signals intent exactly once, the daemon acts on it. The alternatives are more elegant but less reliable.
+
+---
+
+#### What to actually investigate
+
+Before committing to any alternative, these questions need answers:
+
+1. **Does Bedrock support `response_format + tools` simultaneously?** A 10-line test call resolves this. If yes, hybrid structured output is immediately viable for workflow control.
+2. **What does implicit advancement actually look like for a coding task?** Write out the completion criteria for `coding-task-workflow-agentic` phase-0 (classify). Can a daemon reliably detect "Phase 0 is done" without an explicit signal?
+3. **What is the actual failure mode of structured response parsing?** How often does Claude 4.6 Sonnet fail to produce valid JSON when asked to end its turn with a structured summary? Under what conditions?
+4. **What did nexus-core do?** The backlog notes nexus-core as a more advanced system -- how does it handle agent-step transitions?
+
+These are prototype questions, not design questions. Build the smallest possible test for each before committing to any direction.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4508,3 +4508,59 @@ Before committing to any alternative, these questions need answers:
 4. **What did nexus-core do?** The backlog notes nexus-core as a more advanced system -- how does it handle agent-step transitions?
 
 These are prototype questions, not design questions. Build the smallest possible test for each before committing to any direction.
+
+---
+
+### Bundled trigger templates: zero-config workflow automation via worktrain init (Apr 18, 2026)
+
+**Problem:** Every user has to write their own triggers.yml manually. Wrong workflow IDs, missing required fields, wrong workspace paths -- all common mistakes (we hit all three today). There's no "just works" path to workflow automation.
+
+**Solution:** Ship common trigger templates bundled with WorkTrain. `worktrain init` presents a menu and generates a pre-filled triggers.yml.
+
+**Bundled templates to ship:**
+
+```yaml
+# Template: mr-review
+- id: mr-review
+  workflowId: mr-review-workflow-agentic
+  goal: "Review the PR specified in the webhook payload goal field"
+  concurrencyMode: parallel
+  autoCommit: false
+  agentConfig: { maxSessionMinutes: 30 }
+
+# Template: coding-task  
+- id: coding-task
+  workflowId: coding-task-workflow-agentic
+  concurrencyMode: parallel
+  autoCommit: false
+  agentConfig: { maxSessionMinutes: 60 }
+
+# Template: discovery-task
+- id: discovery-task
+  workflowId: wr.discovery
+  concurrencyMode: parallel
+  autoCommit: false
+  agentConfig: { maxSessionMinutes: 60 }
+
+# Template: bug-investigation
+- id: bug-investigation
+  workflowId: bug-investigation.agentic.v2
+  agentConfig: { maxSessionMinutes: 45 }
+
+# Template: weekly-health-scan (cron, when native cron trigger ships)
+# - id: weekly-health-scan
+#   type: cron
+#   schedule: "0 9 * * 0"
+#   workflowId: architecture-scalability-audit
+```
+
+**`worktrain init` flow:**
+1. "Which workflows do you want to run automatically?" (checkbox menu)
+2. For each selected: set `workspacePath` to current directory (overridable)
+3. Generate `triggers.yml` in the workspace root
+4. Validate workflow IDs exist before writing (use the startup validator)
+5. Tell the user how to fire each trigger: `curl -X POST http://localhost:3200/webhook/<id> ...`
+
+**Why this matters:** The difference between WorkTrain being usable by anyone vs only by engineers who read the source code. A new user should be able to go from `worktrain init` to their first automated workflow in under 5 minutes.
+
+**Also needed:** `worktrain trigger add <template-name>` to add a single trigger to an existing triggers.yml without re-running init.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4564,3 +4564,45 @@ These are prototype questions, not design questions. Build the smallest possible
 **Why this matters:** The difference between WorkTrain being usable by anyone vs only by engineers who read the source code. A new user should be able to go from `worktrain init` to their first automated workflow in under 5 minutes.
 
 **Also needed:** `worktrain trigger add <template-name>` to add a single trigger to an existing triggers.yml without re-running init.
+
+---
+
+### Decouple goal from trigger definition -- late-bound goals for daemon sessions (Apr 18, 2026)
+
+**The problem:** `goal` is currently required at trigger-definition time (in triggers.yml). For triggers like `mr-review`, the goal is inherently dynamic -- it's the PR title and description, known only when the webhook fires, not when the trigger is configured.
+
+The current workaround: `goalTemplate: "{{$.goal}}"` with the caller passing `{"goal": "Review PR #123..."}` in the webhook payload. This works but is awkward -- the caller must know the payload field convention, and it's not obvious from the trigger definition.
+
+**The right model:** separate "which workflow" (trigger definition) from "what to do" (dispatch-time goal).
+
+```yaml
+# Trigger definition -- no goal required
+triggers:
+  - id: mr-review
+    workflowId: mr-review-workflow-agentic
+    workspacePath: ~/git/myproject
+    # No goal here -- goal comes from dispatch context
+```
+
+```bash
+# Dispatch with goal at call time
+curl -X POST http://localhost:3200/webhook/mr-review \
+  -d '{"goal": "Review PR #123: fix authentication bug"}'
+
+# Or via worktrain spawn
+worktrain spawn --trigger mr-review --goal "Review PR #123: fix authentication bug"
+```
+
+**Implementation options:**
+
+1. **goalTemplate with `$.goal` as the default** -- if no `goal` is set in the trigger and no `goalTemplate` is set, default to `goalTemplate: "{{$.goal}}"`. The webhook payload's `goal` field becomes the canonical way to pass a dynamic goal. Zero breaking changes.
+
+2. **Late-bound goal field on WorkflowTrigger** -- `executeStartWorkflow` accepts `goal` as a separate parameter. The trigger provides everything except the goal; the dispatcher (TriggerRouter) resolves the goal from the webhook payload or a default. This makes the separation explicit at the type level.
+
+3. **Prompt injection** -- the workflow's first step can read `context.goal` which is injected from the webhook payload. The trigger has a static placeholder; the real goal comes through as a context variable. This is how it currently half-works but without the clean API.
+
+**Preferred: Option 1 (default goalTemplate)** -- minimal change, backward compatible, works immediately. If `goal` is absent from the trigger and the webhook payload contains `{"goal": "..."}`, use it. Document this as the standard pattern for dynamic-goal triggers.
+
+**Also needed:** the `worktrain spawn` CLI command should accept `--goal` as a first-class flag (already partially implemented) so coordinator scripts can pass goals without knowing the webhook payload format.
+
+**Why this matters for WorkTrain being production-ready:** most real-world triggers (PR review, issue investigation, incident response) have dynamic goals that depend on what just happened. Static goals in triggers.yml only work for scheduled/cron tasks. Late-bound goals make the whole trigger system composable with external events.

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -481,6 +481,10 @@ function formatDaemonEventLine(raw: string): string | null {
   const prefix = sessionId ? `[${ts}] [${sessionId}] ${kind}` : `[${ts}] ${kind}`;
 
   switch (kind) {
+    case 'agent_stuck':
+      // WHY prominent label: stuck sessions need to be immediately visible in the log.
+      // The STUCK prefix and reason/detail make it scannable at a glance.
+      return `${prefix}  *** STUCK: ${obj['reason'] ?? '?'} -- ${String(obj['detail'] ?? '').slice(0, 100)}`;
     case 'llm_turn_started':
       return `${prefix}  msgs=${obj['messageCount'] ?? '?'}`;
     case 'llm_turn_completed':
@@ -497,12 +501,33 @@ function formatDaemonEventLine(raw: string): string | null {
       return `${prefix}  tool=${obj['toolName'] ?? '?'} err=${String(obj['error'] ?? '').slice(0, 80)}`;
     case 'session_started':
       return `${prefix}  workflow=${obj['workflowId'] ?? '?'} workspace=${obj['workspacePath'] ?? '?'}`;
-    case 'session_completed':
-      return `${prefix}  workflow=${obj['workflowId'] ?? '?'} outcome=${obj['outcome'] ?? '?'}${obj['detail'] ? ` (${obj['detail']})` : ''}`;
+    case 'session_completed': {
+      // WHY distinct labels per outcome: success/error/timeout are actionable states.
+      // A human scanning logs can see at a glance what happened.
+      const outcome = obj['outcome'];
+      const detail = obj['detail'] ? ` (${obj['detail']})` : '';
+      if (outcome === 'success') {
+        return `${prefix}  workflow=${obj['workflowId'] ?? '?'} -- session complete${detail}`;
+      } else if (outcome === 'error') {
+        return `${prefix}  workflow=${obj['workflowId'] ?? '?'} -- session FAILED${detail}`;
+      } else if (outcome === 'timeout') {
+        return `${prefix}  workflow=${obj['workflowId'] ?? '?'} -- session TIMEOUT${detail}`;
+      }
+      return `${prefix}  workflow=${obj['workflowId'] ?? '?'} outcome=${outcome ?? '?'}${detail}`;
+    }
     case 'step_advanced':
-      return `${prefix}`;
-    case 'issue_reported':
-      return `${prefix}  severity=${obj['severity'] ?? '?'} ${String(obj['summary'] ?? '').slice(0, 80)}`;
+      return `${prefix}  -> step advanced`;
+    case 'issue_reported': {
+      // WHY severity-differentiated labels: fatal and error issues need to stand out.
+      const severity = obj['severity'];
+      const summary = String(obj['summary'] ?? '').slice(0, 100);
+      if (severity === 'fatal') {
+        return `${prefix}  FATAL: ${summary}`;
+      } else if (severity === 'error') {
+        return `${prefix}  ERROR: ${summary}`;
+      }
+      return `${prefix}  severity=${severity ?? '?'} ${summary}`;
+    }
     default:
       return `${prefix}  ${JSON.stringify(obj).slice(0, 120)}`;
   }
@@ -633,6 +658,151 @@ program
         offset = result.newOffset; // Update offset even if no new lines.
       }
     }
+  });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// STATUS COMMAND
+// ═══════════════════════════════════════════════════════════════════════════
+
+program
+  .command('status <sessionId>')
+  .description('Print a health summary for a daemon session. Accepts sessionId (UUID prefix) or workrailSessionId (sess_xxx).')
+  .action(async (sessionId: string) => {
+    const eventsDir = path.join(os.homedir(), '.workrail', 'events', 'daemon');
+    const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+    const filePath = path.join(eventsDir, `${date}.jsonl`);
+
+    let raw: string;
+    try {
+      raw = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      process.stdout.write(`No events today. Is the daemon running? (Expected: ${filePath})\n`);
+      return;
+    }
+
+    // Aggregate stats across all event kinds for this session.
+    let workflowId: string | null = null;
+    let firstTs: number | null = null;
+    let lastTs: number | null = null;
+    let llmTurns = 0;
+    let stepAdvances = 0;
+    let totalToolCalls = 0;
+    let failedToolCalls = 0;
+    let fatalIssues = 0;
+    let errorIssues = 0;
+    let warnIssues = 0;
+    let sessionOutcome: string | null = null;
+    let lastToolName: string | null = null;
+    let lastToolArgs: string | null = null;
+    let stuckCount = 0;
+    let isLive = true;
+
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      let obj: Record<string, unknown>;
+      try {
+        obj = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+
+      // Match by process-local sessionId (UUID) or workrailSessionId (sess_xxx).
+      const sid = typeof obj['sessionId'] === 'string' ? obj['sessionId'] : '';
+      const wrid = typeof obj['workrailSessionId'] === 'string' ? obj['workrailSessionId'] : '';
+      const matches = sid.startsWith(sessionId) || sid === sessionId ||
+        wrid.startsWith(sessionId) || wrid === sessionId;
+      if (!matches) continue;
+
+      const ts = typeof obj['ts'] === 'number' ? obj['ts'] : null;
+      if (ts !== null) {
+        if (firstTs === null || ts < firstTs) firstTs = ts;
+        if (lastTs === null || ts > lastTs) lastTs = ts;
+      }
+
+      const kind = typeof obj['kind'] === 'string' ? obj['kind'] : '';
+      switch (kind) {
+        case 'session_started':
+          workflowId = typeof obj['workflowId'] === 'string' ? obj['workflowId'] : null;
+          break;
+        case 'llm_turn_completed':
+          llmTurns++;
+          break;
+        case 'step_advanced':
+          stepAdvances++;
+          break;
+        case 'tool_call_started':
+          totalToolCalls++;
+          lastToolName = typeof obj['toolName'] === 'string' ? obj['toolName'] : null;
+          lastToolArgs = typeof obj['argsSummary'] === 'string' ? String(obj['argsSummary']).slice(0, 60) : null;
+          break;
+        case 'tool_call_failed':
+          failedToolCalls++;
+          break;
+        case 'issue_reported': {
+          const severity = obj['severity'];
+          if (severity === 'fatal') fatalIssues++;
+          else if (severity === 'error') errorIssues++;
+          else if (severity === 'warn') warnIssues++;
+          break;
+        }
+        case 'agent_stuck':
+          stuckCount++;
+          break;
+        case 'session_completed':
+          sessionOutcome = typeof obj['outcome'] === 'string' ? obj['outcome'] : null;
+          isLive = false;
+          break;
+      }
+    }
+
+    if (firstTs === null) {
+      process.stdout.write(`No events found for session: ${sessionId}\n`);
+      return;
+    }
+
+    // Format duration as human-readable string.
+    const durationMs = (lastTs ?? firstTs) - firstTs;
+    const durationSec = Math.floor(durationMs / 1000);
+    const durationMin = Math.floor(durationSec / 60);
+    const durationRemSec = durationSec % 60;
+    const durationStr = durationMin > 0
+      ? `${durationMin}m ${durationRemSec}s`
+      : `${durationSec}s`;
+
+    const avgTurnSec = llmTurns > 0 ? (durationMs / llmTurns / 1000).toFixed(1) : '?';
+    const failRate = totalToolCalls > 0 ? ((failedToolCalls / totalToolCalls) * 100).toFixed(1) : '0';
+    const sessionStatus = sessionOutcome !== null
+      ? sessionOutcome.toUpperCase()
+      : (isLive ? 'RUNNING' : 'UNKNOWN');
+
+    const issueStr = (fatalIssues + errorIssues + warnIssues) > 0
+      ? `${fatalIssues + errorIssues + warnIssues} (${fatalIssues} fatal, ${errorIssues} error, ${warnIssues} warn)`
+      : '0';
+
+    const lastActivityStr = lastTs !== null
+      ? `${lastToolName ?? 'unknown'} ${lastToolArgs ? `"${lastToolArgs}"` : ''} ${Math.round((Date.now() - lastTs) / 1000)}s ago`
+      : 'unknown';
+
+    process.stdout.write(`\nSession: ${sessionId}    [${sessionStatus}]\n`);
+    if (workflowId) process.stdout.write(`Workflow: ${workflowId}\n`);
+    process.stdout.write(`Duration: ${durationStr}\n`);
+    process.stdout.write(`LLM turns: ${llmTurns}${llmTurns > 0 ? ` (avg ${avgTurnSec}s each)` : ''}\n`);
+    process.stdout.write(`Step advances: ${stepAdvances}\n`);
+    process.stdout.write(`Tool calls: ${totalToolCalls} (${failedToolCalls} failed, ${failRate}% failure rate)\n`);
+    process.stdout.write(`Issues reported: ${issueStr}\n`);
+    process.stdout.write(`Last activity: ${lastActivityStr}\n`);
+
+    if (stuckCount > 0) {
+      process.stdout.write(`*** WARNING: ${stuckCount} stuck signal(s) detected\n`);
+    }
+    if (fatalIssues > 0) {
+      process.stdout.write(`*** WARNING: ${fatalIssues} FATAL issue(s) reported\n`);
+    }
+    if (llmTurns >= 10 && stepAdvances === 0) {
+      process.stdout.write(`*** WARNING: ${llmTurns} turns with 0 step advances (possible stuck)\n`);
+    }
+
+    process.stdout.write('\n');
   });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -245,6 +245,41 @@ export interface ToolCallFailedEvent {
 }
 
 /**
+ * Emitted when the stuck-detection heuristics in workflow-runner.ts identify that
+ * the agent is likely stuck and not making forward progress.
+ *
+ * WHY a separate event kind: stuck is categorically different from a tool failure.
+ * It is a higher-level signal that the agent has entered a loop or is blocked
+ * on a gate it cannot pass. Callers (console, coordinator scripts, worktrain logs)
+ * need to distinguish "this tool call failed once" from "the agent is not progressing".
+ *
+ * WHY reason is a closed union: illegal states must be unrepresentable. A freeform
+ * string for reason would require string parsing at every consumer.
+ *
+ * WHY advisory only: this event does NOT abort the session. It is purely observational.
+ * The fire-and-forget emitter contract means stuck detection never affects correctness.
+ */
+export interface AgentStuckEvent {
+  readonly kind: 'agent_stuck';
+  readonly sessionId: string;
+  /**
+   * Which heuristic triggered:
+   * - repeated_tool_call: same tool + same args called 3+ times in a row
+   * - no_progress: 80%+ of turns used with 0 step advances
+   * - timeout_imminent: wall-clock timeout fired (session already aborting)
+   */
+  readonly reason: 'repeated_tool_call' | 'no_progress' | 'timeout_imminent';
+  /** Human-readable description of why stuck was detected. */
+  readonly detail: string;
+  /** The tool name that was called repeatedly (present for repeated_tool_call). */
+  readonly toolName?: string;
+  /** The argsSummary of the repeated call (present for repeated_tool_call). */
+  readonly argsSummary?: string;
+  /** The WorkRail session ID for correlation. Present when continueToken was decoded. */
+  readonly workrailSessionId?: string;
+}
+
+/**
  * Union of all daemon lifecycle events.
  *
  * Each member has a `kind` discriminant so switch exhaustiveness is enforced
@@ -265,7 +300,8 @@ export type DaemonEvent =
   | LlmTurnCompletedEvent
   | ToolCallStartedEvent
   | ToolCallCompletedEvent
-  | ToolCallFailedEvent;
+  | ToolCallFailedEvent
+  | AgentStuckEvent;
 
 // ---------------------------------------------------------------------------
 // DaemonEventEmitter

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -1127,12 +1127,18 @@ interface IssueRecord {
  * @param emitter - Optional event emitter to fire an issue_reported event.
  * @param workrailSessionId - The WorkRail session ID for event correlation (optional).
  * @param issuesDirOverride - Override the issues directory (for tests).
+ * @param onIssueSummary - Optional callback called synchronously with the issue summary
+ *   string after each successful report_issue call. Used by runWorkflow() to accumulate
+ *   issue summaries for the WORKTRAIN_STUCK marker without async file I/O.
+ *   WHY optional callback: avoids circular dependency and keeps execute() synchronous
+ *   from the caller's perspective. Fire-and-forget writes happen separately.
  */
 export function makeReportIssueTool(
   sessionId: string,
   emitter?: DaemonEventEmitter,
   workrailSessionId?: string | null,
   issuesDirOverride?: string,
+  onIssueSummary?: (summary: string) => void,
 ): AgentTool {
   const issuesDir = issuesDirOverride ?? path.join(os.homedir(), '.workrail', 'issues');
 
@@ -1215,6 +1221,12 @@ export function makeReportIssueTool(
         ...(record.continueToken !== undefined && { continueToken: record.continueToken }),
         ...(workrailSessionId != null ? { workrailSessionId } : {}),
       });
+
+      // Notify the accumulator so runWorkflow() can include issue summaries in
+      // the WORKTRAIN_STUCK marker without async file I/O.
+      // WHY synchronous callback: execute() already runs synchronously from the
+      // agent loop's perspective; the callback push is O(1) and never throws.
+      onIssueSummary?.(record.summary);
 
       const isFatal = record.severity === 'fatal';
       const message = isFatal
@@ -1498,8 +1510,31 @@ export async function runWorkflow(
   // call includes output.notesMarkdown. Used by the trigger layer for delivery (git commit/PR).
   let lastStepNotes: string | undefined;
 
+  // ---- Stuck detection state ----
+  // WHY these variables: the turn_end subscriber needs them to check for stuck signals.
+  // All are closure-scoped to this runWorkflow() call -- no cross-session contamination.
+  //
+  // stepAdvanceCount: incremented in onAdvance() every time continue_workflow advances.
+  // Used by signal 2 (no_progress: N turns with 0 advances).
+  let stepAdvanceCount = 0;
+  //
+  // lastNToolCalls: ring buffer of the last 3 tool_call_started events.
+  // Populated in the onToolCallStarted callback before each tool execution.
+  // Used by signal 1 (repeated_tool_call: same tool+args 3 times).
+  // WHY max 3: conservative threshold avoids false positives on legitimate retries.
+  // WHY argsSummary: same tool with different args is not stuck (e.g. grep on different files).
+  const lastNToolCalls: Array<{ toolName: string; argsSummary: string }> = [];
+  const STUCK_REPEAT_THRESHOLD = 3;
+  //
+  // issueSummaries: push-only array populated by the onIssueSummary callback on report_issue.
+  // Included in the WORKTRAIN_STUCK marker so coordinator scripts can categorize failures.
+  // WHY cap at 10: bounds memory on pathological sessions with many issue_reported calls.
+  const issueSummaries: string[] = [];
+  const MAX_ISSUE_SUMMARIES = 10;
+
   const onAdvance = (stepText: string, _continueToken: string): void => {
     pendingSteerText = stepText;
+    stepAdvanceCount++;
     // Heartbeat on each step advance -- the session is alive and making progress.
     // WHY workrailSessionId: DaemonRegistry is keyed by WorkRail session ID (not process UUID).
     // workrailSessionId is populated after executeStartWorkflow + continueToken decode.
@@ -1616,7 +1651,13 @@ export async function runWorkflow(
     makeBashTool(trigger.workspacePath, schemas, sessionId, emitter, workrailSessionId),
     makeReadTool(schemas, sessionId, emitter, workrailSessionId),
     makeWriteTool(schemas, sessionId, emitter, workrailSessionId),
-    makeReportIssueTool(sessionId, emitter, workrailSessionId),
+    makeReportIssueTool(sessionId, emitter, workrailSessionId, undefined, (summary: string) => {
+      // Accumulate issue summaries for WORKTRAIN_STUCK marker.
+      // WHY cap: bounds memory on pathological sessions.
+      if (issueSummaries.length < MAX_ISSUE_SUMMARIES) {
+        issueSummaries.push(summary);
+      }
+    }),
   ];
 
   // ---- Context loading (soul + workspace + session notes) ----
@@ -1691,6 +1732,14 @@ export async function runWorkflow(
     },
     onToolCallStarted: ({ toolName, argsSummary }) => {
       emitter?.emit({ kind: 'tool_call_started', sessionId, toolName, argsSummary, ...withWorkrailSession(workrailSessionId) });
+      // Update the stuck-detection ring buffer.
+      // WHY here: this callback fires synchronously before tool.execute() so the
+      // ring buffer always reflects the most recent tool calls at turn_end check time.
+      // WHY bounded by STUCK_REPEAT_THRESHOLD: O(1) space, no history accumulation.
+      lastNToolCalls.push({ toolName, argsSummary });
+      if (lastNToolCalls.length > STUCK_REPEAT_THRESHOLD) {
+        lastNToolCalls.shift();
+      }
     },
     onToolCallCompleted: ({ toolName, durationMs, resultSummary }) => {
       emitter?.emit({ kind: 'tool_call_completed', sessionId, toolName, durationMs, resultSummary, ...withWorkrailSession(workrailSessionId) });
@@ -1758,6 +1807,65 @@ export async function runWorkflow(
       timeoutReason = 'max_turns';
       agent.abort();
       return; // Do not inject the next step -- we are aborting.
+    }
+
+    // ---- Stuck detection heuristics ----
+    // WHY here: the turn_end subscriber is the canonical post-turn hook. All state
+    // variables (turnCount, stepAdvanceCount, lastNToolCalls, timeoutReason) are
+    // available here. Detection is advisory-only: emitter?.emit() is fire-and-forget
+    // and never aborts the session.
+    //
+    // Signal 1: same tool + same args called STUCK_REPEAT_THRESHOLD times in a row.
+    // WHY argsSummary comparison: same tool with different args is not stuck
+    // (e.g. grep on different files). argsSummary is JSON-serialized params truncated
+    // to 200 chars -- the truncation boundary is an accepted near-zero false positive.
+    if (
+      lastNToolCalls.length === STUCK_REPEAT_THRESHOLD &&
+      lastNToolCalls.every(
+        (c) => c.toolName === lastNToolCalls[0]?.toolName && c.argsSummary === lastNToolCalls[0]?.argsSummary,
+      )
+    ) {
+      emitter?.emit({
+        kind: 'agent_stuck',
+        sessionId,
+        reason: 'repeated_tool_call',
+        detail: `Same tool+args called ${STUCK_REPEAT_THRESHOLD} times: ${lastNToolCalls[0]?.toolName ?? 'unknown'}`,
+        toolName: lastNToolCalls[0]?.toolName,
+        argsSummary: lastNToolCalls[0]?.argsSummary,
+        ...withWorkrailSession(workrailSessionId),
+      });
+    }
+
+    // Signal 2: 80%+ of turns used with 0 step advances.
+    // WHY 0.8 threshold: conservative -- 80% of turns gone with nothing to show is
+    // a strong stuck signal. The agent may legitimately spend many turns researching
+    // before advancing; the threshold must be high enough to avoid false positives.
+    if (
+      maxTurns > 0 &&
+      turnCount >= Math.floor(maxTurns * 0.8) &&
+      stepAdvanceCount === 0
+    ) {
+      emitter?.emit({
+        kind: 'agent_stuck',
+        sessionId,
+        reason: 'no_progress',
+        detail: `${turnCount} turns used, 0 step advances (${maxTurns} turn limit)`,
+        ...withWorkrailSession(workrailSessionId),
+      });
+    }
+
+    // Signal 3: wall-clock timeout is already firing (session is aborting).
+    // WHY emit here: the abort fires in the timeout Promise rejection path, which
+    // runs after the catch block and does not go through turn_end. Emitting here
+    // gives a clear last-chance signal before the abort propagates.
+    if (timeoutReason !== null) {
+      emitter?.emit({
+        kind: 'agent_stuck',
+        sessionId,
+        reason: 'timeout_imminent',
+        detail: `${timeoutReason === 'wall_clock' ? 'Wall-clock timeout' : 'Max-turn limit'} reached`,
+        ...withWorkrailSession(workrailSessionId),
+      });
     }
 
     // If a step was advanced and workflow is not yet complete, inject the next step.
@@ -1850,11 +1958,18 @@ export async function runWorkflow(
     // Append a structured stuck marker so coordinator scripts can detect and act on it.
     // WHY: parseable by worktrain coordinator scripts without LLM involvement --
     // scripts-over-agent for routing decisions.
+    // WHY these fields: coordinator scripts need enough context to categorize the
+    // failure without reading the full daemon event log.
+    const lastToolCalled = lastNToolCalls.length > 0 ? lastNToolCalls[lastNToolCalls.length - 1] : null;
     const stuckMarker = `\n\nWORKTRAIN_STUCK: ${JSON.stringify({
       reason: 'session_error',
       error: errMsg.slice(0, 500),
       workflowId: trigger.workflowId,
       sessionId,
+      turnCount,
+      stepAdvanceCount,
+      ...(lastToolCalled !== null && { lastToolCalled }),
+      ...(issueSummaries.length > 0 && { issueSummaries }),
     })}`;
     return {
       _tag: 'error',

--- a/src/v2/usecases/console-service.ts
+++ b/src/v2/usecases/console-service.ts
@@ -243,18 +243,35 @@ async function readLiveActivity(
       if (!line.trim()) continue;
       try {
         const event = JSON.parse(line) as Record<string, unknown>;
-        // Accept both coarse stream (tool_called) and fine-grained stream (tool_call_started).
+        // Accept both coarse stream (tool_called) and fine-grained stream (tool_call_started),
+        // plus agent_stuck events which are surfaced prominently in the live activity panel.
         // See dual-stream model docs in ToolCallStartedEvent in daemon-events.ts.
         const isToolEvent =
-          event['kind'] === 'tool_called' || event['kind'] === 'tool_call_started';
+          event['kind'] === 'tool_called' ||
+          event['kind'] === 'tool_call_started' ||
+          event['kind'] === 'agent_stuck';
         if (
           !isToolEvent ||
           event['workrailSessionId'] !== workrailSessionId ||
-          typeof event['toolName'] !== 'string' ||
           typeof event['ts'] !== 'number'
         ) {
           continue;
         }
+
+        if (event['kind'] === 'agent_stuck') {
+          // WHY toolName='agent_stuck': ConsoleToolActivity expects a toolName field.
+          // Using a sentinel value makes agent_stuck events identifiable by the console UI
+          // without requiring a schema change to ConsoleToolActivity.
+          activities.push({
+            toolName: 'agent_stuck',
+            summary: `STUCK: ${String(event['reason'] ?? '?')} -- ${String(event['detail'] ?? '').slice(0, 80)}`,
+            ts: event['ts'],
+          });
+          continue;
+        }
+
+        if (typeof event['toolName'] !== 'string') continue;
+
         activities.push({
           toolName: event['toolName'],
           ...(typeof event['summary'] === 'string' ? { summary: event['summary'] } : {}),

--- a/tests/unit/cli-worktrain-logs.test.ts
+++ b/tests/unit/cli-worktrain-logs.test.ts
@@ -32,6 +32,8 @@ function formatDaemonEventLine(raw: string): string | null {
   const prefix = sessionId ? `[${ts}] [${sessionId}] ${kind}` : `[${ts}] ${kind}`;
 
   switch (kind) {
+    case 'agent_stuck':
+      return `${prefix}  *** STUCK: ${obj['reason'] ?? '?'} -- ${String(obj['detail'] ?? '').slice(0, 100)}`;
     case 'llm_turn_started':
       return `${prefix}  msgs=${obj['messageCount'] ?? '?'}`;
     case 'llm_turn_completed':
@@ -48,12 +50,30 @@ function formatDaemonEventLine(raw: string): string | null {
       return `${prefix}  tool=${obj['toolName'] ?? '?'} err=${String(obj['error'] ?? '').slice(0, 80)}`;
     case 'session_started':
       return `${prefix}  workflow=${obj['workflowId'] ?? '?'} workspace=${obj['workspacePath'] ?? '?'}`;
-    case 'session_completed':
-      return `${prefix}  workflow=${obj['workflowId'] ?? '?'} outcome=${obj['outcome'] ?? '?'}${obj['detail'] ? ` (${obj['detail']})` : ''}`;
+    case 'session_completed': {
+      const outcome = obj['outcome'];
+      const detail = obj['detail'] ? ` (${obj['detail']})` : '';
+      if (outcome === 'success') {
+        return `${prefix}  workflow=${obj['workflowId'] ?? '?'} -- session complete${detail}`;
+      } else if (outcome === 'error') {
+        return `${prefix}  workflow=${obj['workflowId'] ?? '?'} -- session FAILED${detail}`;
+      } else if (outcome === 'timeout') {
+        return `${prefix}  workflow=${obj['workflowId'] ?? '?'} -- session TIMEOUT${detail}`;
+      }
+      return `${prefix}  workflow=${obj['workflowId'] ?? '?'} outcome=${outcome ?? '?'}${detail}`;
+    }
     case 'step_advanced':
-      return `${prefix}`;
-    case 'issue_reported':
-      return `${prefix}  severity=${obj['severity'] ?? '?'} ${String(obj['summary'] ?? '').slice(0, 80)}`;
+      return `${prefix}  -> step advanced`;
+    case 'issue_reported': {
+      const severity = obj['severity'];
+      const summary = String(obj['summary'] ?? '').slice(0, 100);
+      if (severity === 'fatal') {
+        return `${prefix}  FATAL: ${summary}`;
+      } else if (severity === 'error') {
+        return `${prefix}  ERROR: ${summary}`;
+      }
+      return `${prefix}  severity=${severity ?? '?'} ${summary}`;
+    }
     default:
       return `${prefix}  ${JSON.stringify(obj).slice(0, 120)}`;
   }
@@ -246,7 +266,7 @@ describe('formatDaemonEventLine', () => {
     expect(result).toContain('workspace=/home/user/project');
   });
 
-  it('formats session_completed with outcome and optional detail', () => {
+  it('formats session_completed outcome=error with FAILED label and detail', () => {
     const line = makeEvent({
       kind: 'session_completed',
       sessionId: 'aabbccdd-1234',
@@ -256,11 +276,12 @@ describe('formatDaemonEventLine', () => {
     });
     const result = formatDaemonEventLine(line);
     expect(result).not.toBeNull();
-    expect(result).toContain('outcome=error');
+    expect(result).toContain('session FAILED');
     expect(result).toContain('(unhandled exception)');
+    expect(result).not.toContain('outcome=error');
   });
 
-  it('omits detail parenthetical when detail is absent', () => {
+  it('formats session_completed outcome=success with complete label', () => {
     const line = makeEvent({
       kind: 'session_completed',
       sessionId: 'aabbccdd-1234',
@@ -269,16 +290,85 @@ describe('formatDaemonEventLine', () => {
     });
     const result = formatDaemonEventLine(line);
     expect(result).not.toBeNull();
-    expect(result).not.toContain('(');
+    expect(result).toContain('session complete');
+    expect(result).not.toContain('outcome=');
   });
 
-  it('formats step_advanced as bare prefix (no extra fields)', () => {
+  it('formats session_completed outcome=timeout with TIMEOUT label', () => {
+    const line = makeEvent({
+      kind: 'session_completed',
+      sessionId: 'aabbccdd-1234',
+      workflowId: 'wf-123',
+      outcome: 'timeout',
+      detail: 'max_turns',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('session TIMEOUT');
+    expect(result).toContain('(max_turns)');
+  });
+
+  it('formats step_advanced with arrow label', () => {
     const line = makeEvent({ kind: 'step_advanced', sessionId: 'aabbccdd-1234' });
     const result = formatDaemonEventLine(line);
     expect(result).not.toBeNull();
     expect(result).toContain('step_advanced');
-    // Should not have trailing spaces or extra content
-    expect(result!.endsWith('step_advanced')).toBe(true);
+    expect(result).toContain('-> step advanced');
+  });
+
+  it('formats agent_stuck with STUCK label and reason/detail', () => {
+    const line = makeEvent({
+      kind: 'agent_stuck',
+      sessionId: 'aabbccdd-1234',
+      reason: 'repeated_tool_call',
+      detail: 'Same tool+args called 3 times: Bash',
+      toolName: 'Bash',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('*** STUCK:');
+    expect(result).toContain('repeated_tool_call');
+    expect(result).toContain('Same tool+args called 3 times: Bash');
+  });
+
+  it('formats issue_reported severity=fatal with FATAL label', () => {
+    const line = makeEvent({
+      kind: 'issue_reported',
+      sessionId: 'aabbccdd-1234',
+      severity: 'fatal',
+      summary: 'Cannot proceed: assessment gate rejected all attempts',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('FATAL:');
+    expect(result).toContain('Cannot proceed');
+    expect(result).not.toContain('severity=fatal');
+  });
+
+  it('formats issue_reported severity=error with ERROR label', () => {
+    const line = makeEvent({
+      kind: 'issue_reported',
+      sessionId: 'aabbccdd-1234',
+      severity: 'error',
+      summary: 'Build failed with exit code 1',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('ERROR:');
+    expect(result).toContain('Build failed');
+  });
+
+  it('formats issue_reported severity=warn with severity label', () => {
+    const line = makeEvent({
+      kind: 'issue_reported',
+      sessionId: 'aabbccdd-1234',
+      severity: 'warn',
+      summary: 'Retrying after transient failure',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('severity=warn');
+    expect(result).toContain('Retrying after transient failure');
   });
 
   it('uses ? for unknown ts when ts field is missing', () => {

--- a/tests/unit/console-service-live-activity.test.ts
+++ b/tests/unit/console-service-live-activity.test.ts
@@ -430,6 +430,46 @@ describe('ConsoleService isSessionLiveFromEventLog', () => {
     expect(detail.liveActivity![0]!.toolName).toBe('Bash');
   });
 
+  it('liveActivity includes agent_stuck events when session is live', async () => {
+    const sessionId = 'sess_live009aaaaaaaaaaaaaaaa';
+    const events = makeMinimalEvents(sessionId);
+
+    // Build a log with a tool_called event AND an agent_stuck event.
+    const stuckEvent = JSON.stringify({
+      kind: 'agent_stuck',
+      workrailSessionId: sessionId,
+      sessionId: 'internal-daemon-id',
+      reason: 'repeated_tool_call',
+      detail: 'Same tool+args called 3 times: Bash',
+      toolName: 'Bash',
+      ts: 1_700_000_001_500,
+    });
+    const jsonlContent = makeEventLogJSONL(sessionId, { started: true, toolNames: ['Bash'] }) +
+      stuckEvent + '\n';
+    const logPath = todayLogPath();
+
+    mockStat.mockImplementation(async (p: unknown) => {
+      if (p === logPath) return { size: Buffer.byteLength(jsonlContent) };
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    mockReadFile.mockImplementation(async (p: unknown) => {
+      if (p === logPath) return jsonlContent;
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    const service = makeService(sessionId, events);
+    const result = await service.getSessionDetail(sessionId);
+
+    expect(result.isOk()).toBe(true);
+    const detail = result._unsafeUnwrap();
+    expect(detail.isLive).toBe(true);
+    expect(detail.liveActivity).not.toBeNull();
+    // agent_stuck event should appear in liveActivity with toolName='agent_stuck'.
+    const stuckEntries = detail.liveActivity!.filter((a) => a.toolName === 'agent_stuck');
+    expect(stuckEntries.length).toBeGreaterThan(0);
+    expect(stuckEntries[0]!.summary).toContain('STUCK:');
+  });
+
   it('isLive=false when log contains only events for a different session', async () => {
     const sessionId = 'sess_live008aaaaaaaaaaaaaaaa';
     const otherSessionId = 'sess_other01aaaaaaaaaaaaaaaa';

--- a/tests/unit/daemon-events.test.ts
+++ b/tests/unit/daemon-events.test.ts
@@ -186,6 +186,8 @@ describe('DaemonEventEmitter', () => {
       { kind: 'tool_call_started', sessionId: 's1', toolName: 'Bash', argsSummary: '{"command":"git status"}' },
       { kind: 'tool_call_completed', sessionId: 's1', toolName: 'Bash', durationMs: 45, resultSummary: 'On branch main' },
       { kind: 'tool_call_failed', sessionId: 's1', toolName: 'Bash', durationMs: 12, errorMessage: 'Command failed' },
+      // Stuck detection event.
+      { kind: 'agent_stuck', sessionId: 's1', reason: 'repeated_tool_call', detail: 'Same tool+args 3 times', toolName: 'Bash', argsSummary: '{"command":"npm test"}' },
     ];
 
     for (const event of events) {

--- a/triggers.yml
+++ b/triggers.yml
@@ -8,3 +8,16 @@ triggers:
     autoCommit: false
     agentConfig:
       maxSessionMinutes: 60
+
+  # MR review: pass a PR number in the goal to get a full review
+  # Dispatch via: POST /webhook/mr-review {"goal": "Review PR #123: <title>"}
+  # Or use goalTemplate with GitHub polling (when github_poll is configured)
+  - id: mr-review
+    goal: "Review the PR specified in the webhook payload goal field"
+    provider: generic
+    workflowId: mr-review-workflow-agentic
+    workspacePath: /Users/etienneb/git/personal/workrail
+    concurrencyMode: parallel
+    autoCommit: false
+    agentConfig:
+      maxSessionMinutes: 30

--- a/workflows/wr.discovery.json
+++ b/workflows/wr.discovery.json
@@ -1,9 +1,10 @@
 {
   "id": "wr.discovery",
   "name": "Discovery Workflow",
-  "version": "3.1.0",
+  "version": "3.2.0",
+  "validatedAgainstSpecVersion": 3,
   "description": "Use this to explore and think through a problem end-to-end. Moves between landscape exploration, problem framing, candidate generation, adversarial challenge, and uncertainty resolution.",
-  "about": "## Discovery Workflow\n\nThis workflow is for structured thinking through an ambiguous problem, opportunity, or decision  -- the kind where you are not sure of the right answer yet and jumping straight to solutions would be premature.\n\n**What it does:**\nThe workflow selects one of three emphasis paths based on your actual need: `landscape_first` for understanding the current state and comparing options, `full_spectrum` for important or ambiguous problems where both landscape grounding and reframing are needed, and `design_first` when the dominant risk is solving the wrong problem. It then moves through landscape research, stakeholder and problem framing, candidate direction generation, adversarial challenge, and an uncertainty-resolution stage that can close with a recommendation, a targeted research follow-up, or a prototype/test plan. A design document is maintained throughout as the human-facing artifact.\n\n**When to use it:**\n- You face a decision, architectural question, or design problem with no obvious right answer\n- You want to explore an opportunity space before committing to a direction\n- You suspect the stated problem might not be the real problem\n- You need a structured recommendation with explicit tradeoffs and alternatives rather than the first plausible answer\n\n**What it produces:**\nA design document covering: the selected path and framing, landscape takeaways, chosen direction and why it won, the strongest alternative and why it lost, confidence band, residual risks, and next actions.\n\n**How to get good results:**\nDescribe the problem, opportunity, or decision you want help thinking through. State what outcome you want (a recommendation, a comparison, a research plan, a prototype direction). The more context you provide upfront about constraints and anti-goals, the sharper the framing will be.",
+  "about": "## Discovery Workflow\n\nThis workflow is for structured thinking through an ambiguous problem, opportunity, or decision -- the kind where you are not sure of the right answer yet and jumping straight to solutions would be premature.\n\n**What it does:**\nBefore starting any research, the workflow challenges the stated goal: it determines whether you handed it a problem or a solution, surfaces hidden assumptions, and defines what success looks like in concrete observable terms. It then selects one of three emphasis paths based on your actual need: `landscape_first` for understanding the current state and comparing options, `full_spectrum` for important or ambiguous problems where both landscape grounding and reframing are needed, and `design_first` when the dominant risk is solving the wrong problem. The workflow moves through landscape research, stakeholder and problem framing, candidate direction generation, adversarial challenge, and an uncertainty-resolution stage that can close with a recommendation, a targeted research follow-up, or a prototype/test plan. A design document is maintained throughout as the human-facing artifact.\n\n**When to use it:**\n- You face a decision, architectural question, or design problem with no obvious right answer\n- You want to explore an opportunity space before committing to a direction\n- You suspect the stated problem might not be the real problem\n- You need a structured recommendation with explicit tradeoffs and alternatives rather than the first plausible answer\n- You want to make sure you are solving the right problem, not just the one you described\n\n**What it produces:**\nA design document covering: the reframed problem (if the original was solution-framed), the selected path and framing, landscape takeaways, chosen direction and why it won, the strongest alternative and why it lost, confidence band, residual risks, and next actions.\n\n**How to get good results:**\nDescribe the problem, opportunity, or decision you want help thinking through -- or describe the solution you are considering, and let the workflow figure out the underlying problem. State what outcome you want (a recommendation, a comparison, a research plan, a prototype direction). The more context you provide upfront about constraints and anti-goals, the sharper the framing will be.",
   "examples": [
     "Decide whether to build a custom notification system or adopt a third-party service",
     "Explore what the right architecture is for moving our monolith to services",
@@ -54,6 +55,40 @@
   ],
   "steps": [
     {
+      "id": "phase-0-reframe",
+      "title": "Phase 0a: Reframe the Goal Before Jumping to Solutions",
+      "promptBlocks": {
+        "goal": "Challenge the stated goal before we start researching it. Figure out whether I handed you a problem or a solution, surface the assumptions baked into the framing, and define what success actually looks like.",
+        "constraints": [
+          [
+            {
+              "kind": "ref",
+              "refId": "wr.refs.notes_first_durability"
+            }
+          ],
+          "Do not begin landscape research or candidate generation in this step.",
+          "If the goal is stated as a solution, find the problem behind it -- do not just accept the solution as given.",
+          "Challenge assumptions with specificity: name each assumption, state why it might be wrong, and say what evidence would confirm or refute it.",
+          "Define success in terms of outcomes and observable signals, not just delivery of the stated goal."
+        ],
+        "procedure": [
+          "Classify the stated goal as a `solution_statement` (names a specific solution or approach) or a `problem_statement` (describes an outcome, pain, or gap without prescribing the fix). Record this as `goalType`.",
+          "If `goalType = solution_statement`: identify the underlying problem this solution is trying to solve, name at least one materially different way to solve that problem, and state explicitly whether the stated solution is the best match for the problem or just the most familiar one.",
+          "Challenge exactly 3 key assumptions embedded in the stated goal. For each assumption: state the assumption clearly, explain why it might be wrong, and identify what evidence would confirm or refute it. Record these as `challengedAssumptions`.",
+          "Define what success looks like before any candidates are generated. Success criteria must be concrete and observable -- not 'the problem is solved' but 'we can measure X, users do Y, the system behaves Z'. Record these as `successCriteria`.",
+          "Record a one-sentence `reframedProblem` that captures the real underlying problem, stripped of any solution bias from the original goal.",
+          "Set these keys in the next `continue_workflow` call's `context` object: `goalType`, `reframedProblem`, `challengedAssumptions`, `successCriteria`, `goalWasSolutionStatement`."
+        ],
+        "verify": [
+          "Each of the 3 challenged assumptions is specific enough that someone could disagree with the challenge.",
+          "The success criteria would let a skeptic determine whether the work actually succeeded.",
+          "If the goal was a solution-statement, the underlying problem is stated independently of the proposed solution.",
+          "The reframed problem is meaningfully different from the original goal wording, or you have explicitly noted why the original framing was already problem-shaped."
+        ]
+      },
+      "requireConfirmation": false
+    },
+    {
       "id": "phase-0-select-path",
       "title": "Phase 0: Understand, Classify, and Recommend a Path",
       "promptBlocks": {
@@ -71,13 +106,15 @@
         ],
         "procedure": [
           "Capture: `problemStatement`, `desiredOutcome`, `coreConstraints`, `antiGoals`, `primaryUncertainty`, `knownApproaches`, `importantStakeholders`, `rigorMode`, `automationLevel`, `pathRecommendation`, `pathRationale`, `designDocPath`.",
-          "Choose `landscape_first` when my dominant need is understanding the current landscape or comparing options. Choose `full_spectrum` when both landscape grounding and reframing are needed. Choose `design_first` when the dominant risk is solving the wrong problem or shaping the wrong concept.",
+          "If `goalWasSolutionStatement = true`, set `problemStatement` from `reframedProblem` rather than from the stated goal. Record the original stated goal as `statedGoal` in the design doc so the distinction is visible.",
+          "Choose `landscape_first` when my dominant need is understanding the current landscape or comparing options. Choose `full_spectrum` when both landscape grounding and reframing are needed. Choose `design_first` when the dominant risk is solving the wrong problem or shaping the wrong concept. If `goalWasSolutionStatement = true`, bias toward `design_first` unless the stated solution is clearly the correct framing.",
           "Create or update `designDocPath` with sections for Context / Ask, Path Recommendation, Constraints / Anti-goals, Landscape Packet, Problem Frame Packet, Candidate Directions, Challenge Notes, Resolution Notes, Decision Log, and Final Summary.",
           "Set these keys in the next `continue_workflow` call's `context` object: `problemStatement`, `desiredOutcome`, `coreConstraints`, `antiGoals`, `primaryUncertainty`, `knownApproaches`, `importantStakeholders`, `rigorMode`, `automationLevel`, `pathRecommendation`, `pathRationale`, `designDocPath`.",
           "Also set `goal` in the context object: one sentence describing what you are trying to accomplish. This populates the session title in the Workspace console immediately."
         ],
         "verify": [
           "The chosen path is justified against the other two, not just named.",
+          "If `goalWasSolutionStatement = true`, the `problemStatement` reflects the reframed problem, not the stated solution.",
           "The design doc exists and the path recommendation is recorded there."
         ]
       },
@@ -284,10 +321,11 @@
           "Capture users or stakeholders, jobs or outcomes, pains or tensions, constraints that matter in lived use, success criteria, assumptions, and at least 2 reframes or HMW questions.",
           "If `delegationAvailable = true`, decide whether parallel stakeholder lenses would actually sharpen the result. If yes, run them in parallel. If not, keep going yourself. In either case, you must synthesize the result yourself.",
           "Update `designDocPath` using `problemFrameTemplate`.",
+          "Before finishing, name ONE specific concrete condition that would make the current framing wrong -- not a generic caveat, but a specific thing that if discovered to be true would change the path or direction. Record this as `primaryFramingRisk` in the design doc.",
           "Set these keys in the next `continue_workflow` call's `context` object: `problemFrame`, `primaryUsers`, `tensionCount`, `successCriteriaCount`, `framingRiskCount`, `needsChallenge`, `retriageNeeded`."
         ],
         "verify": [
-          "The framing names what could still be wrong.",
+          "The framing names what could still be wrong -- specifically, not generically.",
           "The frame is strong enough to influence candidate generation and later selection."
         ]
       },
@@ -319,10 +357,11 @@
           "Capture users or stakeholders, jobs or outcomes, pains or tensions, constraints that matter in lived use, success criteria, assumptions, and at least 2 reframes or HMW questions.",
           "If `delegationAvailable = true`, decide whether parallel stakeholder lenses would actually sharpen the result. If yes, run them in parallel. If not, keep going yourself. In either case, you must synthesize the result yourself.",
           "Update `designDocPath` using `problemFrameTemplate`.",
+          "Before finishing, name ONE specific concrete condition that would make the current framing wrong -- not a generic caveat, but a specific thing that if discovered to be true would change the path or direction. Record this as `primaryFramingRisk` in the design doc.",
           "Set these keys in the next `continue_workflow` call's `context` object: `problemFrame`, `primaryUsers`, `tensionCount`, `successCriteriaCount`, `framingRiskCount`, `needsChallenge`, `retriageNeeded`."
         ],
         "verify": [
-          "The framing names what could still be wrong.",
+          "The framing names what could still be wrong -- specifically, not generically.",
           "The framing depth is strong enough to justify a design-first path."
         ]
       },
@@ -335,8 +374,20 @@
       "id": "phase-1g-retriage",
       "title": "Phase 1g: Re-Triage After Early Context",
       "runCondition": {
-        "var": "retriageNeeded",
-        "equals": true
+        "or": [
+          {
+            "var": "retriageNeeded",
+            "equals": true
+          },
+          {
+            "var": "pathRecommendation",
+            "equals": "design_first"
+          },
+          {
+            "var": "pathRecommendation",
+            "equals": "full_spectrum"
+          }
+        ]
       },
       "promptBlocks": {
         "goal": "Reassess the path now that you have real landscape and framing context instead of just my initial wording.",


### PR DESCRIPTION
## Summary

- Adds a mandatory Phase 0a goal interrogation step before path selection in `wr.discovery` (v3.1.0 -> v3.2.0)
- The new step classifies goals as solution-statements vs problem-statements, challenges 3 key assumptions for every goal, defines concrete success criteria upfront, and derives a reframed problem when the stated goal describes a solution rather than an outcome
- Phase 0 path selection now uses the reframed problem as the problem statement for solution-framed goals and biases toward `design_first`
- Phases 1e/1f now require naming one concrete falsification condition for the problem frame (not just a generic caveat)
- Phase 1g retriage now always runs for `design_first` and `full_spectrum` paths rather than only when explicitly triggered by the agent

## Context

This improvement was designed through a two-phase WorkRail process:

**Phase 1 (wr.discovery):** Diagnosed the specific structural weaknesses in the existing workflow. Root finding: Phase 0 accepts stated goals without distinguishing solution-framed goals from problem-framed goals, causing path selection to inherit any misframing. The `design_first` path exists for "dominant risk is solving the wrong problem" but path selection itself used the stated goal as input -- a circular problem.

**Phase 2 (workflow-for-workflows):** Designed and implemented the improvements. The wfw chose a stronger architecture than the discovery phase recommended: a mandatory separate Phase 0a step (rather than extending Phase 0 procedure text), with a simpler 2-value goal classification that reduces misclassification risk.

Real examples that motivated the change: (1) MCP simplification discovery produced design candidates but missed that the immediate fix was just adding `artifacts` to the tool; (2) structured output discovery started with the wrong assumption about mixing `response_format + tools`.

## Test plan

- [ ] Run `npm run validate:workflows` -- all 25 workflows should pass (verified locally)
- [ ] Run `npm run validate:registry` -- all variants should pass (verified locally)
- [ ] Start a session with a solution-framed goal (e.g., "add a reframe step to wr.discovery") and verify Phase 0a classifies as `solution_statement`, derives an implied problem, and Phase 0 uses the reframed problem as `problemStatement`
- [ ] Start a session with a problem-framed goal (e.g., "reduce checkout abandonment when root cause is unclear") and verify Phase 0a adds minimal overhead (3-assumption challenge, no impliedProblem derivation required)
- [ ] Verify Phase 1g runs for a `design_first` session without `retriageNeeded` being set

## Discovery docs

- `docs/discovery/wr-discovery-goal-reframing.md` -- full diagnosis with landscape packet, problem frame, candidates, decision log, and final summary
- `docs/discovery/design-candidates.md` -- three candidate directions with comparison and recommendation
- `docs/discovery/design-review-findings.md` -- review findings with no Red/Orange issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)