### PR TITLE
feat(console): add worktrain status overview, rename health command

### DIFF
--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -33,6 +33,8 @@ import {
   executeWorktrainSpawnCommand,
   executeWorktrainAwaitCommand,
   executeWorktrainDaemonCommand,
+  executeWorktrainOverviewCommand,
+  buildConsoleServiceFromDataDir,
   type Priority,
 } from './cli/commands/index.js';
 
@@ -661,15 +663,15 @@ program
   });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// STATUS COMMAND
+// HEALTH COMMAND (renamed from `status <sessionId>`)
 // ═══════════════════════════════════════════════════════════════════════════
 
 program
-  .command('status <sessionId>')
+  .command('health <sessionId>')
   .description('Print a health summary for a daemon session. Accepts sessionId (UUID prefix) or workrailSessionId (sess_xxx).')
-  .action(async (sessionId: string) => {
-    // WHY warn on short IDs: the startsWith() filter below would aggregate events
-    // from ALL sessions sharing the same prefix, silently producing a wrong summary.
+  .action((sessionId: string) => {
+    // WHY warn on short IDs: the startsWith() filter in runHealthSummary aggregates
+    // events from ALL sessions sharing the same prefix, silently producing a wrong summary.
     // Full sess_ IDs are ~31 chars; 20 chars is a safe threshold that warns on
     // short prefixes without triggering on any valid full session ID.
     if (sessionId.length < 20) {
@@ -691,130 +693,206 @@ program
       return;
     }
 
-    // Aggregate stats across all event kinds for this session.
-    let workflowId: string | null = null;
-    let firstTs: number | null = null;
-    let lastTs: number | null = null;
-    let llmTurns = 0;
-    let stepAdvances = 0;
-    let totalToolCalls = 0;
-    let failedToolCalls = 0;
-    let fatalIssues = 0;
-    let errorIssues = 0;
-    let warnIssues = 0;
-    let sessionOutcome: string | null = null;
-    let lastToolName: string | null = null;
-    let lastToolArgs: string | null = null;
-    let stuckCount = 0;
-    let isLive = true;
+    runHealthSummary(sessionId, raw);
+  });
 
-    for (const line of raw.split('\n')) {
-      if (!line.trim()) continue;
-      let obj: Record<string, unknown>;
+// ═══════════════════════════════════════════════════════════════════════════
+// STATUS COMMAND (overview, no args)
+// ═══════════════════════════════════════════════════════════════════════════
+
+program
+  .command('status [sessionId]')
+  .description(
+    'Print an overview of active and recently completed sessions (no args), ' +
+    'or a session health summary when a sessionId is provided (deprecated: use `worktrain health <id>`).',
+  )
+  .option('--json', 'Output machine-readable JSON packet')
+  .option('-w, --workspace <path>', 'Filter sessions by workspace (reserved for future use)')
+  .action(async (sessionId: string | undefined, options: { json?: boolean; workspace?: string }) => {
+    // Backward-compat shim: if a sessionId argument is provided, route to the
+    // health command logic with a deprecation notice.
+    if (sessionId !== undefined) {
+      process.stderr.write(
+        `Deprecation notice: \`worktrain status <sessionId>\` has been renamed to \`worktrain health <sessionId>\`.\n` +
+        `Please update your scripts to use \`worktrain health ${sessionId}\`.\n\n`,
+      );
+
+      // WHY warn on short IDs: same rationale as the health command below.
+      if (sessionId.length < 20) {
+        process.stderr.write(
+          `Warning: session ID "${sessionId}" is shorter than 20 characters -- ` +
+          `provide more characters to avoid matching multiple sessions.\n`,
+        );
+      }
+
+      const eventsDir = path.join(os.homedir(), '.workrail', 'events', 'daemon');
+      const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+      const filePath = path.join(eventsDir, `${date}.jsonl`);
+
+      let raw: string;
       try {
-        obj = JSON.parse(line) as Record<string, unknown>;
+        raw = fs.readFileSync(filePath, 'utf8');
       } catch {
-        continue;
+        process.stdout.write(`No events today. Is the daemon running? (Expected: ${filePath})\n`);
+        return;
       }
 
-      // Match by process-local sessionId (UUID) or workrailSessionId (sess_xxx).
-      const sid = typeof obj['sessionId'] === 'string' ? obj['sessionId'] : '';
-      const wrid = typeof obj['workrailSessionId'] === 'string' ? obj['workrailSessionId'] : '';
-      const matches = sid.startsWith(sessionId) || sid === sessionId ||
-        wrid.startsWith(sessionId) || wrid === sessionId;
-      if (!matches) continue;
+      // Delegate to the same inline logic as the health command.
+      // WHY duplicate instead of extract: the health command body is intentionally
+      // inline in this composition root. Extracting for one shim would be premature.
+      // The shim is expected to be removed once all callers migrate to `health`.
+      process.stdout.write(`\nNote: This is the old \`worktrain status <id>\` output. Use \`worktrain health <id>\` instead.\n\n`);
 
-      const ts = typeof obj['ts'] === 'number' ? obj['ts'] : null;
-      if (ts !== null) {
-        if (firstTs === null || ts < firstTs) firstTs = ts;
-        if (lastTs === null || ts > lastTs) lastTs = ts;
-      }
-
-      const kind = typeof obj['kind'] === 'string' ? obj['kind'] : '';
-      switch (kind) {
-        case 'session_started':
-          workflowId = typeof obj['workflowId'] === 'string' ? obj['workflowId'] : null;
-          break;
-        case 'llm_turn_completed':
-          llmTurns++;
-          break;
-        case 'step_advanced':
-          stepAdvances++;
-          break;
-        case 'tool_call_started':
-          totalToolCalls++;
-          lastToolName = typeof obj['toolName'] === 'string' ? obj['toolName'] : null;
-          lastToolArgs = typeof obj['argsSummary'] === 'string' ? String(obj['argsSummary']).slice(0, 60) : null;
-          break;
-        case 'tool_call_failed':
-          failedToolCalls++;
-          break;
-        case 'issue_reported': {
-          const severity = obj['severity'];
-          if (severity === 'fatal') fatalIssues++;
-          else if (severity === 'error') errorIssues++;
-          else if (severity === 'warn') warnIssues++;
-          break;
-        }
-        case 'agent_stuck':
-          stuckCount++;
-          break;
-        case 'session_completed':
-          sessionOutcome = typeof obj['outcome'] === 'string' ? obj['outcome'] : null;
-          isLive = false;
-          break;
-      }
-    }
-
-    if (firstTs === null) {
-      process.stdout.write(`No events found for session: ${sessionId}\n`);
+      // Re-run the health summary logic (same code as the health command below).
+      runHealthSummary(sessionId, raw);
       return;
     }
 
-    // Format duration as human-readable string.
-    const durationMs = (lastTs ?? firstTs) - firstTs;
-    const durationSec = Math.floor(durationMs / 1000);
-    const durationMin = Math.floor(durationSec / 60);
-    const durationRemSec = durationSec % 60;
-    const durationStr = durationMin > 0
-      ? `${durationMin}m ${durationRemSec}s`
-      : `${durationSec}s`;
-
-    const avgTurnSec = llmTurns > 0 ? (durationMs / llmTurns / 1000).toFixed(1) : '?';
-    const failRate = totalToolCalls > 0 ? ((failedToolCalls / totalToolCalls) * 100).toFixed(1) : '0';
-    const sessionStatus = sessionOutcome !== null
-      ? sessionOutcome.toUpperCase()
-      : (isLive ? 'RUNNING' : 'UNKNOWN');
-
-    const issueStr = (fatalIssues + errorIssues + warnIssues) > 0
-      ? `${fatalIssues + errorIssues + warnIssues} (${fatalIssues} fatal, ${errorIssues} error, ${warnIssues} warn)`
-      : '0';
-
-    const lastActivityStr = lastTs !== null
-      ? `${lastToolName ?? 'unknown'} ${lastToolArgs ? `"${lastToolArgs}"` : ''} ${Math.round((Date.now() - lastTs) / 1000)}s ago`
-      : 'unknown';
-
-    process.stdout.write(`\nSession: ${sessionId}    [${sessionStatus}]\n`);
-    if (workflowId) process.stdout.write(`Workflow: ${workflowId}\n`);
-    process.stdout.write(`Duration: ${durationStr}\n`);
-    process.stdout.write(`LLM turns: ${llmTurns}${llmTurns > 0 ? ` (avg ${avgTurnSec}s each)` : ''}\n`);
-    process.stdout.write(`Step advances: ${stepAdvances}\n`);
-    process.stdout.write(`Tool calls: ${totalToolCalls} (${failedToolCalls} failed, ${failRate}% failure rate)\n`);
-    process.stdout.write(`Issues reported: ${issueStr}\n`);
-    process.stdout.write(`Last activity: ${lastActivityStr}\n`);
-
-    if (stuckCount > 0) {
-      process.stdout.write(`*** WARNING: ${stuckCount} stuck signal(s) detected\n`);
-    }
-    if (fatalIssues > 0) {
-      process.stdout.write(`*** WARNING: ${fatalIssues} FATAL issue(s) reported\n`);
-    }
-    if (llmTurns >= 10 && stepAdvances === 0) {
-      process.stdout.write(`*** WARNING: ${llmTurns} turns with 0 step advances (possible stuck)\n`);
-    }
-
-    process.stdout.write('\n');
+    // No sessionId: new overview mode.
+    await executeWorktrainOverviewCommand(
+      {
+        now: () => Date.now(),
+        buildConsoleService: buildConsoleServiceFromDataDir,
+        homedir: os.homedir,
+        joinPath: path.join,
+        print: (line: string) => process.stdout.write(line + '\n'),
+        getDataDirEnv: () => process.env['WORKRAIL_DATA_DIR'],
+      },
+      {
+        json: options.json,
+        workspace: options.workspace,
+      },
+    );
   });
+
+/**
+ * Print a health summary for a single session from its raw JSONL event log.
+ *
+ * WHY extracted as a function: shared between the `health` command and the
+ * backward-compat shim in `status [sessionId]`. Keeps the logic in one place.
+ */
+function runHealthSummary(sessionId: string, raw: string): void {
+  let workflowId: string | null = null;
+  let firstTs: number | null = null;
+  let lastTs: number | null = null;
+  let llmTurns = 0;
+  let stepAdvances = 0;
+  let totalToolCalls = 0;
+  let failedToolCalls = 0;
+  let fatalIssues = 0;
+  let errorIssues = 0;
+  let warnIssues = 0;
+  let sessionOutcome: string | null = null;
+  let lastToolName: string | null = null;
+  let lastToolArgs: string | null = null;
+  let stuckCount = 0;
+  let isLive = true;
+
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const sid = typeof obj['sessionId'] === 'string' ? obj['sessionId'] : '';
+    const wrid = typeof obj['workrailSessionId'] === 'string' ? obj['workrailSessionId'] : '';
+    const matches = sid.startsWith(sessionId) || sid === sessionId ||
+      wrid.startsWith(sessionId) || wrid === sessionId;
+    if (!matches) continue;
+
+    const ts = typeof obj['ts'] === 'number' ? obj['ts'] : null;
+    if (ts !== null) {
+      if (firstTs === null || ts < firstTs) firstTs = ts;
+      if (lastTs === null || ts > lastTs) lastTs = ts;
+    }
+
+    const kind = typeof obj['kind'] === 'string' ? obj['kind'] : '';
+    switch (kind) {
+      case 'session_started':
+        workflowId = typeof obj['workflowId'] === 'string' ? obj['workflowId'] : null;
+        break;
+      case 'llm_turn_completed':
+        llmTurns++;
+        break;
+      case 'step_advanced':
+        stepAdvances++;
+        break;
+      case 'tool_call_started':
+        totalToolCalls++;
+        lastToolName = typeof obj['toolName'] === 'string' ? obj['toolName'] : null;
+        lastToolArgs = typeof obj['argsSummary'] === 'string' ? String(obj['argsSummary']).slice(0, 60) : null;
+        break;
+      case 'tool_call_failed':
+        failedToolCalls++;
+        break;
+      case 'issue_reported': {
+        const severity = obj['severity'];
+        if (severity === 'fatal') fatalIssues++;
+        else if (severity === 'error') errorIssues++;
+        else if (severity === 'warn') warnIssues++;
+        break;
+      }
+      case 'agent_stuck':
+        stuckCount++;
+        break;
+      case 'session_completed':
+        sessionOutcome = typeof obj['outcome'] === 'string' ? obj['outcome'] : null;
+        isLive = false;
+        break;
+    }
+  }
+
+  if (firstTs === null) {
+    process.stdout.write(`No events found for session: ${sessionId}\n`);
+    return;
+  }
+
+  const durationMs = (lastTs ?? firstTs) - firstTs;
+  const durationSec = Math.floor(durationMs / 1000);
+  const durationMin = Math.floor(durationSec / 60);
+  const durationRemSec = durationSec % 60;
+  const durationStr = durationMin > 0
+    ? `${durationMin}m ${durationRemSec}s`
+    : `${durationSec}s`;
+
+  const avgTurnSec = llmTurns > 0 ? (durationMs / llmTurns / 1000).toFixed(1) : '?';
+  const failRate = totalToolCalls > 0 ? ((failedToolCalls / totalToolCalls) * 100).toFixed(1) : '0';
+  const sessionStatus = sessionOutcome !== null
+    ? sessionOutcome.toUpperCase()
+    : (isLive ? 'RUNNING' : 'UNKNOWN');
+
+  const issueStr = (fatalIssues + errorIssues + warnIssues) > 0
+    ? `${fatalIssues + errorIssues + warnIssues} (${fatalIssues} fatal, ${errorIssues} error, ${warnIssues} warn)`
+    : '0';
+
+  const lastActivityStr = lastTs !== null
+    ? `${lastToolName ?? 'unknown'} ${lastToolArgs ? `"${lastToolArgs}"` : ''} ${Math.round((Date.now() - lastTs) / 1000)}s ago`
+    : 'unknown';
+
+  process.stdout.write(`\nSession: ${sessionId}    [${sessionStatus}]\n`);
+  if (workflowId) process.stdout.write(`Workflow: ${workflowId}\n`);
+  process.stdout.write(`Duration: ${durationStr}\n`);
+  process.stdout.write(`LLM turns: ${llmTurns}${llmTurns > 0 ? ` (avg ${avgTurnSec}s each)` : ''}\n`);
+  process.stdout.write(`Step advances: ${stepAdvances}\n`);
+  process.stdout.write(`Tool calls: ${totalToolCalls} (${failedToolCalls} failed, ${failRate}% failure rate)\n`);
+  process.stdout.write(`Issues reported: ${issueStr}\n`);
+  process.stdout.write(`Last activity: ${lastActivityStr}\n`);
+
+  if (stuckCount > 0) {
+    process.stdout.write(`*** WARNING: ${stuckCount} stuck signal(s) detected\n`);
+  }
+  if (fatalIssues > 0) {
+    process.stdout.write(`*** WARNING: ${fatalIssues} FATAL issue(s) reported\n`);
+  }
+  if (llmTurns >= 10 && stepAdvances === 0) {
+    process.stdout.write(`*** WARNING: ${llmTurns} turns with 0 step advances (possible stuck)\n`);
+  }
+
+  process.stdout.write('\n');
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // ENTRY POINT

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -737,11 +737,11 @@ program
         return;
       }
 
-      // Delegate to the same inline logic as the health command.
-      // WHY duplicate instead of extract: the health command body is intentionally
-      // inline in this composition root. Extracting for one shim would be premature.
-      // The shim is expected to be removed once all callers migrate to `health`.
-      process.stdout.write(`\nNote: This is the old \`worktrain status <id>\` output. Use \`worktrain health <id>\` instead.\n\n`);
+      // WHY this shim block is inline: it is a temporary backward-compat bridge
+      // that routes legacy `worktrain status <id>` calls to runHealthSummary.
+      // It is kept inline because it is expected to be removed once all callers
+      // migrate to `worktrain health <id>` -- extracting it would be premature.
+      process.stderr.write(`\nNote: This is the old \`worktrain status <id>\` output. Use \`worktrain health <id>\` instead.\n\n`);
 
       // Re-run the health summary logic (same code as the health command below).
       runHealthSummary(sessionId, raw);

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -58,3 +58,11 @@ export {
   type WorktrainDaemonCommandDeps,
   type WorktrainDaemonCommandOpts,
 } from './worktrain-daemon.js';
+export {
+  executeWorktrainOverviewCommand,
+  buildConsoleServiceFromDataDir,
+  type WorktrainOverviewCommandDeps,
+  type WorktrainOverviewCommandOpts,
+  type StatusDataPacket,
+  type StatusSession,
+} from './worktrain-overview.js';

--- a/src/cli/commands/worktrain-overview.ts
+++ b/src/cli/commands/worktrain-overview.ts
@@ -37,6 +37,8 @@ export interface StatusSession {
   readonly sessionId: string;
   readonly title: string;
   readonly status: 'active' | 'recent';
+  /** The raw session status from the underlying session record (e.g. 'in_progress', 'blocked', 'dormant', 'complete'). */
+  readonly rawStatus: string;
   /** Workflow step label, or step ID as fallback, or null if unavailable. */
   readonly stepLabel: string | null;
   /** Filesystem mtime of the session directory (epoch ms). */
@@ -231,6 +233,7 @@ export async function executeWorktrainOverviewCommand(
         sessionId: String(s.sessionId),
         title: buildSessionTitle(s),
         status: 'active',
+        rawStatus: s.status,
         stepLabel: extractStepLabel(s),
         lastModifiedMs: lastMod,
         isComplete: false,
@@ -240,6 +243,7 @@ export async function executeWorktrainOverviewCommand(
         sessionId: String(s.sessionId),
         title: buildSessionTitle(s),
         status: 'recent',
+        rawStatus: s.status,
         stepLabel: extractStepLabel(s),
         lastModifiedMs: lastMod,
         isComplete: true,
@@ -290,7 +294,7 @@ export async function executeWorktrainOverviewCommand(
     deps.print(`ACTIVE (${activeSessions.length} session${activeSessions.length !== 1 ? 's' : ''})`);
     for (const s of activeSessions) {
       const runningStr = formatRunningTime(nowMs - s.lastModifiedMs);
-      deps.print(`  in_progress  ${s.title}`);
+      deps.print(`  ${s.rawStatus}  ${s.title}`);
       if (s.stepLabel) {
         deps.print(`               Step -- ${s.stepLabel}  --  ${runningStr}`);
       } else {

--- a/src/cli/commands/worktrain-overview.ts
+++ b/src/cli/commands/worktrain-overview.ts
@@ -1,0 +1,347 @@
+/**
+ * WorkTrain Overview Command  (`worktrain status`)
+ *
+ * Prints a plain-English overview of active and recently completed sessions.
+ * Reads session data directly from ~/.workrail/data/sessions/ -- no daemon required.
+ *
+ * Design:
+ * - Pure function: all I/O injected via WorktrainOverviewCommandDeps
+ * - ConsoleService reads the same session files the console UI uses
+ * - ACTIVE  = isComplete false  AND  lastModifiedMs within configurable threshold
+ * - RECENT  = isComplete true   AND  lastModifiedMs within last 24 hours
+ * - StatusDataPacket exported for reuse by the console landing view
+ *
+ * Follows the same pattern as worktrain-spawn.ts (pure executeXxx + injected deps).
+ */
+
+import { LocalDataDirV2 } from '../../v2/infra/local/data-dir/index.js';
+import { LocalDirectoryListingV2 } from '../../v2/infra/local/directory-listing/index.js';
+import { NodeFileSystemV2 } from '../../v2/infra/local/fs/index.js';
+import { NodeSha256V2 } from '../../v2/infra/local/sha256/index.js';
+import { NodeCryptoV2 } from '../../v2/infra/local/crypto/index.js';
+import { LocalSnapshotStoreV2 } from '../../v2/infra/local/snapshot-store/index.js';
+import { LocalPinnedWorkflowStoreV2 } from '../../v2/infra/local/pinned-workflow-store/index.js';
+import { LocalSessionEventLogStoreV2 } from '../../v2/infra/local/session-store/index.js';
+import { ConsoleService } from '../../v2/usecases/console-service.js';
+import type { ConsoleSessionSummary } from '../../v2/usecases/console-types.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * One session in the overview packet. Designed for reuse by the console
+ * landing view -- do not change field names without updating the console.
+ */
+export interface StatusSession {
+  readonly sessionId: string;
+  readonly title: string;
+  readonly status: 'active' | 'recent';
+  /** Workflow step label, or step ID as fallback, or null if unavailable. */
+  readonly stepLabel: string | null;
+  /** Filesystem mtime of the session directory (epoch ms). */
+  readonly lastModifiedMs: number;
+  /** Whether the workflow run is complete. */
+  readonly isComplete: boolean;
+}
+
+/**
+ * Machine-readable output packet for `worktrain status --json`.
+ * Exported for reuse by the console landing view.
+ */
+export interface StatusDataPacket {
+  /** Epoch ms when this snapshot was taken. */
+  readonly asOfMs: number;
+  readonly activeSessions: readonly StatusSession[];
+  readonly recentSessions: readonly StatusSession[];
+  /** True when the data reflects last-known state (daemon not required). */
+  readonly isDaemonless: true;
+}
+
+// ---------------------------------------------------------------------------
+// Deps interface
+// ---------------------------------------------------------------------------
+
+export interface WorktrainOverviewCommandDeps {
+  /**
+   * Return the current epoch time in milliseconds.
+   * Injected so tests can control "now".
+   */
+  readonly now: () => number;
+  /**
+   * Build and return a ConsoleService instance for the given data directory.
+   * Injected so tests can substitute a fake service without hitting the filesystem.
+   */
+  readonly buildConsoleService: (dataDir: string) => ConsoleService;
+  /** Return the home directory (used to resolve the default data directory). */
+  readonly homedir: () => string;
+  /** Join path segments. */
+  readonly joinPath: (...parts: string[]) => string;
+  /** Write a line to stdout. */
+  readonly print: (line: string) => void;
+  /**
+   * Read the WORKRAIL_DATA_DIR env var. Returns undefined when not set.
+   * Injected for testability.
+   */
+  readonly getDataDirEnv: () => string | undefined;
+}
+
+export interface WorktrainOverviewCommandOpts {
+  /** Output raw JSON packet instead of human-readable text. */
+  readonly json?: boolean;
+  /** Filter sessions by workspace path prefix (reserved, not yet enforced in data). */
+  readonly workspace?: string;
+  /**
+   * Milliseconds of inactivity before an in-progress session is no longer
+   * considered "active". Default: 2 hours.
+   */
+  readonly activeThresholdMs?: number;
+  /**
+   * Milliseconds to look back for "recently completed" sessions.
+   * Default: 24 hours.
+   */
+  readonly recentWindowMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Default active threshold: 2 hours. */
+const DEFAULT_ACTIVE_THRESHOLD_MS = 2 * 60 * 60 * 1000;
+
+/** Default recent window: 24 hours. */
+const DEFAULT_RECENT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Format an epoch ms delta as a human-readable "Xm ago" or "Xh ago" string.
+ */
+function formatRelativeTime(deltaMs: number): string {
+  const totalMinutes = Math.floor(deltaMs / 60_000);
+  if (totalMinutes < 60) return `${totalMinutes}m ago`;
+  const hours = Math.floor(totalMinutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/**
+ * Format an epoch ms delta as "running Xm" or "running Xh" for active sessions.
+ */
+function formatRunningTime(deltaMs: number): string {
+  const totalMinutes = Math.floor(deltaMs / 60_000);
+  if (totalMinutes < 60) return `running ${totalMinutes}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  return `running ${hours}h`;
+}
+
+/**
+ * Build a display title for a session: sessionTitle if available, workflowId as
+ * fallback, or a truncated sessionId as last resort.
+ */
+function buildSessionTitle(s: ConsoleSessionSummary): string {
+  if (s.sessionTitle && s.sessionTitle.trim().length > 0) {
+    return s.sessionTitle.trim();
+  }
+  if (s.workflowName && s.workflowName.trim().length > 0) {
+    return s.workflowName.trim();
+  }
+  if (s.workflowId && s.workflowId.trim().length > 0) {
+    return s.workflowId.trim();
+  }
+  // Last resort: truncated session ID
+  return String(s.sessionId).slice(0, 20) + '...';
+}
+
+/**
+ * Get the human-readable step label from the session summary.
+ * ConsoleSessionSummary does not carry a pendingStepId -- the preferred tip's
+ * stepLabel is surfaced through the DAG node, which requires a full session detail
+ * load. For the overview we have enough: the run status already encodes whether
+ * the session is in_progress / complete, and the session title describes the task.
+ *
+ * We return null here; callers that want the step label should load session detail.
+ * The StatusSession type keeps `stepLabel` for forward-compatibility once the
+ * console integrates this command.
+ */
+function extractStepLabel(_s: ConsoleSessionSummary): string | null {
+  return null;
+}
+
+/**
+ * True when a ConsoleSessionSummary represents a completed run.
+ * Maps the ConsoleSessionStatus discriminated union explicitly.
+ */
+function isCompleted(s: ConsoleSessionSummary): boolean {
+  return s.status === 'complete' || s.status === 'complete_with_gaps';
+}
+
+/**
+ * True when a ConsoleSessionSummary represents an in-progress (or blocked/dormant) run.
+ * We treat blocked/dormant as "still active" for the overview -- the user should know.
+ */
+function isInProgress(s: ConsoleSessionSummary): boolean {
+  return s.status === 'in_progress' || s.status === 'blocked' || s.status === 'dormant';
+}
+
+// ---------------------------------------------------------------------------
+// Command execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute the `worktrain status` overview command.
+ *
+ * Reads sessions directly from the filesystem via ConsoleService. Never connects
+ * to the daemon or any HTTP server. Returns a CliResult for process lifecycle
+ * management, but all user-visible output is written via deps.print().
+ *
+ * Errors from ConsoleService (e.g. sessions dir not found) are surfaced as
+ * informational messages rather than hard failures -- an empty sessions directory
+ * is a valid state for a fresh WorkTrain installation.
+ */
+export async function executeWorktrainOverviewCommand(
+  deps: WorktrainOverviewCommandDeps,
+  opts: WorktrainOverviewCommandOpts = {},
+): Promise<void> {
+  const nowMs = deps.now();
+  const activeThresholdMs = opts.activeThresholdMs ?? DEFAULT_ACTIVE_THRESHOLD_MS;
+  const recentWindowMs = opts.recentWindowMs ?? DEFAULT_RECENT_WINDOW_MS;
+
+  // Resolve data directory: WORKRAIL_DATA_DIR env var takes priority over default.
+  const dataDir = deps.getDataDirEnv()
+    ?? deps.joinPath(deps.homedir(), '.workrail', 'data');
+
+  const consoleService = deps.buildConsoleService(dataDir);
+
+  // Load session list. Gracefully degrade on error: show "no sessions" instead of
+  // crashing. The overview is a convenience command; partial data is better than nothing.
+  const sessionListResult = await consoleService.getSessionList();
+  const sessions = sessionListResult.isOk() ? sessionListResult.value.sessions : [];
+
+  // Classify sessions.
+  const activeSessions: StatusSession[] = [];
+  const recentSessions: StatusSession[] = [];
+
+  for (const s of sessions) {
+    const lastMod = s.lastModifiedMs;
+    const age = nowMs - lastMod;
+
+    if (isInProgress(s) && age <= activeThresholdMs) {
+      activeSessions.push({
+        sessionId: String(s.sessionId),
+        title: buildSessionTitle(s),
+        status: 'active',
+        stepLabel: extractStepLabel(s),
+        lastModifiedMs: lastMod,
+        isComplete: false,
+      });
+    } else if (isCompleted(s) && age <= recentWindowMs) {
+      recentSessions.push({
+        sessionId: String(s.sessionId),
+        title: buildSessionTitle(s),
+        status: 'recent',
+        stepLabel: extractStepLabel(s),
+        lastModifiedMs: lastMod,
+        isComplete: true,
+      });
+    }
+  }
+
+  // Sort: most-recent first within each bucket.
+  activeSessions.sort((a, b) => b.lastModifiedMs - a.lastModifiedMs);
+  recentSessions.sort((a, b) => b.lastModifiedMs - a.lastModifiedMs);
+
+  const packet: StatusDataPacket = {
+    asOfMs: nowMs,
+    activeSessions,
+    recentSessions,
+    isDaemonless: true,
+  };
+
+  if (opts.json) {
+    deps.print(JSON.stringify(packet, null, 2));
+    return;
+  }
+
+  // Human-readable output.
+  const date = new Date(nowMs);
+  const dateStr = date.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  const timeStr = date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+
+  deps.print(`WorkTrain  [${dateStr}  ${timeStr}]`);
+  deps.print('Note: live session detection requires daemon (showing last-known state).');
+  deps.print('');
+
+  if (activeSessions.length === 0 && recentSessions.length === 0) {
+    deps.print('No recent sessions. Run `worktrain daemon` to start.');
+    return;
+  }
+
+  if (activeSessions.length > 0) {
+    deps.print(`ACTIVE (${activeSessions.length} session${activeSessions.length !== 1 ? 's' : ''})`);
+    for (const s of activeSessions) {
+      const runningStr = formatRunningTime(nowMs - s.lastModifiedMs);
+      deps.print(`  in_progress  ${s.title}`);
+      if (s.stepLabel) {
+        deps.print(`               Step -- ${s.stepLabel}  --  ${runningStr}`);
+      } else {
+        deps.print(`               ${runningStr}`);
+      }
+      deps.print('');
+    }
+  }
+
+  if (recentSessions.length > 0) {
+    deps.print(`RECENT (last 24h, ${recentSessions.length} completed)`);
+    for (const s of recentSessions) {
+      const agoStr = formatRelativeTime(nowMs - s.lastModifiedMs);
+      deps.print(`  done  ${s.title}    ${agoStr}`);
+    }
+    deps.print('');
+  }
+
+  deps.print('Run `worktrain console` for full session details.');
+}
+
+// ---------------------------------------------------------------------------
+// Factory: build real ConsoleService from data directory path
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct a ConsoleService that reads from the given data directory.
+ * This is the real implementation used in the CLI composition root.
+ * Tests inject their own fake via the deps interface.
+ */
+export function buildConsoleServiceFromDataDir(dataDir: string): ConsoleService {
+  const envWithDataDir: Record<string, string | undefined> = {
+    ...process.env as Record<string, string | undefined>,
+    WORKRAIL_DATA_DIR: dataDir,
+  };
+
+  const dataDirPort = new LocalDataDirV2(envWithDataDir);
+  const fsPort = new NodeFileSystemV2();
+  const sha256 = new NodeSha256V2();
+  const crypto = new NodeCryptoV2();
+  const directoryListing = new LocalDirectoryListingV2(fsPort);
+  const sessionStore = new LocalSessionEventLogStoreV2(dataDirPort, fsPort, sha256);
+  const snapshotStore = new LocalSnapshotStoreV2(dataDirPort, fsPort, crypto);
+  const pinnedWorkflowStore = new LocalPinnedWorkflowStoreV2(dataDirPort, fsPort);
+
+  return new ConsoleService({
+    directoryListing,
+    dataDir: dataDirPort,
+    sessionStore,
+    snapshotStore,
+    pinnedWorkflowStore,
+    // daemonRegistry omitted: overview command never tracks live daemon heartbeats.
+  });
+}

--- a/tests/unit/cli-worktrain-overview.test.ts
+++ b/tests/unit/cli-worktrain-overview.test.ts
@@ -209,6 +209,7 @@ describe('executeWorktrainOverviewCommand -- active sessions', () => {
 
     expect(lines.some((l) => l.includes('Blocked on approval'))).toBe(true);
     expect(lines.some((l) => l.includes('ACTIVE'))).toBe(true);
+    expect(lines.some((l) => l.includes('blocked'))).toBe(true);
   });
 
   it('shows dormant session within threshold as active', async () => {
@@ -224,6 +225,7 @@ describe('executeWorktrainOverviewCommand -- active sessions', () => {
     await executeWorktrainOverviewCommand(deps);
 
     expect(lines.some((l) => l.includes('Dormant task'))).toBe(true);
+    expect(lines.some((l) => l.includes('dormant'))).toBe(true);
   });
 
   it('shows count in ACTIVE header', async () => {

--- a/tests/unit/cli-worktrain-overview.test.ts
+++ b/tests/unit/cli-worktrain-overview.test.ts
@@ -1,0 +1,557 @@
+/**
+ * Unit tests for executeWorktrainOverviewCommand
+ *
+ * Tests cover:
+ * - Active sessions (in-progress within 2h threshold)
+ * - Recent sessions (completed within 24h)
+ * - Empty state (no sessions)
+ * - JSON output flag
+ * - Session title fallback logic
+ * - Threshold boundary conditions
+ *
+ * Uses fake deps (in-memory ConsoleService fake). No vi.mock() -- follows the
+ * repo pattern of "prefer fakes over mocks".
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
+
+import {
+  executeWorktrainOverviewCommand,
+  type WorktrainOverviewCommandDeps,
+  type WorktrainOverviewCommandOpts,
+  type StatusDataPacket,
+} from '../../src/cli/commands/worktrain-overview.js';
+import type { ConsoleService } from '../../src/v2/usecases/console-service.js';
+import type { ConsoleSessionSummary, ConsoleSessionListResponse } from '../../src/v2/usecases/console-types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal ConsoleSessionSummary stub for testing.
+ *
+ * Fields that are explicitly provided in `overrides` (including null) win over
+ * the defaults. Only truly absent keys fall back to their defaults.
+ * This lets tests set workflowId or workflowName to null explicitly.
+ */
+function makeSession(
+  overrides: Partial<ConsoleSessionSummary> & { sessionId: string },
+): ConsoleSessionSummary {
+  const defaults: ConsoleSessionSummary = {
+    sessionId: overrides.sessionId,
+    sessionTitle: null,
+    workflowId: 'coding-task-workflow-agentic',
+    workflowName: null,
+    workflowHash: null,
+    runId: 'run-1',
+    status: 'in_progress',
+    health: 'healthy',
+    nodeCount: 3,
+    edgeCount: 2,
+    tipCount: 1,
+    hasUnresolvedGaps: false,
+    recapSnippet: null,
+    gitBranch: null,
+    repoRoot: null,
+    lastModifiedMs: Date.now(),
+    isAutonomous: true,
+    isLive: false,
+  };
+  // Spread overrides on top of defaults so explicit null values win.
+  return { ...defaults, ...overrides };
+}
+
+/** Build a fake ConsoleService that returns a fixed session list. */
+function makeFakeConsoleService(sessions: ConsoleSessionSummary[]): ConsoleService {
+  return {
+    getSessionList: async () => ({
+      isOk: () => true,
+      value: { sessions, totalCount: sessions.length } as ConsoleSessionListResponse,
+      match: (onOk: (v: ConsoleSessionListResponse) => void) => onOk({ sessions, totalCount: sessions.length }),
+    }),
+    getSessionsDir: () => '/fake/sessions',
+    getSessionDetail: async () => { throw new Error('not used in overview tests'); },
+    getNodeDetail: async () => { throw new Error('not used in overview tests'); },
+  } as unknown as ConsoleService;
+}
+
+/** Build a fake ConsoleService that returns an error. */
+function makeErrorConsoleService(): ConsoleService {
+  return {
+    getSessionList: async () => ({
+      isOk: () => false,
+      isErr: () => true,
+      error: { code: 'ENUMERATION_FAILED', message: 'sessions dir not found' },
+      match: (_onOk: unknown, onErr: (e: { code: string; message: string }) => void) =>
+        onErr({ code: 'ENUMERATION_FAILED', message: 'sessions dir not found' }),
+    }),
+    getSessionsDir: () => '/fake/sessions',
+    getSessionDetail: async () => { throw new Error('not used'); },
+    getNodeDetail: async () => { throw new Error('not used'); },
+  } as unknown as ConsoleService;
+}
+
+/** Fixed "now" timestamp for deterministic tests: 2026-04-18T14:32:00.000Z */
+const NOW_MS = new Date('2026-04-18T14:32:00.000Z').getTime();
+
+/** 1 hour in milliseconds. */
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+/** Build a standard deps object backed by the given ConsoleService. */
+function makeDeps(
+  consoleService: ConsoleService,
+  overrides: Partial<WorktrainOverviewCommandDeps> = {},
+): { deps: WorktrainOverviewCommandDeps; lines: string[] } {
+  const lines: string[] = [];
+  const deps: WorktrainOverviewCommandDeps = {
+    now: () => NOW_MS,
+    buildConsoleService: () => consoleService,
+    homedir: () => '/home/testuser',
+    joinPath: path.join,
+    print: (line: string) => lines.push(line),
+    getDataDirEnv: () => undefined,
+    ...overrides,
+  };
+  return { deps, lines };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: empty state
+// ---------------------------------------------------------------------------
+
+describe('executeWorktrainOverviewCommand -- empty state', () => {
+  it('prints "No recent sessions" when no sessions exist', async () => {
+    const { deps, lines } = makeDeps(makeFakeConsoleService([]));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('No recent sessions'))).toBe(true);
+  });
+
+  it('prints "worktrain daemon" hint in empty state', async () => {
+    const { deps, lines } = makeDeps(makeFakeConsoleService([]));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('worktrain daemon'))).toBe(true);
+  });
+
+  it('gracefully handles ConsoleService enumeration error (shows empty)', async () => {
+    const { deps, lines } = makeDeps(makeErrorConsoleService());
+    // Should not throw -- should degrade gracefully.
+    await expect(executeWorktrainOverviewCommand(deps)).resolves.toBeUndefined();
+    expect(lines.some((l) => l.includes('No recent sessions'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: active sessions
+// ---------------------------------------------------------------------------
+
+describe('executeWorktrainOverviewCommand -- active sessions', () => {
+  it('shows in_progress session modified 30m ago as ACTIVE', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_active1',
+        sessionTitle: 'Implementing GitHub polling adapter',
+        status: 'in_progress',
+        lastModifiedMs: NOW_MS - 30 * 60_000, // 30 minutes ago
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('ACTIVE'))).toBe(true);
+    expect(lines.some((l) => l.includes('Implementing GitHub polling adapter'))).toBe(true);
+    expect(lines.some((l) => l.includes('in_progress'))).toBe(true);
+  });
+
+  it('shows running time for active session', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_active2',
+        sessionTitle: 'Some task',
+        status: 'in_progress',
+        lastModifiedMs: NOW_MS - 22 * 60_000, // 22 minutes ago
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('22m'))).toBe(true);
+  });
+
+  it('does NOT show active session modified more than 2h ago by default', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_old_active',
+        sessionTitle: 'Old in-progress task',
+        status: 'in_progress',
+        lastModifiedMs: NOW_MS - 3 * ONE_HOUR_MS, // 3 hours ago -- outside 2h threshold
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('Old in-progress task'))).toBe(false);
+  });
+
+  it('shows blocked session within threshold as active', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_blocked',
+        sessionTitle: 'Blocked on approval',
+        status: 'blocked',
+        lastModifiedMs: NOW_MS - 10 * 60_000,
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('Blocked on approval'))).toBe(true);
+    expect(lines.some((l) => l.includes('ACTIVE'))).toBe(true);
+  });
+
+  it('shows dormant session within threshold as active', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_dormant',
+        sessionTitle: 'Dormant task',
+        status: 'dormant',
+        lastModifiedMs: NOW_MS - 45 * 60_000,
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('Dormant task'))).toBe(true);
+  });
+
+  it('shows count in ACTIVE header', async () => {
+    const sessions = [
+      makeSession({ sessionId: 'sess_a1', status: 'in_progress', lastModifiedMs: NOW_MS - 10 * 60_000 }),
+      makeSession({ sessionId: 'sess_a2', status: 'in_progress', lastModifiedMs: NOW_MS - 20 * 60_000 }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('ACTIVE (2 sessions)'))).toBe(true);
+  });
+
+  it('uses singular "session" in ACTIVE header for count of 1', async () => {
+    const sessions = [
+      makeSession({ sessionId: 'sess_a1', status: 'in_progress', lastModifiedMs: NOW_MS - 10 * 60_000 }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('ACTIVE (1 session)'))).toBe(true);
+    expect(lines.some((l) => l.includes('ACTIVE (1 sessions)'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: recent sessions
+// ---------------------------------------------------------------------------
+
+describe('executeWorktrainOverviewCommand -- recent sessions', () => {
+  it('shows completed session from 3h ago in RECENT', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_done1',
+        sessionTitle: 'worktrain init onboarding command',
+        status: 'complete',
+        lastModifiedMs: NOW_MS - 3 * ONE_HOUR_MS,
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('RECENT'))).toBe(true);
+    expect(lines.some((l) => l.includes('worktrain init onboarding command'))).toBe(true);
+    expect(lines.some((l) => l.includes('done'))).toBe(true);
+    expect(lines.some((l) => l.includes('3h ago'))).toBe(true);
+  });
+
+  it('shows complete_with_gaps session in RECENT', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_gaps',
+        sessionTitle: 'Task with gaps',
+        status: 'complete_with_gaps',
+        lastModifiedMs: NOW_MS - 2 * ONE_HOUR_MS,
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('Task with gaps'))).toBe(true);
+    expect(lines.some((l) => l.includes('RECENT'))).toBe(true);
+  });
+
+  it('does NOT show completed session older than 24h', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_old',
+        sessionTitle: 'Very old task',
+        status: 'complete',
+        lastModifiedMs: NOW_MS - 25 * ONE_HOUR_MS, // 25 hours ago
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('Very old task'))).toBe(false);
+  });
+
+  it('shows RECENT count in header', async () => {
+    const sessions = [
+      makeSession({ sessionId: 'sess_d1', status: 'complete', lastModifiedMs: NOW_MS - ONE_HOUR_MS }),
+      makeSession({ sessionId: 'sess_d2', status: 'complete', lastModifiedMs: NOW_MS - 2 * ONE_HOUR_MS }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('RECENT') && l.includes('2 completed'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: title fallback chain
+// ---------------------------------------------------------------------------
+
+describe('executeWorktrainOverviewCommand -- title resolution', () => {
+  it('uses sessionTitle when available', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_t1',
+        sessionTitle: 'My explicit session title',
+        status: 'in_progress',
+        lastModifiedMs: NOW_MS - 5 * 60_000,
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('My explicit session title'))).toBe(true);
+  });
+
+  it('falls back to workflowName when sessionTitle is null', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_t2',
+        sessionTitle: null,
+        workflowName: 'Agentic Coding Task',
+        status: 'in_progress',
+        lastModifiedMs: NOW_MS - 5 * 60_000,
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('Agentic Coding Task'))).toBe(true);
+  });
+
+  it('falls back to workflowId when sessionTitle and workflowName are null', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_t3',
+        sessionTitle: null,
+        workflowName: null,
+        workflowId: 'coding-task-workflow-agentic',
+        status: 'in_progress',
+        lastModifiedMs: NOW_MS - 5 * 60_000,
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('coding-task-workflow-agentic'))).toBe(true);
+  });
+
+  it('falls back to truncated sessionId when all title fields are null', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_s5o2ieem4mwypoqnn6ztzyyag4',
+        sessionTitle: null,
+        workflowName: null,
+        workflowId: null,
+        status: 'in_progress',
+        lastModifiedMs: NOW_MS - 5 * 60_000,
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    // Should show a truncated form of the session ID (first 20 chars + '...')
+    // 'sess_s5o2ieem4mwypoqnn6ztzyyag4'.slice(0, 20) === 'sess_s5o2ieem4mwypoq'
+    expect(lines.some((l) => l.includes('sess_s5o2ieem4mwypoq...'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: --json output
+// ---------------------------------------------------------------------------
+
+describe('executeWorktrainOverviewCommand -- --json output', () => {
+  it('outputs a valid JSON StatusDataPacket', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_active_json',
+        sessionTitle: 'Active task for JSON test',
+        status: 'in_progress',
+        lastModifiedMs: NOW_MS - 30 * 60_000,
+      }),
+      makeSession({
+        sessionId: 'sess_done_json',
+        sessionTitle: 'Completed task for JSON test',
+        status: 'complete',
+        lastModifiedMs: NOW_MS - 5 * ONE_HOUR_MS,
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps, { json: true });
+
+    expect(lines.length).toBe(1);
+    const parsed = JSON.parse(lines[0]) as StatusDataPacket;
+    expect(parsed.isDaemonless).toBe(true);
+    expect(parsed.asOfMs).toBe(NOW_MS);
+    expect(parsed.activeSessions).toHaveLength(1);
+    expect(parsed.recentSessions).toHaveLength(1);
+    expect(parsed.activeSessions[0].title).toBe('Active task for JSON test');
+    expect(parsed.recentSessions[0].title).toBe('Completed task for JSON test');
+  });
+
+  it('JSON output contains session status field', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_j1',
+        status: 'in_progress',
+        lastModifiedMs: NOW_MS - 10 * 60_000,
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps, { json: true });
+
+    const parsed = JSON.parse(lines[0]) as StatusDataPacket;
+    expect(parsed.activeSessions[0].status).toBe('active');
+    expect(parsed.activeSessions[0].isComplete).toBe(false);
+  });
+
+  it('JSON output for recent sessions marks isComplete=true', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_j2',
+        status: 'complete',
+        lastModifiedMs: NOW_MS - 3 * ONE_HOUR_MS,
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps, { json: true });
+
+    const parsed = JSON.parse(lines[0]) as StatusDataPacket;
+    expect(parsed.recentSessions[0].status).toBe('recent');
+    expect(parsed.recentSessions[0].isComplete).toBe(true);
+  });
+
+  it('JSON output is empty when no sessions match', async () => {
+    const { deps, lines } = makeDeps(makeFakeConsoleService([]));
+    await executeWorktrainOverviewCommand(deps, { json: true });
+
+    const parsed = JSON.parse(lines[0]) as StatusDataPacket;
+    expect(parsed.activeSessions).toHaveLength(0);
+    expect(parsed.recentSessions).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: human-readable output header
+// ---------------------------------------------------------------------------
+
+describe('executeWorktrainOverviewCommand -- header and footer', () => {
+  it('always prints WorkTrain header with timestamp', async () => {
+    const { deps, lines } = makeDeps(makeFakeConsoleService([]));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.startsWith('WorkTrain'))).toBe(true);
+  });
+
+  it('always prints daemon note', async () => {
+    const { deps, lines } = makeDeps(makeFakeConsoleService([]));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('last-known state'))).toBe(true);
+  });
+
+  it('prints "Run worktrain console" footer when sessions exist', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_footer',
+        status: 'complete',
+        lastModifiedMs: NOW_MS - ONE_HOUR_MS,
+      }),
+    ];
+    const { deps, lines } = makeDeps(makeFakeConsoleService(sessions));
+    await executeWorktrainOverviewCommand(deps);
+
+    expect(lines.some((l) => l.includes('worktrain console'))).toBe(true);
+  });
+
+  it('does NOT print "Run worktrain console" footer when no sessions', async () => {
+    const { deps, lines } = makeDeps(makeFakeConsoleService([]));
+    await executeWorktrainOverviewCommand(deps);
+
+    // The only console reference in empty state is the "worktrain daemon" suggestion.
+    // The "worktrain console" footer should not appear.
+    const consoleFooterLines = lines.filter((l) => l.includes('worktrain console'));
+    expect(consoleFooterLines).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: custom thresholds
+// ---------------------------------------------------------------------------
+
+describe('executeWorktrainOverviewCommand -- custom thresholds', () => {
+  it('respects custom activeThresholdMs', async () => {
+    // Session modified 90 minutes ago.
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_threshold',
+        sessionTitle: 'Near-threshold task',
+        status: 'in_progress',
+        lastModifiedMs: NOW_MS - 90 * 60_000,
+      }),
+    ];
+    const { deps, lines: linesDefault } = makeDeps(makeFakeConsoleService(sessions));
+    const { deps: deps2, lines: linesCustom } = makeDeps(makeFakeConsoleService(sessions));
+
+    // Default threshold (2h = 120 min): session at 90m should show.
+    await executeWorktrainOverviewCommand(deps);
+    expect(linesDefault.some((l) => l.includes('Near-threshold task'))).toBe(true);
+
+    // Custom threshold (60 min): session at 90m should NOT show.
+    await executeWorktrainOverviewCommand(deps2, { activeThresholdMs: 60 * 60_000 });
+    expect(linesCustom.some((l) => l.includes('Near-threshold task'))).toBe(false);
+  });
+
+  it('respects custom recentWindowMs', async () => {
+    const sessions = [
+      makeSession({
+        sessionId: 'sess_recent_custom',
+        sessionTitle: 'Completed 12h ago',
+        status: 'complete',
+        lastModifiedMs: NOW_MS - 12 * ONE_HOUR_MS,
+      }),
+    ];
+    const { deps, lines: linesDefault } = makeDeps(makeFakeConsoleService(sessions));
+    const { deps: deps2, lines: linesCustom } = makeDeps(makeFakeConsoleService(sessions));
+
+    // Default window (24h): 12h-old completed session should show.
+    await executeWorktrainOverviewCommand(deps);
+    expect(linesDefault.some((l) => l.includes('Completed 12h ago'))).toBe(true);
+
+    // Custom window (6h): 12h-old session should NOT show.
+    await executeWorktrainOverviewCommand(deps2, { recentWindowMs: 6 * ONE_HOUR_MS });
+    expect(linesCustom.some((l) => l.includes('Completed 12h ago'))).toBe(false);
+  });
+});

--- a/tests/unit/workflow-runner-spawn-agent.test.ts
+++ b/tests/unit/workflow-runner-spawn-agent.test.ts
@@ -33,6 +33,8 @@ vi.mock('../../src/mcp/handlers/v2-execution/start.js', () => ({
   executeStartWorkflow: mockExecuteStartWorkflow,
 }));
 
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { makeSpawnAgentTool } from '../../src/daemon/workflow-runner.js';
 import type {
   ChildWorkflowRunResult,
@@ -67,7 +69,7 @@ const FAKE_SCHEMAS = {
 const FAKE_PARAMS = {
   workflowId: 'test-workflow',
   goal: 'do the thing',
-  workspacePath: '/tmp/test',
+  workspacePath: path.join(os.tmpdir(), 'workrail-spawn-agent-test'),
 };
 
 /**


### PR DESCRIPTION
## Summary

- Add `worktrain status` (no args) as a plain-English overview of active and recently completed sessions -- reads directly from `~/.workrail/data/sessions/` via ConsoleService, no daemon required
- Rename `worktrain status <sessionId>` to `worktrain health <sessionId>` (same functionality, clearer name)
- Backward-compat shim: `worktrain status <id>` still works with a deprecation notice pointing to `worktrain health <id>`
- Export `StatusDataPacket` type for reuse by the console landing view
- 28 unit tests covering active/recent/empty cases, JSON output, title fallback chain, and custom thresholds

## Key behavior

ACTIVE = `isComplete === false` and `lastModifiedMs` within 2h (configurable)
RECENT = completed within last 24h (configurable)

```
WorkTrain  [Fri Apr 18, 2026  14:32]
Note: live session detection requires daemon (showing last-known state).

ACTIVE (1 session)
  in_progress  Implementing GitHub polling adapter
               running 22m

RECENT (last 24h, 1 completed)
  done  worktrain init onboarding command    3h ago

Run `worktrain console` for full session details.
```

## Test plan

- [x] `npm run build` passes clean
- [x] 28 new unit tests pass (`tests/unit/cli-worktrain-overview.test.ts`)
- [x] Existing test suite passes (340 test files, 4829 tests)
- [x] `worktrain status` with no args prints human-readable overview
- [x] `worktrain status --json` outputs `StatusDataPacket` JSON
- [x] `worktrain health <id>` works (renamed from status)
- [x] `worktrain status <id>` shows deprecation notice and still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)