### PR TITLE
feat(mcp): add user notifications for daemon session completion

### DIFF
--- a/docs/design/notification-design-candidates.md
+++ b/docs/design/notification-design-candidates.md
@@ -1,0 +1,131 @@
+# WorkTrain User Notifications: Design Candidates
+
+Raw investigative material for the main implementation agent. Honest analysis over polished presentation.
+
+---
+
+## Problem Understanding
+
+**What is being asked:** fire user-facing notifications (macOS native, generic webhook) when the WorkTrain daemon completes a session or encounters a problem. Config via `~/.workrail/config.json`.
+
+**Tensions:**
+
+1. **Fire-and-forget vs. correctness guarantee** -- notifications involve async I/O (osascript subprocess, HTTP POST). They must never delay semaphore release, affect the workflow result, or propagate errors upward. Solution: `notify()` is void/sync, async work is detached in a void Promise that unconditionally swallows all errors (DaemonEventEmitter model).
+
+2. **Global config vs. per-trigger config** -- the simplest and most consistent design is global config (`~/.workrail/config.json`). Per-trigger config is additive later. Per YAGNI: global-only for MVP.
+
+3. **Child session isolation** -- `spawn_agent` calls `runWorkflow()` directly for child sessions. If notifications fire from inside `runWorkflow()`, sub-agent completions notify the user. The correct seam is at the top-level dispatch boundary (TriggerRouter), not inside the workflow executor.
+
+4. **Platform detection** -- osascript is macOS-only. If `WORKTRAIN_NOTIFY_MACOS=true` on Linux, the call fails silently (or logs a warning). Runtime `process.platform === 'darwin'` guard required.
+
+**Likely seam:** `TriggerRouter.route()` and `TriggerRouter.dispatch()` -- after `runWorkflowFn()` returns. This is the only call site that: (a) has a complete `WorkflowRunResult`, (b) is called only for root-level sessions, (c) already has the pattern for injected optional behaviors.
+
+**What makes this hard:** The child session problem. A junior developer would add notifications inside `runWorkflow()` and flood the user with sub-agent notifications. The correct boundary is `TriggerRouter` because it is the external dispatch surface.
+
+---
+
+## Philosophy Constraints
+
+From `CLAUDE.md` and repo patterns:
+
+- **Errors-as-data:** `notify()` swallows all async errors internally (never returns a Result -- it is observability, not delivery). The webhook channel can log the error; it must not propagate.
+- **DI for I/O boundaries:** `execFileFn` (for osascript) and `fetchFn` (for webhook HTTP) are injected constructor parameters, allowing test fakes without mocking child_process or global fetch.
+- **Immutability by default:** `NotificationService` is immutable after construction. Config is a plain readonly struct passed to the constructor.
+- **YAGNI:** No retry logic, no per-trigger config, no Slack/email integrations.
+- **Single-responsibility:** TriggerRouter dispatches; NotificationService notifies. Not mixed.
+
+**Conflicts:** None. CLAUDE.md and repo patterns align.
+
+---
+
+## Impact Surface
+
+Files that must remain consistent after this change:
+
+- `src/trigger/trigger-router.ts` -- gains one optional constructor param (`notificationService?`)
+- `src/trigger/trigger-listener.ts` -- constructs `NotificationService` from config and injects
+- `src/config/config-file.ts` -- gains 2 new allowed keys: `WORKTRAIN_NOTIFY_MACOS`, `WORKTRAIN_NOTIFY_WEBHOOK`
+- `src/trigger/__tests__/trigger-router.test.ts` -- existing tests should be unaffected (new param is optional); new tests verify notify() is called with correct args
+
+No breaking changes to public types or existing behavior.
+
+---
+
+## Candidates
+
+### Candidate 1: Inline notification in TriggerRouter
+
+**Summary:** Add `notifyMacOs: boolean` and `notifyWebhookUrl: string | undefined` constructor params to TriggerRouter. After `runWorkflowFn()` returns in `route()` and `dispatch()`, call `execFile('osascript', [...])` and/or `fetch(webhookUrl, {...})` inline. Errors caught and swallowed.
+
+- **Tensions resolved:** fire-and-forget (detached void Promise), child isolation (TriggerRouter boundary). Accepts: single-responsibility violation.
+- **Boundary:** TriggerRouter -- correct for child isolation.
+- **Failure mode:** TriggerRouter test suite must mock execFile and fetch; future channels (Slack, Linux) bloat the class.
+- **Repo pattern:** departs from optional-injection pattern (emitter, execFn are injected services, not bare params).
+- **Gains:** smallest diff, no new files.
+- **Losses:** testability burden, extensibility, single-responsibility.
+- **Scope:** too narrow -- makes future channels harder.
+- **Philosophy:** violates DI (no injection seam for osascript/fetch in tests), single-responsibility.
+
+---
+
+### Candidate 2: New NotificationService class (recommended)
+
+**Summary:** `NotificationService` class in `src/trigger/notification-service.ts`. Constructor: `{ macOs: boolean, webhookUrl?: string, execFileFn?: ExecFileFn, fetchFn?: FetchFn }`. Method: `notify(result: WorkflowRunResult, goal: string): void` -- fire-and-forget. TriggerRouter gets optional `notificationService?: NotificationService` constructor param. `trigger-listener.ts` constructs it from config. Tests inject fakes.
+
+- **Tensions resolved:** all 4. Fire-and-forget via detached void Promise. Child isolation via TriggerRouter boundary. DI for testability. Platform detection inside `notify()`.
+- **Boundary:** NotificationService owns notification; TriggerRouter owns routing. Clean split.
+- **Why this boundary is best fit:** mirrors `DaemonEventEmitter` exactly -- same optional-injection, same fire-and-forget contract, same "observability must never affect correctness" invariant.
+- **Failure mode:** if the void Promise is not truly detached (e.g., `await notify()` accidentally holds the semaphore). Must verify the pattern. Low risk given DaemonEventEmitter precedent.
+- **Repo pattern:** directly follows `DaemonEventEmitter` (daemon-events.ts) and `execFn` injection (trigger-router.ts, delivery-client.ts).
+- **Gains:** clean seam, testable with fakes, extensible (future channels are additive), follows all repo conventions.
+- **Losses:** one new file (negligible).
+- **Scope:** best-fit.
+- **Philosophy:** honors DI, errors-as-data, immutability, single-responsibility, YAGNI. No conflicts.
+
+---
+
+### Candidate 3: DaemonEventEmitter subscriber (rejected)
+
+**Summary:** Add subscriber pattern to `DaemonEventEmitter`. On `session_completed` events, a `NotificationService` listener fires notifications.
+
+- **Critical failure:** `session_completed` fires for all `runWorkflow()` calls including child sessions spawned by `spawn_agent`. Violates child isolation invariant -- users get flooded with sub-agent notifications.
+- **Additional problem:** `DaemonEventEmitter` is an append-only JSONL logger, not a pub/sub bus. Adding subscriber semantics is a disproportionate architectural change.
+- **Scope:** too broad.
+- **Rejected.**
+
+---
+
+## Comparison and Recommendation
+
+| Tension | Candidate 1 | Candidate 2 | Candidate 3 |
+|---|---|---|---|
+| Fire-and-forget | resolved | resolved | resolved |
+| Child session isolation | resolved | resolved | **violated** |
+| Testability | weak | strong | n/a |
+| Extensibility | poor | good | n/a |
+| Repo pattern fit | departs | follows | departs |
+
+**Recommendation: Candidate 2 (NotificationService).**
+
+Reasons: follows the exact DaemonEventEmitter optional-injection precedent, clean single-responsibility boundary, strong testability via injected fakes, extensible for future channels without touching TriggerRouter. Cost is one small new file.
+
+---
+
+## Self-Critique
+
+**Strongest counter-argument against Candidate 2:** Candidate 1 is a smaller diff with no new files. If notifications are low-priority and never extended, NotificationService is over-engineered. YAGNI could justify inline.
+
+**Why Candidate 1 still loses:** The testability argument is concrete and immediate. TriggerRouter already has complex semaphore/delivery/autoCommit logic. Adding osascript/fetch inline makes the test suite harder now. NotificationService is one small file -- the cost is negligible.
+
+**Broader option that might be justified:** A `NotificationBus` with channel registration and routing (like an EventEmitter). Only justified if multiple channels need independent retry, priority, or filtering. No evidence of that in the backlog.
+
+**Invalidating assumption:** If console-dispatched sessions (via `dispatch()`) should NOT notify the user (because they are interactive). Currently both `route()` and `dispatch()` are treated the same. If this is wrong, `notify()` gains a `source?: 'webhook' | 'console'` parameter and gates on it.
+
+---
+
+## Open Questions for the Main Agent
+
+1. Should `dispatch()` (console-initiated) fire notifications the same as `route()` (webhook/poll)? Current assumption: yes -- both are daemon-executed sessions the user cannot directly observe.
+2. What message format for the macOS notification? Suggested: title = "WorkTrain", subtitle = workflowId, body = human-readable outcome + goal snippet.
+3. What JSON payload for the webhook POST? Suggested: `{ event: "session_completed", workflowId, outcome: "success"|"error"|"timeout"|"delivery_failed", detail: string, goal: string, timestamp: ISO8601 }`.
+4. Should `delivery_failed` generate a distinct notification message vs. plain `error`? Suggested: yes -- "session succeeded but result delivery failed" is a different user action than "session failed".

--- a/docs/design/notification-design-review.md
+++ b/docs/design/notification-design-review.md
@@ -1,0 +1,84 @@
+# WorkTrain Notifications: Design Review Findings
+
+Concise findings for the implementation agent.
+
+---
+
+## Tradeoff Review
+
+All accepted tradeoffs are sound under realistic conditions:
+
+- **Global-only config** -- acceptable for single-user local daemon. Additive per-trigger config is possible without touching NotificationService.
+- **No retry on webhook** -- best-effort delivery matches DaemonEventEmitter contract. Acceptable.
+- **No Linux/Windows** -- webhook is the universal channel. Linux `notify-send` is additive.
+- **Fire-and-forget errors swallowed** -- `console.warn` inside catch provides minimal observability. Correct for observability infrastructure.
+
+---
+
+## Failure Mode Review
+
+All failure modes covered:
+
+| Failure mode | Mitigation | Risk |
+|---|---|---|
+| osascript stall | execFile `timeout: 5000` + SIGKILL | Low |
+| Webhook unreachable | AbortController 30s + catch/warn/swallow | Low |
+| Webhook non-2xx | res.ok check + warn + swallow | Low |
+| Invalid webhook URL | URL.canParse at construction, warn + treat as absent | Low |
+| macOS permission denied | osascript exits non-zero, caught and swallowed | Low |
+| Future accidental await | notify() returns void (not Promise<void>) -- TypeScript rejects await | None |
+
+No high-risk failure modes.
+
+---
+
+## Runner-Up / Simpler Alternative Review
+
+- **Runner-up (inline in TriggerRouter):** no strengths worth borrowing. Loses on testability and single-responsibility.
+- **Simpler (module-level function instead of class):** viable but class matches DaemonEventEmitter precedent, enables constructor-time URL validation, and makes injection cleaner in tests.
+- **Hybrid:** none warranted. Selected approach already is the pattern-following hybrid.
+
+---
+
+## Philosophy Alignment
+
+All CLAUDE.md principles satisfied:
+
+- DI for I/O boundaries: execFileFn and fetchFn injected
+- Immutability: NotificationService immutable post-construction
+- Errors are data: async errors logged, discarded at boundary
+- YAGNI: MVP scope only
+
+Minor tensions (acceptable):
+- macOS-on-Linux: runtime guard (`process.platform === 'darwin'`) rather than type-level. Acceptable for config flags.
+
+---
+
+## Findings
+
+**No Red or Orange findings.** Design is implementation-ready.
+
+**Yellow (informational):**
+
+- Y1: `notify()` should return `void` (not `Promise<void>`) to make the fire-and-forget contract type-enforced. Async work is detached via `void this._doNotify(...).catch(...)` inside a sync method -- exactly as DaemonEventEmitter does.
+- Y2: osascript execFile call should use `timeout: 5000` option (ms). Do not use the shell timeout command -- execFile handles this natively.
+- Y3: The `delivery_failed` outcome notification message should distinguish 'session completed, result delivery failed' from 'session failed'. Both are error states but from the user's perspective they are different actions.
+- Y4: Config-load warning: if `WORKTRAIN_NOTIFY_MACOS=true` but `process.platform !== 'darwin'`, log one `console.warn` at construction time (not on every notify() call).
+
+---
+
+## Recommended Revisions
+
+None to the architecture. Implement as designed:
+
+1. `src/trigger/notification-service.ts` -- NotificationService class, void notify(), macOS + webhook channels
+2. `src/trigger/trigger-router.ts` -- add optional `notificationService?` constructor param; call `notificationService?.notify(result, trigger.goal)` in route() after runWorkflowFn() and `notificationService?.notify(result, workflowTrigger.goal)` in dispatch() after runWorkflowFn()
+3. `src/config/config-file.ts` -- add WORKTRAIN_NOTIFY_MACOS and WORKTRAIN_NOTIFY_WEBHOOK to ALLOWED_CONFIG_FILE_KEYS
+4. `src/trigger/trigger-listener.ts` -- read the two config values, construct NotificationService if either is set, inject into TriggerRouter
+5. `src/trigger/__tests__/notification-service.test.ts` -- unit tests with injected fakes
+
+---
+
+## Residual Concerns
+
+None material. Design is sound and implementation-ready.

--- a/docs/design/notification-implementation-plan.md
+++ b/docs/design/notification-implementation-plan.md
@@ -1,0 +1,181 @@
+# WorkTrain Notifications: Implementation Plan
+
+---
+
+## 1. Problem Statement
+
+WorkTrain daemon silently starts and finishes sessions. Unless the user watches the console or tails a log, they have no awareness that work happened. This plan implements macOS native notifications (via `osascript`) and a generic webhook channel, firing on session completion (success/error/timeout/delivery_failed). Config lives in `~/.workrail/config.json`.
+
+---
+
+## 2. Acceptance Criteria
+
+- When `WORKTRAIN_NOTIFY_MACOS=true` in `~/.workrail/config.json` and `process.platform === 'darwin'`, a macOS notification appears after every root-level session completes (success, error, timeout, or delivery_failed).
+- When `WORKTRAIN_NOTIFY_WEBHOOK=<url>` in `~/.workrail/config.json`, an HTTP POST is sent to that URL after every root-level session completes.
+- Notification fires for both webhook-triggered sessions (`route()`) and console-dispatched sessions (`dispatch()`).
+- A failed notification (osascript crash, network error) never affects the workflow result and never causes the daemon to throw.
+- Child sessions spawned via `spawn_agent` do NOT fire user notifications.
+- If both `WORKTRAIN_NOTIFY_MACOS` and `WORKTRAIN_NOTIFY_WEBHOOK` are absent or false/empty, zero overhead (no NotificationService constructed).
+- If `WORKTRAIN_NOTIFY_MACOS=true` but `process.platform !== 'darwin'`, a `console.warn` is logged once at daemon startup and notifications are skipped.
+- If `WORKTRAIN_NOTIFY_WEBHOOK` is set to a non-URL value, a `console.warn` is logged once at startup and webhook channel is disabled.
+- All new behavior is unit-testable via injected fakes (no test mocks of child_process or global fetch needed).
+
+---
+
+## 3. Non-goals
+
+- Linux/Windows OS notifications (`notify-send`, PowerShell toast)
+- Slack/Discord/Teams/email first-class channel integrations
+- Mobile push notifications
+- Outbox.jsonl integration
+- Per-trigger notification config (global-only for MVP)
+- Retry logic for webhook delivery
+- Notification batching or debouncing
+- Child session notifications (spawn_agent sub-tasks)
+
+---
+
+## 4. Philosophy-driven Constraints
+
+- `notify()` returns `void` (not `Promise<void>`). Async work is detached via `void this._doNotify(...).catch(() => {})`. TypeScript rejects `await` on void -- fire-and-forget is type-enforced.
+- `execFileFn` (for osascript) and `fetchFn` (for HTTP POST) are injected constructor parameters. Tests use fakes, never mock child_process or global fetch.
+- `NotificationService` is immutable after construction. All config is resolved in the constructor.
+- All async errors are swallowed unconditionally inside NotificationService. Logging via `console.warn` is the only observability.
+- macOS platform check and webhook URL validation happen at construction time (validate at boundaries, trust inside).
+
+---
+
+## 5. Invariants
+
+1. `notify()` never throws, never propagates errors, never affects `WorkflowRunResult`.
+2. `notify()` fires only from `TriggerRouter` (not inside `runWorkflow()` or `spawn_agent` child sessions).
+3. osascript is invoked via `execFile` (never `exec`). No shell injection risk.
+4. Webhook is a global config channel, not per-trigger.
+5. All 4 `WorkflowRunResult._tag` variants (`success`, `error`, `timeout`, `delivery_failed`) are notifiable.
+6. `delivery_failed` notification message body is distinct: "session completed but result delivery failed".
+
+---
+
+## 6. Selected Approach
+
+**NotificationService class** in `src/trigger/notification-service.ts`. Optional-injection into `TriggerRouter` constructor. Follows `DaemonEventEmitter` optional-injection pattern exactly.
+
+**Runner-up:** Inline in TriggerRouter. Lost on testability and single-responsibility. No strengths worth borrowing.
+
+**Rationale:** TriggerRouter is the only call site that processes root-level sessions exclusively (child sessions use `runWorkflow()` directly). NotificationService follows `DaemonEventEmitter` precedent -- same pattern, same contract, same rationale. Clean separation of concerns. Injected fakes eliminate test mocking burden.
+
+---
+
+## 7. Vertical Slices
+
+### Slice 1: NotificationService core + config keys
+
+**Scope:**
+- `src/trigger/notification-service.ts` -- new file
+- `src/config/config-file.ts` -- add 2 allowed keys
+- `src/trigger/__tests__/notification-service.test.ts` -- new test file
+
+**Done when:**
+- `NotificationService` constructor accepts `{ macOs: boolean, webhookUrl?: string, execFileFn?: ExecFileFn, fetchFn?: FetchFn }`
+- `notify(result: WorkflowRunResult, goal: string): void` is implemented
+- macOS channel: calls `execFileFn('osascript', ['-e', `display notification "..." with title "WorkTrain"`], { timeout: 5000 })`
+- Webhook channel: POSTs `{ event: 'session_completed', workflowId, outcome, detail, goal, timestamp }` to webhookUrl with 30s AbortController
+- Platform guard: if macOs=true and platform !== darwin, logs warn at construction and skips osascript
+- URL validation: if webhookUrl is provided but not a valid URL, logs warn at construction and disables webhook channel
+- Unit tests cover: success fires both channels; error/timeout/delivery_failed each fire; macOS-on-linux is guarded; invalid webhook URL is disabled; failed osascript does not throw; failed webhook does not throw; injected fake execFileFn receives correct args
+- `WORKTRAIN_NOTIFY_MACOS` and `WORKTRAIN_NOTIFY_WEBHOOK` are in `ALLOWED_CONFIG_FILE_KEYS`
+
+### Slice 2: TriggerRouter injection
+
+**Scope:**
+- `src/trigger/trigger-router.ts` -- add optional `notificationService?` param to constructor; call in `route()` and `dispatch()`
+
+**Done when:**
+- `TriggerRouter` constructor accepts optional `notificationService?: NotificationService` (7th param position or via an options bag -- check existing param order)
+- `route()` calls `this.notificationService?.notify(result, trigger.goal)` after `runWorkflowFn()` resolves and before `maybeRunDelivery()`
+- `dispatch()` calls `this.notificationService?.notify(result, workflowTrigger.goal)` after `runWorkflowFn()` resolves
+- Existing TriggerRouter tests are unaffected (new param is optional, defaults to undefined)
+- New test verifies notify() is called with the correct result and goal in both route() and dispatch() paths
+
+### Slice 3: trigger-listener.ts wiring
+
+**Scope:**
+- `src/trigger/trigger-listener.ts` -- read config values and inject NotificationService
+
+**Done when:**
+- After reading `~/.workrail/config.json`, `trigger-listener.ts` reads `WORKTRAIN_NOTIFY_MACOS` and `WORKTRAIN_NOTIFY_WEBHOOK`
+- If either is set, constructs `NotificationService` and injects into `TriggerRouter`
+- If neither is set, `notificationService` is undefined (no overhead)
+- Manual integration test: set `WORKTRAIN_NOTIFY_MACOS=true` in config.json, start daemon, trigger a session, verify notification appears on macOS
+
+---
+
+## 8. Test Design
+
+**Unit tests (Vitest, fakes):**
+
+`notification-service.test.ts`:
+- success result fires macOS notification with title "WorkTrain" and body containing workflowId and "completed"
+- error result fires notification with "failed" in body
+- timeout result fires notification with "timed out" in body
+- delivery_failed result fires notification with "delivery failed" in body (distinct from generic error)
+- macOS=true + platform=darwin: execFileFn called with correct args
+- macOS=true + platform=linux: execFileFn NOT called, console.warn emitted at construction
+- webhookUrl set + valid URL: fetchFn called with correct URL and JSON body
+- webhookUrl set + invalid URL: fetchFn NOT called, console.warn emitted at construction
+- execFileFn throws: notify() does not throw, error is swallowed
+- fetchFn rejects: notify() does not throw, error is swallowed
+- fetchFn returns non-2xx: notify() does not throw, console.warn emitted
+
+`trigger-router.test.ts` additions:
+- route() with notificationService: notificationService.notify() called with correct WorkflowRunResult and goal after workflow completes
+- dispatch() with notificationService: same
+- route() without notificationService: no error (undefined?.notify() is safe)
+
+**Integration test (manual):**
+- `WORKTRAIN_NOTIFY_MACOS=true` in config.json -> trigger a session -> verify macOS notification appears
+- `WORKTRAIN_NOTIFY_WEBHOOK=https://httpbin.org/post` -> trigger a session -> verify POST received
+
+---
+
+## 9. Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| osascript stall | Low | Low | execFile timeout: 5000ms |
+| Webhook timeout | Low | Low | AbortController 30s |
+| Future accidental await on notify() | Low | Medium | notify() returns void (not Promise<void>) |
+| macOS permission denied | Medium | Low | errors swallowed, user sees nothing |
+| Wrong TriggerRouter param position | Low | Low | Check existing param order before editing |
+
+---
+
+## 10. PR Packaging Strategy
+
+**SinglePR** on branch `feat/daemon-notifications`. All 3 slices in one PR -- they are cohesive and none makes sense without the others. Slices are committed sequentially so the diff is reviewable.
+
+---
+
+## 11. Philosophy Alignment
+
+| Principle | Status | Note |
+|---|---|---|
+| DI for I/O boundaries | Satisfied | execFileFn and fetchFn injected |
+| Immutability by default | Satisfied | NotificationService immutable post-construction |
+| Errors are data | Satisfied | async errors logged then discarded at boundary |
+| Validate at boundaries | Satisfied | URL and platform validated at construction |
+| YAGNI | Satisfied | No retry, no per-trigger, no Slack |
+| Make illegal states unrepresentable | Tension | macOS-on-Linux is representable via config; mitigated by construction-time guard |
+| Single-responsibility | Satisfied | TriggerRouter routes; NotificationService notifies |
+| Prefer fakes over mocks | Satisfied | execFileFn and fetchFn are injectable fakes |
+
+---
+
+## 12. Metrics
+
+- `implementationPlan`: complete
+- `slices`: 3 (NotificationService core, TriggerRouter injection, trigger-listener wiring)
+- `estimatedPRCount`: 1
+- `unresolvedUnknownCount`: 0
+- `planConfidenceBand`: High
+- `followUpTickets`: Linux `notify-send` support, per-trigger notification config, webhook retry

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -5697,3 +5697,71 @@ Tested empirically today. This is what actually works, not what's specced.
 - Need enough volume to be statistically meaningful
 
 **Starting point:** the mr-review workflow is the easiest to benchmark objectively. Start with 20 PRs where bugs were later discovered and 20 PRs that shipped cleanly. Run each through `mr-review-workflow-agentic` on several model tiers. Measure recall and precision. That's a publishable result with one weekend of work.
+
+---
+
+### Autonomous feature development: scope → breakdown → parallel execution → merge (Apr 18, 2026)
+
+**The vision:** give WorkTrain a feature scope -- from a vague idea to a fully groomed ticket -- and it figures out the rest. Discovery if needed, design if needed, breakdown into parallel slices, execution across worktrees, context management across agents, bringing it all back together.
+
+**The four pillars the user cares about:**
+1. **Autonomy** -- WorkTrain takes a scope and figures out the work breakdown without hand-holding
+2. **Quality** -- comes FROM autonomy + workflow enforcement + coordination. Each slice goes through the right phases.
+3. **Throughput** -- parallel slices across worktrees simultaneously. N agents working while you focus elsewhere.
+4. **Visibility** -- one coherent work unit you can track at a glance, not N unrelated sessions in a flat list.
+
+**The pipeline for a scope:**
+
+```
+Input: "add GitHub polling support" (any level of definition -- idea to full spec)
+  │
+  ├── [if vague] ideation + spec authoring → output: BRD / acceptance criteria
+  ├── classify-task → taskComplexity, hasUI, touchesArchitecture, taskMaturity
+  ├── [if Medium/Large] discovery → context bundle, invariants, candidate files
+  ├── [if touchesArchitecture] design → candidates, review, selected approach
+  ├── breakdown → parallel slices with dependency graph
+  │     ├── Slice 1: types + schema         (worktree A)
+  │     ├── Slice 2: polling adapter        (worktree B, depends: 1)
+  │     ├── Slice 3: scheduler integration  (worktree C, depends: 2)
+  │     └── Slice 4: tests                 (worktree D, depends: 1-3)
+  ├── [parallel execution] each slice: implement → review → (fix if needed) → approved
+  ├── [serial integration] merge slices in dependency order, verify after each
+  └── [final] integration test → PR created → notification to user
+```
+
+**Context management across agents:**
+- Coordinator maintains a "work unit manifest": current phase, slice status, shared invariants, decisions made in design phase
+- Each spawned agent receives a context bundle: relevant portion of the manifest + files it needs + decisions from upstream phases
+- Agents don't rediscover what the coordinator already knows
+- After each agent completes, its findings update the manifest (new invariants found, scope changes, follow-up tickets)
+
+**Worktree coordination:**
+- Each slice gets its own worktree (already done via `--isolation worktree`)
+- Coordinator tracks which files each slice touches -- detects conflicts before they happen
+- Independent slices run in parallel; dependent slices queue automatically
+- Merge order follows the dependency graph, not wall-clock completion time
+
+**Knowing when to spawn a new main agent:**
+- When a slice is too large or discovers unexpected scope, it requests a breakdown from the coordinator
+- When a review finds a Critical finding, the coordinator spawns a dedicated fix agent with the finding + relevant context
+- When integration reveals a regression, coordinator spawns an investigation agent before retrying the merge
+
+**The coordinator's job (what stays in scripts, not LLM):**
+- Maintain the manifest (JSON file, append-only)
+- Compute the dependency graph
+- Decide parallelism vs serialization
+- Route: clean → merge, minor findings → fix agent, critical → escalate
+- Track worktrees, detect conflicts
+- Sequence the merge order
+
+**What requires LLM cognition:**
+- Discovery (what are the invariants, which files matter)
+- Design (which approach, what tradeoffs)
+- Implementation (write the code)
+- Review (is this correct and complete)
+- Breakdown (what are the right slice boundaries)
+
+**The minimum viable version:**
+A coordinator that handles a Medium/Small scoped task (already classified, no need for ideation or design). Takes 2-4 parallel slices, runs them, reviews each, merges when clean. No escalation handling in v1 -- if anything fails, notify the user.
+
+This is the thing that makes WorkTrain feel like a senior engineer taking ownership of a task, not a tool you have to supervise step by step.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -5765,3 +5765,15 @@ Input: "add GitHub polling support" (any level of definition -- idea to full spe
 A coordinator that handles a Medium/Small scoped task (already classified, no need for ideation or design). Takes 2-4 parallel slices, runs them, reviews each, merges when clean. No escalation handling in v1 -- if anything fails, notify the user.
 
 This is the thing that makes WorkTrain feel like a senior engineer taking ownership of a task, not a tool you have to supervise step by step.
+
+---
+
+### Coordinator design decision: MVP-first, generalize after (Apr 18, 2026)
+
+**Decision:** Build the first coordinator as a PR review-specific script. Generalize to a reusable coordinator framework after proving it works end-to-end.
+
+**Rationale:** Three discovery runs all converged on the architecture (TypeScript script, `CoordinatorDeps` interface, 2-call HTTP for notes). The risk is over-engineering for hypothetical pipelines before validating the real one. PR review is the highest-value first use case with a clear success criterion.
+
+**The generic coordinator architecture is already designed** (see `docs/discovery/coordinator-script-design.md`). The `CoordinatorDeps` interface and `AgentResult` bridge type make migration to a generic coordinator trivial -- the PR review script uses these types, so generalizing is additive, not a rewrite.
+
+**Migration path:** once PR review coordinator is proven in production, extract the routing logic (`parseFindings`, `routeByFindings`) and `CoordinatorDeps` interface into `src/coordinators/base.ts`. The PR review coordinator becomes one implementation of the base pattern.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -5777,3 +5777,22 @@ This is the thing that makes WorkTrain feel like a senior engineer taking owners
 **The generic coordinator architecture is already designed** (see `docs/discovery/coordinator-script-design.md`). The `CoordinatorDeps` interface and `AgentResult` bridge type make migration to a generic coordinator trivial -- the PR review script uses these types, so generalizing is additive, not a rewrite.
 
 **Migration path:** once PR review coordinator is proven in production, extract the routing logic (`parseFindings`, `routeByFindings`) and `CoordinatorDeps` interface into `src/coordinators/base.ts`. The PR review coordinator becomes one implementation of the base pattern.
+
+---
+
+### Architecture decisions from Apr 17-18 sessions (to record before files are cleaned up)
+
+**Decision 1: Structured output + tool calls can coexist (Apr 18)**
+Validated empirically via integration test. The beta API (`client.beta.messages.create()`) supports both JSON schema enforcement AND tool calls in the same request. Schema enforcement applies at `end_turn` only. Bedrock is more consistent than direct Anthropic API for system-prompt fallback behavior. This opens a future path for replacing `complete_step` with structured output, but `complete_step` remains the chosen primitive for now.
+
+**Decision 2: `complete_step` is the preferred daemon workflow-control primitive (Apr 18)**
+PR #569 merged. The daemon holds the continueToken in a closure; LLM calls `complete_step(notes)` and never handles the token directly. Structured output (`beta.messages.create` with JSON schema) was evaluated as an alternative and deferred -- it's a viable migration path for a future version but adds API complexity today. Follow-up: track a structured output migration as a future improvement, not a current priority.
+
+**Decision 3: AgentLoop error handling contract -- FatalToolError (Apr 16)**
+`FatalToolError` subclass selected for distinguishing recoverable from non-recoverable tool failures in the AgentLoop. The contract: user-facing tools (Bash, Read, Write) catch failures and return `isError: true` in the tool_result (loop continues, LLM can retry). Coordination tools with unrecoverable failures (session store corruption, token decode failure) throw `FatalToolError` -- `_executeTools` instanceof-checks this and kills the session rather than surfacing a confusing error to the LLM. This contract is part of the AgentLoop architecture and must be followed by any new tool implementations.
+
+**Decision 4: Use `wr.discovery` for discovery-only tasks, not `coding-task-workflow-agentic` (Apr 17)**
+Discovered from a broken session: `coding-task-workflow-agentic` dispatched with "do discovery only, no code" ran 11 step advances then stopped without `run_completed`. The workflow's implementation phases fired even with explicit instructions not to code. Lesson: when a trigger or coordinator wants pure discovery/research, use `wr.discovery` as the workflowId. `coding-task-workflow-agentic` should only be dispatched when implementation is the actual goal.
+
+**Decision 5: Bug -- MCP server EPIPE crash (Apr 18)**
+Root cause confirmed with 15 production crash log entries: `process.stderr` is missing an `'error'` event handler in `registerFatalHandlers()`. When an MCP client disconnects, Node.js emits `EPIPE` on stderr which crashes the process with an unhandled error. `process.stdout` already has equivalent protection via `wireStdoutShutdown()`. Fix: mirror the stdout protection for stderr. One-line fix being implemented in PR `fix/mcp-stderr-epipe-crash`.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -5796,3 +5796,33 @@ Discovered from a broken session: `coding-task-workflow-agentic` dispatched with
 
 **Decision 5: Bug -- MCP server EPIPE crash (Apr 18)**
 Root cause confirmed with 15 production crash log entries: `process.stderr` is missing an `'error'` event handler in `registerFatalHandlers()`. When an MCP client disconnects, Node.js emits `EPIPE` on stderr which crashes the process with an unhandled error. `process.stdout` already has equivalent protection via `wireStdoutShutdown()`. Fix: mirror the stdout protection for stderr. One-line fix being implemented in PR `fix/mcp-stderr-epipe-crash`.
+
+---
+
+### worktrain status → console integration (Apr 18, 2026)
+
+The `worktrain status` CLI command is Phase 1. Phase 2: the same data and rendering lives inside the console as the default landing view when you open it -- not the sessions list, the overview. Same `StatusDataPacket` type, two surfaces. The console overview replaces the need to run a CLI command; it auto-refreshes and stays live.
+
+---
+
+### WorkTrain as a native macOS app (Apr 18, 2026)
+
+Long-term vision: WorkTrain becomes a full native Mac app -- not just a CLI + web console, but a proper macOS application with a menubar icon, system notifications, windows, and native UX.
+
+**What this unlocks:**
+- Always-on menubar presence showing daemon status at a glance
+- Native macOS notifications (already built via osascript -- the app version uses UserNotifications framework directly)
+- The `worktrain status` overview as a native window, not a browser tab
+- Message queue and inbox as a native interface (type a message from anywhere on your Mac, not just the terminal)
+- Background daemon management -- start/stop/restart from the menubar without terminal
+- Deep system integration: file system events, calendar, Contacts, native share sheet
+
+**Tech stack options:**
+- Swift/SwiftUI: full native, best macOS integration, steeper learning curve from TypeScript
+- Electron + existing console UI: fastest path, same TypeScript codebase, but heavy
+- Tauri: Rust core + existing web frontend, lighter than Electron, good macOS support
+- React Native macOS: reuses React knowledge, not quite native feel
+
+**Recommended path:** Tauri wrapping the existing console UI. The console is already a React/Vite app. Tauri gives native menubar, notifications, and system APIs without rewriting the frontend. The WorkTrain daemon stays as a separate process managed by the app.
+
+**This is a post-v1 platform decision** -- not a near-term priority, but worth designing toward. Don't make architectural decisions that would make the Tauri wrapper hard later.

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -77,6 +77,12 @@ const ALLOWED_CONFIG_FILE_KEYS = new Set([
   // in trigger-listener.ts and passed to TriggerRouter as a number).
   // Example in config.json: "maxConcurrentSessions": "3"
   'maxConcurrentSessions',
+
+  // daemon notification channels
+  // "WORKTRAIN_NOTIFY_MACOS": "true"  -- enable macOS native notifications (darwin only)
+  // "WORKTRAIN_NOTIFY_WEBHOOK": "https://hooks.example.com/worktrain"  -- generic webhook POST
+  'WORKTRAIN_NOTIFY_MACOS',
+  'WORKTRAIN_NOTIFY_WEBHOOK',
 ]);
 
 // =============================================================================

--- a/src/trigger/notification-service.ts
+++ b/src/trigger/notification-service.ts
@@ -1,0 +1,338 @@
+/**
+ * WorkTrain Daemon: User Notification Service
+ *
+ * Fires user-facing notifications when a daemon session completes or fails.
+ * Supports two channels: macOS native notifications (osascript) and a generic
+ * webhook (HTTP POST).
+ *
+ * Design notes:
+ * - notify() returns void synchronously. All async work runs in a detached
+ *   Promise that unconditionally swallows errors. This is the same contract
+ *   as DaemonEventEmitter.emit() -- observability must never affect correctness.
+ * - execFileFn (for osascript) and fetchFn (for HTTP POST) are injected
+ *   constructor parameters so tests can use fakes without mocking child_process
+ *   or global fetch. Production code omits both (defaults apply).
+ * - Platform guard: if macOs=true but process.platform !== 'darwin', a warning
+ *   is logged once at construction and the macOS channel is disabled.
+ * - URL validation: if webhookUrl is not a valid URL, a warning is logged once
+ *   at construction and the webhook channel is disabled.
+ * - NotificationService is immutable after construction.
+ *
+ * Config keys in ~/.workrail/config.json:
+ *   "WORKTRAIN_NOTIFY_MACOS": "true"           -- enable macOS notifications
+ *   "WORKTRAIN_NOTIFY_WEBHOOK": "https://..."  -- enable generic webhook
+ */
+
+import * as childProcess from 'node:child_process';
+import * as os from 'node:os';
+import type { WorkflowRunResult } from '../daemon/workflow-runner.js';
+
+// ---------------------------------------------------------------------------
+// Injected function types
+// ---------------------------------------------------------------------------
+
+/**
+ * execFile signature subset used by the macOS notification channel.
+ * Injected for testability -- production code uses child_process.execFile.
+ *
+ * WHY a bare (not promisified) callback form: we do not await the result.
+ * The detached-void-Promise pattern fires and forgets. The callback form
+ * is simpler to type and to fake in tests.
+ */
+export type ExecFileNotifyFn = (
+  file: string,
+  args: readonly string[],
+  options: { timeout: number },
+  callback: (error: Error | null) => void,
+) => void;
+
+/**
+ * fetch signature subset used by the webhook channel.
+ * Injected for testability -- production code uses globalThis.fetch.
+ */
+export type FetchNotifyFn = (
+  url: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+    signal: AbortSignal;
+  },
+) => Promise<{ ok: boolean; status: number }>;
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface NotificationConfig {
+  /**
+   * Enable macOS native notification channel.
+   * Requires process.platform === 'darwin'. A warning is logged at construction
+   * time if true on a non-darwin platform, and the channel is disabled.
+   */
+  readonly macOs: boolean;
+  /**
+   * Webhook URL for generic HTTP POST notification channel.
+   * Must be a valid http:// or https:// URL. A warning is logged at construction
+   * time if the value is not a valid URL, and the channel is disabled.
+   */
+  readonly webhookUrl?: string;
+  /**
+   * Injectable exec function for the macOS channel.
+   * Production: defaults to child_process.execFile.
+   * Tests: pass a fake to capture calls without spawning osascript.
+   */
+  readonly execFileFn?: ExecFileNotifyFn;
+  /**
+   * Injectable fetch function for the webhook channel.
+   * Production: defaults to globalThis.fetch.
+   * Tests: pass a fake to capture calls without real HTTP.
+   */
+  readonly fetchFn?: FetchNotifyFn;
+  /**
+   * Injectable platform detection function.
+   * Production: defaults to os.platform().
+   * Tests: pass a fake to simulate different platforms without spying on ESM
+   * exports (vi.spyOn on ESM node:os exports is not supported in Vitest).
+   */
+  readonly platformFn?: () => NodeJS.Platform;
+}
+
+// ---------------------------------------------------------------------------
+// Notification payload (webhook POST body)
+// ---------------------------------------------------------------------------
+
+export interface NotificationPayload {
+  readonly event: 'session_completed';
+  readonly workflowId: string;
+  readonly outcome: 'success' | 'error' | 'timeout' | 'delivery_failed';
+  readonly detail: string;
+  readonly goal: string;
+  readonly timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// Message building (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the macOS notification body string for a given WorkflowRunResult.
+ *
+ * WHY pure function: deterministic, testable in isolation from the side-effecting
+ * channel delivery. Same inputs always produce the same notification text.
+ */
+export function buildNotificationBody(result: WorkflowRunResult, goal: string): string {
+  const truncated = goal.length > 60 ? `${goal.slice(0, 57)}...` : goal;
+  switch (result._tag) {
+    case 'success':
+      return `Session completed: ${truncated}`;
+    case 'error':
+      return `Session failed: ${truncated}`;
+    case 'timeout':
+      return `Session timed out: ${truncated}`;
+    case 'delivery_failed':
+      return `Session completed but result delivery failed: ${truncated}`;
+  }
+}
+
+/**
+ * Build the outcome string for the webhook NotificationPayload.
+ */
+export function buildOutcome(result: WorkflowRunResult): NotificationPayload['outcome'] {
+  return result._tag;
+}
+
+/**
+ * Build a human-readable detail string for the NotificationPayload.
+ */
+export function buildDetail(result: WorkflowRunResult): string {
+  switch (result._tag) {
+    case 'success':
+      return `stopReason: ${result.stopReason}`;
+    case 'error':
+      return result.message;
+    case 'timeout':
+      return result.message;
+    case 'delivery_failed':
+      return `stopReason: ${result.stopReason}; deliveryError: ${result.deliveryError}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// NotificationService
+// ---------------------------------------------------------------------------
+
+/**
+ * Fires user-facing notifications after a daemon session completes.
+ *
+ * Constructed once at daemon startup from ~/.workrail/config.json values and
+ * injected optionally into TriggerRouter. When neither macOs nor webhookUrl is
+ * configured, no instance is created -- zero overhead.
+ *
+ * WHY optional injection (not singleton): consistent with DaemonEventEmitter
+ * and execFn patterns in TriggerRouter. Callers that do not inject an instance
+ * pay zero cost.
+ */
+export class NotificationService {
+  private readonly _macOsEnabled: boolean;
+  private readonly _webhookUrl: string | undefined;
+  private readonly _execFileFn: ExecFileNotifyFn;
+  private readonly _fetchFn: FetchNotifyFn;
+
+  constructor(config: NotificationConfig) {
+    const getPlatform = config.platformFn ?? os.platform.bind(os);
+    // Platform guard: macOS channel requires darwin.
+    if (config.macOs && getPlatform() !== 'darwin') {
+      console.warn(
+        '[NotificationService] WORKTRAIN_NOTIFY_MACOS=true but platform is not darwin ' +
+        `(platform: ${os.platform()}). macOS notifications are disabled.`,
+      );
+      this._macOsEnabled = false;
+    } else {
+      this._macOsEnabled = config.macOs;
+    }
+
+    // URL validation: webhook channel requires a valid http(s) URL.
+    if (config.webhookUrl !== undefined && config.webhookUrl !== '') {
+      let valid = false;
+      try {
+        const parsed = new URL(config.webhookUrl);
+        valid = parsed.protocol === 'http:' || parsed.protocol === 'https:';
+      } catch {
+        valid = false;
+      }
+      if (!valid) {
+        console.warn(
+          `[NotificationService] WORKTRAIN_NOTIFY_WEBHOOK is not a valid http(s) URL ` +
+          `("${config.webhookUrl}"). Webhook notifications are disabled.`,
+        );
+        this._webhookUrl = undefined;
+      } else {
+        this._webhookUrl = config.webhookUrl;
+      }
+    } else {
+      this._webhookUrl = undefined;
+    }
+
+    // Default production implementations.
+    this._execFileFn = config.execFileFn ?? ((file, args, options, callback) => {
+      childProcess.execFile(file, args as string[], options, callback);
+    });
+    this._fetchFn = config.fetchFn ?? ((url, init) => globalThis.fetch(url, init));
+  }
+
+  /**
+   * Fire user-facing notifications for a completed session.
+   *
+   * Returns void synchronously. All async work runs in a detached Promise that
+   * unconditionally swallows errors. A failed notification never affects the
+   * workflow result or propagates to the caller.
+   *
+   * WHY void (not Promise<void>): TypeScript cannot await a void return value.
+   * This makes the fire-and-forget contract type-enforced -- accidental await
+   * is a compile error.
+   *
+   * @param result - The WorkflowRunResult from the completed session.
+   * @param goal - The goal string passed to start_workflow (for the notification body).
+   */
+  notify(result: WorkflowRunResult, goal: string): void {
+    void this._doNotify(result, goal).catch(() => {
+      // Intentionally empty: errors are silently swallowed.
+      // Observability must never affect correctness.
+    });
+  }
+
+  /**
+   * Internal async notification implementation.
+   *
+   * WHY separated from notify(): keeps notify() synchronous and makes the
+   * async I/O path unit-testable in isolation.
+   */
+  private async _doNotify(result: WorkflowRunResult, goal: string): Promise<void> {
+    const body = buildNotificationBody(result, goal);
+
+    const deliveries: Promise<void>[] = [];
+
+    if (this._macOsEnabled) {
+      deliveries.push(this._notifyMacOs(body, result.workflowId));
+    }
+
+    if (this._webhookUrl !== undefined) {
+      deliveries.push(this._notifyWebhook(result, goal));
+    }
+
+    // Run both channels concurrently. Individual errors are caught per-channel.
+    await Promise.allSettled(deliveries);
+  }
+
+  /**
+   * Fire a macOS native notification via osascript.
+   *
+   * Uses execFile (not exec) so the notification text is passed as discrete args
+   * and is never interpolated into a shell string. Shell metacharacters have no effect.
+   *
+   * The 5000ms timeout guards against osascript stalls (documented on some macOS
+   * versions under heavy load). A stall kills the process (SIGKILL via execFile
+   * timeout) and the error is caught and logged.
+   */
+  private _notifyMacOs(body: string, workflowId: string): Promise<void> {
+    const script = `display notification ${JSON.stringify(body)} with title "WorkTrain" subtitle ${JSON.stringify(workflowId)}`;
+    return new Promise<void>((resolve) => {
+      this._execFileFn(
+        'osascript',
+        ['-e', script],
+        { timeout: 5000 },
+        (error) => {
+          if (error) {
+            console.warn(
+              `[NotificationService] macOS notification failed: ${error.message}`,
+            );
+          }
+          resolve();
+        },
+      );
+    });
+  }
+
+  /**
+   * POST a notification payload to the configured webhook URL.
+   *
+   * Uses AbortController with a 30-second timeout (same as delivery-client.ts).
+   * Non-2xx responses and network errors are caught, logged, and discarded.
+   */
+  private async _notifyWebhook(result: WorkflowRunResult, goal: string): Promise<void> {
+    const url = this._webhookUrl!;
+    const payload: NotificationPayload = {
+      event: 'session_completed',
+      workflowId: result.workflowId,
+      outcome: buildOutcome(result),
+      detail: buildDetail(result),
+      goal,
+      timestamp: new Date().toISOString(),
+    };
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30_000);
+
+    try {
+      const res = await this._fetchFn(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        console.warn(
+          `[NotificationService] Webhook notification failed: HTTP ${res.status} from ${url}`,
+        );
+      }
+    } catch (e: unknown) {
+      console.warn(
+        `[NotificationService] Webhook notification error: ${String(e)}`,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/trigger/notification-service.ts
+++ b/src/trigger/notification-service.ts
@@ -185,7 +185,7 @@ export class NotificationService {
     if (config.macOs && getPlatform() !== 'darwin') {
       console.warn(
         '[NotificationService] WORKTRAIN_NOTIFY_MACOS=true but platform is not darwin ' +
-        `(platform: ${os.platform()}). macOS notifications are disabled.`,
+        `(platform: ${getPlatform()}). macOS notifications are disabled.`,
       );
       this._macOsEnabled = false;
     } else {

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -27,6 +27,7 @@ import { loadTriggerConfigFromFile, buildTriggerIndex } from './trigger-store.js
 import type { TriggerStoreError } from './trigger-store.js';
 import { TriggerRouter, type RunWorkflowFn } from './trigger-router.js';
 import { loadWorkrailConfigFile, loadWorkspacesFromConfigFile } from '../config/config-file.js';
+import { NotificationService } from './notification-service.js';
 import { runWorkflow, runStartupRecovery } from '../daemon/workflow-runner.js';
 import type { WebhookEvent, WorkspaceConfig } from './types.js';
 import { asTriggerId } from './types.js';
@@ -332,9 +333,19 @@ export async function startTriggerListener(
   const parsed = parseInt(maxConcurrencyRaw ?? '', 10);
   const maxConcurrentSessions = !isNaN(parsed) ? parsed : undefined;
 
+  // Construct NotificationService if either notification channel is configured.
+  // WHY constructed here (not in TriggerRouter): trigger-listener.ts owns config loading.
+  // TriggerRouter receives the service as an optional injection -- it does not know about
+  // config.json keys. This keeps TriggerRouter free of config knowledge.
+  const notifyMacOs = (workrailConfig.kind === 'ok' && workrailConfig.value['WORKTRAIN_NOTIFY_MACOS'] === 'true');
+  const notifyWebhook = workrailConfig.kind === 'ok' ? workrailConfig.value['WORKTRAIN_NOTIFY_WEBHOOK'] : undefined;
+  const notificationService = (notifyMacOs || (notifyWebhook !== undefined && notifyWebhook !== ''))
+    ? new NotificationService({ macOs: notifyMacOs, webhookUrl: notifyWebhook })
+    : undefined;
+
   // Create router and Express app
   const runWorkflowFn: RunWorkflowFn = options.runWorkflowFn ?? runWorkflow;
-  const router = new TriggerRouter(triggerIndex, ctx, apiKey, runWorkflowFn, undefined, maxConcurrentSessions, options.emitter);
+  const router = new TriggerRouter(triggerIndex, ctx, apiKey, runWorkflowFn, undefined, maxConcurrentSessions, options.emitter, notificationService);
   const app = createTriggerApp(router);
 
   // Create and start the polling scheduler.

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -37,6 +37,7 @@ import type {
 import { parseHandoffArtifact, runDelivery } from './delivery-action.js';
 import type { ExecFn } from './delivery-action.js';
 import type { DaemonEventEmitter } from '../daemon/daemon-events.js';
+import type { NotificationService } from './notification-service.js';
 
 /**
  * Default production exec function: promisify(execFile).
@@ -408,6 +409,7 @@ export class TriggerRouter {
   private readonly semaphore: Semaphore;
   private readonly _maxConcurrentSessions: number;
   private readonly emitter: DaemonEventEmitter | undefined;
+  private readonly notificationService: NotificationService | undefined;
 
   constructor(
     private readonly index: ReadonlyMap<string, TriggerDefinition>,
@@ -427,9 +429,21 @@ export class TriggerRouter {
      * When absent, no events are emitted (zero overhead).
      */
     emitter?: DaemonEventEmitter,
+    /**
+     * Optional notification service for user-facing notifications.
+     * When provided, fires macOS/webhook notifications after each session completes.
+     * When absent, no notifications are fired (zero overhead).
+     *
+     * WHY optional injection (not a direct config): follows the DaemonEventEmitter
+     * pattern -- the caller constructs the service and injects it. This keeps
+     * TriggerRouter free of notification config knowledge and makes both sides
+     * independently testable.
+     */
+    notificationService?: NotificationService,
   ) {
     this.execFn = execFn ?? execFileAsync;
     this.emitter = emitter;
+    this.notificationService = notificationService;
     // Validate and clamp: maxConcurrentSessions must be >= 1.
     // A value of 0 or negative would deadlock all dispatches -- make it impossible.
     const requested = maxConcurrentSessions ?? DEFAULT_MAX_CONCURRENT_SESSIONS;
@@ -608,6 +622,12 @@ export class TriggerRouter {
             `workflowId=${trigger.workflowId} error=${result.message} stopReason=${result.stopReason}`,
         );
       }
+      // User notifications: fire after logging, before delivery.
+      // Fire-and-forget -- notify() returns void and swallows all errors.
+      // Uses the final `result` (post-delivery_failed reassignment) so the
+      // notification reflects the actual outcome the user cares about.
+      this.notificationService?.notify(result, workflowTrigger.goal);
+
       // Post-workflow delivery: runs after the workflow result is logged.
       // Best-effort -- errors are logged and discarded, never change the workflow result.
       // Use originalResult (not result) so callbackUrl failure does not skip autoCommit.
@@ -675,6 +695,10 @@ export class TriggerRouter {
             `error=${result.message} stopReason=${result.stopReason}`,
         );
       }
+      // User notifications: fire after logging.
+      // Fire-and-forget -- notify() returns void and swallows all errors.
+      this.notificationService?.notify(result, workflowTrigger.goal);
+
       // NOTE: delivery is not run for console-dispatched workflows because WorkflowTrigger
       // does not carry autoCommit/autoOpenPR flags (those live on TriggerDefinition, keyed
       // by triggerId). The dispatch() path does not have a triggerId to look up the definition.

--- a/tests/unit/notification-service.test.ts
+++ b/tests/unit/notification-service.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Tests for src/trigger/notification-service.ts
+ *
+ * Covers:
+ * - buildNotificationBody: correct text for each WorkflowRunResult variant
+ * - buildOutcome / buildDetail: correct values for each variant
+ * - NotificationService construction: platform guard, URL validation
+ * - notify(): macOS channel called with correct osascript args
+ * - notify(): webhook channel called with correct URL and JSON body
+ * - notify(): both channels fire concurrently when both configured
+ * - notify(): does not throw when execFileFn throws
+ * - notify(): does not throw when fetchFn rejects
+ * - notify(): does not throw when fetchFn returns non-2xx
+ * - notify(): macOS channel skipped when platform is not darwin
+ * - notify(): webhook channel skipped when URL is invalid
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  NotificationService,
+  buildNotificationBody,
+  buildOutcome,
+  buildDetail,
+  type ExecFileNotifyFn,
+  type FetchNotifyFn,
+  type NotificationPayload,
+} from '../../src/trigger/notification-service.js';
+import type { WorkflowRunResult } from '../../src/daemon/workflow-runner.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSuccess(workflowId = 'test-workflow'): WorkflowRunResult {
+  return { _tag: 'success', workflowId, stopReason: 'stop' };
+}
+
+function makeError(workflowId = 'test-workflow'): WorkflowRunResult {
+  return { _tag: 'error', workflowId, message: 'Something broke', stopReason: 'error' };
+}
+
+function makeTimeout(workflowId = 'test-workflow'): WorkflowRunResult {
+  return { _tag: 'timeout', workflowId, reason: 'wall_clock', message: 'Timed out after 30 minutes' };
+}
+
+function makeDeliveryFailed(workflowId = 'test-workflow'): WorkflowRunResult {
+  return { _tag: 'delivery_failed', workflowId, stopReason: 'stop', deliveryError: 'HTTP 503' };
+}
+
+function makeFakeExecFile(): {
+  fn: ExecFileNotifyFn;
+  calls: Array<{ file: string; args: readonly string[]; options: { timeout: number } }>;
+} {
+  const calls: Array<{ file: string; args: readonly string[]; options: { timeout: number } }> = [];
+  const fn: ExecFileNotifyFn = (file, args, options, callback) => {
+    calls.push({ file, args, options });
+    // Simulate success synchronously
+    callback(null);
+  };
+  return { fn, calls };
+}
+
+function makeFakeExecFileError(error: Error): {
+  fn: ExecFileNotifyFn;
+} {
+  const fn: ExecFileNotifyFn = (_file, _args, _options, callback) => {
+    callback(error);
+  };
+  return { fn };
+}
+
+function makeFakeFetch(
+  response: { ok: boolean; status: number } = { ok: true, status: 200 },
+): {
+  fn: FetchNotifyFn;
+  calls: Array<{ url: string; body: NotificationPayload }>;
+} {
+  const calls: Array<{ url: string; body: NotificationPayload }> = [];
+  const fn: FetchNotifyFn = async (url, init) => {
+    calls.push({ url, body: JSON.parse(init.body) as NotificationPayload });
+    return response;
+  };
+  return { fn, calls };
+}
+
+function makeFakeFetchReject(error: Error): { fn: FetchNotifyFn } {
+  const fn: FetchNotifyFn = async () => {
+    throw error;
+  };
+  return { fn };
+}
+
+/**
+ * Wait for the detached Promise inside notify() to settle.
+ * notify() fires-and-forgets, so we flush the microtask queue.
+ */
+async function flushNotify(): Promise<void> {
+  // Two rounds: one for the _doNotify() Promise, one for the channel Promises.
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+// ---------------------------------------------------------------------------
+// Pure function tests
+// ---------------------------------------------------------------------------
+
+describe('buildNotificationBody', () => {
+  it('success: includes "completed" and truncated goal', () => {
+    const body = buildNotificationBody(makeSuccess(), 'Review PR #123');
+    expect(body).toContain('completed');
+    expect(body).toContain('Review PR #123');
+  });
+
+  it('error: includes "failed" and goal', () => {
+    const body = buildNotificationBody(makeError(), 'Fix the bug');
+    expect(body).toContain('failed');
+    expect(body).toContain('Fix the bug');
+  });
+
+  it('timeout: includes "timed out" and goal', () => {
+    const body = buildNotificationBody(makeTimeout(), 'Long task');
+    expect(body).toContain('timed out');
+    expect(body).toContain('Long task');
+  });
+
+  it('delivery_failed: includes "delivery failed" and goal', () => {
+    const body = buildNotificationBody(makeDeliveryFailed(), 'Short task');
+    expect(body).toContain('delivery failed');
+    expect(body).toContain('Short task');
+  });
+
+  it('truncates long goals at 60 chars', () => {
+    const longGoal = 'A'.repeat(80);
+    const body = buildNotificationBody(makeSuccess(), longGoal);
+    // After truncation the body should contain the first 57 chars + '...'
+    expect(body).toContain('A'.repeat(57) + '...');
+    expect(body).not.toContain('A'.repeat(58));
+  });
+});
+
+describe('buildOutcome', () => {
+  it('maps each _tag to the correct outcome string', () => {
+    expect(buildOutcome(makeSuccess())).toBe('success');
+    expect(buildOutcome(makeError())).toBe('error');
+    expect(buildOutcome(makeTimeout())).toBe('timeout');
+    expect(buildOutcome(makeDeliveryFailed())).toBe('delivery_failed');
+  });
+});
+
+describe('buildDetail', () => {
+  it('success: includes stopReason', () => {
+    expect(buildDetail(makeSuccess())).toContain('stop');
+  });
+
+  it('error: is the error message', () => {
+    expect(buildDetail(makeError())).toBe('Something broke');
+  });
+
+  it('timeout: is the timeout message', () => {
+    expect(buildDetail(makeTimeout())).toContain('30 minutes');
+  });
+
+  it('delivery_failed: includes both stopReason and deliveryError', () => {
+    const detail = buildDetail(makeDeliveryFailed());
+    expect(detail).toContain('stop');
+    expect(detail).toContain('HTTP 503');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NotificationService construction
+// ---------------------------------------------------------------------------
+
+describe('NotificationService construction', () => {
+  it('accepts valid config without warnings', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fn: execFileFn } = makeFakeExecFile();
+    const { fn: fetchFn } = makeFakeFetch();
+    new NotificationService({
+      macOs: true,
+      webhookUrl: 'https://hooks.example.com/notify',
+      execFileFn,
+      fetchFn,
+      platformFn: () => 'darwin',
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('warns and disables macOS channel when macOs=true but platform is not darwin', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fn: execFileFn, calls } = makeFakeExecFile();
+    const svc = new NotificationService({
+      macOs: true,
+      execFileFn,
+      platformFn: () => 'linux',
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('platform is not darwin'),
+    );
+    // Verify channel is disabled by calling notify and checking execFileFn is not called
+    svc.notify(makeSuccess(), 'test goal');
+    expect(calls).toHaveLength(0);
+    warnSpy.mockRestore();
+  });
+
+  it('warns and disables webhook channel when URL is invalid', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fn: fetchFn, calls } = makeFakeFetch();
+    const svc = new NotificationService({ macOs: false, webhookUrl: 'not-a-url', fetchFn });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('not a valid http(s) URL'),
+    );
+    // Verify channel is disabled
+    svc.notify(makeSuccess(), 'test goal');
+    expect(calls).toHaveLength(0);
+    warnSpy.mockRestore();
+  });
+
+  it('warns and disables webhook channel when URL is a non-http scheme', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fn: fetchFn } = makeFakeFetch();
+    new NotificationService({ macOs: false, webhookUrl: 'ftp://example.com/notify', fetchFn });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('not a valid http(s) URL'),
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// macOS channel
+// ---------------------------------------------------------------------------
+
+describe('NotificationService: macOS channel', () => {
+  it('calls osascript with correct args on success', async () => {
+    const { fn: execFileFn, calls } = makeFakeExecFile();
+    const svc = new NotificationService({
+      macOs: true,
+      execFileFn,
+      platformFn: () => 'darwin',
+    });
+    svc.notify(makeSuccess('my-workflow'), 'Review PR #1');
+    await flushNotify();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].file).toBe('osascript');
+    expect(calls[0].args[0]).toBe('-e');
+    expect(calls[0].args[1]).toContain('display notification');
+    expect(calls[0].args[1]).toContain('my-workflow');
+    expect(calls[0].options.timeout).toBe(5000);
+  });
+
+  it('calls osascript for error result', async () => {
+    const { fn: execFileFn, calls } = makeFakeExecFile();
+    const svc = new NotificationService({
+      macOs: true,
+      execFileFn,
+      platformFn: () => 'darwin',
+    });
+    svc.notify(makeError(), 'Fix bug');
+    await flushNotify();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[1]).toContain('failed');
+  });
+
+  it('does not throw when osascript fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fn: execFileFn } = makeFakeExecFileError(new Error('osascript not found'));
+    const svc = new NotificationService({
+      macOs: true,
+      execFileFn,
+      platformFn: () => 'darwin',
+    });
+    // Should not throw
+    expect(() => svc.notify(makeSuccess(), 'goal')).not.toThrow();
+    await flushNotify();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('macOS notification failed'),
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Webhook channel
+// ---------------------------------------------------------------------------
+
+describe('NotificationService: webhook channel', () => {
+  it('POSTs correct payload on success', async () => {
+    const { fn: fetchFn, calls } = makeFakeFetch();
+    const svc = new NotificationService({
+      macOs: false,
+      webhookUrl: 'https://hooks.example.com/notify',
+      fetchFn,
+    });
+    svc.notify(makeSuccess('wf-1'), 'Do the thing');
+    await flushNotify();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://hooks.example.com/notify');
+    const payload = calls[0].body;
+    expect(payload.event).toBe('session_completed');
+    expect(payload.workflowId).toBe('wf-1');
+    expect(payload.outcome).toBe('success');
+    expect(payload.goal).toBe('Do the thing');
+    expect(payload.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('POSTs delivery_failed with distinct outcome', async () => {
+    const { fn: fetchFn, calls } = makeFakeFetch();
+    const svc = new NotificationService({
+      macOs: false,
+      webhookUrl: 'https://hooks.example.com/notify',
+      fetchFn,
+    });
+    svc.notify(makeDeliveryFailed(), 'goal');
+    await flushNotify();
+    expect(calls[0].body.outcome).toBe('delivery_failed');
+    expect(calls[0].body.detail).toContain('HTTP 503');
+  });
+
+  it('does not throw when fetchFn rejects', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fn: fetchFn } = makeFakeFetchReject(new Error('network error'));
+    const svc = new NotificationService({
+      macOs: false,
+      webhookUrl: 'https://hooks.example.com/notify',
+      fetchFn,
+    });
+    expect(() => svc.notify(makeSuccess(), 'goal')).not.toThrow();
+    await flushNotify();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Webhook notification error'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('does not throw when fetchFn returns non-2xx', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fn: fetchFn } = makeFakeFetch({ ok: false, status: 503 });
+    const svc = new NotificationService({
+      macOs: false,
+      webhookUrl: 'https://hooks.example.com/notify',
+      fetchFn,
+    });
+    expect(() => svc.notify(makeSuccess(), 'goal')).not.toThrow();
+    await flushNotify();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('HTTP 503'),
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Both channels
+// ---------------------------------------------------------------------------
+
+describe('NotificationService: both channels', () => {
+  it('fires both macOS and webhook when both configured', async () => {
+    const { fn: execFileFn, calls: execCalls } = makeFakeExecFile();
+    const { fn: fetchFn, calls: fetchCalls } = makeFakeFetch();
+    const svc = new NotificationService({
+      macOs: true,
+      webhookUrl: 'https://hooks.example.com/notify',
+      execFileFn,
+      fetchFn,
+      platformFn: () => 'darwin',
+    });
+    svc.notify(makeSuccess(), 'goal');
+    await flushNotify();
+    expect(execCalls).toHaveLength(1);
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  it('fires no channels when both disabled', async () => {
+    const { fn: execFileFn, calls: execCalls } = makeFakeExecFile();
+    const { fn: fetchFn, calls: fetchCalls } = makeFakeFetch();
+    const svc = new NotificationService({ macOs: false, execFileFn, fetchFn });
+    svc.notify(makeSuccess(), 'goal');
+    await flushNotify();
+    expect(execCalls).toHaveLength(0);
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/tests/unit/trigger-router.test.ts
+++ b/tests/unit/trigger-router.test.ts
@@ -26,6 +26,7 @@ import type { ExecFn } from '../../src/trigger/delivery-action.js';
 import type { TriggerDefinition, WebhookEvent } from '../../src/trigger/types.js';
 import { asTriggerId } from '../../src/trigger/types.js';
 import type { V2ToolContext } from '../../src/mcp/types.js';
+import type { NotificationService } from '../../src/trigger/notification-service.js';
 import { tmpPath } from '../helpers/platform.js';
 
 // ---------------------------------------------------------------------------
@@ -1165,5 +1166,119 @@ describe('TriggerRouter maxConcurrentSessions semaphore', () => {
     expect(router.maxConcurrentSessions).toBe(1);
 
     warnSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TriggerRouter: notify() wiring
+//
+// Verifies that TriggerRouter calls notificationService.notify() after each
+// workflow session completes, and that it passes the FINAL result (post
+// callbackUrl delivery reassignment) to notify().
+// ---------------------------------------------------------------------------
+
+describe('TriggerRouter notify() wiring', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('route(): calls notify() with the workflow result when session completes successfully', async () => {
+    // WHY: proves the wiring in route() -- after runWorkflowFn returns a success result,
+    // notificationService.notify() must be called with that result and the goal string.
+    const fakeNotify = { notify: vi.fn() };
+    const trigger = makeTrigger();
+    const { fn } = makeFakeRunWorkflow();
+    const router = new TriggerRouter(
+      makeIndex(trigger),
+      FAKE_CTX,
+      FAKE_API_KEY,
+      fn,
+      undefined,  // execFn
+      undefined,  // maxConcurrentSessions
+      undefined,  // emitter
+      fakeNotify as unknown as NotificationService,
+    );
+
+    router.route(makeEvent());
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fakeNotify.notify).toHaveBeenCalledOnce();
+    const [result, goal] = fakeNotify.notify.mock.calls[0] as [{ _tag: string }, string];
+    expect(result._tag).toBe('success');
+    expect(goal).toBe(trigger.goal);
+  });
+
+  it('dispatch(): calls notify() with the workflow result when session fails', async () => {
+    // WHY: proves the wiring in dispatch() -- when runWorkflowFn returns an error result,
+    // notificationService.notify() must be called with that error result.
+    const fakeNotify = { notify: vi.fn() };
+    const trigger = makeTrigger();
+
+    // Custom runWorkflowFn that returns an error result
+    const errorFn: RunWorkflowFn = async (t) => ({
+      _tag: 'error' as const,
+      workflowId: t.workflowId,
+      message: 'simulated agent error',
+      stopReason: 'stop',
+    });
+
+    const router = new TriggerRouter(
+      makeIndex(trigger),
+      FAKE_CTX,
+      FAKE_API_KEY,
+      errorFn,
+      undefined,  // execFn
+      undefined,  // maxConcurrentSessions
+      undefined,  // emitter
+      fakeNotify as unknown as NotificationService,
+    );
+
+    const workflowTrigger = {
+      workflowId: trigger.workflowId,
+      goal: trigger.goal,
+      workspacePath: trigger.workspacePath,
+      context: {},
+    };
+    router.dispatch(workflowTrigger);
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fakeNotify.notify).toHaveBeenCalledOnce();
+    const [result] = fakeNotify.notify.mock.calls[0] as [{ _tag: string }, string];
+    expect(result._tag).toBe('error');
+  });
+
+  it('route(): notify() receives delivery_failed (not success) when callbackUrl POST fails', async () => {
+    // WHY: proves the ordering invariant -- route() reassigns result to delivery_failed
+    // BEFORE calling notify(). If this fails, notify() would receive 'success' and the
+    // user notification would not reflect the actual outcome.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => 'Service Unavailable',
+    }));
+
+    const fakeNotify = { notify: vi.fn() };
+    const trigger = makeTrigger({ callbackUrl: 'https://example.com/callback' });
+    const { fn } = makeFakeRunWorkflow();
+    const router = new TriggerRouter(
+      makeIndex(trigger),
+      FAKE_CTX,
+      FAKE_API_KEY,
+      fn,
+      undefined,  // execFn
+      undefined,  // maxConcurrentSessions
+      undefined,  // emitter
+      fakeNotify as unknown as NotificationService,
+    );
+
+    router.route(makeEvent());
+    await new Promise((r) => setTimeout(r, 50));
+
+    // notify() must have been called with the post-reassignment result
+    expect(fakeNotify.notify).toHaveBeenCalledOnce();
+    const [result] = fakeNotify.notify.mock.calls[0] as [{ _tag: string }, string];
+    // Critical: must be 'delivery_failed', not 'success' -- proves result was reassigned
+    // before notify() was called (trigger-router.ts lines 578-629).
+    expect(result._tag).toBe('delivery_failed');
   });
 });


### PR DESCRIPTION
## Summary

- Adds `NotificationService` class (`src/trigger/notification-service.ts`) that fires user-facing notifications when a daemon session completes (success, error, timeout, or delivery_failed)
- **macOS channel**: uses `osascript` via `execFile` (zero dependencies, no shell injection) with a 5s timeout guard
- **Webhook channel**: HTTP POST to any configured URL with a 30s AbortController timeout
- Configured globally via `WORKTRAIN_NOTIFY_MACOS=true` and `WORKTRAIN_NOTIFY_WEBHOOK=https://...` in `~/.workrail/config.json`

## Design

Follows the `DaemonEventEmitter` optional-injection pattern exactly:
- `notify(result, goal): void` -- fire-and-forget, swallows all errors, never affects `WorkflowRunResult`
- Injected into `TriggerRouter` constructor (8th optional param)
- Constructed in `trigger-listener.ts` from config.json values
- Fires only at `TriggerRouter` level (not inside `runWorkflow()`), so child sessions from `spawn_agent` do not fire user notifications

Key type-system guarantee: `notify()` returns `void` (not `Promise<void>`), making accidental `await` a TypeScript compile error.

All four `WorkflowRunResult._tag` variants are handled: `success`, `error`, `timeout`, `delivery_failed`. The `delivery_failed` message body is distinct ("session completed but result delivery failed").

## Test plan

- [ ] `tests/unit/notification-service.test.ts` -- 23 unit tests covering all 4 result variants, macOS channel, webhook channel, both channels, error swallowing, construction-time guards
- [ ] `tests/unit/trigger-router.test.ts` -- existing 44 tests passing (new param is optional, zero regressions)
- [ ] Full unit test suite: 288 test files, 3577/3580 passing (3 pre-existing skips)
- [ ] TypeScript: no errors
- [ ] Manual: set `WORKTRAIN_NOTIFY_MACOS=true` in `~/.workrail/config.json`, trigger a session, verify macOS notification appears

## Follow-up

- Linux `notify-send` support
- Per-trigger notification config
- Webhook retry logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)