### PR TITLE
feat(daemon): add complete_step tool -- daemon manages continueToken internally

### DIFF
--- a/docs/design/daemon-complete-step-tool-candidates.md
+++ b/docs/design/daemon-complete-step-tool-candidates.md
@@ -1,0 +1,160 @@
+# daemon complete_step tool -- Design Candidates
+
+## Problem Understanding
+
+### Core Tensions
+
+1. **Simplicity vs. completeness of the blocked-response path**: The naive solution handles the happy path (advance) but misses blocked responses. On a blocked response, `executeContinueWorkflow` returns a `retryContinueToken`. The LLM needs to retry `complete_step` with corrected notes, but what token should the tool inject? It must be the retry token, not the original session token -- so the closure variable MUST be updated to the retry token on blocked responses.
+
+2. **Crash safety vs. simplicity**: The existing `makeContinueWorkflowTool` calls `persistTokens()` inside `execute()` before calling `onAdvance()`. The `complete_step` tool must maintain this same invariant: persist the new token to disk before signaling the advance.
+
+3. **Backward compatibility vs. system prompt clarity**: `continue_workflow` must stay in the tools list (it's used by MCP sessions outside the daemon). But if `complete_step` exists alongside it, the system prompt must clearly tell the daemon agent to prefer `complete_step`.
+
+4. **Token update ownership**: `currentContinueToken` is written by two paths: (a) `onAdvance` after a successful advance, and (b) blocked retry in `makeCompleteStepTool.execute()`. Sequential tool execution (`toolExecution: 'sequential'` in AgentLoop) ensures no race condition, but the two write paths must be documented.
+
+### Likely Seam
+
+The seam is in `runWorkflow()`: the `onAdvance` callback signature `(stepText: string, continueToken: string) => void` already passes the new `continueToken` as the second parameter. `runWorkflow()` currently ignores it (because `continue_workflow` doesn't need it -- the LLM round-trips the token). For `complete_step`, we just need to use it.
+
+### What Makes This Hard
+
+- Two token update paths (advance + blocked retry) must both be correct
+- Token must be persisted before `onAdvance` fires (crash safety invariant)
+- Blocked response feedback must not include `continueToken` in the text (LLM doesn't need to see it)
+- System prompt needs to be updated to prefer `complete_step` without breaking existing `continue_workflow` callers
+
+---
+
+## Philosophy Constraints
+
+Sources: `CLAUDE.md` (workspace root), repo patterns in `src/daemon/workflow-runner.ts`
+
+**Active principles:**
+- **Immutability by default**: confine mutation to the minimal API -- `currentContinueToken` updated only via callbacks
+- **YAGNI with discipline**: avoid speculative abstractions
+- **Prefer fakes over mocks**: test with fake `executeContinueWorkflow` injection
+- **Document "why" not "what"**: add WHY comments explaining the daemon token injection
+- **Make illegal states unrepresentable**: `notes` required with `minLength: 50` at JSON Schema level
+
+No philosophy conflicts found between stated rules and repo patterns.
+
+---
+
+## Impact Surface
+
+- `src/daemon/workflow-runner.ts`: new factory function + updates to `runWorkflow()`, `getSchemas()`, `BASE_SYSTEM_PROMPT`
+- `tests/unit/workflow-runner-complete-step.test.ts`: new test file
+- `continue_workflow` tool: unchanged (backward compat)
+- Public MCP tools list: unchanged (`complete_step` is daemon-only, not exposed via MCP)
+- `V2ContinueWorkflowInputShape` / output schemas: unchanged
+
+---
+
+## Candidates
+
+### Candidate 1: Inline closure variable + two callback paths (RECOMMENDED)
+
+**Summary:** Add `let currentContinueToken = startContinueToken` to `runWorkflow()`; update it in the existing `onAdvance` closure (which already receives `continueToken` as a second param but ignores it); for blocked-retry token updates, add an `onTokenUpdate: (t: string) => void` callback parameter to `makeCompleteStepTool()`; `makeCompleteStepTool()` uses `getCurrentToken: () => string` to inject the token.
+
+**Tensions resolved:**
+- Crash safety: identical `persistTokens` path before callbacks
+- Blocked retry: `onTokenUpdate` callback updates `currentContinueToken` to retry token
+- Backward compat: additive only, both tools in list
+
+**Tensions accepted:**
+- Two token-update paths (onAdvance for advance, onTokenUpdate for blocked) could diverge if future developers update one but forget the other
+
+**Boundary solved at:** `runWorkflow()` closure + new factory function alongside existing one
+
+**Why this boundary is the best fit:** The seam already exists -- `onAdvance` receives the new `continueToken` but ignores it. Adding a single `onTokenUpdate` callback for blocked responses follows the same pattern used by `onIssueSummary` in `makeReportIssueTool`.
+
+**Failure mode:** Developer forgets to update `currentContinueToken` on blocked retry, causing second TOKEN_BAD_SIGNATURE on retry.
+
+**Repo-pattern relationship:** Follows exactly -- same closure pattern, same fake injection, same `persistTokens` placement.
+
+**Gains:**
+- Zero new abstractions
+- Easy to test with same fake injection pattern
+- Minimal change surface
+
+**Losses:**
+- Two write paths for `currentContinueToken` (minor)
+
+**Scope judgment:** Best-fit
+
+**Philosophy fit:** Honors YAGNI, immutability, fakes over mocks. No conflicts.
+
+---
+
+### Candidate 2: Token ref object `{ get(): string; set(t: string): void }`
+
+**Summary:** Introduce a typed `TokenRef` interface; instantiate once in `runWorkflow()` with `currentContinueToken` as internal state; pass the ref to both `makeCompleteStepTool` and `makeContinueWorkflowTool`; both tools call `ref.set()` on advance and blocked-retry.
+
+**Tensions resolved:**
+- Single token update path (only `ref.set()` is called in both tools)
+
+**Tensions accepted:**
+- Adds a new abstraction (`TokenRef`) not present elsewhere in the repo
+- Requires modifying `makeContinueWorkflowTool` signature (breaks backward compat of the function signature, though not behavior)
+
+**Boundary solved at:** New `TokenRef` interface shared across factory functions
+
+**Why this boundary is the best fit:** Only justified if both tools are converted. The spec says keep `continue_workflow` for backward compat -- converting it is out of scope.
+
+**Failure mode:** Over-engineering; `TokenRef` is unnecessary if `makeContinueWorkflowTool` isn't converted.
+
+**Repo-pattern relationship:** Departs from existing patterns (no mutable ref objects elsewhere).
+
+**Gains:** Single token update path, explicit ownership model
+
+**Losses:** New concept to understand, marginal benefit, violates YAGNI
+
+**Scope judgment:** Too broad -- would require modifying `makeContinueWorkflowTool` signature, which isn't needed
+
+**Philosophy fit:** Honors explicit domain types. Conflicts with YAGNI with discipline.
+
+---
+
+## Comparison and Recommendation
+
+| Criterion | Candidate 1 | Candidate 2 |
+|-----------|-------------|-------------|
+| Zero new abstractions | Yes | No |
+| Single token update path | No (two paths) | Yes |
+| Matches repo patterns | Yes | Departs |
+| Requires makeContinueWorkflowTool change | No | Yes |
+| YAGNI | Passes | Fails |
+| Test complexity | Same fake injection | Same |
+
+**Recommendation: Candidate 1.**
+
+The two write paths are manageable because:
+1. They are clearly distinct: `onAdvance` fires on successful advance, `onTokenUpdate` fires on blocked retry
+2. Both have WHY comments explaining their role
+3. `toolExecution: 'sequential'` makes races impossible
+
+Candidate 2 fails the YAGNI test. The single update path benefit only matters if `makeContinueWorkflowTool` is also converted -- which is explicitly out of scope.
+
+---
+
+## Self-Critique
+
+**Strongest counter-argument:** Candidate 2's `TokenRef` would prevent the two-path divergence risk. If a future developer adds a third code path that updates the token (e.g., a hypothetical `rehydrate_step` tool), Candidate 1 requires a third callback while Candidate 2 just needs another `ref.set()` call.
+
+**Narrower option:** Don't add `onTokenUpdate` at all; instead update `currentContinueToken` directly inside `makeCompleteStepTool.execute()` by passing a setter into the factory. This is functionally identical to `onTokenUpdate` -- just named differently.
+
+**Broader option threshold:** `TokenRef` would be justified when a second token-managing tool (e.g., `rehydrate_step`) is being added in the same PR.
+
+**Assumption that would invalidate:** If `toolExecution: 'sequential'` is ever changed to parallel, the two write paths could race. But sequential execution is a fundamental requirement for workflow step ordering and will not change.
+
+---
+
+## Open Questions for the Main Agent
+
+1. Should `complete_step` include `continueToken` in the success response text? (The spec says return `{ status: 'advanced', nextStep: string }` or `{ status: 'complete' }` -- so no token in the response text. This is correct and important.)
+
+2. Should the blocked-response feedback text for `complete_step` say "call complete_step again" instead of "call continue_workflow"? Yes -- the blocked feedback must be updated to reference `complete_step`.
+
+3. The spec says `notes: string` required min 50 chars. Should this be enforced at JSON Schema level (LLM sees validation error) or inside `execute()` (tool throws)? JSON Schema is preferred -- it gives the LLM a clear validation error before the tool even runs.
+
+4. Should `workspacePath` be removed from `complete_step` (since the daemon always knows it)? Yes -- daemon context is always available, no need to pass it through.

--- a/docs/design/daemon-complete-step-tool-design-review.md
+++ b/docs/design/daemon-complete-step-tool-design-review.md
@@ -1,0 +1,82 @@
+# daemon complete_step tool -- Design Review Findings
+
+## Tradeoff Review
+
+### T1: Two token write paths (onAdvance + onTokenUpdate)
+**Assessment:** Acceptable. The two paths are structurally mutually exclusive (`kind: 'ok'` vs `kind: 'blocked'` response branches). Sequential tool execution prevents races. The response kind enum is closed (`ok` | `blocked`). No future third path is anticipated.
+**Condition for re-evaluation:** If a third response kind is added that carries a new token.
+
+### T2: Blocked feedback references `complete_step`
+**Assessment:** Acceptable. The daemon's tool list will have `complete_step` as the primary tool. Blocked feedback pointing to it is correct.
+
+### T3: `notes` minLength enforced at JSON Schema + runtime
+**Finding:** JSON Schema `minLength` is informational to the LLM but NOT enforced by AgentLoop. Runtime check inside `execute()` is required.
+**Revision:** Add `if (!params.notes || params.notes.length < 50) throw new Error(...)` inside `execute()`.
+
+---
+
+## Failure Mode Review
+
+| Failure Mode | Covered? | Mitigation |
+|---|---|---|
+| FM1: Wrong token on blocked retry | Yes | `onTokenUpdate` called with retry token from blocked response |
+| FM2: Notes too short not caught | Fixed | Runtime length check in `execute()` |
+| FM3: Token in response text | Yes | Response text does not include token |
+| FM4: LLM calls `continue_workflow` with hallucinated token | Partial | System prompt marks it deprecated; accepted as transition risk |
+| FM5: Wrong intent used | Yes | `intent: 'advance'` hardcoded, not a parameter |
+
+---
+
+## Runner-Up / Simpler Alternative Review
+
+- `TokenRef` object: not worth pulling in -- requires `makeContinueWorkflowTool` signature change which is out of scope
+- Simpler variant (inline `setCurrentToken` vs `onTokenUpdate` callback): functionally identical, cosmetic only
+- No hybrid opportunity that reduces complexity
+
+**Verdict:** Selected design is the simplest that satisfies all criteria.
+
+---
+
+## Philosophy Alignment
+
+| Principle | Status |
+|---|---|
+| Immutability by default | Satisfied -- mutation confined to callbacks |
+| YAGNI with discipline | Satisfied -- zero new abstractions |
+| Prefer fakes over mocks | Satisfied -- fake injection pattern |
+| Validate at boundaries | Satisfied after fix -- runtime check added |
+| Make illegal states unrepresentable | Satisfied -- notes required, intent hardcoded |
+| Determinism | Acceptable tension -- sequential execution makes mutable state deterministic |
+
+---
+
+## Findings
+
+### Yellow: Two token write paths (manageable)
+The `currentContinueToken` closure variable is updated in two places: `onAdvance` (on successful advance) and `onTokenUpdate` (on blocked retry). These are mutually exclusive branches. Risk is low because sequential execution prevents races, but it should be documented with WHY comments.
+
+**Action:** Add WHY comment above each update explaining which response kind it handles.
+
+### Yellow: Runtime notes validation missing
+JSON Schema `minLength: 50` is informational only. Without a runtime check, a notes string of 10 chars would pass through to `executeContinueWorkflow`, potentially causing a downstream blocked response. Better to fail fast in the tool.
+
+**Action:** Add runtime check in `execute()` before calling `executeContinueWorkflow`.
+
+---
+
+## Recommended Revisions
+
+1. **Add runtime notes validation**: `if (!params.notes || params.notes.length < 50) throw new Error('complete_step: notes is required and must be at least 50 characters. Include what you did and what you produced.')`
+
+2. **Document two token write paths**: Add WHY comments above each `currentContinueToken` update explaining which execution branch it covers.
+
+3. **Blocked feedback text**: Replace `call continue_workflow` references in blocked feedback with `call complete_step again with corrected notes`.
+
+4. **System prompt update**: Add explicit guidance that `complete_step` is the preferred advancement tool and `continue_workflow` is deprecated in daemon sessions. Keep the `continue_workflow` description updated with `[DEPRECATED in daemon sessions]`.
+
+---
+
+## Residual Concerns
+
+- **FM4 (LLM using deprecated continue_workflow)**: Accepted. During transition, the LLM might call `continue_workflow` with a correctly round-tripped token (from the initial prompt or a previous response). This is functional but defeats the purpose. The system prompt must be strong enough to prevent this.
+- **`continueToken` in initial prompt**: The initial prompt currently includes `continueToken: ${startContinueToken}`. With `complete_step`, this is no longer needed since the daemon manages the token. The initial prompt should be updated to remove the token and use `call complete_step when done` instead. This is a UX improvement, not a correctness issue.

--- a/docs/design/daemon-complete-step-tool-implementation-plan.md
+++ b/docs/design/daemon-complete-step-tool-implementation-plan.md
@@ -1,0 +1,166 @@
+# Implementation Plan: daemon complete_step tool
+
+## Problem Statement
+
+The daemon's `continue_workflow` tool requires the LLM to round-trip a `continueToken` (an HMAC-signed opaque token). The LLM frequently mangles this token, causing TOKEN_BAD_SIGNATURE errors that kill sessions. The fix: add a `complete_step` tool where the daemon injects the `continueToken` internally -- the LLM never sees it.
+
+## Acceptance Criteria
+
+1. `makeCompleteStepTool()` function exists in `src/daemon/workflow-runner.ts`, exported alongside `makeContinueWorkflowTool()`
+2. `complete_step` accepts: `notes: string` (required, min 50 chars), `artifacts?: unknown[]`, `context?: Record<string, unknown>`
+3. The tool injects the current session's `continueToken` internally before calling `executeContinueWorkflow` -- LLM never provides it
+4. `continueToken` is managed via a closure variable `currentContinueToken` in `runWorkflow()`, updated on advance and blocked-retry
+5. On successful advance: returns `{ status: 'advanced', nextStep: '<step title>' }` text
+6. On workflow complete: returns `{ status: 'complete' }` text
+7. On blocked: returns human-readable feedback saying 'call complete_step again' (not continue_workflow)
+8. Runtime validation: throws if `notes.length < 50`
+9. `complete_step` is in the daemon tools list in `runWorkflow()` alongside `continue_workflow`
+10. `continue_workflow` description is marked `[DEPRECATED in daemon sessions -- use complete_step]`
+11. `BASE_SYSTEM_PROMPT` lists `complete_step` as the primary advancement tool
+12. Initial prompt removes `continueToken: ${startContinueToken}` and says 'Call complete_step with your notes when done'
+13. Unit tests cover: happy-path advance, workflow complete, blocked response (retryable + non-retryable), notes too short, artifacts pass-through
+14. All existing tests pass
+
+## Non-Goals
+
+- No schema changes to `V2ContinueWorkflowInputShape` or public MCP tools
+- No new HTTP routes or public API changes
+- `complete_step` is daemon-only -- NOT added to the MCP server's public tools list
+- No migration of `makeContinueWorkflowTool` to use `TokenRef` pattern
+- No removal of `continue_workflow` from the daemon tools list (backward compat)
+- No changes to `rehydrate` flow
+
+## Philosophy-Driven Constraints
+
+- **Immutability by default**: `currentContinueToken` is the only mutable shared state; confined to `runWorkflow()` closure
+- **Validate at boundaries**: runtime `notes.length` check in `execute()` (JSON Schema is informational only)
+- **Prefer fakes over mocks**: tests use fake `executeContinueWorkflow` injection
+- **YAGNI**: zero new abstraction types
+- **Document "why" not "what"**: WHY comments on all non-obvious decisions
+
+## Invariants
+
+1. `persistTokens(sessionId, newToken, ...)` is always called BEFORE `onAdvance()` fires (crash safety)
+2. `currentContinueToken` is updated to the advance token on `kind: 'ok'` responses
+3. `currentContinueToken` is updated to the retry token on `kind: 'blocked'` responses
+4. `continueToken` never appears in `complete_step` response text
+5. `intent: 'advance'` is hardcoded -- LLM cannot pass `rehydrate` via `complete_step`
+6. `complete_step` is NOT exposed in the MCP server's public tool registration
+
+## Selected Approach
+
+**Candidate 1: Inline closure variable + two callback paths**
+
+`runWorkflow()` holds `let currentContinueToken = startContinueToken`. The variable is updated:
+- In `onAdvance(stepText, continueToken)` -- uses the `continueToken` param (already available, currently ignored)
+- Via `onTokenUpdate: (t: string) => void` callback passed to `makeCompleteStepTool()` -- called on blocked retry
+
+`makeCompleteStepTool()` signature:
+```typescript
+export function makeCompleteStepTool(
+  sessionId: string,
+  ctx: V2ToolContext,
+  getCurrentToken: () => string,
+  onAdvance: (nextStepText: string, continueToken: string) => void,
+  onComplete: (notes: string | undefined) => void,
+  onTokenUpdate: (t: string) => void,
+  schemas: Record<string, any>,
+  _executeContinueWorkflowFn?: typeof executeContinueWorkflow,
+  emitter?: DaemonEventEmitter,
+  workrailSessionId?: string | null,
+): AgentTool
+```
+
+**Runner-up:** Candidate 2 (`TokenRef` object) -- rejected: requires `makeContinueWorkflowTool` signature change (out of scope), violates YAGNI.
+
+## Vertical Slices
+
+### Slice 1: Schema and factory function
+**Files:** `src/daemon/workflow-runner.ts`
+**Work:**
+- Add `CompleteStepParams` JSON Schema to `getSchemas()`:
+  ```json
+  {
+    "type": "object",
+    "properties": {
+      "notes": { "type": "string", "minLength": 50, "description": "..." },
+      "artifacts": { "type": "array", "items": {}, "description": "..." },
+      "context": { "type": "object", "additionalProperties": true }
+    },
+    "required": ["notes"],
+    "additionalProperties": false
+  }
+  ```
+- Add `makeCompleteStepTool()` factory function (described above)
+- Runtime notes validation inside `execute()`
+- Full blocked/advance/complete handling (mirror `makeContinueWorkflowTool` but without token in response text)
+
+**AC:** Function exists, exported, executes correctly with fake injection
+
+### Slice 2: runWorkflow() integration
+**Files:** `src/daemon/workflow-runner.ts`
+**Work:**
+- Add `let currentContinueToken = startContinueToken` after `startContinueToken` is assigned
+- Update `onAdvance` to set `currentContinueToken = continueToken` (second param was ignored before)
+- Add `complete_step` to the tools list with `makeCompleteStepTool(..., () => currentContinueToken, onAdvance, onComplete, (t) => { currentContinueToken = t; }, ...)`
+- Mark `continue_workflow` description as deprecated
+
+**AC:** `runWorkflow()` compiles; `currentContinueToken` is updated on advance
+
+### Slice 3: System prompt + initial prompt updates
+**Files:** `src/daemon/workflow-runner.ts`
+**Work:**
+- Update `BASE_SYSTEM_PROMPT` tools section: add `complete_step` as primary tool, mark `continue_workflow` as deprecated
+- Update `initialPrompt` in `runWorkflow()`: remove `continueToken: ${startContinueToken}` from the text; change 'call continue_workflow' to 'call complete_step'
+
+**AC:** Prompt does not contain the continueToken string; 'complete_step' appears as primary tool
+
+### Slice 4: Tests
+**Files:** `tests/unit/workflow-runner-complete-step.test.ts`
+**Test cases:**
+- TC1: notes present, advance returns `{ status: 'advanced', nextStep: '...' }`
+- TC2: workflow complete returns `{ status: 'complete' }`
+- TC3: blocked retryable -- feedback says 'call complete_step again', `onTokenUpdate` called with retry token
+- TC4: blocked non-retryable -- feedback says cannot proceed without resolving
+- TC5: notes too short (< 50 chars) -- tool throws
+- TC6: notes absent -- tool throws
+- TC7: artifacts pass-through -- artifacts forwarded to executeContinueWorkflow
+- TC8: no artifacts, no output artifact object constructed (empty array guard)
+- TC9: `continueToken` NOT in response text (regression guard)
+- TC10: `getCurrentToken()` is called (not a hardcoded token) -- verify via fake that captures input
+
+**AC:** All 10 tests pass; `npm run test:unit` green
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| LLM uses deprecated continue_workflow with hallucinated token | Low | Medium | System prompt deprecation notice; transition risk accepted |
+| Token not updated on blocked retry | Low | High | Test TC3 catches this |
+| `continueToken` in response text | Low | Medium | Test TC9 catches this |
+| Initial prompt still contains token string | Low | Medium | Test prompt content in system-prompt test |
+
+## PR Packaging Strategy
+
+Single PR: `feat/daemon-complete-step-tool`
+
+All 4 slices go in one commit per slice (or a single clean commit). No multi-PR needed -- change is additive, no breaking changes.
+
+## Philosophy Alignment
+
+| Slice | Principle | Status |
+|---|---|---|
+| Slice 1: Schema | Make illegal states unrepresentable | Satisfied -- notes required, intent hardcoded |
+| Slice 1: Factory | Validate at boundaries | Satisfied -- runtime check in execute() |
+| Slice 1: Factory | Immutability by default | Satisfied -- mutation via callbacks only |
+| Slice 2: runWorkflow | Determinism | Acceptable tension -- sequential execution makes mutable state deterministic |
+| Slice 3: Prompts | Document "why" | Satisfied -- prompts explain the tool's purpose |
+| Slice 4: Tests | Prefer fakes over mocks | Satisfied -- fake injection pattern |
+| All slices | YAGNI | Satisfied -- zero new abstractions |
+
+## Unresolved Unknowns
+
+None material. All design decisions are confirmed.
+
+- `unresolvedUnknownCount`: 0
+- `planConfidenceBand`: High

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4751,3 +4751,113 @@ The daemon assembles a pre-packaged context bundle from these sources before the
 - How do you handle a trigger that spans multiple systems (e.g. a Jira ticket about a GitHub PR)?
 
 **This is a design-first item** -- the ideas are promising but the right shape isn't obvious. Needs a discovery pass before any implementation.
+
+---
+
+### Rethinking the subagent loop from first principles (Apr 18, 2026)
+
+**Step back from all assumptions.** The current design assumes subagent spawning works like Claude Code's `mcp__nested-subagent__Task` -- the LLM decides when to spawn, what to give it, and handles the result. That's not the only model, and it might not be the best one for WorkTrain.
+
+---
+
+#### The current assumption (inherited from Claude Code)
+
+```
+Agent decides → calls spawn_agent tool → subagent runs → agent gets result → agent continues
+```
+
+The LLM is the orchestrator. It decides when parallelism is needed, what context to pass, how to handle results.
+
+**Problems with this:**
+- LLMs are bad at orchestration decisions -- they sometimes delegate when they shouldn't, sometimes don't when they should
+- Context passing is lossy -- the LLM decides what to include, which is usually insufficient
+- Subagent output competes with everything else in the parent's context window
+- The LLM has to reason about the subagent's output before continuing -- burns context and turns
+- No enforcement -- the LLM can skip delegation entirely and just do the work itself (often wrong)
+
+---
+
+#### Alternative model: workflow-declared parallelism, daemon-enforced
+
+**The workflow spec is the orchestration. The daemon is the orchestrator. The LLM is the executor.**
+
+```yaml
+# Workflow step definition
+- id: parallel-review
+  type: parallel
+  agents:
+    - workflow: routine-correctness-review
+      contextFrom: [phase-3-output, candidateFiles]
+    - workflow: routine-philosophy-alignment  
+      contextFrom: [phase-0-output, philosophySources]
+    - workflow: routine-hypothesis-challenge
+      contextFrom: [phase-2-output, selectedApproach]
+  synthesisStep: synthesize-parallel-review
+```
+
+The daemon sees this step definition and:
+1. Automatically spawns 3 child sessions with specified workflows
+2. Injects the declared context bundles (from prior step outputs) into each child
+3. Waits for all 3 to complete
+4. Passes all 3 results to a synthesis step
+5. Injects the synthesis into the parent agent's next turn
+
+**The parent LLM never decides to spawn anything.** It just does its part. The workflow declares the orchestration pattern. The daemon enforces it.
+
+---
+
+#### What this changes about the agent's job
+
+Today: "Do this work, and decide when to delegate parts of it to subagents."
+
+New model: "Do this bounded cognitive task. The daemon handles everything else."
+
+The agent's job becomes strictly about the cognitive work -- reasoning, writing, deciding within a defined scope. Orchestration, parallelism, context packaging, result synthesis -- all daemon responsibilities defined by the workflow spec.
+
+---
+
+#### The agent gives context to the daemon, not to subagents directly
+
+Instead of the LLM calling `spawn_agent({ goal: "...", context: {...} })`, the workflow step has:
+
+```yaml
+- id: context-gathering
+  output:
+    contextFor:
+      - step: parallel-review
+        keys: [candidateFiles, invariants, philosophySources]
+```
+
+The agent writes outputs as structured artifacts. The daemon routes those artifacts to the right child agents at the right time. The LLM never packages context for a subagent -- it just produces outputs, and the workflow spec declares where those outputs go.
+
+**This is the shift:** from "agent as orchestrator" to "workflow as orchestrator, daemon as executor, agent as cognitive unit."
+
+---
+
+#### What the subagent loop might look like
+
+```
+Parent workflow step completes
+  ↓ Daemon reads step output artifacts
+  ↓ Daemon checks workflow spec for parallel/sequential children
+  ↓ Daemon spawns child sessions with structured context bundles
+  ↓ Children run their bounded tasks
+  ↓ Daemon collects child outputs
+  ↓ Daemon passes synthesized context to parent's next step
+  ↓ Parent continues with full context
+```
+
+No LLM orchestration. No token-burning context packaging decisions. No "did I remember to delegate this?" uncertainty.
+
+---
+
+#### What needs to be designed (don't implement yet)
+
+1. **Workflow step schema for parallelism** -- how does the workflow spec declare parallel agents, sequential chains, fan-out/fan-in patterns?
+2. **Context routing spec** -- how does a step's output get routed to specific child agents? What's the schema for `contextFor`?
+3. **Synthesis patterns** -- how do multiple child outputs get combined? (concatenate? LLM synthesis step? structured merge?)
+4. **Failure handling** -- if one child fails, what happens? (fail-fast? continue with partial results? retry?)
+5. **Depth limits** -- same constraints as native agent spawning, but enforced at the workflow level not tool level
+6. **Backward compatibility** -- workflows that currently use `mcp__nested-subagent__Task` can be migrated incrementally
+
+**This is a design-first item.** Run a discovery session to explore the design space before any implementation. The current assumptions about subagent loops may be entirely wrong.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4861,3 +4861,62 @@ No LLM orchestration. No token-burning context packaging decisions. No "did I re
 6. **Backward compatibility** -- workflows that currently use `mcp__nested-subagent__Task` can be migrated incrementally
 
 **This is a design-first item.** Run a discovery session to explore the design space before any implementation. The current assumptions about subagent loops may be entirely wrong.
+
+---
+
+### Workflow runtime adapter: one spec, two runtimes (Apr 18, 2026)
+
+**The core insight:** as workflows evolve (potentially morphing significantly once the subagent loop is rethought), the workflow JSON becomes the canonical spec for *what work needs to happen*. How that spec gets executed depends on the runtime. A single adapter layer translates the canonical spec to runtime-specific execution plans.
+
+**Two runtimes, one spec:**
+
+```
+workflows/mr-review-workflow-agentic.json  ← canonical spec (unchanged)
+         ↓
+WorkflowAdapter.forRuntime('mcp')          ← MCP runtime interpretation
+WorkflowAdapter.forRuntime('daemon')       ← Daemon runtime interpretation
+```
+
+**What each adapter does:**
+
+MCP adapter (human-in-the-loop):
+- Preserves `requireConfirmation` gates
+- Presents `continue_workflow` tool call interface
+- LLM drives subagent spawning manually via `mcp__nested-subagent__Task`
+- Maintains backward compat with all existing Claude Code usage
+
+Daemon adapter (fully autonomous):
+- Removes or auto-bypasses `requireConfirmation` gates
+- Replaces `continue_workflow` with `complete_step` (daemon manages tokens)
+- Converts workflow-declared parallelism into automatic child session spawning
+- Routes step outputs to child agents per workflow spec
+- Enforces output contracts at step boundaries
+
+**Why this matters as workflows evolve:**
+
+Once the subagent loop is rethought (workflow-as-orchestrator model), workflow steps will likely declare parallelism, context routing, and synthesis patterns explicitly. These declarations make no sense to the MCP runtime (a human is already deciding this in real-time). The adapter translates them:
+
+```yaml
+# Workflow spec (future shape)
+- id: parallel-review
+  type: parallel
+  agents: [correctness, philosophy, hypothesis-challenge]
+  contextFrom: [phase-3-output]
+```
+
+MCP adapter sees this → renders as: "You should spawn 3 reviewer subagents now. Here's a template..."
+Daemon adapter sees this → actually spawns 3 child sessions automatically
+
+The workflow spec describes the intent. The adapter knows how each runtime fulfills it.
+
+**Key guarantee:** workflow improvements automatically benefit both runtimes. Improving `mr-review-workflow-agentic`'s philosophy alignment step shows up whether a human runs it through Claude Code or WorkTrain runs it autonomously. No dual maintenance.
+
+**Also eliminates "autonomous workflow variants":** the backlog had a separate item for autonomous variants of workflows. With the adapter, the canonical workflow spec is the only version -- the daemon adapter handles what "autonomy: full" means in practice. No parallel workflow files.
+
+**Build order:**
+1. Define the canonical workflow spec surface (what can be declared)
+2. MCP adapter (largely a no-op -- existing behavior, but formally defined)
+3. Daemon adapter (the interesting one -- translates declarations to daemon execution)
+4. Converter for upgrading existing workflow JSONs to the new canonical spec if the schema evolves
+
+**Dependencies:** requires the subagent loop rethinking to be resolved first -- the adapter can't be designed until we know what the workflow spec will declare.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4920,3 +4920,51 @@ The workflow spec describes the intent. The adapter knows how each runtime fulfi
 4. Converter for upgrading existing workflow JSONs to the new canonical spec if the schema evolves
 
 **Dependencies:** requires the subagent loop rethinking to be resolved first -- the adapter can't be designed until we know what the workflow spec will declare.
+
+---
+
+### User notifications when daemon starts and finishes work (Apr 18, 2026)
+
+**The problem:** the daemon silently starts and finishes sessions. Unless you're watching the console or tailing the log, you have no idea work happened or completed. For autonomous sessions that run over minutes or hours, this is a significant UX gap.
+
+**What users need to know:**
+- Session started: "WorkTrain started reviewing PR #566" (with a link)
+- Session completed: "WorkTrain finished reviewing PR #566 -- APPROVED, no findings" (with session link)
+- Session failed/stuck: "WorkTrain got stuck on PR #566 after 15 turns -- needs attention" (with details)
+
+**Notification channels (multiple, user-configurable):**
+
+1. **macOS notification** -- `osascript -e 'display notification "..." with title "WorkTrain"'`. Zero config, works immediately on Mac.
+2. **Outbox.jsonl** -- already spec'd in the message queue backlog. `worktrain inbox` reads it, mobile client polls it.
+3. **Slack webhook** -- POST to a configured webhook URL. Simple delivery target using the existing callbackUrl pattern.
+4. **Email** -- SMTP delivery for completion/failure. Low-friction for async awareness.
+5. **Desktop badge** -- update the `worktrain console` window title or icon badge with active session count.
+
+**Implementation (start simple):**
+The `DaemonEventEmitter` already emits `session_started` and `session_completed` events. The simplest implementation: a `NotificationEmitter` that subscribes to these events and fires macOS notifications for `session_completed` with `outcome: success/error/timeout`.
+
+```typescript
+// In startTriggerListener, after daemon starts:
+if (process.platform === 'darwin') {
+  emitter.on('session_completed', (event) => {
+    const icon = event.outcome === 'success' ? '✅' : '❌';
+    execFile('osascript', ['-e', 
+      `display notification "${icon} ${event.workflowId}: ${event.outcome}" with title "WorkTrain"`
+    ]);
+  });
+}
+```
+
+**Config:**
+```yaml
+# ~/.workrail/config.json
+notifications:
+  onSessionStart: false          # usually too noisy
+  onSessionComplete: true        # the useful one
+  onSessionFailed: true          # urgent
+  onStuck: true                  # urgent
+  channels: [macos, slack]
+  slackWebhookUrl: $SLACK_WEBHOOK_URL
+```
+
+**Build order:** macOS notification on session_completed (30 min) → outbox.jsonl integration (already partially built) → Slack webhook → configurable per-channel.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4932,39 +4932,46 @@ The workflow spec describes the intent. The adapter knows how each runtime fulfi
 - Session completed: "WorkTrain finished reviewing PR #566 -- APPROVED, no findings" (with session link)
 - Session failed/stuck: "WorkTrain got stuck on PR #566 after 15 turns -- needs attention" (with details)
 
-**Notification channels (multiple, user-configurable):**
+**Notification channels -- anything the user wants:**
 
-1. **macOS notification** -- `osascript -e 'display notification "..." with title "WorkTrain"'`. Zero config, works immediately on Mac.
-2. **Outbox.jsonl** -- already spec'd in the message queue backlog. `worktrain inbox` reads it, mobile client polls it.
-3. **Slack webhook** -- POST to a configured webhook URL. Simple delivery target using the existing callbackUrl pattern.
-4. **Email** -- SMTP delivery for completion/failure. Low-friction for async awareness.
-5. **Desktop badge** -- update the `worktrain console` window title or icon badge with active session count.
+The notification system should be open-ended. Any channel that accepts a webhook or has an API should be configurable. The architecture is: `DaemonEventEmitter` → `NotificationRouter` → one or more configured channels.
 
-**Implementation (start simple):**
-The `DaemonEventEmitter` already emits `session_started` and `session_completed` events. The simplest implementation: a `NotificationEmitter` that subscribes to these events and fires macOS notifications for `session_completed` with `outcome: success/error/timeout`.
+Short-term (easiest to ship):
+- **Outbox.jsonl** -- already spec'd. `worktrain inbox` reads it, mobile client polls it. Works everywhere, zero config.
+- **Generic webhook** -- HTTP POST to any URL. Covers Slack, Discord, Teams, PagerDuty, Zapier, IFTTT, and anything else that accepts webhooks. One implementation, infinite integrations.
+- **macOS notification** -- `osascript` on Mac. Useful for local dev awareness.
+- **Linux/Windows notification** -- `notify-send` on Linux, Windows Toast via PowerShell.
 
-```typescript
-// In startTriggerListener, after daemon starts:
-if (process.platform === 'darwin') {
-  emitter.on('session_completed', (event) => {
-    const icon = event.outcome === 'success' ? '✅' : '❌';
-    execFile('osascript', ['-e', 
-      `display notification "${icon} ${event.workflowId}: ${event.outcome}" with title "WorkTrain"`
-    ]);
-  });
+Medium-term (first-class integrations):
+- **Slack** (direct API, not just webhook -- enables threading, reactions, rich formatting)
+- **Discord** (webhook, then bot for richer interactions)
+- **Microsoft Teams** (Adaptive Cards)
+- **Telegram** (popular for personal automation)
+- **Email** (SMTP for async, digest mode)
+
+Long-term (when mobile exists):
+- **Mobile push notifications** -- the mobile app (spec'd in backlog) receives push notifications directly. When the app exists, this becomes the primary channel -- native push is better than any polling-based alternative.
+- **Desktop app** -- if WorkTrain ever has a desktop app, native notifications from there.
+
+**The outbox is the universal foundation.** Every notification goes through `~/.workrail/outbox.jsonl` first. Channel-specific delivery (webhook, Slack, push) is a fan-out from the outbox. This means: a mobile app polling the outbox gets ALL notifications regardless of which other channels are configured.
+
+**Config:**
+```json
+// ~/.workrail/config.json
+{
+  "notifications": {
+    "onSessionComplete": true,
+    "onSessionFailed": true,
+    "onStuck": true,
+    "onSessionStart": false,
+    "channels": [
+      { "type": "webhook", "url": "$SLACK_WEBHOOK_URL" },
+      { "type": "webhook", "url": "$DISCORD_WEBHOOK_URL" },
+      { "type": "macos" },
+      { "type": "outbox" }
+    ]
+  }
 }
 ```
 
-**Config:**
-```yaml
-# ~/.workrail/config.json
-notifications:
-  onSessionStart: false          # usually too noisy
-  onSessionComplete: true        # the useful one
-  onSessionFailed: true          # urgent
-  onStuck: true                  # urgent
-  channels: [macos, slack]
-  slackWebhookUrl: $SLACK_WEBHOOK_URL
-```
-
-**Build order:** macOS notification on session_completed (30 min) → outbox.jsonl integration (already partially built) → Slack webhook → configurable per-channel.
+**Build order:** outbox.jsonl integration (foundation, works everywhere) → generic webhook (covers Slack/Discord/Teams/anything) → platform notifications (macOS/Linux/Windows) → mobile app push (when mobile exists).

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4384,12 +4384,12 @@ The existing `DaemonEventEmitter` (written in #498) writes to a separate daily l
 2. Add `llm_turn_started`/`llm_turn_completed` events
 3. Console Timeline tab reads and renders the new event kinds
 4. Wire `report_issue_recorded` and `steer_injected` events
+5. Deprecate `DaemonEventEmitter` once console reads from session events
 
 ---
 
 ### FatalToolError: distinguish recoverable from non-recoverable tool failures (follow-up from PR #523)
 The blanket try/catch in AgentLoop._executeTools() converts ALL tool throws to isError tool_results. This is correct for Bash/Read/Write (LLM can see and retry), but potentially wrong for continue_workflow failures (LLM retrying with a broken token loops). The discovery agent proposed a FatalToolError subclass: tools throw FatalToolError for non-recoverable errors (session corruption, bad tokens), plain Error for recoverable failures. _executeTools catches plain Error and returns isError; FatalToolError propagates and kills the session. Combined with the DEFAULT_MAX_TURNS cap (PR followup), this provides defense-in-depth.
-5. Deprecate `DaemonEventEmitter` once console reads from session events
 
 ---
 

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -788,6 +788,35 @@ function getSchemas(): Record<string, any> {
       },
       required: ['continueToken'],
     },
+    CompleteStepParams: {
+      type: 'object',
+      properties: {
+        notes: {
+          type: 'string',
+          minLength: 50,
+          description:
+            'What you did in this step (required, at least 50 characters). Write for a human reader. ' +
+            'Include: what you did and key decisions, what you produced (files, tests, numbers), ' +
+            'anything notable (risks, open questions, things you chose NOT to do and why). ' +
+            'Use markdown: headings, bullets, bold. 10-30 lines is ideal.',
+        },
+        artifacts: {
+          type: 'array',
+          items: {},
+          description:
+            'Optional structured artifacts to attach to this step. ' +
+            'Include wr.assessment objects here when the step requires an assessment gate. ' +
+            'Example: [{ "kind": "wr.assessment", "assessmentId": "<id>", "dimensions": { "<dimensionId>": "high" } }]',
+        },
+        context: {
+          type: 'object',
+          additionalProperties: true,
+          description: 'Updated context variables (only changed values). Omit entirely if no facts changed.',
+        },
+      },
+      required: ['notes'],
+      additionalProperties: false,
+    },
     BashParams: {
       type: 'object',
       properties: {
@@ -834,6 +863,7 @@ export function makeContinueWorkflowTool(
   return {
     name: 'continue_workflow',
     description:
+      '[DEPRECATED in daemon sessions -- use complete_step instead] ' +
       'Advance the WorkRail workflow to the next step. Call this after completing all work ' +
       'required by the current step. Include your notes in notesMarkdown. ' +
       'When the step requires an assessment gate, include wr.assessment objects in artifacts.',
@@ -946,6 +976,213 @@ export function makeContinueWorkflowTool(
         : `Step advanced. continueToken: ${continueToken}`;
 
       onAdvance(stepText, continueToken);
+
+      return {
+        content: [{ type: 'text', text: stepText }],
+        details: out,
+      };
+    },
+  };
+}
+
+/**
+ * Build the complete_step tool for daemon sessions.
+ *
+ * WHY this tool exists: continue_workflow requires the LLM to round-trip a
+ * continueToken (an HMAC-signed opaque token). The LLM frequently mangles
+ * this token, causing TOKEN_BAD_SIGNATURE errors that kill sessions. complete_step
+ * eliminates this failure mode by having the daemon inject the continueToken
+ * internally -- the LLM only provides notes, artifacts, and context.
+ *
+ * WHY two token-update paths: the continueToken must be updated on both
+ * (a) successful advance: getCurrentToken() returns the new next-step token
+ *     from the response, which onAdvance will have stored before the next call.
+ * (b) blocked retry: the engine returns a retryContinueToken that must be used
+ *     on the retry call; onTokenUpdate updates the closure variable so the next
+ *     complete_step call injects the correct retry token.
+ * Both paths are mutually exclusive (kind: 'ok' vs kind: 'blocked') and cannot
+ * race because AgentLoop runs tools sequentially (toolExecution: 'sequential').
+ *
+ * WHY getCurrentToken is a getter (not a value): the closure variable
+ * currentContinueToken in runWorkflow() is updated after each step advance.
+ * The getter captures the variable by reference so each complete_step call
+ * reads the current token at call time, not at construction time.
+ *
+ * @param sessionId - Process-local UUID for crash-recovery token persistence.
+ * @param ctx - V2ToolContext from the shared DI container.
+ * @param getCurrentToken - Getter that returns the current continueToken from the
+ *   runWorkflow() closure. Called at tool execution time, not construction time.
+ * @param onAdvance - Called after a successful step advance with the next step text
+ *   and the new continueToken. Sets pendingSteerText and updates currentContinueToken.
+ * @param onComplete - Called when the workflow is complete.
+ * @param onTokenUpdate - Called when the continueToken changes without an advance
+ *   (i.e., on a blocked retry). Updates currentContinueToken in the runWorkflow() closure.
+ * @param schemas - Plain JSON Schema map from getSchemas().
+ * @param _executeContinueWorkflowFn - Optional injection point for testing.
+ * @param emitter - Optional event emitter for structured lifecycle events.
+ * @param workrailSessionId - WorkRail session ID for event correlation.
+ */
+export function makeCompleteStepTool(
+  sessionId: string,
+  ctx: V2ToolContext,
+  getCurrentToken: () => string,
+  onAdvance: (nextStepText: string, continueToken: string) => void,
+  onComplete: (notes: string | undefined) => void,
+  onTokenUpdate: (t: string) => void,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  schemas: Record<string, any>,
+  // Optional injection point for testing -- defaults to the real implementation.
+  _executeContinueWorkflowFn: typeof executeContinueWorkflow = executeContinueWorkflow,
+  emitter?: DaemonEventEmitter,
+  workrailSessionId?: string | null,
+): AgentTool {
+  return {
+    name: 'complete_step',
+    description:
+      'Mark the current WorkRail workflow step as complete and advance to the next one. ' +
+      'Call this after completing all work required by the current step. ' +
+      'Include your substantive notes (min 50 characters) describing what you did. ' +
+      'The daemon manages the session token internally -- you do not need a continueToken. ' +
+      'When the step requires an assessment gate, include wr.assessment objects in artifacts.',
+    inputSchema: schemas['CompleteStepParams'],
+    label: 'Complete Step',
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    execute: async (
+      _toolCallId: string,
+      params: any,
+    ): Promise<AgentToolResult<unknown>> => {
+      console.log(`[WorkflowRunner] Tool: complete_step sessionId=${sessionId}`);
+      emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'complete_step', summary: 'advance', ...withWorkrailSession(workrailSessionId) });
+
+      // WHY runtime validation: JSON Schema minLength is informational to the LLM
+      // but NOT enforced by AgentLoop. We must validate here so the LLM gets a
+      // clear error immediately, rather than a downstream blocked response from
+      // the engine. Fail fast at the boundary.
+      const notes = params.notes as string | undefined;
+      if (!notes || notes.length < 50) {
+        throw new Error(
+          `complete_step: notes is required and must be at least 50 characters. ` +
+          `Provide substantive notes describing what you did, what you produced, and any notable decisions. ` +
+          `Current length: ${notes?.length ?? 0} characters.`,
+        );
+      }
+
+      // WHY inject getCurrentToken(): the daemon holds the continueToken in a
+      // closure variable (currentContinueToken in runWorkflow()). The LLM never
+      // sees this token -- we inject it here so the engine can authenticate the
+      // advance call. This is the core value of complete_step over continue_workflow.
+      const continueToken = getCurrentToken();
+
+      const result = await _executeContinueWorkflowFn(
+        {
+          continueToken,
+          intent: 'advance',
+          // WHY: output is constructed when notes is present (always true after validation)
+          // or when artifacts is a non-empty array (e.g. assessment-only steps without notes,
+          // though complete_step always requires notes). An empty artifacts array must not
+          // spread {} or {} with artifacts: [] -- use ?.length to guard against this.
+          output: (notes || (params.artifacts as unknown[] | undefined)?.length)
+            ? {
+                notesMarkdown: notes,
+                ...((params.artifacts as unknown[] | undefined)?.length ? { artifacts: params.artifacts } : {}),
+              }
+            : undefined,
+          context: params.context,
+        },
+        ctx,
+      );
+
+      if (result.isErr()) {
+        throw new Error(`complete_step failed: ${result.error.kind} -- ${JSON.stringify(result.error)}`);
+      }
+
+      const out = result.value.response;
+
+      // Persist tokens atomically before returning -- crash safety invariant.
+      // WHY this must happen before onAdvance/onTokenUpdate: a crash between
+      // executeContinueWorkflow returning and the token being persisted would
+      // leave no recoverable state. Persisting first ensures crash recovery works.
+      const newContinueToken = out.continueToken ?? '';
+      const checkpointToken = out.checkpointToken ?? null;
+      // WHY blocked uses retry token: on a blocked response, the engine returns a
+      // retryContinueToken (via nextCall.params.continueToken). The session token
+      // advances to this retry token -- the original session token is consumed.
+      const persistToken = (out.kind === 'blocked' ? out.nextCall?.params.continueToken : undefined) ?? newContinueToken;
+      if (persistToken) {
+        await persistTokens(sessionId, persistToken, checkpointToken);
+      }
+
+      // WHY onTokenUpdate on blocked: the next complete_step call must inject the
+      // retry token (not the original session token). We update the closure variable
+      // so getCurrentToken() returns the correct retry token on the next call.
+      // This is a separate path from onAdvance because a blocked response does NOT
+      // advance the step -- it only changes which token is valid for retry.
+      if (out.kind === 'blocked') {
+        const retryToken = out.nextCall?.params.continueToken ?? newContinueToken;
+        // Update the closure token to the retry token for the next complete_step call.
+        onTokenUpdate(retryToken);
+
+        const lines: string[] = ['## Step blocked -- action required\n'];
+
+        for (const blocker of out.blockers.blockers) {
+          lines.push(blocker.message);
+          if (blocker.suggestedFix) {
+            lines.push(`\nWhat to do: ${blocker.suggestedFix}`);
+          }
+          lines.push('');
+        }
+
+        if (out.validation) {
+          if (out.validation.issues.length > 0) {
+            lines.push('**Issues:**');
+            for (const issue of out.validation.issues) lines.push(`- ${issue}`);
+            lines.push('');
+          }
+          if (out.validation.suggestions.length > 0) {
+            lines.push('**Suggestions:**');
+            for (const s of out.validation.suggestions) lines.push(`- ${s}`);
+            lines.push('');
+          }
+        }
+
+        if (out.assessmentFollowup) {
+          lines.push(`**Follow-up required:** ${out.assessmentFollowup.title}`);
+          lines.push(out.assessmentFollowup.guidance);
+          lines.push('');
+        }
+
+        if (out.retryable) {
+          lines.push(`Retry the same step: call complete_step again with corrected notes.`);
+        } else {
+          lines.push(`You cannot proceed without resolving this. Inform the user and wait for their response, then call complete_step.`);
+        }
+
+        const feedback = lines.join('\n');
+        return {
+          content: [{ type: 'text', text: feedback }],
+          details: out,
+        };
+      }
+
+      if (out.isComplete) {
+        onComplete(notes);
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ status: 'complete' }) }],
+          details: out,
+        };
+      }
+
+      const pending = out.pending;
+      // WHY no continueToken in the response text: the LLM does not need the token.
+      // Including it would invite the LLM to store it and pass it to continue_workflow,
+      // defeating the purpose of complete_step.
+      const nextStepTitle = pending?.title ?? 'Next step';
+      const stepText = pending
+        ? `${JSON.stringify({ status: 'advanced', nextStep: pending.title })}\n\n## ${pending.title}\n\n${pending.prompt}`
+        : JSON.stringify({ status: 'advanced', nextStep: nextStepTitle });
+
+      onAdvance(stepText, newContinueToken);
 
       return {
         content: [{ type: 'text', text: stepText }],
@@ -1278,20 +1515,21 @@ Bad pattern: "I'll analyze both layers." (no justification)
 Good pattern: "Question: Should I check the middleware? Answer: The workflow step says 'trace the full call chain', and the AGENTS.md says the entry point is in the middleware layer. Yes, start there."
 
 ## Your tools
-- \`continue_workflow\`: Advance to the next step. Call this after completing each step's work. Always include your notes in notesMarkdown and round-trip the continueToken exactly.
+- \`complete_step\`: Mark the current step complete and advance to the next one. Call this after completing ALL work required by the step. Include your notes (min 50 characters) in the notes field. The daemon manages the session token internally -- you do NOT need a continueToken. This is the preferred advancement tool for daemon sessions.
+- \`continue_workflow\`: [DEPRECATED -- use complete_step instead] Legacy advancement tool. Requires a continueToken that you must round-trip exactly. Only use this if complete_step is unavailable.
 - \`Bash\`: Run shell commands. Use for building, testing, running scripts.
 - \`Read\`: Read files.
 - \`Write\`: Write files.
-- \`report_issue\`: Record a structured issue, error, or unexpected behavior. Call this AND continue_workflow (unless fatal). Does not stop the session -- it creates a record for the auto-fix coordinator.
+- \`report_issue\`: Record a structured issue, error, or unexpected behavior. Call this AND complete_step (unless fatal). Does not stop the session -- it creates a record for the auto-fix coordinator.
 
 ## Execution contract
 1. Read the step carefully. Do ALL the work the step asks for.
-2. Call \`continue_workflow\` with your notes. Include the continueToken exactly.
+2. Call \`complete_step\` with your notes. No continueToken needed -- the daemon manages it.
 3. Repeat until the workflow reports it is complete.
-4. Do NOT skip steps. Do NOT call \`continue_workflow\` without completing the step's work.
+4. Do NOT skip steps. Do NOT call \`complete_step\` without completing the step's work.
 
 ## The workflow is the contract
-Every step must be fully completed before you call continue_workflow. The workflow step prompt is the specification of what 'done' means -- not a suggestion. Don't advance until the work is actually done.
+Every step must be fully completed before you call complete_step. The workflow step prompt is the specification of what 'done' means -- not a suggestion. Don't advance until the work is actually done.
 
 Your cognitive mode changes per step: some steps make you a researcher, others a reviewer, others an implementer. Adopt the mode the step describes. Don't bring your own agenda.
 
@@ -1302,7 +1540,10 @@ If something goes wrong: call report_issue, then continue unless severity is 'fa
 Don't narrate what you're about to do. Use the tool and report what you found. Token efficiency matters -- you have a wall-clock timeout.
 
 ## You don't have a user. You have a workflow and a soul.
-If you're unsure, consult the oracle above. If nothing answers the question, make a reasoned decision, call report_issue with kind='self_correction' to document it, and continue.\
+If you're unsure, consult the oracle above. If nothing answers the question, make a reasoned decision, call report_issue with kind='self_correction' to document it, and continue.
+
+## IMPORTANT: Never use continue_workflow in daemon sessions
+complete_step is your advancement tool. It does not require a continueToken. Do NOT call continue_workflow with a token you found in a previous message -- use complete_step instead.\
 `;
 
 /**
@@ -1532,9 +1773,15 @@ export async function runWorkflow(
   const issueSummaries: string[] = [];
   const MAX_ISSUE_SUMMARIES = 10;
 
-  const onAdvance = (stepText: string, _continueToken: string): void => {
+  const onAdvance = (stepText: string, continueToken: string): void => {
     pendingSteerText = stepText;
     stepAdvanceCount++;
+    // WHY update currentContinueToken here: complete_step injects the token from
+    // this closure variable. After each successful advance, the engine returns a new
+    // continueToken for the next step. Updating here ensures the next complete_step
+    // call injects the correct token. The second parameter was previously unused
+    // (continue_workflow relied on the LLM round-tripping the token instead).
+    currentContinueToken = continueToken;
     // Heartbeat on each step advance -- the session is alive and making progress.
     // WHY workrailSessionId: DaemonRegistry is keyed by WorkRail session ID (not process UUID).
     // workrailSessionId is populated after executeStartWorkflow + continueToken decode.
@@ -1587,6 +1834,18 @@ export async function runWorkflow(
 
   const startContinueToken = firstStep.continueToken ?? '';
   const startCheckpointToken = firstStep.checkpointToken ?? null;
+
+  // ---- Current continue token (for complete_step daemon tool) ----
+  // WHY a mutable variable: complete_step injects the continueToken internally so
+  // the LLM never needs to round-trip it. This variable starts with the initial
+  // session token and is updated by onAdvance after each step advance.
+  // WHY let (not const): the value changes on every successful step advance and on
+  // blocked-retry responses. Mutation is confined to onAdvance and the onTokenUpdate
+  // callback passed to makeCompleteStepTool.
+  // INVARIANT: this variable is always updated AFTER persistTokens() is called,
+  // so a crash between advance and the next complete_step call can still recover
+  // the correct token from the persisted state file.
+  let currentContinueToken = startContinueToken;
 
   // ---- Decode WorkRail session ID from the continueToken ----
   // WHY: daemonRegistry.register() and daemon event emitter both need the WorkRail
@@ -1646,7 +1905,29 @@ export async function runWorkflow(
   // ---- Tools ----
   // start_workflow is NOT in this list: the daemon calls executeStartWorkflow()
   // directly above so the LLM cannot call it again.
+  //
+  // WHY complete_step is listed before continue_workflow: the preferred tool for
+  // daemon sessions is complete_step -- it hides the continueToken from the LLM
+  // and eliminates TOKEN_BAD_SIGNATURE errors from token mangling. continue_workflow
+  // is kept for backward compatibility but is marked deprecated in its description.
+  // The LLM should prefer complete_step as directed by the system prompt.
   const tools: AgentTool[] = [
+    makeCompleteStepTool(
+      sessionId,
+      ctx,
+      () => currentContinueToken,
+      onAdvance,
+      onComplete,
+      // WHY onTokenUpdate: on a blocked response, the engine returns a retryContinueToken.
+      // This callback updates currentContinueToken so the next complete_step call
+      // injects the correct retry token. This is the second (and only other) write
+      // path for currentContinueToken alongside onAdvance above.
+      (t: string) => { currentContinueToken = t; },
+      schemas,
+      executeContinueWorkflow,
+      emitter,
+      workrailSessionId,
+    ),
     makeContinueWorkflowTool(sessionId, ctx, onAdvance, onComplete, schemas, executeContinueWorkflow, emitter, workrailSessionId),
     makeBashTool(trigger.workspacePath, schemas, sessionId, emitter, workrailSessionId),
     makeReadTool(schemas, sessionId, emitter, workrailSessionId),
@@ -1685,24 +1966,22 @@ export async function runWorkflow(
   // ---- Initial prompt: first step content from start_workflow ----
   // The daemon has already called executeStartWorkflow() and has the first step.
   // Pass the step content directly -- the LLM starts working on step 1 immediately.
-  // Appending the continueToken so the LLM can pass it to continue_workflow.
-  // WHY closing directive: an explicit imperative at the end of the initial prompt directs
-  // the agent to complete the step work before calling continue_workflow. Without this,
-  // the agent may produce a "thinking aloud" turn before the first tool call, which
-  // wastes tokens and delays step execution.
+  // WHY no continueToken in the initial prompt: the daemon uses complete_step which
+  // manages the token internally. Including the token would invite the LLM to store
+  // it and call continue_workflow (deprecated) instead of complete_step, defeating
+  // the purpose of the new tool.
+  // WHY closing directive: an explicit imperative at the end of the initial prompt
+  // directs the agent to complete the step work before calling complete_step. Without
+  // this, the agent may produce a "thinking aloud" turn before the first tool call,
+  // which wastes tokens and delays step execution.
   const contextJson = trigger.context
     ? `\n\nTrigger context:\n\`\`\`json\n${JSON.stringify(trigger.context, null, 2)}\n\`\`\``
     : '';
 
-  // WHY: an explicit imperative at the end of the initial prompt directs the agent
-  // to complete the step work before calling continue_workflow. Without this,
-  // the agent may produce a "thinking aloud" turn before the first tool call, which
-  // wastes tokens and delays step execution.
   const initialPrompt =
     (firstStep.pending?.prompt ?? 'No step content available') +
-    `\n\ncontinueToken: ${startContinueToken}` +
     contextJson +
-    '\n\nComplete all step work, then call continue_workflow with your notes to begin.';
+    '\n\nComplete all step work, then call complete_step with your notes to advance.';
 
   // ---- Observability callbacks for AgentLoop ----
   // Wire structured event emission for LLM turns and tool calls.

--- a/tests/unit/workflow-runner-complete-step.test.ts
+++ b/tests/unit/workflow-runner-complete-step.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Unit tests for makeCompleteStepTool().
+ *
+ * Verifies that:
+ * - Happy-path advance returns { status: 'advanced', nextStep: ... }
+ * - Workflow complete returns { status: 'complete' }
+ * - Blocked retryable response calls onTokenUpdate and says 'call complete_step again'
+ * - Blocked non-retryable response says 'cannot proceed without resolving'
+ * - Notes shorter than 50 chars cause the tool to throw
+ * - Notes absent cause the tool to throw
+ * - Artifacts are forwarded to executeContinueWorkflow
+ * - Empty artifacts array does NOT construct a spurious output.artifacts
+ * - continueToken is NOT included in response text (regression guard)
+ * - getCurrentToken() is called to inject the token (not a hardcoded value)
+ *
+ * WHY fake injection over mocking: follows the "prefer fakes over mocks"
+ * principle from CLAUDE.md. The optional `_executeContinueWorkflowFn`
+ * parameter accepts a real fake, keeping tests deterministic and realistic.
+ *
+ * Note: persistTokens() writes to ~/.workrail/daemon-sessions/<sessionId>.json.
+ * Each test uses a unique UUID session ID so files never collide. Files are
+ * cleaned up in afterEach.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, afterEach } from 'vitest';
+import { okAsync, errAsync } from 'neverthrow';
+import type { V2ToolContext } from '../../src/mcp/types.js';
+import { makeCompleteStepTool } from '../../src/daemon/workflow-runner.js';
+import { DAEMON_SESSIONS_DIR } from '../../src/daemon/workflow-runner.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/** Minimal ok response for a successful advance with a next step. */
+function makeOkResponse(overrides: { isComplete?: boolean; continueToken?: string } = {}) {
+  const nextToken = overrides.continueToken ?? 'ct_nexttoken12345678901234567890';
+  return {
+    kind: 'ok' as const,
+    continueToken: nextToken,
+    checkpointToken: undefined,
+    isComplete: overrides.isComplete ?? false,
+    pending: overrides.isComplete ? null : {
+      stepId: 'step-2',
+      title: 'Step 2: Do More Work',
+      prompt: 'Do the second piece of work now.',
+    },
+    preferences: {
+      autonomy: 'full_auto_never_stop' as const,
+      riskPolicy: 'balanced' as const,
+    },
+    nextIntent: 'perform_pending_then_continue' as const,
+    nextCall: {
+      tool: 'complete_step' as const,
+      params: { continueToken: nextToken },
+    },
+  };
+}
+
+/** Minimal blocked response (retryable by default). */
+function makeBlockedResponse(overrides: {
+  retryable?: boolean;
+  retryToken?: string;
+} = {}) {
+  const retryToken = overrides.retryToken ?? 'ct_retrytoken12345678901234567';
+  return {
+    kind: 'blocked' as const,
+    continueToken: 'ct_sessiontoken123456789012345',
+    checkpointToken: undefined,
+    isComplete: false,
+    pending: {
+      stepId: 'step-1',
+      title: 'Step 1',
+      prompt: 'Do the work.',
+    },
+    preferences: {
+      autonomy: 'full_auto_never_stop' as const,
+      riskPolicy: 'balanced' as const,
+    },
+    nextIntent: 'perform_pending_then_continue' as const,
+    nextCall: {
+      tool: 'continue_workflow' as const,
+      params: { continueToken: retryToken },
+    },
+    blockers: {
+      blockers: [
+        {
+          code: 'MISSING_REQUIRED_NOTES' as const,
+          pointer: { kind: 'workflow_step' as const, stepId: 'step-1' },
+          message: 'Notes are required for this step.',
+          suggestedFix: 'Include output.notesMarkdown with at least 10 lines.',
+        },
+      ],
+    },
+    retryable: overrides.retryable ?? true,
+    retryContinueToken: retryToken,
+    validation: {
+      issues: ['Notes are missing or too short'],
+      suggestions: ['Add at least 10 lines to notes'],
+    },
+    assessmentFollowup: undefined,
+  };
+}
+
+/**
+ * Fake executeContinueWorkflow that captures input for inspection.
+ *
+ * WHY a mutable container object: destructuring `captured` from the returned
+ * object would snapshot its value at destructure time (null). Using a container
+ * object lets tests read `container.captured` after the async call completes
+ * and see the updated value.
+ */
+function makeFakeCapturingExec(responseFactory: () => ReturnType<typeof makeOkResponse> | ReturnType<typeof makeBlockedResponse> = makeOkResponse): {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  container: { captured: any | null };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fake: (input: any, _ctx: any) => ReturnType<typeof okAsync>;
+} {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const container: { captured: any | null } = { captured: null };
+  return {
+    container,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fake: (input: any, _ctx: any) => {
+      container.captured = input;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return okAsync({ response: responseFactory() as any });
+    },
+  };
+}
+
+/** Fake that returns a blocked response. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeFakeBlockedExec(blocked: ReturnType<typeof makeBlockedResponse>): (input: any, _ctx: any) => ReturnType<typeof okAsync> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (_input: any, _ctx: any) => okAsync({ response: blocked as any });
+}
+
+/** Null V2ToolContext -- not used by the fake. */
+const NULL_CTX = {} as unknown as V2ToolContext;
+
+/** Stub schemas -- CompleteStepParams not needed in tests (tool uses inputSchema from getSchemas). */
+const STUB_SCHEMAS = { CompleteStepParams: {} };
+
+/** Notes that satisfy the 50-char minimum. */
+const VALID_NOTES = 'I reviewed the code and found the relevant module. Everything is in order.';
+
+/** A sample wr.assessment artifact. */
+const SAMPLE_ASSESSMENT = {
+  kind: 'wr.assessment',
+  assessmentId: 'some-gate',
+  dimensions: { some_dimension: 'high' },
+};
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+const sessionIdsToClean: string[] = [];
+
+afterEach(async () => {
+  for (const sessionId of sessionIdsToClean) {
+    const filePath = path.join(DAEMON_SESSIONS_DIR, `${sessionId}.json`);
+    await fs.unlink(filePath).catch(() => { /* ignore if not created */ });
+  }
+  sessionIdsToClean.length = 0;
+});
+
+function makeSessionId(): string {
+  const id = randomUUID();
+  sessionIdsToClean.push(id);
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('makeCompleteStepTool()', () => {
+
+  describe('TC1: happy-path advance', () => {
+    it('returns { status: advanced, nextStep } and calls onAdvance', async () => {
+      const sessionId = makeSessionId();
+      let advancedWith: { stepText: string; continueToken: string } | null = null;
+      const { fake } = makeFakeCapturingExec(() => makeOkResponse({ continueToken: 'ct_nexttoken12345678901234567890' }));
+
+      const tool = makeCompleteStepTool(
+        sessionId,
+        NULL_CTX,
+        () => 'ct_current12345678901234567890',
+        (stepText, continueToken) => { advancedWith = { stepText, continueToken }; },
+        () => {},
+        () => {},
+        STUB_SCHEMAS,
+        fake,
+      );
+
+      const result = await tool.execute('call-1', { notes: VALID_NOTES });
+
+      expect(result.content[0].text).toContain('"status":"advanced"');
+      expect(result.content[0].text).toContain('Step 2: Do More Work');
+      expect(advancedWith).not.toBeNull();
+      expect(advancedWith!.continueToken).toBe('ct_nexttoken12345678901234567890');
+    });
+  });
+
+  describe('TC2: workflow complete', () => {
+    it('returns { status: complete } and calls onComplete with notes', async () => {
+      const sessionId = makeSessionId();
+      let completedWith: string | undefined = undefined;
+      const { fake } = makeFakeCapturingExec(() => makeOkResponse({ isComplete: true }));
+
+      const tool = makeCompleteStepTool(
+        sessionId,
+        NULL_CTX,
+        () => 'ct_current12345678901234567890',
+        () => {},
+        (notes) => { completedWith = notes; },
+        () => {},
+        STUB_SCHEMAS,
+        fake,
+      );
+
+      const result = await tool.execute('call-1', { notes: VALID_NOTES });
+
+      expect(result.content[0].text).toBe(JSON.stringify({ status: 'complete' }));
+      expect(completedWith).toBe(VALID_NOTES);
+    });
+  });
+
+  describe('TC3: blocked retryable', () => {
+    it('calls onTokenUpdate with retry token and says call complete_step again', async () => {
+      const sessionId = makeSessionId();
+      let tokenUpdatedTo: string | null = null;
+      const blocked = makeBlockedResponse({ retryable: true, retryToken: 'ct_retrytoken1234567890' });
+
+      const tool = makeCompleteStepTool(
+        sessionId,
+        NULL_CTX,
+        () => 'ct_current12345678901234567890',
+        () => {},
+        () => {},
+        (t) => { tokenUpdatedTo = t; },
+        STUB_SCHEMAS,
+        makeFakeBlockedExec(blocked),
+      );
+
+      const result = await tool.execute('call-1', { notes: VALID_NOTES });
+
+      expect(tokenUpdatedTo).toBe('ct_retrytoken1234567890');
+      expect(result.content[0].text).toContain('call complete_step again');
+      expect(result.content[0].text).not.toContain('continue_workflow');
+    });
+  });
+
+  describe('TC4: blocked non-retryable', () => {
+    it('says cannot proceed without resolving', async () => {
+      const sessionId = makeSessionId();
+      const blocked = makeBlockedResponse({ retryable: false });
+
+      const tool = makeCompleteStepTool(
+        sessionId,
+        NULL_CTX,
+        () => 'ct_current12345678901234567890',
+        () => {},
+        () => {},
+        () => {},
+        STUB_SCHEMAS,
+        makeFakeBlockedExec(blocked),
+      );
+
+      const result = await tool.execute('call-1', { notes: VALID_NOTES });
+
+      expect(result.content[0].text).toContain('cannot proceed without resolving');
+    });
+  });
+
+  describe('TC5: notes too short (< 50 chars)', () => {
+    it('throws with a descriptive error', async () => {
+      const sessionId = makeSessionId();
+      const { fake } = makeFakeCapturingExec();
+
+      const tool = makeCompleteStepTool(
+        sessionId,
+        NULL_CTX,
+        () => 'ct_current12345678901234567890',
+        () => {},
+        () => {},
+        () => {},
+        STUB_SCHEMAS,
+        fake,
+      );
+
+      await expect(
+        tool.execute('call-1', { notes: 'Too short' })
+      ).rejects.toThrow(/at least 50 characters/);
+    });
+  });
+
+  describe('TC6: notes absent', () => {
+    it('throws with a descriptive error', async () => {
+      const sessionId = makeSessionId();
+      const { fake } = makeFakeCapturingExec();
+
+      const tool = makeCompleteStepTool(
+        sessionId,
+        NULL_CTX,
+        () => 'ct_current12345678901234567890',
+        () => {},
+        () => {},
+        () => {},
+        STUB_SCHEMAS,
+        fake,
+      );
+
+      await expect(
+        tool.execute('call-1', {})
+      ).rejects.toThrow(/notes is required/);
+    });
+  });
+
+  describe('TC7: artifacts pass-through', () => {
+    it('forwards artifacts to executeContinueWorkflow', async () => {
+      const sessionId = makeSessionId();
+      const { container, fake } = makeFakeCapturingExec();
+
+      const tool = makeCompleteStepTool(
+        sessionId,
+        NULL_CTX,
+        () => 'ct_current12345678901234567890',
+        () => {},
+        () => {},
+        () => {},
+        STUB_SCHEMAS,
+        fake,
+      );
+
+      await tool.execute('call-1', {
+        notes: VALID_NOTES,
+        artifacts: [SAMPLE_ASSESSMENT],
+      });
+
+      expect(container.captured?.output?.artifacts).toEqual([SAMPLE_ASSESSMENT]);
+      expect(container.captured?.output?.notesMarkdown).toBe(VALID_NOTES);
+    });
+  });
+
+  describe('TC8: empty artifacts array', () => {
+    it('does NOT include artifacts in output when array is empty', async () => {
+      const sessionId = makeSessionId();
+      const { container, fake } = makeFakeCapturingExec();
+
+      const tool = makeCompleteStepTool(
+        sessionId,
+        NULL_CTX,
+        () => 'ct_current12345678901234567890',
+        () => {},
+        () => {},
+        () => {},
+        STUB_SCHEMAS,
+        fake,
+      );
+
+      await tool.execute('call-1', {
+        notes: VALID_NOTES,
+        artifacts: [],
+      });
+
+      // Empty artifacts array: output is constructed only because notes is present.
+      // artifacts should not be present in the output object.
+      expect(container.captured?.output?.artifacts).toBeUndefined();
+      expect(container.captured?.output?.notesMarkdown).toBe(VALID_NOTES);
+    });
+  });
+
+  describe('TC9: continueToken NOT in response text (regression guard)', () => {
+    it('advance response does not include continueToken string', async () => {
+      const sessionId = makeSessionId();
+      const injectedToken = 'ct_current12345678901234567890';
+      const { fake } = makeFakeCapturingExec(() => makeOkResponse({ continueToken: 'ct_nexttoken12345678901234567890' }));
+
+      const tool = makeCompleteStepTool(
+        sessionId,
+        NULL_CTX,
+        () => injectedToken,
+        () => {},
+        () => {},
+        () => {},
+        STUB_SCHEMAS,
+        fake,
+      );
+
+      const result = await tool.execute('call-1', { notes: VALID_NOTES });
+
+      // The LLM must never see the continueToken in tool responses.
+      expect(result.content[0].text).not.toContain(injectedToken);
+      expect(result.content[0].text).not.toContain('ct_nexttoken12345678901234567890');
+      expect(result.content[0].text).not.toContain('continueToken');
+    });
+  });
+
+  describe('TC10: getCurrentToken() is called at execution time', () => {
+    it('injects the token from getCurrentToken, not a stale value', async () => {
+      const sessionId = makeSessionId();
+      let tokenUsedByEngine: string | undefined;
+
+      // The token changes between calls (simulating onAdvance updating currentContinueToken).
+      let currentToken = 'ct_token_first_call_1234567890';
+      const { fake } = makeFakeCapturingExec(() => {
+        // Capture the token that was passed to executeContinueWorkflow.
+        return makeOkResponse({ continueToken: 'ct_nexttoken12345678901234567890' });
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const capturingFake = (input: any, ctx: any) => {
+        tokenUsedByEngine = input.continueToken;
+        return fake(input, ctx);
+      };
+
+      const tool = makeCompleteStepTool(
+        sessionId,
+        NULL_CTX,
+        () => currentToken,
+        () => {},
+        () => {},
+        () => {},
+        STUB_SCHEMAS,
+        capturingFake,
+      );
+
+      // First call with initial token
+      await tool.execute('call-1', { notes: VALID_NOTES });
+      expect(tokenUsedByEngine).toBe('ct_token_first_call_1234567890');
+
+      // Simulate onAdvance updating the closure variable
+      currentToken = 'ct_token_second_call_234567890';
+      await tool.execute('call-2', { notes: VALID_NOTES });
+      expect(tokenUsedByEngine).toBe('ct_token_second_call_234567890');
+    });
+  });
+
+  describe('TC11: executeContinueWorkflow error propagates', () => {
+    it('throws when executeContinueWorkflow returns an error', async () => {
+      const sessionId = makeSessionId();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const errorFake = (_input: any, _ctx: any) =>
+        errAsync({ kind: 'validation_failed' as const, failure: { code: 'TOKEN_BAD_SIGNATURE', message: 'bad sig' } as any });
+
+      const tool = makeCompleteStepTool(
+        sessionId,
+        NULL_CTX,
+        () => 'ct_current12345678901234567890',
+        () => {},
+        () => {},
+        () => {},
+        STUB_SCHEMAS,
+        errorFake,
+      );
+
+      await expect(
+        tool.execute('call-1', { notes: VALID_NOTES })
+      ).rejects.toThrow(/complete_step failed/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `makeCompleteStepTool()` to `src/daemon/workflow-runner.ts` as a replacement for `continue_workflow` in daemon sessions. The daemon injects the `continueToken` from a closure variable -- the LLM only provides `notes`, `artifacts`, and `context`, eliminating TOKEN_BAD_SIGNATURE errors from token mangling.
- Adds `currentContinueToken` closure variable in `runWorkflow()` updated by `onAdvance` and `onTokenUpdate` callbacks; `complete_step` is the first (preferred) tool in the tools list.
- Updates `BASE_SYSTEM_PROMPT` to list `complete_step` as the primary advancement tool and adds an explicit warning against using `continue_workflow`.
- Removes `continueToken` from `initialPrompt` so the LLM never sees it.
- Keeps `continue_workflow` in the tools list for backward compatibility but marks it deprecated.
- 11 unit tests covering all code paths.

## What problem this solves

The daemon's `continue_workflow` tool requires the LLM to round-trip an HMAC-signed opaque token. The LLM frequently mangles this token, causing TOKEN_BAD_SIGNATURE errors that kill sessions mid-workflow. `complete_step` eliminates this failure mode entirely.

## Key design decisions

- **Closure variable pattern**: `let currentContinueToken = startContinueToken` in `runWorkflow()`; updated via `onAdvance` (advance path) and `onTokenUpdate` (blocked-retry path). Both paths are mutually exclusive and safe under sequential tool execution.
- **Runtime notes validation**: `notes.length < 50` check inside `execute()` because AgentLoop does not enforce JSON Schema `minLength` constraints.
- **No token in response text**: `complete_step` never includes the continueToken in its tool response, preventing the LLM from storing and misusing it.
- **Backward compat**: `continue_workflow` remains fully functional for MCP sessions and as a fallback.

## Test plan

- [ ] `npx vitest run tests/unit/workflow-runner-complete-step.test.ts` -- 11 tests, all passing
- [ ] `npx vitest run tests/unit/workflow-runner-*.test.ts tests/unit/daemon-*.test.ts` -- 120 tests, all passing
- [ ] `npx tsc --noEmit` -- no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)