### PR TITLE
fix(console): scope sessions to their own repo in workspace join

### DIFF
--- a/console/src/views/workspace-types.ts
+++ b/console/src/views/workspace-types.ts
@@ -240,8 +240,21 @@ export function joinSessionsAndWorktrees(
       continue;
     }
 
-    // When multiple repos share the same branch name, add the session to all of them.
-    for (const entry of entries) {
+    // When session.repoRoot is known, restrict to the repo it belongs to.
+    // This prevents a session from appearing under every repo that happens to
+    // have a worktree on the same branch name (e.g. 'main').
+    // Both session.repoRoot (LocalWorkspaceAnchorV2) and entry.repoRoot
+    // (resolveRepoRoot in worktree-service) are derived from the same
+    // `git rev-parse --git-common-dir` call, so they match for the same repo.
+    // Fall back to all entries when session.repoRoot is null (legacy sessions
+    // predating workspace anchor) or when no entry matches (defensive).
+    let matchedEntries = entries;
+    if (session.repoRoot !== null) {
+      const filtered = entries.filter(e => e.repoRoot === session.repoRoot);
+      if (filtered.length > 0) matchedEntries = filtered;
+    }
+
+    for (const entry of matchedEntries) {
       const key = `${session.gitBranch}\0${entry.repoRoot}`;
       const existing = sessionsByKey.get(key);
       if (existing) {

--- a/tests/unit/console-workspace-types.test.ts
+++ b/tests/unit/console-workspace-types.test.ts
@@ -170,10 +170,10 @@ describe('joinSessionsAndWorktrees', () => {
     expect(items[0]!.allSessions).toHaveLength(2);
   });
 
-  it('correctly separates same branch name across different repos', () => {
-    // Two repos each have a 'feature/x' branch -- sessions appear in both
-    const session1 = makeSession({ sessionId: 'sess_0000000000000000000000001', gitBranch: 'feature/x' });
-    const session2 = makeSession({ sessionId: 'sess_0000000000000000000000002', gitBranch: 'feature/x' });
+  it('places each session under its own repo when repoRoot is set', () => {
+    // Two repos each have a 'feature/x' branch -- each session knows its own repo
+    const session1 = makeSession({ sessionId: 'sess_0000000000000000000000001', gitBranch: 'feature/x', repoRoot: '/repo-a' });
+    const session2 = makeSession({ sessionId: 'sess_0000000000000000000000002', gitBranch: 'feature/x', repoRoot: '/repo-b' });
     const wt1 = makeWorktree({ branch: 'feature/x', path: '/repo-a' });
     const wt2 = makeWorktree({ branch: 'feature/x', path: '/repo-b' });
     const repo1 = makeRepo('/repo-a', [wt1]);
@@ -181,10 +181,27 @@ describe('joinSessionsAndWorktrees', () => {
 
     const items = joinSessionsAndWorktrees([session1, session2], [repo1, repo2]);
 
-    // Sessions appear in both repos since we can't determine which repo they belong to
-    expect(items.length).toBeGreaterThanOrEqual(2);
-    expect(items.map(i => i.repoRoot).sort()).toContain('/repo-a');
-    expect(items.map(i => i.repoRoot).sort()).toContain('/repo-b');
+    // Each session appears under its own repo only -- no cross-repo fan-out
+    expect(items).toHaveLength(2);
+    const repoA = items.find(i => i.repoRoot === '/repo-a');
+    const repoB = items.find(i => i.repoRoot === '/repo-b');
+    expect(repoA?.allSessions.map(s => s.sessionId)).toEqual(['sess_0000000000000000000000001']);
+    expect(repoB?.allSessions.map(s => s.sessionId)).toEqual(['sess_0000000000000000000000002']);
+  });
+
+  it('falls back to all matching repos when session.repoRoot is null (legacy sessions)', () => {
+    // Sessions without repoRoot still fan out to all repos with the same branch name
+    const session = makeSession({ sessionId: 'sess_0000000000000000000000003', gitBranch: 'feature/x', repoRoot: null });
+    const wt1 = makeWorktree({ branch: 'feature/x', path: '/repo-a' });
+    const wt2 = makeWorktree({ branch: 'feature/x', path: '/repo-b' });
+    const repo1 = makeRepo('/repo-a', [wt1]);
+    const repo2 = makeRepo('/repo-b', [wt2]);
+
+    const items = joinSessionsAndWorktrees([session], [repo1, repo2]);
+
+    // Legacy session (no repoRoot) appears under both repos -- graceful degradation
+    expect(items).toHaveLength(2);
+    expect(items.every(i => i.allSessions[0]?.sessionId === 'sess_0000000000000000000000003')).toBe(true);
   });
 
   it('excludes detached HEAD worktrees (null branch) from items', () => {


### PR DESCRIPTION
## Summary

- Sessions were appearing under every project in the Workspace page when multiple repos shared the same branch name (e.g. `main`)
- Root cause: `joinSessionsAndWorktrees()` was unconditionally adding each session to all repos with a worktree on the matching branch, never consulting `session.repoRoot`
- Fix: when `session.repoRoot` is non-null, filter `entries` to those where `entry.repoRoot === session.repoRoot` before the join loop
- Both sides derive `repoRoot` from `git rev-parse --git-common-dir` so values are identical for the same repo
- Falls back to all entries when `session.repoRoot` is null (graceful degradation for legacy sessions)

## Test plan

- [x] Updated multi-repo test: sessions with `repoRoot` set land under their own repo only
- [x] Added regression test: `repoRoot: null` sessions still fan out to all matching repos (legacy fallback)
- [x] `npx vitest run tests/unit/console-workspace-types.test.ts` -- 44/44 passed
- [x] `npx vitest run` (full suite) -- 338 files, 4788/4788 passed