### PR TITLE
feat(console): add worktrain run pr-review coordinator

### DIFF
--- a/docs/discovery/coordinator-design-review.md
+++ b/docs/discovery/coordinator-design-review.md
@@ -1,0 +1,73 @@
+# Design Review Findings: PR Review Coordinator
+
+*Review completed: 2026-04-18*
+
+## Tradeoff Review
+
+| Tradeoff | Verdict | Conditions for Failure |
+|----------|---------|------------------------|
+| Port discovery duplicated from worktrain-spawn.ts | Acceptable | Lock file names change (low risk, bounded) |
+| Two-tier parser is heuristic | Acceptable for MVP | False escalation rate > 20% of clean PRs |
+| Fix-agent loop max 3 passes | Acceptable | If 3 passes is too few for real codebases (tunable) |
+
+## Failure Mode Review
+
+| Failure Mode | Coverage | Risk |
+|-------------|----------|------|
+| null recapMarkdown -> unknown -> escalate | Full | Low -- conservative, correct |
+| Fix loop 3 passes, persistent minor -> escalate | Full | Low |
+| ECONNREFUSED -> clear error exit | Partial (needs timeout) | Low |
+| Keyword false positive -> false escalation | Partial (needs negation check) | Medium |
+| gh pr merge failure -> escalate without retry | Full | Low |
+| Zombie session (null childSessionId) | Full | Low |
+
+## Runner-Up / Simpler Alternative Review
+
+Candidate A (subprocess model) has nothing worth borrowing. No beneficial hybrid exists. Candidate B is the correct shape. One naming improvement identified: `postResult` -> `writeFile(path, content)` for clarity.
+
+## Philosophy Alignment
+
+- All 8 CLAUDE.md principles satisfied
+- Two minor tensions: mutable loop counter (acceptable, local), two-tier parser as patch (acceptable, follow-up filed)
+
+---
+
+## Findings
+
+### ORANGE: Keyword false positive risk -- negation context not handled
+
+The keyword scanner will match `BLOCKING` in contexts like 'this is not technically blocking'. This is the most likely source of false escalations in practice.
+
+**Recommended revision:** Before returning `'blocking'`, check that the `BLOCKING` keyword is not preceded by a negation within ~30 chars: `/\b(?:not|no|without)\b.{0,30}\bblocking\b/i` -> if this matches, do not classify as blocking. Apply same check to CRITICAL.
+
+### ORANGE: No fetch timeout on HTTP calls
+
+`spawnSession()` and `getAgentResult()` use bare `fetch()` with no timeout. If the daemon is running but unresponsive, the coordinator hangs indefinitely.
+
+**Recommended revision:** Add `AbortSignal.timeout(30_000)` to all dispatch and session/node fetch calls. Catch `AbortError` and return `err('Daemon request timed out after 30s')`.
+
+### YELLOW: `postResult` dep name is unclear
+
+The `postResult(notes: string)` name is ambiguous -- does it post to Slack? Write to a file? Create a GitHub comment?
+
+**Recommended revision:** Rename to `writeFile(path: string, content: string): Promise<void>`. The coordinator decides the report file path. This matches the UX spec: `Full report: ./coordinator-pr-review-2026-04-18.md`.
+
+### YELLOW: Rule 3 adaptation not explicit in original 5 robustness rules spec
+
+The original Rule 3 (go/no-go time check) was designed for daemon sessions with known `maxSessionMinutes`. The CLI coordinator has no such parameter.
+
+**Recommended revision:** Explicit Rule 3 adaptation: `const coordinatorStartMs = deps.now()` at startup; before each `spawnSession()` call, check `deps.now() - coordinatorStartMs > 70 * 60 * 1000` (70 min = 90 min coordinator max - 20 min buffer) and refuse to spawn if exceeded.
+
+---
+
+## Recommended Revisions
+
+1. Add negation context check in keyword parser (`/\b(?:not|no|without)\b.{0,30}\bblocking\b/i`)
+2. Add `AbortSignal.timeout(30_000)` to fetch calls
+3. Rename `postResult` to `writeFile(path, content)`
+4. Add explicit wall-clock Rule 3 adaptation to implementation spec
+
+## Residual Concerns
+
+- The two-tier parser's keyword scan is a heuristic. False escalation rate unknown until tested against real mr-review outputs. Follow-up: update mr-review-workflow to emit `## COORDINATOR_OUTPUT` JSON block.
+- The coordinator's own timeout (90 minutes) is hardcoded. Should be configurable via `--max-runtime` flag if needed. Not for MVP.

--- a/docs/discovery/coordinator-script-design.md
+++ b/docs/discovery/coordinator-script-design.md
@@ -1,745 +1,162 @@
-# Coordinator Script Architecture Discovery
+# PR Review Coordinator Script: Design Candidates
 
-**Date:** 2026-04-18
-**Discovery path:** design_first (goal was a solution statement; risk is solving the wrong abstraction)
-**Status:** In progress
+*Discovery run: 2026-04-18. Three runs completed. Design settled.*
 
 ---
 
-## Artifact Strategy
+## Problem Understanding
 
-This document is a **human-readable discovery report** for Etienne and future pipeline authors. It is NOT workflow execution memory -- that lives in WorkRail step notes and context variables. If this file and the WorkRail session disagree, the session notes are authoritative.
+### Core Tensions
 
-**What this doc is for:**
-- Architecture recommendation with rationale
-- Key design decisions and tradeoffs
-- Open questions and risks
-- Reference for implementation
+1. **Parseability vs. output format:** The `mr-review-workflow` final step (`phase-6-final-handoff`) produces free-form markdown designed for human readers. The coordinator needs machine-parseable output. Adding `## COORDINATOR_OUTPUT` to the workflow prompt would make parsing reliable, but changes a workflow other users may run standalone. Decision: two-tier parser in coordinator only; update the workflow prompt as a separate follow-up.
 
-**What this doc is not for:**
-- Tracking workflow execution state
-- Storing session continue tokens or checkpoint data
+2. **HTTP API vs. CLI subprocess for dispatch:** Using CLI subprocess (`execFile('worktrain', ['spawn', ...])`) is simpler (no port discovery logic), but loses context passing and adds subprocess overhead. Using HTTP directly (`POST /api/v2/auto/dispatch`) requires port discovery (same logic as `worktrain-spawn.ts`), but enables the `context` field. Decision: HTTP direct, copy port discovery pattern.
 
----
+3. **Coordinator as CLI script vs. daemon workflow:** Could run the coordinator as a WorkRail workflow, getting durability. But that adds circular dependency (WorkRail spawning WorkRail sessions from inside a WorkRail session). The backlog explicitly says "scripts-first coordinator" -- deterministic TypeScript logic, not LLM orchestration. Decision: standalone CLI script.
 
-## Context / Ask
+4. **Fix-agent loop termination:** Max 3 passes is the rule, but what if pass 2 comes back minor again? Need another review pass. The tension: another review = another 15-minute wait. Solution: enforce max 3 passes strictly via counter, track in coordinator state per PR.
 
-**Stated goal:** Design the first coordinator script template -- the script that drives a multi-phase WorkRail pipeline using worktrain spawn/await.
+### What Makes This Hard
 
-**Reframed problem (solution-bias stripped):** How should multi-phase WorkRail pipelines be orchestrated -- what is the right abstraction layer, locus of control, and failure model for driving sequential and parallel child sessions?
+1. **Notes extraction requires 2 sequential HTTP calls:** `GET /api/v2/sessions/:id` must succeed and return a valid `preferredTipNodeId` before the node detail call. If either fails, coordinator must treat as `unknown` severity (conservative, escalate).
 
-**Goal was a solution statement.** The original framing assumed: (a) a script is the right locus, (b) worktrain spawn/await are the right primitives, (c) a reusable template is achievable. These assumptions are challenged below.
+2. **Fix agent loop state management:** Need to track per-PR: pass count, current handle, previous findings. This is mutable state, which conflicts with the immutability preference. Resolution: keep loop counter local to the per-PR processing function, not exposed as shared state.
 
----
+3. **`worktrain await` does NOT return session notes:** `await` returns only `{ results: [...SessionResult], allSucceeded }`. To get what the agent actually found, a separate 2-call HTTP sequence is needed after `await` returns.
 
-## Path Recommendation
+4. **Keyword scan ambiguity:** The mr-review markdown may use ambiguous language (e.g., "minor architectural blocking concern"). Conservative default: `unknown` -> blocking always wins over minor.
 
-**design_first** -- The dominant risk is shaping the wrong abstraction. Two viable architectures exist (coordinator script vs. native WorkRail workflow with spawn_agent). Without clarifying the real problem first, we risk building the wrong thing at the wrong layer.
+### Likely Seam
 
-Rationale against `landscape_first`: the landscape is already well-understood from code reading. The risk is not ignorance of options, it is premature commitment to the script model without examining the native workflow alternative.
-
-Rationale against `full_spectrum`: the reframing is already complete from Step 1. The uncertainty is architectural (which layer owns coordination), not conceptual (what is coordination).
+The real seam is `CoordinatorDeps` -- all HTTP calls, CLI calls (`gh`, `git`), and stderr output sit behind this interface. The coordinator core is pure TypeScript with no side effects except through deps.
 
 ---
 
-## Constraints / Anti-goals
+## Philosophy Constraints
 
-**Core constraints:**
-- Zero LLM cost for coordination routing decisions (scripts, not LLM reasoning, for deterministic logic)
-- Coordinator must be observable: console DAG must show parent-child session tree
-- Coordinator must be testable without a live daemon (mockable spawn/await primitives)
-- Must not require engine changes to add a new pipeline
-- Must handle fan-out parallelism (spawn N child sessions, collect all N results)
+Source: `/Users/etienneb/CLAUDE.md`
 
-**Anti-goals:**
-- Do NOT build a coordinator that uses an LLM to route between phases
-- Do NOT require modifications to trigger-router.ts or workflow-runner.ts for each new pipeline
-- Do NOT produce a template so generic it cannot express mr-review's loop-with-retry topology
-- Do NOT couple the coordinator's failure model to the daemon's Semaphore (no deadlock risk)
+- **Immutability by default** -- coordinator state as read-only data structures; mutation only in explicit loop counters
+- **Errors as data** -- `Result<T, E>` return types from `parseFindingsFromNotes()`, `getAgentResult()` -- no throws
+- **Validate at boundaries** -- validate port, workspace path at CoordinatorDeps wiring time (CLI entry point), trust internally
+- **DI for I/O** -- all fetch, execFile, stderr injected via CoordinatorDeps; no direct imports in coordinator core
+- **Explicit domain types** -- `ReviewSeverity = 'clean' | 'minor' | 'blocking' | 'unknown'` not plain string
+- **Exhaustiveness everywhere** -- switch on `ReviewSeverity` must be exhaustive
+- **YAGNI with discipline** -- build this coordinator, not a coordinator framework
 
----
-
-## Key Facts From Code Reading
-
-### worktrain spawn (worktrain-spawn.ts)
-- Flags: `--workflow <id>`, `--goal <text>`, `--workspace <path>`, `[--port <n>]`
-- HTTP POST to `/api/v2/auto/dispatch` with `{ workflowId, goal, workspacePath }`
-- Output to stdout: session handle (string, e.g. `sess_abc123`)
-- Output to stderr: progress/errors
-- Return: CliResult success | failure | misuse
-- **Does NOT pass context variables** -- only workflowId, goal, workspacePath
-
-### worktrain await (worktrain-await.ts)
-- Flags: `--sessions <h1,h2,...>`, `[--mode all|any]`, `[--timeout 30m]`
-- Polls GET `/api/v2/sessions/:sessionId` every 3 seconds
-- Terminal statuses: `complete`, `complete_with_gaps`, `blocked`, `dormant`
-- Output to stdout: JSON `{ results: [{ handle, outcome, status, durationMs }], allSucceeded }`
-- **CRITICAL GAP: No step notes, no findings, no structured artifacts returned**
-- Exit code 0 if all succeeded, 1 if any failed/timed out
-
-### spawn_agent tool (workflow-runner.ts L1415)
-- Available inside workflow steps (not as a CLI command)
-- Blocking: parent AgentLoop pauses inside execute() until child completes
-- Returns: `{ childSessionId, outcome: 'success'|'error'|'timeout', notes: string }`
-- Depth-limited: default max depth 3
-- **Returns last step notes from child** -- actionable content available immediately
-- **Serial only**: cannot fan out N children in parallel (each call blocks)
-- Parent session's maxSessionMinutes keeps ticking while child runs
-
-### trigger-router.ts dispatch()
-- Fire-and-forget via KeyedAsyncQueue
-- Returns immediately (202 pattern)
-- Uses global Semaphore (max 3 concurrent by default)
-- **Why spawn_agent cannot use dispatch()**: dispatch is fire-and-forget; calling it inside a running session would lose the result. Direct runWorkflow() call is used instead.
-
-### classify-task-workflow.json
-- Single-step, fast, no tools, no subagents
-- Outputs: taskComplexity, riskLevel, hasUI, touchesArchitecture, taskType, affectedDomains, recommendedPipeline
-- `recommendedPipeline` is an ordered array of workflow IDs
-- Notes are the output channel -- no structured context variables emitted
+**No conflicts** between stated philosophy and repo patterns.
 
 ---
 
-## Critical Gap: worktrain await Does Not Return Session Content
+## Impact Surface
 
-The backlog pseudocode (backlog.md L1793-1795) shows:
-```
-3. Calls `await_sessions(handles)` → structured findings (script waits)
-4. Parses the findings JSON block from each session's output (script)
-5. Routes: clean → merge queue, minor → spawn fix agent, blocking → escalate
-```
-
-But the real `worktrain await` output is `{ handle, outcome, status, durationMs }` -- no findings, no notes.
-
-**To route on content, the coordinator must:**
-1. `worktrain await --sessions h1,h2` -- wait for completion
-2. For each completed session handle, call GET `/api/v2/sessions/:sessionId` -- retrieve step notes
-3. Parse the structured block from notes
-4. Route on parsed content
-
-This is a missing primitive: **worktrain notes <session-handle>** (or a --include-notes flag on worktrain await).
+- `src/cli-worktrain.ts` -- adds `run pr-review` subcommand (minimal change, follows existing pattern)
+- `src/cli/commands/index.ts` -- exports new command types
+- `workflows/mr-review-workflow.agentic.v2.json` -- NOT changed in this PR; the coordinator's two-tier parser handles current output
+- `POST /api/v2/auto/dispatch` -- used by coordinator via HTTP (no change to route)
+- `GET /api/v2/sessions/:id` + `GET /api/v2/sessions/:id/nodes/:nodeId` -- read-only; no changes
 
 ---
 
-## Two Candidate Architectures
+## Candidates
 
-### Candidate A: Coordinator Script (TypeScript/Shell)
+### Candidate A: Minimal CLI Script (subprocess model)
 
-```
-coordinator-mr-review.ts
-  1. spawn handles[] = worktrain spawn --workflow mr-review for each PR (parallel fire-and-forget)
-  2. await results = worktrain await --sessions h1,h2,h3
-  3. for each handle: GET /api/v2/sessions/:id -> parse step notes -> extract findings
-  4. route: clean -> merge queue, minor -> spawn fix agent, blocking -> escalate
-  5. await fix agents -> re-review loop (circuit breaker at 3)
-  6. merge clean PRs
-```
+**Summary:** `worktrain run pr-review` as a thin TypeScript wrapper shelling out to `worktrain spawn` and `worktrain await` CLIs via `execFile`, parsing stdout manually, calling `gh` directly.
 
-**Pros:**
-- True parallel fan-out (fire-and-forget spawn, batch await)
-- Deterministic routing (zero LLM cost for coordination)
-- Testable: mock fetch, mock worktrain CLI
-- Reusable: script is a standalone artifact others can copy
+- **Tensions resolved:** Simplest possible change; reuses existing CLI contracts
+- **Tensions accepted:** No context passing; subprocess overhead; harder to test
+- **Boundary:** CoordinatorDeps wraps `execFile` for all subprocess calls
+- **Failure mode:** `worktrain spawn` output format change breaks coordinator silently
+- **Repo-pattern relationship:** Departs -- `delivery-action.ts` uses direct function calls, not subprocesses
+- **Gain:** Minimal new code
+- **Loss:** No context passing, no type safety on spawn/await results, poor testability
+- **Scope:** Too narrow
+- **Philosophy:** Violates 'prefer fakes over mocks' (exec calls hard to fake cleanly); violates 'errors as data'
 
-**Cons:**
-- Invisible to WorkRail: coordinator script is not a session in the DAG
-- No session DAG for the coordinator itself (only child sessions are visible)
-- Requires a running process outside the daemon (shell script lifetime)
-- Must handle port discovery, daemon connectivity separately
-- **Missing primitive:** must query session notes separately after await
+### Candidate B: HTTP-first with CoordinatorDeps Interface (RECOMMENDED)
 
-### Candidate B: WorkRail Workflow with spawn_agent Steps
+**Summary:** `src/coordinators/pr-review.ts` with a `CoordinatorDeps` readonly interface. Core logic is pure functions. CLI wiring in `src/cli-worktrain.ts` provides real HTTP/CLI deps. Tests inject fakes.
 
-```
-coordinator-mr-review-workflow.json
-  Step 1: Gather PRs
-  Step 2: For each PR, call spawn_agent(mr-review-workflow) -- SERIAL (one at a time)
-  Step 3: Route based on outcome + notes from spawn_agent
-  Step 4: spawn_agent(fix-workflow) if needed, re-review
-  Step 5: Merge
-```
-
-**Pros:**
-- Full WorkRail observability: coordinator IS a session in the DAG
-- Child sessions linked via parentSessionId
-- Console DAG shows the full tree
-- spawn_agent returns notes directly (no separate query needed)
-- Session state is durable (daemon crash recovery)
-
-**Cons:**
-- Serial only: cannot spawn N review sessions in parallel
-- Parent session time limit accumulates across all child runs
-- At depth limit 3 (default), nested spawn_agent chains are constrained
-- Coordinator logic is in workflow JSON prompt blocks, not testable TypeScript
-
-### Candidate C: Hybrid -- Script Coordinator with Session Registration
-
-A TypeScript coordinator script that:
-- Calls worktrain spawn (parallel) + worktrain await (batch)
-- Registers itself as a coordinator session with a workflowId (so it appears in the DAG)
-- After await, queries session notes via HTTP, routes on content
-- Reports phase transitions back to the daemon as structured events
-
-**Pros:** Parallel fan-out + DAG visibility + testable TypeScript
-**Cons:** Requires new engine primitive (coordinator session registration) -- not yet built
-
----
-
-## Landscape Packet
-
-### Current State Summary
-
-Two orchestration primitives exist today (both shipped, neither battle-tested):
-
-| Primitive | Layer | Parallelism | Returns Content | Observable in DAG |
-|-----------|-------|-------------|-----------------|-------------------|
-| `worktrain spawn` + `worktrain await` | CLI / HTTP | Yes (fire N, await all) | No (outcome + status only) | No (script is invisible) |
-| `spawn_agent` tool | Engine / workflow step | No (blocking, serial) | Yes (notes returned inline) | Yes (parentSessionId in store) |
-
-Neither primitive is complete for the target use case:
-- Script model: parallel but content-blind
-- Native model: content-aware but serial
-
-### Existing Workflows Available as Targets
-- `coding-task-workflow-agentic` (lean v2)
-- `mr-review-workflow.agentic.v2`
-- `routine-context-gathering`, `routine-hypothesis-challenge`, `routine-philosophy-alignment`
-- `ui-ux-design-workflow`, `production-readiness-audit`, `architecture-scalability-audit`
-- `bug-investigation.agentic.v2`, `wr.discovery`
-- `classify-task-workflow` (new, single-step, outputs recommendedPipeline array)
-
-### Engineering State (git log context)
-- `spawn_agent` shipped in commit `4254feb7` (feat: in-process child session delegation)
-- `worktrain spawn` / `worktrain await` -- Tier 3 in Apr 18 grooming: "already merged, needs real-world test"
-- `classify-task-workflow` exists but not yet wired into any coordinator
-- `parentSessionId` is in session store; console tree view is the next planned feature
-
-### Hard Constraints From Code
-1. `dispatch()` in TriggerRouter is fire-and-forget + Semaphore-gated. Calling from inside a running session deadlocks. This is why `spawn_agent` uses direct `runWorkflow()` call, not `dispatch()`.
-2. `worktrain await` stdout schema is `AwaitResult = { results: [{ handle, outcome, status, durationMs }], allSucceeded }`. No notes.
-3. `worktrain spawn` CLI: `{ workflowId, goal, workspacePath }` only. No context variable passing.
-4. `spawn_agent` depth limit: default max 3. Root (0) → child (1) → grandchild (2) → blocked at 3.
-5. `spawn_agent` blocks the parent AgentLoop's execute() method. The parent cannot do other work while child runs.
-
-### Obvious Contradictions
-
-**C1: Backlog assumes findings from await, but CLI returns none.**
-Backlog pseudocode (backlog.md L1793): `await_sessions(handles) → structured findings`. Real CLI returns `{ outcome, status, durationMs }` only. Every coordinator that routes on content has an undocumented extra HTTP step.
-
-**C2: Backlog envisions parallel fan-out, but spawn_agent is serial.**
-Backlog (backlog.md L2190): `await_sessions({ handles: [...], mode: 'all' })` implies a non-blocking spawn primitive. But `spawn_agent` (the native tool) blocks. The CLI (`worktrain spawn` / `worktrain await`) can do parallel, but returns no content.
-
-**C3: classify-task output is in notes, not in context variables.**
-The classify-task workflow outputs via step notes (a markdown block), not via WorkRail context variables. A coordinator that reads classify output must parse the notes string -- there is no structured `context.taskComplexity` to read directly.
-
-### Evidence Gaps
-- **Gap 1:** Whether GET /api/v2/sessions/:id currently returns full step notes in the runs array (the await code reads `runs[0].status` but not notes -- unclear if notes are included in the response body)
-- **Gap 2:** Whether a `--context` flag for `worktrain spawn` is planned (needed to pass classify output to coding-task session)
-- **Gap 3:** Whether non-blocking spawn_agent (fire + await_all) is on the roadmap (would resolve C2)
-
----
-
-## Problem Frame Packet (Deep)
-
-### Stakeholders
-
-**Primary user: Etienne (WorkTrain builder / first pipeline author)**
-- Job: Wire up an autonomous pipeline that runs the full develop-review-fix-merge cycle without manual coordination
-- Outcome: Spend Monday morning reviewing Slack, not manually driving 8 agent sessions in sequence
-- Pain: Today every handoff (review complete -> spawn fix agent -> re-review) requires Etienne to be online, read the findings, and manually kick the next step
-- Constraint: Must be able to reason about what went wrong when a pipeline fails at 2am
-
-**Secondary user: Future WorkTrain pipeline authors (teams adopting WorkTrain)**
-- Job: Add their own pipelines (onboarding pipeline, data migration pipeline, etc.)
-- Outcome: Write a new pipeline by copying a template and changing workflow IDs and routing rules
-- Pain: If the coordinator pattern is hard to understand or extend, each team rewrites it from scratch
-- Constraint: Cannot be expected to understand the WorkRail engine internals
-
-### Jobs / Desired Outcomes
-
-1. **Full autonomy:** A trigger fires, the pipeline runs, a Slack message arrives with outcome. No human in the loop.
-2. **Debuggability:** When something goes wrong, Etienne can trace exactly what each phase did and why the coordinator made each routing decision.
-3. **Composability:** The pipeline is assembled from existing workflow primitives, not a monolithic LLM session.
-4. **Parallelism:** Review N PRs simultaneously, not one at a time.
-
-### Tensions
-
-**T1: Observability vs. Parallelism**
-- Native `spawn_agent` (observable in DAG, serial) vs. script + worktrain CLI (parallel, invisible to DAG)
-- You cannot have both today. Console DAG tree = serial. Parallel fan-out = invisible coordinator.
-
-**T2: Content access vs. Simplicity**
-- Routing on findings requires 2-call HTTP sequence (session detail + node detail) after worktrain await
-- Simpler coordinator ignores findings and routes only on exit code (succeeded / failed) -- but this loses the clean/minor/blocking distinction
-- The backlog explicitly wants content-based routing; simplicity would sacrifice the main value proposition
-
-**T3: Template reuse vs. Pipeline specificity**
-- A generic pipeline runner (execute recommendedPipeline array from classify-task) is maximally reusable but cannot express mr-review's loop-with-retry
-- A specialized mr-review coordinator can express the full topology but is not reusable
-- The first coordinator template will set the pattern -- wrong abstraction level here propagates to all future pipelines
-
-**T4: Build now vs. Build right**
-- worktrain spawn/await are merged but untested (Tier 3 Apr 18 grooming)
-- spawn_agent just shipped (commit 4254feb7) and needs real-world validation
-- Building the coordinator NOW uses primitives that are still in "needs testing" state
-- Waiting for primitives to stabilize reduces rework risk but delays the autonomous pipeline
-
-**T5: Script model vs. Workflow model (the central architectural tension)**
-- Script: parallel, testable, zero LLM cost, but invisible to DAG and no native failure recovery
-- Workflow: observable, content-aware via spawn_agent, but serial and time-budget constrained
-- The backlog explicitly names coordinator scripts as the intended model -- but the code reality shows spawn_agent is the more capable primitive for content-based routing
-
-### Success Criteria (observable)
-
-1. A coordinator triggers from a cron or webhook, runs the mr-review pipeline for all open PRs, and posts a Slack summary -- without Etienne touching anything
-2. When findings are "blocking", the coordinator spawns a fix agent and re-reviews (not just logs and exits)
-3. When a child session fails, the coordinator's Slack summary names WHICH PR failed and WHY (the finding text)
-4. The console DAG shows all child sessions linked to the coordinator as a tree (even if the coordinator itself is invisible as a script)
-5. A second pipeline (e.g. implement-feature) can be added by writing a new 50-line TypeScript file and changing 3 workflow IDs
-
-### Primary Framing Risk
-
-**If spawn_agent becomes non-blocking (fire + await_all) in the near term, the entire script-vs-workflow calculus inverts.**
-
-Currently the script model wins on parallelism (the only dimension where it beats native workflows). If spawn_agent gets a non-blocking mode with batch-await, native workflows become strictly better: same parallelism, plus DAG observability, plus notes available inline, plus no separate HTTP calls. In that scenario, building a coordinator script template today would be building the wrong abstraction -- the right abstraction would be a coordinator workflow JSON file.
-
-This is not generic. It is a specific condition (spawn_agent async mode shipping) that would make the current framing wrong. The decision hinges on whether to build the script now or wait for/build the async spawn_agent first.
-
-## Open Questions
-
-1. **Parallel fan-out with spawn_agent:** Is there a plan to make spawn_agent non-blocking (fire-and-forget + await_all)? If yes, Candidate B becomes viable for parallel pipelines.
-2. **worktrain await --include-notes flag:** Is this planned? Without it, every coordinator routing on content needs a separate HTTP call.
-3. **worktrain spawn --context flag:** The current CLI does not pass context variables to the spawned session. How does the coordinator pass classify-task output (taskComplexity, recommendedPipeline) to the coding-task session?
-4. **Coordinator session registration:** Is there a plan for scripts to register as coordinator sessions so they appear in the DAG?
-5. **Session notes API:** Is GET /api/v2/sessions/:id currently returning full step notes in the runs array? The await code reads `runs[0].status` but not notes.
-
----
-
-## Problem Frame Packet
-
-**Primary uncertainty:** Whether the script model or the native workflow model is the right long-term abstraction -- given that spawn_agent is blocking+serial today, but the backlog explicitly describes async spawn + batch await as the desired primitive.
-
-**Known approaches:** Coordinator script (Candidate A), native workflow (Candidate B), hybrid (Candidate C).
-
-**Key stakeholders:** Anyone building a coordinator pipeline (today: Etienne; soon: teams using WorkTrain autonomously).
-
----
-
-## Candidate Directions
-
-### Candidate Generation Expectations
-
-This is a **design_first** pass with **THOROUGH** rigor. Requirements for the candidate set:
-1. At least one candidate must meaningfully reframe the problem (not just package an obvious solution)
-2. All candidates must address the central tension: observability vs. parallelism
-3. All candidates must specify how they handle content-based routing (the 2-call HTTP gap or native notes)
-4. One candidate must represent the "build now with current primitives" position (pragmatic)
-5. One candidate must represent the "build the right primitive first" position (strategic)
-6. The spread must not cluster -- candidates genuinely differ in abstraction level
-
----
-
-### Candidate 1: TypeScript Coordinator Script (Minimal, Build Now)
-
-**One-sentence summary:** A standalone TypeScript file with DI-injected spawn/await/HTTP effects that drives the mr-review pipeline using today's worktrain spawn/await CLI plus a 2-call HTTP sequence to retrieve step notes for routing.
-
-**Concrete shape:**
+**CoordinatorDeps interface:**
 ```typescript
-// coordinator-mr-review.ts
 interface CoordinatorDeps {
-  readonly spawnSession: (workflowId: string, goal: string, workspace: string) => Promise<string>; // returns sessionHandle
-  readonly awaitSessions: (handles: string[], mode: 'all'|'any', timeoutMs: number) => Promise<AwaitResult>;
-  readonly getSessionNotes: (handle: string) => Promise<string | null>; // GET /api/v2/sessions/:id/nodes/:tipNodeId -> recapMarkdown
-  readonly listOpenPRs: () => Promise<PullRequest[]>; // gh pr list --json
-  readonly mergePR: (number: number) => Promise<void>;
-  readonly postSlack: (message: string) => Promise<void>;
+  readonly spawnSession: (workflowId: string, goal: string, workspace: string) => Promise<string>; // sessionHandle
+  readonly awaitSessions: (handles: string[], timeoutMs?: number) => Promise<AwaitResult>;
+  readonly getAgentResult: (sessionHandle: string) => Promise<string | null>; // recapMarkdown
+  readonly listOpenPRs: (workspace: string) => Promise<PrSummary[]>;
+  readonly mergePR: (prNumber: number, workspace: string) => Promise<void>;
+  readonly postResult: (notes: string) => Promise<void>;
   readonly stderr: (line: string) => void;
-}
-
-type FindingsSeverity = 'clean' | 'minor' | 'blocking';
-
-async function runMrReviewPipeline(deps: CoordinatorDeps, workspace: string): Promise<CoordinatorResult>
-```
-
-Notes are retrieved via: GET /api/v2/sessions/:id (get tip nodeId from runs[0].nodes[preferredTipNodeId]) then GET /api/v2/sessions/:id/nodes/:nodeId (get recapMarkdown). Parsed by a `parseFindings(recapMarkdown: string): FindingsSeverity` function that scans for known severity markers.
-
-**Tensions resolved:** T3 (specific topology: loop-with-retry), T2 (content access via explicit 2-call HTTP)
-**Tensions accepted:** T1 (no parallelism), T4 (build now, not right)
-**Wait -- parallelism:** This candidate CAN achieve parallel fan-out by calling `spawnSession` N times before calling `awaitSessions([h1, h2, h3, ...])`. The `awaitSessions` dep wraps `worktrain await` which polls all sessions concurrently. **This resolves T1.**
-
-**Boundary solved at:** TypeScript module boundary. All I/O injected via `CoordinatorDeps`. Testable with fake deps (no live daemon).
-
-**Failure mode to watch:** `parseFindings` is a string parser on LLM-generated markdown. If the mr-review workflow changes its notes format, the parser silently misclassifies. Must have a `'unknown'` severity fallback that defaults to 'blocking' (conservative).
-
-**Relation to existing patterns:** Directly follows `WorktrainSpawnCommandDeps` / `WorktrainAwaitCommandDeps` DI pattern. Same injectable interface shape.
-
-**Gains:** Ships today. Uses stable primitives. Fully testable. Parallel fan-out. Content-based routing.
-**Gives up:** Invisible to console DAG (coordinator is not a WorkRail session). No durable state (script crash = lost progress). Notes parsing is brittle.
-
-**Impact surface:** None -- coordinator is a standalone file. Does not require engine changes.
-
-**Scope:** Best-fit for "first coordinator template."
-
-**Philosophy honored:** Errors as data (CliResult pattern), Dependency injection, Exhaustiveness (FindingsSeverity union), Validate at boundaries (parseFindings validates at HTTP response boundary)
-**Philosophy tension:** Not fully deterministic if notes format varies (string parsing on LLM output)
-
----
-
-### Candidate 2: Serial Coordinator Workflow (Native, Observable)
-
-**One-sentence summary:** A WorkRail workflow JSON file where each pipeline phase is a step that calls `spawn_agent` once, receives notes inline, and uses those notes to set context variables that the next step reads.
-
-**Concrete shape:**
-```json
-{
-  "id": "coordinator-mr-review",
-  "steps": [
-    {
-      "id": "gather-prs",
-      "procedure": ["Run gh pr list --json, set context.openPRs"]
-    },
-    {
-      "id": "review-loop",
-      "loopCondition": "context.openPRs.length > 0",
-      "procedure": [
-        "Pop one PR from context.openPRs",
-        "Call spawn_agent(mr-review-workflow-agentic, goal: 'Review PR #N')",
-        "Read spawn_agent result.notes",
-        "If notes contain CLEAN: add to context.mergeQueue",
-        "If notes contain MINOR: call spawn_agent(coding-task-workflow-agentic, 'Fix: <finding>')",
-        "If notes contain BLOCKING: add to context.escalationList"
-      ]
-    },
-    {
-      "id": "merge-queue",
-      "procedure": ["For each PR in mergeQueue: run git merge sequence"]
-    }
-  ]
+  readonly now: () => number;
+  readonly port: number;
 }
 ```
 
-Each `spawn_agent` call blocks until child completes, then returns `{ outcome, notes }`. Notes are available immediately -- no HTTP polling needed.
+**Pure functions:**
+- `parseFindingsFromNotes(markdown: string | null): Result<ReviewFindings, string>` -- two-tier (JSON block first, keyword scan fallback)
+- `classifySeverity(findings: ReviewFindings): ReviewSeverity`
+- `buildFixGoal(prNumber: number, findings: ReviewFindings): string`
 
-**Tensions resolved:** T1 (fully observable in console DAG), T2 (notes available inline)
-**Tensions accepted:** T1 partial (serial review -- one PR at a time, not parallel), T4 (cannot build right now, needs workflow JSON authoring)
+- **Tensions resolved:** Context passing possible (HTTP direct), type safety, testability, all 5 robustness rules
+- **Tensions accepted:** Slightly more code vs A; port discovery logic duplicated from spawn.ts (intentional)
+- **Boundary:** `CoordinatorDeps` -- exactly the same pattern as `WorktrainSpawnCommandDeps`
+- **Failure mode:** `recapMarkdown` is null -> treated as `unknown` -> escalate (conservative, correct)
+- **Repo-pattern relationship:** Follows `WorktrainSpawnCommandDeps` pattern exactly; adapts `parseHandoffArtifact` two-tier parser
+- **Gain:** Full type safety, testable pure core, context passing, matches existing architecture
+- **Loss:** More code (but correct code)
+- **Scope:** Best-fit -- 3 new files
+- **Philosophy:** Honors all -- immutability, DI for I/O, errors as data, explicit domain types, validate at boundaries, prefer fakes over mocks
 
-**Boundary solved at:** WorkRail workflow step boundary. All coordination logic in workflow JSON prompt instructions + agent reasoning.
+### Candidate C: Generic Coordinator Framework + pr-review Instance
 
-**Failure mode to watch:** Parent session's maxSessionMinutes accumulates across all spawn_agent calls. Reviewing 10 PRs with a 30-minute child budget each requires the parent to have 300+ minutes. Time budget explosion is silent -- parent times out while children are running.
+**Summary:** Build `src/coordinators/base.ts` with `CoordinatorDeps<TInput, TOutput>` generic and pipeline pattern, then implement pr-review as an instance.
 
-**Relation to existing patterns:** Directly uses spawn_agent as designed. Follows the workflow-runner.ts spawn_agent pattern (blocking, errors as data, parentSessionId).
-
-**Gains:** Full DAG observability. Session state is durable (daemon restart recovers). Notes available inline, no separate HTTP call.
-**Gives up:** Serial reviews (10 PRs = 10x review time). Time budget scales linearly. Routing logic is in LLM-readable prompt, not testable TypeScript.
-
-**Impact surface:** None. A new workflow JSON file.
-
-**Scope:** Best-fit IF serial review is acceptable.
-
-**Philosophy honored:** Errors as data (spawn_agent returns outcome), Exhaustiveness (outcome enum), Observable state
-**Philosophy tension:** Routing logic is LLM prompt text, not typed domain logic. Coordinator philosophy says scripts, not LLM reasoning -- this violates the scripts-first principle.
-
----
-
-### Candidate 3: Build Async spawn_agent First, Then Native Coordinator Workflow
-
-**One-sentence summary:** Extend spawn_agent with a non-blocking mode (`blocking: false`) that returns a `pendingHandle` immediately, add an `await_agents` tool that takes an array of pendingHandles and blocks until all complete, then build the coordinator as a WorkRail workflow that uses these new tools for parallel + observable + content-aware orchestration.
-
-**Concrete shape (new engine API):**
-```typescript
-// New tool: spawn_agent with blocking: false
-spawn_agent({ workflowId, goal, workspacePath, blocking: false }) 
-  → { pendingHandle: string } // returns immediately
-
-// New tool: await_agents  
-await_agents({ handles: ['ph_abc', 'ph_def'], mode: 'all' })
-  → [{ handle, childSessionId, outcome, notes }] // blocks until all complete
-```
-
-The coordinator workflow then becomes:
-```
-Step 1: Gather PRs (script/bash)
-Step 2: Spawn all review sessions in parallel (call spawn_agent with blocking:false for each PR)
-Step 3: Await all (call await_agents)
-Step 4: Route on notes (typed context variables set from parsed notes)
-Step 5: Spawn fix agents (blocking spawn_agent, one at a time)
-Step 6: Merge
-```
-
-**Tensions resolved:** T1 (parallel + observable), T2 (notes inline from await_agents), T4 (builds the right primitive)
-**Tensions accepted:** T4 partial (does not ship today -- requires engine work)
-
-**Boundary solved at:** WorkRail engine boundary. New tools in workflow-runner.ts.
-
-**Failure mode to watch:** The non-blocking spawn pattern must not use `dispatch()` (deadlock risk via Semaphore + queue slot). The implementation must use the same `runWorkflow()` pattern as the blocking spawn_agent, but launch it as a concurrent Promise that is tracked in a coordinator-owned pending map.
-
-**Relation to existing patterns:** Extends spawn_agent in workflow-runner.ts (L1415). The blocking version already exists -- non-blocking is an additive extension. `pendingHandle` concept mirrors the CLI's sessionHandle.
-
-**Gains:** Resolves all 5 decision criteria. Parallel fan-out + observability + content routing + DAG tree + extensible. The coordinator workflow is the long-term correct abstraction.
-**Gives up:** Does not exist today. Requires engine PR before coordinator can be built. 2-4 week delay (estimate).
-
-**Impact surface:** workflow-runner.ts (new makeAwaitAgentsTool), workflow-runner.ts (extend makeSpawnAgentTool), possibly workflow-runner.ts executeWorkflowLoop for pending handle tracking.
-
-**Scope:** Too broad for "first coordinator template" alone, but correctly scoped for "right long-term architecture."
-
-**Philosophy honored:** All 5 decision criteria. Architectural fixes over patches. Make illegal states unrepresentable (pending handle as a typed domain type).
-**Philosophy tension:** YAGNI -- this builds a speculative primitive before any coordinator has validated the need in production.
-
----
-
-### Candidate 4: Minimal Script + Structured Notes Contract (Pragmatic + Future-Proof)
-
-**One-sentence summary:** Build Candidate 1 (TypeScript coordinator script) but add a structured `## COORDINATOR_OUTPUT` JSON block to the mr-review workflow's final step notes as a first-class contract, making the coordinator's dependency on notes format explicit and versioned rather than fragile string parsing.
-
-**Concrete shape:**
-
-In `mr-review-workflow.agentic.v2.json` final step, add to `outputRequired`:
-```json
-{
-  "coordinatorOutput": "JSON block in exact format:\n```json\n{\"findings\": [{\"severity\": \"clean|minor|blocking\", \"summary\": \"...\", \"prNumber\": N}]}\n```"
-}
-```
-
-In the coordinator script:
-```typescript
-function parseCoordinatorOutput(notes: string): Result<CoordinatorOutput, ParseError> {
-  const match = /```json\n([\s\S]+?)\n```/.exec(notes);
-  if (!match) return err({ kind: 'missing_block' });
-  return parseJson(match[1]).andThen(validateCoordinatorOutput);
-}
-```
-
-The coordinator is now a typed consumer of a versioned contract, not a fragile markdown parser.
-
-**Tensions resolved:** T2 (typed content-based routing), T3 (mr-review topology with loop-with-retry), T1 partial (parallel via worktrain spawn + await)
-**Tensions accepted:** T1 (invisible to DAG), T4 (builds now at script layer)
-
-**Boundary solved at:** Notes contract boundary (between workflow and coordinator). The contract is the seam.
-
-**Failure mode to watch:** The coordinator output contract must be maintained in sync with the workflow JSON. If the workflow changes the JSON block format without updating the coordinator, parsing fails. Needs schema versioning or a shared type definition.
-
-**Relation to existing patterns:** The handoff artifact (delivery-action.ts `parseHandoffArtifact`) already does exactly this -- parses a structured JSON block from step notes. The coordinator contract is the same pattern at the coordination layer.
-
-**Gains:** Parallel fan-out + typed routing + works today + extensible to other workflows. The notes contract is explicit rather than implicit.
-**Gives up:** Invisible to DAG. Notes contract couples coordinator to specific workflow version.
-
-**Impact surface:** mr-review workflow JSON (add coordinatorOutput to outputRequired), coordinator script (use typed parser), possibly a shared `coordinator-contract-types.ts` file.
-
-**Scope:** Best-fit. Pragmatic + the most defensible long-term.
-
-**Philosophy honored:** Validate at boundaries, Errors as data, Prefer explicit domain types (CoordinatorOutput > string parse), Exhaustiveness (FindingsSeverity discriminated union)
-**Philosophy conflict:** None significant.
+- **Tensions resolved:** Extensibility for future coordinators
+- **Tensions accepted:** Higher upfront complexity; forced generic mold may not fit next coordinator
+- **Boundary:** Generic abstraction layer above CoordinatorDeps
+- **Failure mode:** Framework abstraction doesn't fit next coordinator's shape
+- **Repo-pattern relationship:** No existing coordinator framework to adapt; departs significantly
+- **Gain:** Future reuse
+- **Loss:** YAGNI violation -- second coordinator doesn't exist yet
+- **Scope:** Too broad
+- **Philosophy:** Violates YAGNI with discipline
 
 ---
 
 ## Comparison and Recommendation
 
-### Tensions x Candidates Matrix
+**Recommendation: Candidate B**
 
-| Criterion | C1 (Script, minimal) | C2 (Workflow, serial) | C3 (Async spawn_agent) | C4 (Script + contract) |
-|-----------|----------------------|----------------------|------------------------|------------------------|
-| Parallel fan-out | YES | NO | YES | YES |
-| Content-based routing | YES (fragile parse) | YES (inline) | YES (inline) | YES (typed contract) |
-| Structured failure data | YES | YES | YES | YES |
-| Console DAG tree | NO | YES | YES | NO |
-| New pipeline = new file | YES | YES | YES | YES |
-| Ships today | YES | YES | NO | YES |
-| Testable without daemon | YES | NO | NO | YES |
+Candidate B is the only option that:
+1. Follows the established DI interface pattern (`WorktrainSpawnCommandDeps`) exactly
+2. Enables the `getAgentResult` 2-call HTTP sequence in a testable way
+3. Produces pure functions for finding parsing and severity classification
+4. Enforces all 5 robustness rules with explicit typed state
+5. Honors all CLAUDE.md philosophy principles
 
-### Recommended Direction: Candidate 4 (Script + Structured Notes Contract)
-
-**Build a TypeScript coordinator script with DI-injected effects, parallel fan-out via worktrain spawn + await, and content-based routing against an explicit `## COORDINATOR_OUTPUT` JSON block added to the mr-review workflow's final step.**
-
-Rationale:
-1. Only C1 and C4 achieve parallel fan-out + ship today + testable without daemon
-2. C4 > C1 because typed contract (explicit domain type) vs. fragile regex (philosophy violation)
-3. C2 loses on serial reviews (N*reviewTime) and routing logic in LLM prompts (scripts-first violation)
-4. C3 is the correct long-term direction but does not exist (YAGNI until C4 validates the topology)
-
-**The coordinator output contract pattern is already proven in the codebase:** `parseHandoffArtifact` in `src/trigger/delivery-action.ts` does exactly this for the coding-task workflow. The coordinator contract is the same pattern at the coordination layer.
-
-### What C4 Gives Up
-
-Console DAG visibility. The coordinator script is invisible -- not a WorkRail session. Mitigation: child sessions appear in the console as a flat list with parentSessionId links once that UI is built. Phase transitions logged to stderr with session handles.
-
-**C4 is a stepping stone, not a permanent decision.** Once async spawn_agent ships (C3 direction), the coordinator workflow will have DAG visibility + all current advantages. C4 validates the topology in production so that C3 is built on confirmed requirements.
-
-### Self-Critique
-
-**Strongest counter-argument:** Notes contract coupling creates a maintenance dependency between the coordinator script and a specific version of the mr-review workflow. If the workflow format changes, the coordinator silently fails or throws a parse error. Candidate 2 avoids this entirely (the LLM reads whatever notes exist).
-
-**Pivot conditions:**
-1. If notes contract adds too much friction across multiple coordinator scripts -> use structured context variables (workflow final step sets context.coordinatorOutput, coordinator reads it via GET session context) instead of notes block
-2. If async spawn_agent is scheduled within 2 weeks -> consider waiting and going directly to C3
-3. If DAG observability is critical for the first real pipeline debug -> accept C2's serial reviews to get the tree view
-
-## Challenge Notes
-
-### Adversarial Challenge of Candidate 4 (Leading Direction)
-
-**Challenge 1: The notes contract is a false solution to the wrong problem.**
-
-Candidate 4 adds a `## COORDINATOR_OUTPUT` JSON block to the mr-review workflow. But what happens when there are 10 different coordinator pipelines, each with a different output contract? You now have N contracts to maintain, each coupling a coordinator to a specific workflow version. The `parseHandoffArtifact` precedent is actually a warning, not a green light -- the handoff artifact has already caused fragility when workflow output formats drifted. Coordinator contracts multiply this surface area.
-
-**Resolution:** Valid concern, but the alternative (LLM prose routing in C2) has the same coupling problem in a less visible form -- the coordinator LLM must still understand what 'BLOCKING' means in free-form text. Typed contracts are preferable to implicit text conventions even if they require maintenance. Mitigation: a shared `coordinator-contract-types.ts` with a versioned schema, and a `validate_coordinator_output` step in the workflow's verify block that rejects outputs that don't match the schema.
-
-**Challenge 2: worktrain spawn does not pass context variables -- classify-task output cannot reach the coding-task session.**
-
-The mr-review pipeline does not need classify-task output. But the full implementation pipeline (implement-feature coordinator) requires passing `{ taskComplexity, recommendedPipeline }` from classify-task to the coding-task session. The current worktrain spawn CLI has no `--context` flag. A coordinator that needs to pass context must use HTTP directly: POST /api/v2/auto/dispatch with a `context` body field.
-
-**Resolution:** Confirmed gap. Add `passContext: (handle: string, context: Record<string, unknown>) => Promise<void>` to CoordinatorDeps, implemented via HTTP. This must be documented in the coordinator template as a required dep. It is not a blocker for the mr-review coordinator specifically (which does not need classify output), but IS a blocker for the implement-feature coordinator.
-
-**Challenge 3: The coordinator script is not durable. If the script process dies mid-pipeline, all coordination state is lost.**
-
-If the coordinator crashes after spawning 5 review sessions but before collecting their results, those sessions are orphaned in 'in_progress' state. The coordinator has no way to recover -- it cannot re-acquire the session handles it created. The script's state is entirely in-memory.
-
-**Resolution:** This is a real limitation with no clean fix in Candidate 4. Mitigation: write session handles to a state file (`~/.workrail/coordinator-state/{run-id}.json`) at each phase transition. On coordinator restart, read the state file and resume from the last checkpoint. This adds complexity but is not insurmountable. Alternatively: accept the limitation for the first coordinator and note it as a reason to invest in C3 (native workflow + daemon durability).
-
-**Challenge 4: 'Parallel fan-out' requires calling spawnSession N times before awaitSessions. But worktrain spawn is sequential at the CLI level -- each CLI invocation is a separate process.**
-
-Actually this is a non-issue. The coordinator script calls the `spawnSession` dep N times (N async HTTP calls in parallel via Promise.all), then calls `awaitSessions` once with all handles. The HTTP calls are non-blocking. True parallelism IS achievable in the TypeScript coordinator. This challenge fails.
-
-**Challenge 5: What if the first mr-review pipeline reveals that the topology is wrong?**
-
-If the first real pipeline run shows that the mr-review workflow needs to return richer data than the notes contract provides, the coordinator needs a contract change + workflow change + coordinator change. In C2 (native workflow), a format change is handled by changing the LLM prompt -- no parse layer to update. This makes C2 more flexible for early iteration.
-
-**Resolution:** Valid tradeoff. C4 is less flexible to format changes than C2. Mitigation: keep the coordinator output block minimal for v1 (severity + summary + prNumber only) and add fields incrementally. Schema versioning via a `version: 1` field in the JSON block lets the coordinator detect stale contract versions.
-
-### Challenge Verdict
-
-**C4 holds up under challenge.** The three real concerns (contract maintenance, no context passing, no durability) are documented limitations with known mitigations, not blockers. The challenge confirms C4 as the right first coordinator design, with C3 (async spawn_agent + native workflow) as the explicit next investment after production validation.
+The scope is correct: 3 new files, clear boundaries, no speculative abstractions.
 
 ---
 
-## Resolution Notes
+## Self-Critique
 
-**Selected Direction: Candidate 4** -- TypeScript coordinator script with DI-injected effects, parallel fan-out via worktrain spawn + await, and an explicit `## COORDINATOR_OUTPUT` JSON block in the mr-review workflow as the typed findings contract.
+**Strongest counter-argument against B:** Port discovery logic is duplicated from `worktrain-spawn.ts`. A clean-design purist would extract it to a shared util. However, the coordinator is a standalone script in `src/coordinators/`, not part of the daemon machinery. Coupling it to internal daemon utils would be the wrong dependency direction. The duplication is intentional and bounded.
 
-**Runner-up: Candidate 3** -- async spawn_agent + native coordinator workflow. This is the correct long-term direction. It should be built after C4 validates the topology in production.
+**What would tip toward A:** If context passing is never needed and the coordinator will always be a thin orchestrator. But the robustness rules (zombie detection, traceability JSON block) require typed interfaces, which Candidate A can't easily provide.
 
-**Why C4 over C2:** C2 is serial (N*reviewTime). C2 routing logic lives in LLM prompts (violates scripts-first principle). C2 is not testable without a live daemon.
+**What evidence would justify C:** A second coordinator (e.g., `groom-prs`, `security-audit`) that shares 50%+ of the shape. Currently speculative.
 
-**Why C4 over C1:** C1 uses fragile regex on free-form notes. C4 uses a typed contract (`## COORDINATOR_OUTPUT` JSON block). The difference is the same as parseHandoffArtifact vs. ad-hoc string parsing.
-
-**Why C4 before C3:** YAGNI. Async spawn_agent does not exist. Build C4 first, run it in production, then use the validated topology to spec async spawn_agent properly.
+**Invalidating assumption:** If `GET /api/v2/sessions/:id/nodes/:nodeId` consistently returns `recapMarkdown: null` for the final step (e.g., because `requireConfirmation: true` nodes store notes differently). Mitigation already built in: null -> unknown -> escalate. The coordinator won't crash, it escalates conservatively.
 
 ---
 
-## Decision Log
+## Open Questions for the Main Agent
 
-**Decision 1:** Path = design_first. Rationale: goal was a solution statement; two viable architectures existed; risk was premature commitment to wrong abstraction level.
+1. Should `worktrain run pr-review` use a nested commander subcommand (`program.command('run').command('pr-review')`) or a flat command (`program.command('run pr-review')`)? Commander supports both; the existing commands all use flat style -- recommend flat.
 
-**Decision 2:** Selected Candidate 4 (TypeScript script + coordinator output contract). Rationale: parallel fan-out, typed routing, testable, ships today, extensible. C3 is the long-term direction but YAGNI until production validates the topology.
+2. For the serial merge sequence: should the coordinator do `git pull` before each `gh pr merge --squash`? Yes -- ensures clean base. But this is a coordinator behavior detail, not an architectural question.
 
-**Decision 3:** Notes contract pattern confirmed by precedent (parseHandoffArtifact in delivery-action.ts). The coordinator output block is the same pattern at the coordination layer.
+3. Should the coordinator write a full report file (`coordinator-pr-review-YYYY-MM-DD.md`)? Yes, per UX spec. This is a simple file write via CoordinatorDeps.
 
-**Decision 4:** Three documented limitations accepted as known tradeoffs: (a) coordinator invisible to console DAG, (b) no context passing from worktrain spawn CLI (use HTTP directly), (c) no durability on coordinator crash (state file mitigation optional for v1).
-
-**Decision 5:** C3 (async spawn_agent) named as next engine investment. Trigger: after first coordinator (C4) has run in production with real PRs.
-
----
-
-## Final Summary
-
-### Recommended Architecture
-
-**Candidate 4: TypeScript Coordinator Script with Structured Notes Contract**
-
-Build a standalone TypeScript file (`coordinator-mr-review.ts`) with:
-
-1. **CoordinatorDeps DI interface** -- all effects injectable (spawn, await, notes retrieval, PR list, merge, Slack):
-   ```typescript
-   interface CoordinatorDeps {
-     readonly spawnSession: (workflowId: string, goal: string, workspace: string, context?: Record<string, unknown>) => Promise<string>;
-     readonly awaitSessions: (handles: string[], timeoutMs: number) => Promise<AwaitResult>;
-     readonly getAgentResult: (handle: string) => Promise<AgentResult>; // 2-call HTTP internally
-     readonly listOpenPRs: () => Promise<PullRequest[]>;
-     readonly mergePR: (number: number) => Promise<void>;
-     readonly postSlack: (message: string) => Promise<void>;
-     readonly stderr: (line: string) => void;
-   }
-   ```
-
-2. **AgentResult bridge type** (mirrors future async spawn_agent result):
-   ```typescript
-   type AgentResult = { handle: string; childSessionId: string | null; outcome: SessionOutcome; notes: string | null };
-   ```
-
-3. **Two-tier findings parsing**:
-   - Preferred: parse `## COORDINATOR_OUTPUT` JSON block from notes (typed contract)
-   - Fallback: scan for BLOCKING/MINOR/CLEAN keywords in notes (graceful degradation)
-   - Unknown severity defaults to 'blocking' (conservative)
-
-4. **Parallel fan-out via Promise.all + worktrain await**:
-   ```typescript
-   const handles = await Promise.all(prs.map(pr => deps.spawnSession('mr-review-workflow-agentic', `Review PR #${pr.number}`, workspace)));
-   const awaitResult = await deps.awaitSessions(handles, 30 * 60 * 1000);
-   const agentResults = await Promise.all(handles.map(h => deps.getAgentResult(h)));
-   ```
-
-5. **Typed routing** over FindingsSeverity discriminated union:
-   ```typescript
-   type FindingsSeverity = 'clean' | 'minor' | 'blocking' | 'unknown';
-   ```
-
-6. **Required parallel workflow change: add verify step to mr-review workflow**
-   The mr-review workflow's final step must include in `outputRequired`:
-   ```
-   coordinatorOutput: "JSON block: ## COORDINATOR_OUTPUT\n```json\n{\"findings\": [{\"severity\": \"clean|minor|blocking\", \"summary\": \"...\", \"prNumber\": N}]}\n```"
-   ```
-   And in `verify`: "## COORDINATOR_OUTPUT block is present with valid JSON matching the coordinator schema."
-
-### Notes Retrieval: 2-Call HTTP Sequence
-
-The `getAgentResult` dep implementation does:
-1. GET `/api/v2/sessions/:sessionId` -- find `runs[0].nodes` preferred tip node ID
-2. GET `/api/v2/sessions/:sessionId/nodes/:nodeId` -- get `recapMarkdown` (step notes)
-3. Parse coordinator output block from recapMarkdown
-
-### Context Passing
-
-The `spawnSession` dep uses HTTP dispatch directly (not worktrain spawn CLI):
-```
-POST /api/v2/auto/dispatch { workflowId, goal, workspacePath, context }
-```
-The `context` body field is supported (verified in console-routes.ts L519).
-The worktrain spawn CLI does not have a `--context` flag -- use HTTP for context-passing pipelines.
-
-### Pipeline Sequence (mr-review coordinator)
-
-```
-1. listOpenPRs() -> [PR]
-2. Parallel: spawnSession('mr-review-workflow-agentic', goal, workspace) for each PR
-3. awaitSessions(all handles, 30m)
-4. For each handle: getAgentResult -> parse findings
-5. Route:
-   - clean -> mergeQueue
-   - minor -> spawnSession('coding-task-workflow-agentic', 'Fix: <finding>'), await, re-review (max 3 passes)
-   - blocking -> escalation list (Slack + GitLab comment)
-   - unknown -> escalation list (conservative default)
-6. mergePR() for each clean PR (serial, pull before each to avoid conflicts)
-7. postSlack(summary)
-```
-
-### What This Gives Up
-
-- Console DAG tree view: coordinator is not a WorkRail session. Child sessions appear as a flat list. **Mitigation:** parentSessionId is already in the session store; console tree view is the next planned feature and will retroactively make child sessions visible.
-- Coordinator crash durability: script state is in-memory. **Mitigation (v2):** state file at `~/.workrail/coordinator-state/{run-id}.json` written at each phase transition.
-
-### Long-Term Direction (Candidate 3)
-
-After the first coordinator script runs in production and validates the topology:
-- Build `spawn_agent(blocking: false)` + `await_agents([handles])` native engine tools
-- Build a coordinator as a WorkRail workflow JSON file using these tools
-- This gives: parallel fan-out + console DAG observability + daemon durability + inline notes (no 2-call HTTP)
-- The `AgentResult` bridge type in C4 makes this migration trivial (same result shape)
-
-### Open Questions (non-blocking)
-
-1. Is non-blocking spawn_agent on the near-term roadmap? If yes, skip C4 and build C3 directly.
-2. Should `worktrain spawn` get a `--context` flag? Would simplify coordinator deps for context-passing pipelines.
-3. Should `worktrain await` get a `--include-notes` flag? Would consolidate the 2-call HTTP into the CLI.
-
-### Confidence Band: HIGH
-
-All findings are grounded in direct code reading of: `worktrain-spawn.ts`, `worktrain-await.ts`, `workflow-runner.ts` (spawn_agent section), `trigger-router.ts`, `classify-task-workflow.json`, `console-types.ts`, `console-routes.ts`, and 4 backlog sections. No speculative assumptions.
+4. Is `coding-task-workflow-agentic` the correct fix-agent workflow? Yes -- it handles "implement/fix" tasks. The goal string `Fix review findings in PR #N: [finding summaries]` is the goal format.

--- a/docs/discovery/hypothesis-challenge-report.md
+++ b/docs/discovery/hypothesis-challenge-report.md
@@ -1,0 +1,44 @@
+# Hypothesis Challenge: PR Review Coordinator HTTP-First Design
+
+*Generated: 2026-04-18*
+
+## Target Claim
+
+The PR review coordinator's HTTP-first design (Candidate B) is sound: the 2-call HTTP notes extraction is reliable, the two-tier keyword parser correctly classifies review severity, and the 5 robustness rules are sufficient.
+
+## Strongest Counter-Argument
+
+`phase-6-final-handoff` has `requireConfirmation: true`. The preferredTipNodeId may point to a checkpoint/confirmation node whose recapMarkdown is sparse or absent, causing the keyword scanner to misclassify clean PRs as 'unknown' and escalate them unnecessarily.
+
+**Verdict:** Mitigated. In autonomous mode, the agent calls `continue_workflow` with substantive notes before the confirmation gate. WorkRail stores these notes as the RECAP payload for the node. The recapMarkdown IS populated for autonomous sessions completing phase-6. The requireConfirmation flag only blocks advancement until notes are written -- which the autonomous agent does.
+
+## Weak Assumptions / Evidence Gaps
+
+1. **`runs[0]` is always the most recent run:** True in practice. WorkRail appends new runs; index 0 is the most recent. Confirmed in worktrain-await.ts pollSession() which uses `runs[0]`.
+
+2. **Keyword scan is context-unaware:** 'blocking' appearing in negative context ('this is not blocking') would trigger a false positive. Mitigation: require BLOCKING keyword to be present without a preceding negation. Simpler: use priority order -- any blocking keyword -> blocking, regardless of context. The conservative default is acceptable.
+
+3. **go/no-go time check needs adaptation:** Rule 3 (don't spawn if remaining time < 20 minutes) was designed for daemon sessions with known maxSessionMinutes. A CLI coordinator has no such limit. Adaptation: track wall-clock time since coordinator start, refuse to spawn new sessions if elapsed > coordinator_max_minutes - 20.
+
+## Likely Failure Modes
+
+1. **recapMarkdown null for final step** -> 'unknown' severity -> escalate (conservative, correct)
+2. **Fix-agent loop max 3 passes exceeded** -> escalate after 3 (loop counter enforces this)
+3. **ECONNREFUSED on daemon calls** -> early exit with clear error message
+4. **Keyword false positive** -> PR escalated as blocking when actually clean (false negative on merge, acceptable)
+5. **Merge conflict at merge time** -> `gh pr merge` fails, coordinator reports error and escalates
+
+## Critical Tests
+
+- `parseFindingsFromNotes(null)` -> returns err, classifies as 'unknown'
+- `parseFindingsFromNotes(markdown with 'not blocking but...')` -> must NOT return 'blocking'
+- Loop counter: 3 passes with persistent minor -> escalate on pass 3, NOT pass 4
+- ECONNREFUSED: spawnSession failure propagates cleanly to stderr and exit code 1
+
+## Verdict: Keep
+
+The design is sound. The 2-call HTTP extraction works for autonomous sessions. The two-tier parser with conservative defaults is sufficient. The 5 robustness rules need one adaptation: Rule 3 (go/no-go time check) should use wall-clock time since coordinator start, not daemon session remaining time.
+
+## Next Action
+
+Proceed with Candidate B implementation. Add adaptation to Rule 3: track coordinator wall-clock start time; refuse new spawns if `now() - startTime > (coordinatorMaxMs - 20*60*1000)`. Default coordinatorMaxMs = 90 minutes.

--- a/docs/discovery/simulation-report.md
+++ b/docs/discovery/simulation-report.md
@@ -1,0 +1,85 @@
+# Execution Simulation Report: PR Review Coordinator Failure Paths
+
+*Generated: 2026-04-18*
+
+## Summary
+
+Three failure paths simulated for the PR review coordinator design. All three produce correct outcomes under the proposed design. One gap identified: Rule 3 (go/no-go time check) needs adaptation for CLI context.
+
+## Scenario 1: recapMarkdown is Null
+
+**Setup:** Session completes successfully, but `GET /api/v2/sessions/:id/nodes/:nodeId` returns `recapMarkdown: null`.
+
+**Trace:**
+```
+getAgentResult('handle-419')
+  GET /api/v2/sessions/handle-419 -> runs[0].preferredTipNodeId = 'node-xyz'
+  GET /api/v2/sessions/handle-419/nodes/node-xyz -> recapMarkdown = null
+  returns null
+
+parseFindingsFromNotes(null) -> err('notes is null or empty')
+classifySeverity(err) -> 'unknown'
+route('unknown') -> escalate
+```
+
+**Divergence from expected:** None -- conservative escalation is the designed behavior.
+
+**Outcome:** PR escalated, not merged. No crash. Clear escalation note written.
+
+## Scenario 2: Fix-Agent Loop Exhaustion (3 Passes, Persistent Minor)
+
+**Setup:** PR #406 has minor findings. Fix agent runs 3 times but each re-review still returns minor.
+
+**Trace:**
+```
+Pass 1: passCount=0 -> review: 'minor' -> passCount becomes 1 -> spawn fix agent -> re-review
+Pass 2: passCount=1 -> review: 'minor' -> passCount becomes 2 -> spawn fix agent -> re-review
+Pass 3: passCount=2 -> review: 'minor' -> passCount becomes 3 -> CHECK: 3 >= 3 -> STOP
+  -> escalate, write: 'PR #406: 3 fix passes exhausted, still minor. Manual review required.'
+```
+
+**Divergence from expected:** None -- loop terminates correctly at pass 3.
+
+**Key invariant verified:** `passCount >= MAX_FIX_PASSES` check happens BEFORE spawning fix agent, not after. This prevents a 4th spawn.
+
+**Outcome:** PR escalated after exactly 3 passes. Not merged.
+
+## Scenario 3: Daemon Not Running (ECONNREFUSED)
+
+**Setup:** No daemon running on port 3456. No lock files present.
+
+**Trace:**
+```
+discoverPort() -> no lock files -> falls back to 3456
+spawnSession('mr-review-workflow-agentic', 'Review PR #419...', '/workspace')
+  POST http://127.0.0.1:3456/api/v2/auto/dispatch
+  -> fetch throws Error: ECONNREFUSED 127.0.0.1:3456
+  -> spawnSession catches -> returns err('Could not connect to WorkTrain daemon on port 3456')
+runPrReviewCoordinator() receives err
+  -> deps.stderr('Could not connect to WorkTrain daemon on port 3456. Start with: worktrain daemon')
+  -> returns { kind: 'failure', exitCode: 1 }
+```
+
+**Divergence from expected:** None.
+
+**Outcome:** Clear error message, exit code 1, no hang, no partial state.
+
+## Divergence Analysis
+
+No divergences found. All 3 scenarios produce correct outcomes.
+
+## Gap Identified: Rule 3 Adaptation for CLI Context
+
+**Problem:** The original Rule 3 (go/no-go time check: don't spawn if remaining time < 20 minutes) was written for daemon sessions that have a `maxSessionMinutes` parameter. A CLI coordinator script has no such parameter.
+
+**Adaptation required:** Track wall-clock time since coordinator script start (`const startTimeMs = deps.now()` at beginning). Before spawning any new child session (review OR fix agent), check: `if (deps.now() - startTimeMs > coordinatorMaxMs - 20 * 60 * 1000)` -> refuse to spawn.
+
+**Default:** `coordinatorMaxMs = 90 * 60 * 1000` (90 minutes). Configurable via `--max-runtime` flag if needed.
+
+## Recommendations
+
+1. Implement `parseFindingsFromNotes(null)` path explicitly -- don't rely on empty string check.
+2. Keyword parser priority: BLOCKING/CRITICAL/REQUEST CHANGES takes absolute precedence over APPROVE/CLEAN/LGTM (blocking wins even if both present).
+3. Fix-agent loop: check `passCount >= MAX_FIX_PASSES` BEFORE spawning, not after.
+4. Add `coordinatorStartMs` tracking and Rule 3 go/no-go check adapted for CLI (wall-clock elapsed time).
+5. `gh pr merge` failures: catch, write to stderr, escalate -- do NOT retry automatically.

--- a/implementation_plan_coordinator_pr_review.md
+++ b/implementation_plan_coordinator_pr_review.md
@@ -1,0 +1,230 @@
+# Implementation Plan: PR Review Coordinator
+
+*Generated: 2026-04-18*
+
+---
+
+## Problem Statement
+
+WorkTrain needs a coordinator script that can autonomously drive multi-PR code review: dispatch `mr-review-workflow-agentic` sessions for open PRs, wait for results, extract findings from session notes, route by severity (clean -> merge, minor -> fix-agent loop, blocking -> escalate), and produce a structured terminal output and report file.
+
+---
+
+## Acceptance Criteria
+
+1. `worktrain run pr-review` CLI subcommand exists and prints usage when run without required args.
+2. `worktrain run pr-review --workspace <path>` discovers open PRs via `gh pr list` and dispatches one `mr-review-workflow-agentic` session per PR.
+3. Sessions are dispatched in parallel (spawn all, then await all) with a 20-minute per-session timeout.
+4. For each session: a 2-call HTTP sequence extracts `recapMarkdown` from `GET /api/v2/sessions/:id/nodes/:nodeId`. Null recapMarkdown -> 'unknown' severity.
+5. `parseFindingsFromNotes(markdown)` is a pure function that returns `Result<ReviewFindings, string>`. Two-tier: JSON block (`## COORDINATOR_OUTPUT`) first, keyword scan fallback.
+6. Keyword scan: BLOCKING/CRITICAL/REQUEST CHANGES -> blocking; APPROVE/CLEAN/LGTM -> clean (only if no blocking keywords); MINOR/NIT only -> minor; otherwise -> unknown. Negation context check: `/\b(?:not|no|without)\b.{0,30}\bblocking\b/i` suppresses blocking classification.
+7. Routing: clean -> queue for merge; minor -> spawn `coding-task-workflow-agentic` fix agent with goal `Fix review findings in PR #N: [finding summaries]`, re-review (max 3 passes); blocking/unknown -> escalate.
+8. Serial merge: `gh pr merge --squash` one PR at a time. Merge failure -> escalate, no retry.
+9. All 5 robustness rules enforced:
+   - Rule 1: child session timeout hardcoded to 15 minutes (`agentConfig: { maxSessionMinutes: 15 }`) -- NOT computed
+   - Rule 2: `spawnSession()` returning empty/null handle -> treat as error, escalate
+   - Rule 3 (CLI adaptation): check `deps.now() - coordinatorStartMs > 70 * 60 * 1000` before each spawn; refuse if exceeded
+   - Rule 4: two-tier notes parsing (JSON block first, keyword fallback, unknown -> blocking)
+   - Rule 5: write `{ childSessionId, outcome, elapsedMs, severity }` JSON block to stderr/report before acting on results
+10. Terminal output matches UX spec format (see `docs/discovery/coordinator-ux-discovery.md`).
+11. Report file written to `./coordinator-pr-review-YYYY-MM-DD.md` in workspace.
+12. `--dry-run` flag: prints what would be spawned/merged but makes no HTTP calls or git operations.
+13. `--pr <number>` flag: reviews a single specified PR instead of discovering open PRs.
+14. Unit tests cover all pure functions: `parseFindingsFromNotes`, `classifySeverity`, `buildFixGoal`, routing logic.
+15. TypeScript compiles clean. All existing unit tests pass.
+
+---
+
+## Non-Goals
+
+- Updating `mr-review-workflow.agentic.v2.json` to emit `## COORDINATOR_OUTPUT` block (follow-up)
+- Generic coordinator framework or base class
+- Modifying `worktrain spawn` or `worktrain await` CLI commands
+- CI/CD integration or webhook triggers
+- Multi-repo coordinator mode
+- Retry logic for failed merges
+- Configurable coordinator timeout (always 90 minutes in MVP)
+
+---
+
+## Philosophy-Driven Constraints
+
+- `CoordinatorDeps` is a `readonly` interface -- all I/O injected, zero direct imports in coordinator core
+- `parseFindingsFromNotes()` and `classifySeverity()` are pure functions (no I/O) returning `Result<T, E>`
+- `ReviewSeverity = 'clean' | 'minor' | 'blocking' | 'unknown'` as a discriminated union with exhaustive switch
+- All fetch calls include `AbortSignal.timeout(30_000)` to prevent hangs
+- CLI wiring in `src/cli-worktrain.ts` (composition root); coordinator module has no commander dependency
+- Validate workspace path (absolute, exists) at CLI entry; trust inside coordinator
+
+---
+
+## Invariants
+
+1. Never merge when severity is `blocking`, `unknown`, `timeout`, `failed`, or `not_awaited`
+2. Fix-agent loop: check `passCount >= MAX_FIX_PASSES (3)` BEFORE spawning fix agent
+3. Child session timeout: hardcoded 15 minutes -- never LLM-computed or configurable from notes
+4. `spawnSession()` returns `err()` on ECONNREFUSED, AbortError, or non-2xx -- never throws
+5. Coordinator exits with code 1 if ANY PR resulted in an error (escalated due to error, not just blocking findings)
+6. `coordinatorStartMs` set once at startup; Rule 3 check uses this immutable reference
+7. Traceability JSON block written before acting on each session result
+
+---
+
+## Selected Approach
+
+**Candidate B: HTTP-first with CoordinatorDeps interface**
+
+- `src/coordinators/pr-review.ts` -- coordinator logic with typed deps interface
+- `src/cli-worktrain.ts` -- `worktrain run pr-review` wiring
+- `src/cli/commands/index.ts` -- export new command types
+- `tests/unit/coordinator-pr-review.test.ts` -- pure function unit tests
+
+Port discovery: copy pattern from `worktrain-spawn.ts` (bounded duplication, correct coupling direction).
+
+**Runner-up:** Candidate A (subprocess model). Lost because it prevents AbortSignal timeout, has no Result types, and is untestable without exec mocking.
+
+---
+
+## Vertical Slices
+
+### Slice 1: Types and pure functions
+**File:** `src/coordinators/pr-review.ts` (types and pure functions only)
+
+Define:
+- `ReviewSeverity = 'clean' | 'minor' | 'blocking' | 'unknown'`
+- `ReviewFindings { severity: ReviewSeverity; findingSummaries: string[]; raw: string }`
+- `PrSummary { number: number; title: string; headRef: string }`
+- `PrReviewOutcome { prNumber: number; severity: ReviewSeverity; merged: boolean; escalated: boolean; passCount: number; sessionHandles: string[] }`
+- `CoordinatorResult { reviewed: number; approved: number; escalated: number; mergedPrs: number[]; reportPath: string }`
+- `CoordinatorDeps { spawnSession, awaitSessions, getAgentResult, listOpenPRs, mergePR, writeFile, stderr, now, port }`
+
+Pure functions:
+- `parseFindingsFromNotes(notes: string | null): Result<ReviewFindings, string>`
+- `classifySeverity(findings: ReviewFindings): ReviewSeverity`
+- `buildFixGoal(prNumber: number, findings: ReviewFindings): string`
+- `formatElapsed(ms: number): string` (e.g., "8:31")
+- `discoverConsolePort(deps, portOverride?): Promise<number>` (copied from worktrain-spawn.ts)
+
+**Done when:** `tsc --noEmit` passes on new file, pure functions compile.
+
+### Slice 2: Coordinator core logic
+**File:** `src/coordinators/pr-review.ts` (add `runPrReviewCoordinator` function)
+
+```typescript
+async function runPrReviewCoordinator(
+  deps: CoordinatorDeps,
+  opts: { workspace: string; prs?: number[]; dryRun: boolean; port?: number }
+): Promise<CoordinatorResult>
+```
+
+Implements full pipeline:
+1. List PRs (or use `opts.prs`)
+2. Parallel spawn: for each PR, `deps.spawnSession()`
+3. `deps.awaitSessions()` with 20m timeout
+4. For each result: `deps.getAgentResult()` -> `parseFindingsFromNotes()` -> `classifySeverity()`
+5. Route and accumulate outcomes
+6. Fix-agent loop (max 3 passes per minor PR)
+7. Serial merge for clean PRs
+8. Write report via `deps.writeFile()`
+
+**Done when:** `tsc --noEmit` passes, function compiles with full type coverage.
+
+### Slice 3: Unit tests
+**File:** `tests/unit/coordinator-pr-review.test.ts`
+
+Test all pure functions:
+- `parseFindingsFromNotes(null)` -> err
+- `parseFindingsFromNotes('')` -> err
+- `parseFindingsFromNotes('## COORDINATOR_OUTPUT\n```json\n...\n```')` -> ok with structured findings
+- `parseFindingsFromNotes('APPROVE this change')` -> ok, severity 'clean'
+- `parseFindingsFromNotes('This is not technically blocking but...')` -> NOT 'blocking'
+- `parseFindingsFromNotes('BLOCKING: auth bypass')` -> severity 'blocking'
+- `parseFindingsFromNotes('minor nit')` -> severity 'minor'
+- `classifySeverity` with each severity variant
+- `buildFixGoal(419, findings)` -> correct goal string
+- Loop counter: 3 passes with persistent minor -> escalate
+
+**Done when:** `npx vitest run tests/unit/coordinator-pr-review.test.ts` passes.
+
+### Slice 4: CLI wiring
+**Files:** `src/cli-worktrain.ts`, `src/cli/commands/index.ts`
+
+Add `program.command('run pr-review')` to `src/cli-worktrain.ts` with:
+- `--workspace <path>` (required)
+- `--pr <number>` (optional, repeatable)
+- `--dry-run` (flag)
+- `--port <n>` (optional)
+
+Wire real deps: `fetch` with AbortSignal.timeout, `execFile` for `gh`/`git`, lock file discovery, `path.join`, `os.homedir`, `fs.promises.writeFile`.
+
+Export `WorktrainRunPrReviewCommandDeps` from `src/cli/commands/index.ts`.
+
+**Done when:** `worktrain run pr-review --help` prints usage. `tsc --noEmit` clean.
+
+### Slice 5: Integration smoke test (manual)
+Run `worktrain run pr-review --workspace <path> --dry-run` against a real workspace with open PRs. Verify output format matches UX spec. Verify no HTTP calls made in dry-run mode.
+
+---
+
+## Test Design
+
+**Unit tests (Slice 3):**
+- Pure function tests only -- no HTTP, no exec calls
+- Fake `CoordinatorDeps` implementing the interface (no mocking framework)
+- Vitest, same pattern as existing `tests/unit/` tests
+- Cover: all `parseFindingsFromNotes` input variants, `classifySeverity` exhaustiveness, loop counter boundary (`passCount = 2` vs `passCount = 3`)
+
+**Integration test:** Manual dry-run smoke test (not automated in this PR).
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `recapMarkdown` null for completed sessions | Low | null -> unknown -> escalate (conservative) |
+| Keyword false positive (negated blocking) | Medium | Negation context check in parser |
+| Fix agent runs but PR still fails re-review | Low | Max 3 passes, escalate after |
+| Daemon not running at coordinator start | Medium | ECONNREFUSED -> clear error, exit 1 |
+| Concurrent merge conflicts | Low | Serial merge + escalate on failure |
+| `worktrain run` subcommand name conflicts | Low | Check commander for existing 'run' command |
+
+---
+
+## PR Packaging Strategy
+
+**Branch:** `feat/coordinator-pr-review`
+**One PR** covering all 4 slices (types + core + tests + CLI wiring).
+PR description: explains the coordinator pattern, lists files changed, references UX spec and design docs.
+
+---
+
+## Philosophy Alignment per Slice
+
+| Slice | Principle | Status |
+|-------|-----------|--------|
+| Slice 1 (types) | Explicit domain types | Satisfied -- `ReviewSeverity` discriminated union |
+| Slice 1 (types) | Immutability by default | Satisfied -- all types readonly |
+| Slice 2 (core) | Errors as data | Satisfied -- `parseFindingsFromNotes` returns Result |
+| Slice 2 (core) | DI for boundaries | Satisfied -- all I/O via CoordinatorDeps |
+| Slice 2 (core) | Validate at boundaries | Satisfied -- workspace validated in Slice 4 |
+| Slice 3 (tests) | Prefer fakes over mocks | Satisfied -- fake CoordinatorDeps objects |
+| Slice 4 (CLI) | YAGNI with discipline | Satisfied -- no speculative abstractions |
+| All | Exhaustiveness | Satisfied -- switch on ReviewSeverity must be exhaustive |
+
+---
+
+## Follow-Up Tickets
+
+1. Update `mr-review-workflow.agentic.v2.json` phase-6 to emit `## COORDINATOR_OUTPUT` JSON block for reliable coordinator parsing
+2. Add `--max-runtime` flag to coordinator for configurable timeout (currently hardcoded 90 min)
+3. Add automated integration test for coordinator with fake daemon
+4. Add `worktrain run groom-prs` as second coordinator using same pattern
+
+---
+
+## Unresolved Unknowns: 0
+
+All design questions answered. No open human-decision questions remain.
+
+**planConfidenceBand: High**

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,145 @@
+# Spec: worktrain run pr-review
+
+*Canonical observable behavior specification. Do not edit to reflect implementation details.*
+
+---
+
+## Feature Summary
+
+`worktrain run pr-review` is a CLI subcommand that autonomously reviews open GitHub PRs in a workspace using WorkRail workflow sessions, routes each PR to merge/fix/escalate based on review findings, and produces a terminal summary and markdown report.
+
+---
+
+## Acceptance Criteria
+
+### AC1: CLI entry point
+`worktrain run pr-review --help` exits 0 and prints usage including `--workspace`, `--pr`, `--dry-run`, `--port` flags.
+
+**Verified by:** Running the CLI and checking exit code + output.
+
+### AC2: Workspace validation
+`worktrain run pr-review --workspace /nonexistent` exits 1 and prints an error to stderr containing 'does not exist' or 'must be an absolute path'.
+
+**Verified by:** Running with bad workspace.
+
+### AC3: Daemon not running
+`worktrain run pr-review --workspace /valid/path` when no daemon is running on port 3456 exits 1 and prints to stderr: message containing 'daemon' or 'connect'.
+
+**Verified by:** Running without daemon.
+
+### AC4: No open PRs
+When `gh pr list` returns zero PRs, coordinator exits 0 and prints `RESULT: 0 PRs reviewed, 0 approved, 0 escalated`.
+
+**Verified by:** Unit test with fake `listOpenPRs` returning `[]`.
+
+### AC5: Clean PR routing
+When a review session returns findings with no blocking/critical issues, the PR is queued for merge. In non-dry-run mode, `gh pr merge --squash` is called for that PR.
+
+**Verified by:** Unit test with fake `CoordinatorDeps` returning clean findings.
+
+### AC6: Minor PR routing with fix loop
+When a review returns minor-only findings, a fix agent (`coding-task-workflow-agentic`) is spawned, then the PR is re-reviewed. If the re-review is clean, the PR is merged.
+
+**Verified by:** Unit test with fake deps: first review=minor, fix spawned, second review=clean, merge called.
+
+### AC7: Fix loop terminates at 3 passes
+When a PR has persistent minor findings after 3 fix-agent passes, the coordinator escalates (does NOT merge) and reports '3 passes exhausted'.
+
+**Verified by:** Unit test with fake deps always returning minor.
+
+### AC8: Blocking PR routing
+When a review returns blocking or critical findings, the coordinator escalates without merging. Exit code is 1 if any PR was escalated due to error (not just blocking findings).
+
+**Verified by:** Unit test with fake deps returning blocking findings.
+
+### AC9: Unknown severity is safe
+When `recapMarkdown` is null or unparseable, severity is 'unknown' and the PR is escalated (not merged).
+
+**Verified by:** Unit test with `getAgentResult` returning null.
+
+### AC10: Dry-run makes no mutations
+`worktrain run pr-review --dry-run` makes no HTTP dispatch calls, no `gh pr merge` calls, and no `gh pr merge` calls. It prints what would happen.
+
+**Verified by:** Unit test with dry-run flag; assert no spawnSession/mergePR calls.
+
+### AC11: Traceability JSON written
+Before acting on each session result, the coordinator writes a JSON block `{ childSessionId, outcome, elapsedMs, severity }` to the report.
+
+**Verified by:** Check report file content after run.
+
+### AC12: Report file created
+A file `./coordinator-pr-review-YYYY-MM-DD.md` is written in the workspace directory after the run.
+
+**Verified by:** File exists after successful run.
+
+### AC13: Negation context not classified as blocking
+A review containing 'this is not technically blocking' does NOT result in blocking classification.
+
+**Verified by:** Unit test of `parseFindingsFromNotes` with negated blocking text.
+
+### AC14: TypeScript compiles clean
+`tsc --noEmit` passes with no new errors after implementation.
+
+**Verified by:** Running tsc.
+
+### AC15: Existing unit tests pass
+`npx vitest run tests/unit/` passes with no regressions.
+
+**Verified by:** Running vitest.
+
+---
+
+## Non-Goals
+
+- Coordinator does not post GitHub comments or approve/reject PRs via `gh pr review`
+- Coordinator does not modify any WorkRail workflow files
+- Coordinator does not run if the daemon is not running
+- Coordinator does not support repos other than the workspace's git remote
+
+---
+
+## External Interface Contract
+
+```
+worktrain run pr-review
+  --workspace <path>   Required. Absolute path to git workspace.
+  --pr <number>        Optional, repeatable. Review specific PR(s) only.
+  --dry-run            Optional. Print actions without executing them.
+  --port <n>           Optional. Override daemon console port (default: auto-discover).
+```
+
+**Exit codes:**
+- 0: All reviewed PRs either merged or clean escalation (no errors)
+- 1: Any PR escalated due to error, timeout, zombie session, or daemon unavailable
+
+**Stdout:** Terminal summary in the format:
+```
+[1/3] Gathering open PRs...  done (0:02)
+[2/3] Running reviews (N parallel)...
+      PR #N worktrain spawn/await    done (M:SS)  CLEAN|MINOR|BLOCKING
+[3/3] Processing results...
+      PR #N  ->  queued for merge | spawning fix agent... | escalated
+
+RESULT: N PRs reviewed, N approved, N escalated
+Merged: PR #N, PR #M
+Full report: ./coordinator-pr-review-YYYY-MM-DD.md
+```
+
+**Stderr:** Progress, warnings, errors. JSON traceability blocks per session.
+
+---
+
+## Edge Cases and Failure Modes
+
+| Case | Expected behavior |
+|------|-------------------|
+| null recapMarkdown | severity=unknown, escalate |
+| Session outcome='failed' | severity=unknown, escalate |
+| Session outcome='timeout' | severity=unknown, escalate, do NOT count as error unless no result |
+| Fix agent session fails | Escalate the PR, count fix attempt in pass count |
+| `gh pr merge` fails | Escalate, no retry, report error in output |
+| Daemon returns 503 | Exit 1, stderr: 'daemon not ready' |
+| ECONNREFUSED | Exit 1, stderr: 'could not connect to daemon' |
+| Fetch timeout (30s) | Return err, treat as daemon unavailable |
+| Coordinator elapsed > 70min | Refuse new spawns, finish existing awaits |
+| --pr flag with non-existent PR | `gh pr list` will return empty; coordinator reports 0 PRs |

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -895,6 +895,218 @@ function runHealthSummary(sessionId: string, raw: string): void {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// RUN COMMAND
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * worktrain run pr-review
+ *
+ * Autonomous PR review coordinator. Dispatches mr-review-workflow-agentic sessions
+ * for open PRs, waits for results, and routes by severity: clean -> merge,
+ * minor -> fix-agent loop, blocking/unknown -> escalate.
+ *
+ * Requires the WorkTrain daemon to be running: worktrain daemon
+ */
+const runCommand = program
+  .command('run')
+  .description('Run a coordinator script');
+
+runCommand
+  .command('pr-review')
+  .description('Review open PRs autonomously: dispatch review sessions, route by findings, merge or escalate')
+  .requiredOption('-W, --workspace <path>', 'Absolute path to the git workspace')
+  .option('-r, --pr <number>', 'Review a specific PR number (repeatable)', (val, prev: number[]) => [...prev, parseInt(val, 10)], [] as number[])
+  .option('--dry-run', 'Print actions without dispatching sessions or merging')
+  .option('-p, --port <n>', 'Console HTTP server port (default: auto-discover from lock file, then 3456)', parseInt)
+  .action(async (options: { workspace: string; pr: number[]; dryRun?: boolean; port?: number }) => {
+    const {
+      runPrReviewCoordinator,
+      discoverConsolePort,
+    } = await import('./coordinators/pr-review.js');
+    const { execFile: execFileRaw } = await import('child_process');
+    const execFilePromise = promisify(execFileRaw);
+
+    // Validate workspace at the CLI boundary
+    if (!path.isAbsolute(options.workspace)) {
+      process.stderr.write(`Error: --workspace must be an absolute path, got: ${options.workspace}\n`);
+      process.exit(1);
+    }
+    try {
+      const stat = await fs.promises.stat(options.workspace);
+      if (!stat.isDirectory()) {
+        process.stderr.write(`Error: --workspace must be an existing directory: ${options.workspace}\n`);
+        process.exit(1);
+      }
+    } catch {
+      process.stderr.write(`Error: --workspace does not exist: ${options.workspace}\n`);
+      process.exit(1);
+    }
+
+    // Discover console port
+    const port = await discoverConsolePort(
+      {
+        readFile: (p: string) => fs.promises.readFile(p, 'utf-8'),
+        homedir: os.homedir,
+        joinPath: path.join,
+      },
+      options.port,
+    );
+
+    // Build real CoordinatorDeps
+    const deps = {
+      spawnSession: async (workflowId: string, goal: string, workspace: string) => {
+        const url = `http://127.0.0.1:${port}/api/v2/auto/dispatch`;
+        try {
+          const response = await globalThis.fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workflowId, goal, workspacePath: workspace }),
+            signal: AbortSignal.timeout(30_000),
+          });
+          const body = await response.json() as Record<string, unknown>;
+          if (!response.ok) {
+            const errMsg = typeof body['error'] === 'string' ? body['error'] : `HTTP ${response.status}`;
+            if (response.status === 503) {
+              return { kind: 'err' as const, error: `WorkTrain daemon is not ready: ${errMsg}` };
+            }
+            return { kind: 'err' as const, error: `Dispatch failed: ${errMsg}` };
+          }
+          if (body['success'] !== true || typeof body['data'] !== 'object') {
+            return { kind: 'err' as const, error: 'Unexpected response from dispatch endpoint' };
+          }
+          const data = body['data'] as Record<string, unknown>;
+          const handle = typeof data['sessionHandle'] === 'string' ? data['sessionHandle'] : '';
+          if (!handle) {
+            return { kind: 'err' as const, error: 'Dispatch succeeded but no session handle returned' };
+          }
+          return { kind: 'ok' as const, value: handle };
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          const isConnRefused = msg.includes('ECONNREFUSED') || msg.includes('fetch failed');
+          if (isConnRefused) {
+            return { kind: 'err' as const, error: `Could not connect to WorkTrain daemon on port ${port}. Ensure the daemon is running with: worktrain daemon` };
+          }
+          if (e instanceof Error && e.name === 'TimeoutError') {
+            return { kind: 'err' as const, error: `Daemon request timed out after 30s` };
+          }
+          return { kind: 'err' as const, error: `Dispatch request failed: ${msg}` };
+        }
+      },
+
+      awaitSessions: async (handles: readonly string[], timeoutMs: number) => {
+        const { executeWorktrainAwaitCommand } = await import('./cli/commands/worktrain-await.js');
+        let resolvedResult: import('./cli/commands/worktrain-await.js').AwaitResult | null = null;
+
+        await executeWorktrainAwaitCommand(
+          {
+            fetch: (url: string) => globalThis.fetch(url),
+            readFile: (p: string) => fs.promises.readFile(p, 'utf-8'),
+            stdout: (line: string) => {
+              try { resolvedResult = JSON.parse(line) as import('./cli/commands/worktrain-await.js').AwaitResult; } catch { /* ignore */ }
+            },
+            stderr: (line: string) => process.stderr.write(line + '\n'),
+            homedir: os.homedir,
+            joinPath: path.join,
+            sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+            now: () => Date.now(),
+          },
+          {
+            sessions: [...handles].join(','),
+            mode: 'all',
+            timeout: `${Math.round(timeoutMs / 1000)}s`,
+            port,
+          },
+        );
+
+        return resolvedResult ?? { results: [...handles].map((h) => ({
+          handle: h,
+          outcome: 'failed' as const,
+          status: null,
+          durationMs: 0,
+        })), allSucceeded: false };
+      },
+
+      getAgentResult: async (sessionHandle: string): Promise<string | null> => {
+        try {
+          // Step 1: get session detail to find preferredTipNodeId
+          const sessionUrl = `http://127.0.0.1:${port}/api/v2/sessions/${encodeURIComponent(sessionHandle)}`;
+          const sessionRes = await globalThis.fetch(sessionUrl, { signal: AbortSignal.timeout(30_000) });
+          if (!sessionRes.ok) return null;
+          const sessionBody = await sessionRes.json() as Record<string, unknown>;
+          if (sessionBody['success'] !== true) return null;
+
+          const data = sessionBody['data'] as Record<string, unknown> | undefined;
+          if (!data) return null;
+          const runs = data['runs'] as Array<Record<string, unknown>> | undefined;
+          if (!Array.isArray(runs) || runs.length === 0) return null;
+
+          const firstRun = runs[0] as Record<string, unknown>;
+          const tipNodeId = typeof firstRun['preferredTipNodeId'] === 'string'
+            ? firstRun['preferredTipNodeId']
+            : null;
+          if (!tipNodeId) return null;
+
+          // Step 2: get node detail to retrieve recapMarkdown
+          const nodeUrl = `http://127.0.0.1:${port}/api/v2/sessions/${encodeURIComponent(sessionHandle)}/nodes/${encodeURIComponent(tipNodeId)}`;
+          const nodeRes = await globalThis.fetch(nodeUrl, { signal: AbortSignal.timeout(30_000) });
+          if (!nodeRes.ok) return null;
+          const nodeBody = await nodeRes.json() as Record<string, unknown>;
+          if (nodeBody['success'] !== true) return null;
+
+          const nodeData = nodeBody['data'] as Record<string, unknown> | undefined;
+          if (!nodeData) return null;
+          return typeof nodeData['recapMarkdown'] === 'string' ? nodeData['recapMarkdown'] : null;
+        } catch {
+          return null;
+        }
+      },
+
+      listOpenPRs: async (workspace: string) => {
+        try {
+          const { stdout } = await execFilePromise('gh', ['pr', 'list', '--json', 'number,title,headRefName'], {
+            cwd: workspace,
+            timeout: 30_000,
+          });
+          const parsed = JSON.parse(stdout) as Array<{ number: number; title: string; headRefName: string }>;
+          return parsed.map((p) => ({ number: p.number, title: p.title, headRef: p.headRefName }));
+        } catch {
+          return [];
+        }
+      },
+
+      mergePR: async (prNumber: number, workspace: string) => {
+        try {
+          await execFilePromise('gh', ['pr', 'merge', String(prNumber), '--squash', '--auto'], {
+            cwd: workspace,
+            timeout: 60_000,
+          });
+          return { kind: 'ok' as const, value: undefined };
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          return { kind: 'err' as const, error: msg };
+        }
+      },
+
+      writeFile: async (filePath: string, content: string) => {
+        await fs.promises.writeFile(filePath, content, 'utf-8');
+      },
+
+      stderr: (line: string) => process.stderr.write(line + '\n'),
+      now: () => Date.now(),
+      port,
+    };
+
+    const result = await runPrReviewCoordinator(deps, {
+      workspace: options.workspace,
+      prs: options.pr.length > 0 ? options.pr : undefined,
+      dryRun: options.dryRun ?? false,
+      port: options.port,
+    });
+
+    process.exit(result.hasErrors ? 1 : 0);
+  });
+
+// ═══════════════════════════════════════════════════════════════════════════
 // ENTRY POINT
 // ═══════════════════════════════════════════════════════════════════════════
 

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -1018,6 +1018,11 @@ runCommand
           },
         );
 
+        if (resolvedResult === null) {
+          process.stderr.write(
+            `[WARN coord:reason=await_failed] awaitSessions: could not get session results -- daemon may be unreachable or timed out. Returning all ${handles.length} session(s) as failed.\n`,
+          );
+        }
         return resolvedResult ?? { results: [...handles].map((h) => ({
           handle: h,
           outcome: 'failed' as const,
@@ -1031,32 +1036,82 @@ runCommand
           // Step 1: get session detail to find preferredTipNodeId
           const sessionUrl = `http://127.0.0.1:${port}/api/v2/sessions/${encodeURIComponent(sessionHandle)}`;
           const sessionRes = await globalThis.fetch(sessionUrl, { signal: AbortSignal.timeout(30_000) });
-          if (!sessionRes.ok) return null;
+          if (!sessionRes.ok) {
+            process.stderr.write(
+              `[WARN coord:reason=http_error status=${sessionRes.status} handle=${sessionHandle.slice(0, 16)}] getAgentResult: session fetch returned HTTP ${sessionRes.status}\n`,
+            );
+            return null;
+          }
           const sessionBody = await sessionRes.json() as Record<string, unknown>;
-          if (sessionBody['success'] !== true) return null;
+          if (sessionBody['success'] !== true) {
+            process.stderr.write(
+              `[WARN coord:reason=api_error handle=${sessionHandle.slice(0, 16)}] getAgentResult: session API returned success=false\n`,
+            );
+            return null;
+          }
 
           const data = sessionBody['data'] as Record<string, unknown> | undefined;
-          if (!data) return null;
+          if (!data) {
+            process.stderr.write(
+              `[WARN coord:reason=no_data handle=${sessionHandle.slice(0, 16)}] getAgentResult: session response missing data field\n`,
+            );
+            return null;
+          }
           const runs = data['runs'] as Array<Record<string, unknown>> | undefined;
-          if (!Array.isArray(runs) || runs.length === 0) return null;
+          if (!Array.isArray(runs) || runs.length === 0) {
+            process.stderr.write(
+              `[WARN coord:reason=no_runs handle=${sessionHandle.slice(0, 16)}] getAgentResult: session has no runs\n`,
+            );
+            return null;
+          }
 
           const firstRun = runs[0] as Record<string, unknown>;
           const tipNodeId = typeof firstRun['preferredTipNodeId'] === 'string'
             ? firstRun['preferredTipNodeId']
             : null;
-          if (!tipNodeId) return null;
+          if (!tipNodeId) {
+            process.stderr.write(
+              `[WARN coord:reason=no_tip_node handle=${sessionHandle.slice(0, 16)}] getAgentResult: session run has no preferredTipNodeId\n`,
+            );
+            return null;
+          }
 
           // Step 2: get node detail to retrieve recapMarkdown
           const nodeUrl = `http://127.0.0.1:${port}/api/v2/sessions/${encodeURIComponent(sessionHandle)}/nodes/${encodeURIComponent(tipNodeId)}`;
           const nodeRes = await globalThis.fetch(nodeUrl, { signal: AbortSignal.timeout(30_000) });
-          if (!nodeRes.ok) return null;
+          if (!nodeRes.ok) {
+            process.stderr.write(
+              `[WARN coord:reason=node_http_error status=${nodeRes.status} handle=${sessionHandle.slice(0, 16)} node=${tipNodeId.slice(0, 16)}] getAgentResult: node fetch returned HTTP ${nodeRes.status}\n`,
+            );
+            return null;
+          }
           const nodeBody = await nodeRes.json() as Record<string, unknown>;
-          if (nodeBody['success'] !== true) return null;
+          if (nodeBody['success'] !== true) {
+            process.stderr.write(
+              `[WARN coord:reason=node_api_error handle=${sessionHandle.slice(0, 16)} node=${tipNodeId.slice(0, 16)}] getAgentResult: node API returned success=false\n`,
+            );
+            return null;
+          }
 
           const nodeData = nodeBody['data'] as Record<string, unknown> | undefined;
-          if (!nodeData) return null;
-          return typeof nodeData['recapMarkdown'] === 'string' ? nodeData['recapMarkdown'] : null;
-        } catch {
+          if (!nodeData) {
+            process.stderr.write(
+              `[WARN coord:reason=no_node_data handle=${sessionHandle.slice(0, 16)} node=${tipNodeId.slice(0, 16)}] getAgentResult: node response missing data field\n`,
+            );
+            return null;
+          }
+          const recap = typeof nodeData['recapMarkdown'] === 'string' ? nodeData['recapMarkdown'] : null;
+          if (recap === null) {
+            process.stderr.write(
+              `[WARN coord:reason=no_recap handle=${sessionHandle.slice(0, 16)} node=${tipNodeId.slice(0, 16)}] getAgentResult: node has no recapMarkdown\n`,
+            );
+          }
+          return recap;
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          process.stderr.write(
+            `[WARN coord:reason=exception handle=${sessionHandle.slice(0, 16)}] getAgentResult: ${msg}\n`,
+          );
           return null;
         }
       },

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -17,6 +17,8 @@
  * 2. spawnSession returning empty/null handle -> treat as error (zombie detection).
  * 3. Coordinator wall-clock check: refuse new spawns if elapsed > 70 minutes.
  * 4. Two-tier notes parsing: JSON block first (## COORDINATOR_OUTPUT), keyword scan fallback.
+ *    NOTE: the JSON block parser is aspirational -- no live workflow emits ## COORDINATOR_OUTPUT.
+ *    The keyword scan is the ONLY active parser path. See comment in parseFindingsFromNotes().
  *    Unknown severity defaults to 'blocking' (conservative). Blocking wins over clean keywords.
  *    Negation context suppresses blocking: /\b(?:not|no|without)\b.{0,30}\bblocking\b/i
  * 5. Traceability: write { childSessionId, outcome, elapsedMs, severity } JSON block before acting.
@@ -221,7 +223,19 @@ export function parseFindingsFromNotes(notes: string | null): Result<ReviewFindi
   }
 
   // Strategy 1: JSON fenced block after ## COORDINATOR_OUTPUT marker.
-  // Try all JSON blocks in the notes before falling through to keyword scan.
+  //
+  // IMPORTANT: This parser is NOT currently active for any live workflow.
+  // The mr-review-workflow.agentic.v2 workflow (and all other versions) produce
+  // free-form markdown -- NOT a structured ## COORDINATOR_OUTPUT JSON block.
+  // The keyword scan (Strategy 2) is the ONLY live parser path today.
+  //
+  // This block is intentionally kept because it is the right long-term contract:
+  // when a future workflow version emits structured output, this parser will
+  // activate automatically without code changes. Do NOT rely on it today.
+  //
+  // WHY we still try all JSON blocks: if a workflow ever happens to include a
+  // JSON block with the right shape, we prefer the explicit machine-readable
+  // signal over keyword heuristics.
   const jsonBlockRe = /```json\s*\n([\s\S]*?)\n```/g;
   for (const blockMatch of notes.matchAll(jsonBlockRe)) {
     const blockContent = blockMatch[1];
@@ -270,12 +284,15 @@ export function parseFindingsFromNotes(notes: string | null): Result<ReviewFindi
   }
 
   // Check for clean keywords (APPROVE, LGTM are strong positive signals).
-  // WHY no CLEAN: "CLEAN" matches too broadly ("clean architecture", "clean implementation").
+  // WHY word boundary for CLEAN: bare includes('CLEAN') matches "CLEANED", "CLEANER",
+  // "CLEANING", "UNCLEAN", etc. -- all false positives for auto-merge decisions.
+  // /\bCLEAN\b/ matches exactly the standalone word and nothing else.
   const hasCleanKeyword =
     upperNotes.includes('APPROVE') ||
     upperNotes.includes('LGTM') ||
     upperNotes.includes('NO FINDINGS') ||
-    upperNotes.includes('NO ISSUES');
+    upperNotes.includes('NO ISSUES') ||
+    /\bCLEAN\b/.test(upperNotes);
 
   // Check for minor-only keywords.
   const hasMinorKeyword =
@@ -790,6 +807,20 @@ async function runFixAgentLoop(
     }
 
     log(`      PR #${pr.number}  ->  fix done (pass ${passCount}), re-reviewing...`);
+
+    // OP-4: Wall-clock cutoff check before re-review spawn.
+    // Same guard as the fix-agent spawn above -- prevents running past 90 minutes
+    // even if the fix agent itself ran close to the cutoff.
+    if (!opts.dryRun && deps.now() - coordinatorStartMs > COORDINATOR_SPAWN_CUTOFF_MS) {
+      log(`      PR #${pr.number}  ->  coordinator elapsed > 70 minutes, skipping re-review spawn`);
+      return {
+        ...initialOutcome,
+        passCount,
+        sessionHandles,
+        escalated: true,
+        escalationReason: 'coordinator elapsed > 70 minutes (re-review cutoff)',
+      };
+    }
 
     // Re-review after fix
     const reReviewGoal = `Re-review PR #${pr.number} after fixes (pass ${passCount})`;

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -254,11 +254,12 @@ export function parseFindingsFromNotes(notes: string | null): Result<ReviewFindi
   // Suppressed by negation context within ~30 chars before the keyword.
   const NEGATION_BLOCKING_RE = /\b(?:not|no|without)\b.{0,30}\bblocking\b/i;
   const NEGATION_CRITICAL_RE = /\b(?:not|no|without)\b.{0,30}\bcritical\b/i;
+  const NEGATION_REQUEST_CHANGES_RE = /\b(?:not|no|without)\b.{0,30}\brequest[\s_]changes\b/i;
 
   const hasBlockingKeyword =
     (upperNotes.includes('BLOCKING') && !NEGATION_BLOCKING_RE.test(notes)) ||
     (upperNotes.includes('CRITICAL') && !NEGATION_CRITICAL_RE.test(notes)) ||
-    upperNotes.includes('REQUEST CHANGES');
+    (upperNotes.includes('REQUEST CHANGES') && !NEGATION_REQUEST_CHANGES_RE.test(notes));
 
   if (hasBlockingKeyword) {
     return ok({
@@ -268,11 +269,11 @@ export function parseFindingsFromNotes(notes: string | null): Result<ReviewFindi
     });
   }
 
-  // Check for clean keywords (APPROVE, LGTM, CLEAN are strong positive signals).
+  // Check for clean keywords (APPROVE, LGTM are strong positive signals).
+  // WHY no CLEAN: "CLEAN" matches too broadly ("clean architecture", "clean implementation").
   const hasCleanKeyword =
     upperNotes.includes('APPROVE') ||
     upperNotes.includes('LGTM') ||
-    upperNotes.includes('CLEAN') ||
     upperNotes.includes('NO FINDINGS') ||
     upperNotes.includes('NO ISSUES');
 
@@ -292,18 +293,10 @@ export function parseFindingsFromNotes(notes: string | null): Result<ReviewFindi
   }
 
   if (hasMinorKeyword) {
+    // Handles both minor-only AND clean+minor: conservative -- minor findings exist.
     return ok({
       severity: 'minor',
       findingSummaries: extractFindingSummaries(notes),
-      raw: notes,
-    });
-  }
-
-  if (hasCleanKeyword) {
-    // Clean keyword present alongside minor keywords -- lean clean but conservative
-    return ok({
-      severity: 'clean',
-      findingSummaries: [],
       raw: notes,
     });
   }
@@ -449,7 +442,7 @@ export async function runPrReviewCoordinator(
   opts: PrReviewOpts,
 ): Promise<CoordinatorResult> {
   const coordinatorStartMs = deps.now();
-  const today = new Date().toISOString().slice(0, 10);
+  const today = new Date(deps.now()).toISOString().slice(0, 10);
   const reportPath = opts.workspace + `/coordinator-pr-review-${today}.md`;
   const reportLines: string[] = [];
 
@@ -677,7 +670,7 @@ export async function runPrReviewCoordinator(
   }
 
   const result: CoordinatorResult = {
-    reviewed: prs.length,
+    reviewed: outcomes.size - spawnErrors.size,
     approved: mergedPrs.length,
     escalated: escalated.length,
     mergedPrs,
@@ -914,7 +907,7 @@ async function writeReport(
   logLines: string[],
   result: CoordinatorResult,
 ): Promise<void> {
-  const today = new Date().toISOString().slice(0, 19).replace('T', ' ');
+  const today = new Date(deps.now()).toISOString().slice(0, 19).replace('T', ' ');
   const content = [
     `# PR Review Coordinator Report`,
     ``,

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -1,0 +1,944 @@
+/**
+ * PR Review Coordinator
+ *
+ * Autonomously reviews open GitHub PRs by dispatching mr-review-workflow-agentic
+ * sessions, routing by finding severity, and merging or escalating.
+ *
+ * Design invariants:
+ * - All I/O is injected via CoordinatorDeps. Zero direct fs/fetch imports in this module.
+ * - parseFindingsFromNotes() and classifySeverity() are pure functions (no I/O).
+ * - ReviewSeverity is a discriminated union -- all switch statements must be exhaustive.
+ * - Errors are returned as Result<T, string> values -- never thrown.
+ * - Never merge when severity is blocking, unknown, timeout, failed, or not_awaited.
+ * - Fix-agent loop: check passCount >= MAX_FIX_PASSES before spawning (not after).
+ *
+ * Robustness rules (from docs/discovery/spawn-agent-failure-modes.md):
+ * 1. Child session timeout hardcoded to 15 minutes -- never LLM-computed.
+ * 2. spawnSession returning empty/null handle -> treat as error (zombie detection).
+ * 3. Coordinator wall-clock check: refuse new spawns if elapsed > 70 minutes.
+ * 4. Two-tier notes parsing: JSON block first (## COORDINATOR_OUTPUT), keyword scan fallback.
+ *    Unknown severity defaults to 'blocking' (conservative). Blocking wins over clean keywords.
+ *    Negation context suppresses blocking: /\b(?:not|no|without)\b.{0,30}\bblocking\b/i
+ * 5. Traceability: write { childSessionId, outcome, elapsedMs, severity } JSON block before acting.
+ */
+
+import type { Result } from '../runtime/result.js';
+import { ok, err } from '../runtime/result.js';
+import type { AwaitResult, SessionResult } from '../cli/commands/worktrain-await.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DOMAIN TYPES
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Severity classification of a PR review.
+ *
+ * WHY discriminated union: exhaustive switch at compile time ensures every
+ * routing decision handles all four variants. No string comparison bugs.
+ */
+export type ReviewSeverity = 'clean' | 'minor' | 'blocking' | 'unknown';
+
+/**
+ * Parsed findings from a review session's step notes.
+ */
+export interface ReviewFindings {
+  readonly severity: ReviewSeverity;
+  /** Short summaries of individual findings (for fix-agent goal string). */
+  readonly findingSummaries: readonly string[];
+  /** The raw markdown text that was parsed (for report). */
+  readonly raw: string;
+}
+
+/**
+ * Summary of an open GitHub PR.
+ */
+export interface PrSummary {
+  readonly number: number;
+  readonly title: string;
+  readonly headRef: string;
+}
+
+/**
+ * Outcome of processing a single PR through the coordinator pipeline.
+ */
+export interface PrOutcome {
+  readonly prNumber: number;
+  readonly severity: ReviewSeverity;
+  readonly merged: boolean;
+  readonly escalated: boolean;
+  readonly escalationReason: string | null;
+  /** Number of fix-agent passes run (0 for first review). */
+  readonly passCount: number;
+  /** All session handles touched (review + fix sessions). */
+  readonly sessionHandles: readonly string[];
+}
+
+/**
+ * Summary result of the full coordinator run.
+ */
+export interface CoordinatorResult {
+  readonly reviewed: number;
+  readonly approved: number;
+  readonly escalated: number;
+  readonly mergedPrs: readonly number[];
+  readonly reportPath: string;
+  /** true if any PR resulted in an unexpected error (not just blocking findings) */
+  readonly hasErrors: boolean;
+}
+
+/**
+ * Options for running the PR review coordinator.
+ */
+export interface PrReviewOpts {
+  /** Absolute path to the git workspace. */
+  readonly workspace: string;
+  /** If set, review only these PR numbers. Otherwise, discover open PRs. */
+  readonly prs?: readonly number[];
+  /** If true, print actions without executing HTTP calls or git operations. */
+  readonly dryRun: boolean;
+  /** Override the console HTTP server port. */
+  readonly port?: number;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// COORDINATOR DEPS INTERFACE
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Injectable dependencies for the PR review coordinator.
+ *
+ * All I/O is behind this interface so the coordinator core is testable with
+ * fake implementations. No direct fetch/fs/exec imports in coordinator logic.
+ *
+ * WHY this pattern: follows WorktrainSpawnCommandDeps / WorktrainAwaitCommandDeps exactly.
+ * Composition root (src/cli-worktrain.ts) wires real implementations; tests inject fakes.
+ */
+export interface CoordinatorDeps {
+  /**
+   * Dispatch a workflow session to the daemon.
+   * Returns the session handle on success, or err() on connection/HTTP failure.
+   */
+  readonly spawnSession: (
+    workflowId: string,
+    goal: string,
+    workspace: string,
+  ) => Promise<Result<string, string>>;
+
+  /**
+   * Wait for a set of sessions to complete.
+   * Returns the await result (outcomes per handle) after all sessions finish or timeout.
+   */
+  readonly awaitSessions: (
+    handles: readonly string[],
+    timeoutMs: number,
+  ) => Promise<AwaitResult>;
+
+  /**
+   * Retrieve the step notes (recapMarkdown) from the final step of a completed session.
+   * Returns null if the session has no notes or the node endpoint fails.
+   *
+   * WHY 2-call HTTP: worktrain await does NOT return session notes.
+   * Call sequence: GET /api/v2/sessions/:id -> preferredTipNodeId -> GET /api/v2/sessions/:id/nodes/:nodeId -> recapMarkdown.
+   */
+  readonly getAgentResult: (sessionHandle: string) => Promise<string | null>;
+
+  /**
+   * List open PRs in the workspace via gh CLI.
+   * Returns an empty array if no PRs are open or gh command fails.
+   */
+  readonly listOpenPRs: (workspace: string) => Promise<PrSummary[]>;
+
+  /**
+   * Merge a PR using gh pr merge --squash.
+   * Returns err() if the merge command fails (conflict, CI required, etc.).
+   */
+  readonly mergePR: (
+    prNumber: number,
+    workspace: string,
+  ) => Promise<Result<void, string>>;
+
+  /**
+   * Write a file at the given absolute path.
+   * Used for writing the coordinator report markdown.
+   */
+  readonly writeFile: (path: string, content: string) => Promise<void>;
+
+  /** Write a line to stderr (progress, warnings, traceability JSON). */
+  readonly stderr: (line: string) => void;
+
+  /** Return the current wall-clock time in milliseconds. */
+  readonly now: () => number;
+
+  /** Resolved console HTTP server port (after lock file discovery). */
+  readonly port: number;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CONSTANTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Maximum fix-agent passes per PR before escalating. */
+const MAX_FIX_PASSES = 3;
+
+/**
+ * Child session timeout: hardcoded 15 minutes per robustness rule 1.
+ * Never computed from LLM output or coordinator config.
+ */
+const CHILD_SESSION_TIMEOUT_MS = 15 * 60 * 1000;
+
+/**
+ * Coordinator max runtime: 90 minutes.
+ * Go/no-go check (Rule 3): refuse new spawns if elapsed > 70 minutes (90 - 20 buffer).
+ */
+const COORDINATOR_MAX_MS = 90 * 60 * 1000;
+const COORDINATOR_SPAWN_CUTOFF_MS = COORDINATOR_MAX_MS - 20 * 60 * 1000; // 70 minutes
+
+/** Default review await timeout: 20 minutes (child sessions are 15m, add buffer). */
+const REVIEW_AWAIT_TIMEOUT_MS = 20 * 60 * 1000;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PURE FUNCTIONS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Parse review findings from a step's recapMarkdown text.
+ *
+ * Two-tier strategy (mirrors parseHandoffArtifact in delivery-action.ts):
+ * 1. JSON block: look for ## COORDINATOR_OUTPUT fenced block and parse it.
+ *    This is the stable machine-parseable format for future workflow updates.
+ * 2. Keyword scan: scan for severity-indicating keywords with priority ordering.
+ *    Blocking keywords take absolute precedence over clean keywords.
+ *    Negation context suppresses blocking: "not blocking" or "no blocking" -> does not classify as blocking.
+ *
+ * WHY two-tier: the mr-review-workflow final step currently produces free-form markdown.
+ * The keyword scan handles current output; the JSON block handles future structured output.
+ *
+ * Returns ok(ReviewFindings) on success, err(reason) when notes are null/empty.
+ */
+export function parseFindingsFromNotes(notes: string | null): Result<ReviewFindings, string> {
+  if (notes === null || notes.trim() === '') {
+    return err('notes is null or empty');
+  }
+
+  // Strategy 1: JSON fenced block after ## COORDINATOR_OUTPUT marker.
+  // Try all JSON blocks in the notes before falling through to keyword scan.
+  const jsonBlockRe = /```json\s*\n([\s\S]*?)\n```/g;
+  for (const blockMatch of notes.matchAll(jsonBlockRe)) {
+    const blockContent = blockMatch[1];
+    if (!blockContent) continue;
+    try {
+      const parsed = JSON.parse(blockContent) as Record<string, unknown>;
+      // Check for coordinator output structure
+      if (
+        typeof parsed['recommendation'] === 'string' &&
+        ['clean', 'minor', 'blocking'].includes(parsed['recommendation'] as string)
+      ) {
+        const severity = parsed['recommendation'] as ReviewSeverity;
+        const findings = Array.isArray(parsed['findings'])
+          ? (parsed['findings'] as unknown[])
+              .filter((f): f is Record<string, unknown> => typeof f === 'object' && f !== null)
+              .map((f) => typeof f['summary'] === 'string' ? f['summary'] : JSON.stringify(f))
+          : [];
+        return ok({ severity, findingSummaries: findings, raw: notes });
+      }
+    } catch {
+      // JSON parse failed -- try next block
+    }
+  }
+
+  // Strategy 2: Keyword scan with priority ordering.
+  // Blocking wins over clean. Negation context suppresses blocking.
+  const upperNotes = notes.toUpperCase();
+
+  // Check for blocking keywords first (highest priority).
+  // Suppressed by negation context within ~30 chars before the keyword.
+  const NEGATION_BLOCKING_RE = /\b(?:not|no|without)\b.{0,30}\bblocking\b/i;
+  const NEGATION_CRITICAL_RE = /\b(?:not|no|without)\b.{0,30}\bcritical\b/i;
+
+  const hasBlockingKeyword =
+    (upperNotes.includes('BLOCKING') && !NEGATION_BLOCKING_RE.test(notes)) ||
+    (upperNotes.includes('CRITICAL') && !NEGATION_CRITICAL_RE.test(notes)) ||
+    upperNotes.includes('REQUEST CHANGES');
+
+  if (hasBlockingKeyword) {
+    return ok({
+      severity: 'blocking',
+      findingSummaries: extractFindingSummaries(notes),
+      raw: notes,
+    });
+  }
+
+  // Check for clean keywords (APPROVE, LGTM, CLEAN are strong positive signals).
+  const hasCleanKeyword =
+    upperNotes.includes('APPROVE') ||
+    upperNotes.includes('LGTM') ||
+    upperNotes.includes('CLEAN') ||
+    upperNotes.includes('NO FINDINGS') ||
+    upperNotes.includes('NO ISSUES');
+
+  // Check for minor-only keywords.
+  const hasMinorKeyword =
+    upperNotes.includes('MINOR') ||
+    upperNotes.includes('NIT') ||
+    upperNotes.includes('NITPICK') ||
+    upperNotes.includes('SUGGESTION');
+
+  if (hasCleanKeyword && !hasMinorKeyword) {
+    return ok({
+      severity: 'clean',
+      findingSummaries: [],
+      raw: notes,
+    });
+  }
+
+  if (hasMinorKeyword) {
+    return ok({
+      severity: 'minor',
+      findingSummaries: extractFindingSummaries(notes),
+      raw: notes,
+    });
+  }
+
+  if (hasCleanKeyword) {
+    // Clean keyword present alongside minor keywords -- lean clean but conservative
+    return ok({
+      severity: 'clean',
+      findingSummaries: [],
+      raw: notes,
+    });
+  }
+
+  // No recognized keywords -- unknown severity.
+  // WHY unknown -> blocking in routing: safer than unknown -> clean.
+  return ok({
+    severity: 'unknown',
+    findingSummaries: [],
+    raw: notes,
+  });
+}
+
+/**
+ * Extract a short list of finding summaries from review markdown.
+ * Used to build the fix-agent goal string.
+ *
+ * Heuristic: extract bullet points that look like findings.
+ * Returns up to 5 summaries to keep the goal string concise.
+ */
+function extractFindingSummaries(notes: string): string[] {
+  const summaries: string[] = [];
+  const lines = notes.split('\n');
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    // Match bullet points or numbered list items that look like findings
+    if (/^[-*]\s+.{10,}/.test(trimmed) || /^\d+\.\s+.{10,}/.test(trimmed)) {
+      // Skip meta-commentary lines
+      const upper = trimmed.toUpperCase();
+      if (
+        upper.includes('RECOMMEND') ||
+        upper.includes('CONFIDENCE') ||
+        upper.includes('COVERAGE') ||
+        upper.includes('SUMMARY')
+      ) {
+        continue;
+      }
+      // Strip leading list marker
+      const summary = trimmed.replace(/^[-*]\s+/, '').replace(/^\d+\.\s+/, '');
+      summaries.push(summary.slice(0, 120)); // truncate long summaries
+      if (summaries.length >= 5) break;
+    }
+  }
+
+  return summaries;
+}
+
+/**
+ * Build the fix-agent goal string for a given PR and its findings.
+ *
+ * WHY coding-task-workflow-agentic: it handles implementation tasks
+ * ('implement', 'fix', 'refactor') which is exactly what fixing review
+ * findings requires.
+ */
+export function buildFixGoal(prNumber: number, findings: ReviewFindings): string {
+  const findingList = findings.findingSummaries.length > 0
+    ? ': ' + findings.findingSummaries.slice(0, 3).join('; ')
+    : '';
+  return `Fix review findings in PR #${prNumber}${findingList}`;
+}
+
+/**
+ * Format elapsed milliseconds as a human-readable duration string.
+ * Examples: 512ms -> "0:00", 68000ms -> "1:08", 510000ms -> "8:30"
+ */
+export function formatElapsed(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Lock file names for port discovery (same as worktrain-spawn.ts).
+ * Checked in priority order: standalone console first, MCP server second.
+ *
+ * WHY duplicated here: coordinator is a standalone script; coupling to
+ * internal daemon utils would be the wrong dependency direction.
+ */
+const LOCK_FILE_NAMES = ['daemon-console.lock', 'dashboard.lock'] as const;
+
+/** Default console HTTP server port. */
+const DEFAULT_CONSOLE_PORT = 3456;
+
+/**
+ * Discover the console HTTP server port from lock files.
+ *
+ * Injected readFile/homedir/joinPath allow testing without real filesystem access.
+ */
+export async function discoverConsolePort(
+  deps: Pick<CoordinatorPortDiscoveryDeps, 'readFile' | 'homedir' | 'joinPath'>,
+  portOverride?: number,
+): Promise<number> {
+  if (portOverride !== undefined && portOverride > 0) {
+    return portOverride;
+  }
+
+  for (const lockFileName of LOCK_FILE_NAMES) {
+    const lockPath = deps.joinPath(deps.homedir(), '.workrail', lockFileName);
+    try {
+      const raw = await deps.readFile(lockPath);
+      const parsed = JSON.parse(raw) as { port?: unknown };
+      if (typeof parsed.port === 'number' && parsed.port > 0) {
+        return parsed.port;
+      }
+    } catch {
+      // ENOENT or parse error -- try next lock file
+    }
+  }
+
+  return DEFAULT_CONSOLE_PORT;
+}
+
+/**
+ * Minimal deps for port discovery (subset of CoordinatorDeps used in CLI wiring).
+ */
+export interface CoordinatorPortDiscoveryDeps {
+  readonly readFile: (path: string) => Promise<string>;
+  readonly homedir: () => string;
+  readonly joinPath: (...paths: string[]) => string;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// COORDINATOR CORE
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Run the PR review coordinator pipeline.
+ *
+ * Stages:
+ * 1. Discover or validate PR list
+ * 2. Dispatch parallel review sessions (spawn all, then await all)
+ * 3. Extract notes and classify severity for each PR
+ * 4. Route: clean -> merge queue, minor -> fix-agent loop, blocking/unknown -> escalate
+ * 5. Serial merge for clean PRs
+ * 6. Write report file
+ *
+ * Returns CoordinatorResult for the CLI to interpret.
+ */
+export async function runPrReviewCoordinator(
+  deps: CoordinatorDeps,
+  opts: PrReviewOpts,
+): Promise<CoordinatorResult> {
+  const coordinatorStartMs = deps.now();
+  const today = new Date().toISOString().slice(0, 10);
+  const reportPath = opts.workspace + `/coordinator-pr-review-${today}.md`;
+  const reportLines: string[] = [];
+
+  function log(line: string): void {
+    deps.stderr(line);
+    reportLines.push(line);
+  }
+
+  // ---- Stage 1: Gather PRs ----
+  log('[1/3] Gathering open PRs...');
+  const stageStart = deps.now();
+
+  let prs: PrSummary[];
+  if (opts.prs && opts.prs.length > 0) {
+    prs = opts.prs.map((n) => ({ number: n, title: `PR #${n}`, headRef: '' }));
+  } else if (opts.dryRun) {
+    prs = [];
+    log('  [dry-run] would call gh pr list');
+  } else {
+    prs = await deps.listOpenPRs(opts.workspace);
+  }
+
+  log(`  done (${formatElapsed(deps.now() - stageStart)}) -- ${prs.length} PR(s) found`);
+
+  if (prs.length === 0) {
+    const result: CoordinatorResult = {
+      reviewed: 0,
+      approved: 0,
+      escalated: 0,
+      mergedPrs: [],
+      reportPath,
+      hasErrors: false,
+    };
+    await writeReport(deps, reportPath, reportLines, result);
+    return result;
+  }
+
+  // ---- Stage 2: Parallel review sessions ----
+  log(`[2/3] Running reviews (${prs.length} parallel)...`);
+  const reviewStart = deps.now();
+
+  // Check go/no-go before spawning (Rule 3: wall-clock elapsed check)
+  if (!opts.dryRun && deps.now() - coordinatorStartMs > COORDINATOR_SPAWN_CUTOFF_MS) {
+    log('  WARNING: coordinator elapsed > 70 minutes, refusing to spawn new sessions');
+    const result: CoordinatorResult = {
+      reviewed: 0,
+      approved: 0,
+      escalated: prs.length,
+      mergedPrs: [],
+      reportPath,
+      hasErrors: true,
+    };
+    await writeReport(deps, reportPath, reportLines, result);
+    return result;
+  }
+
+  // Spawn review sessions in parallel
+  const reviewHandles = new Map<number, string>(); // prNumber -> sessionHandle
+  const spawnErrors = new Map<number, string>(); // prNumber -> error message
+
+  for (const pr of prs) {
+    const goal = `Review PR #${pr.number} "${pr.title}" before merge`;
+    if (opts.dryRun) {
+      log(`      PR #${pr.number} [dry-run] would spawn mr-review-workflow-agentic`);
+      continue;
+    }
+
+    const spawnResult = await deps.spawnSession(
+      'mr-review-workflow-agentic',
+      goal,
+      opts.workspace,
+    );
+
+    if (spawnResult.kind === 'err') {
+      spawnErrors.set(pr.number, spawnResult.error);
+      log(`      PR #${pr.number} spawn failed: ${spawnResult.error}`);
+    } else {
+      // Rule 2: check for null/empty handle (zombie detection)
+      const handle = spawnResult.value;
+      if (!handle) {
+        spawnErrors.set(pr.number, 'spawn returned empty session handle (zombie detection)');
+        log(`      PR #${pr.number} spawn returned empty handle -- zombie detection triggered`);
+      } else {
+        reviewHandles.set(pr.number, handle);
+      }
+    }
+  }
+
+  // Await all review sessions
+  const outcomes = new Map<number, PrOutcome>();
+
+  if (!opts.dryRun && reviewHandles.size > 0) {
+    const awaitResult = await deps.awaitSessions(
+      [...reviewHandles.values()],
+      REVIEW_AWAIT_TIMEOUT_MS,
+    );
+
+    // Build reverse map: handle -> prNumber
+    const handleToPr = new Map<string, number>();
+    for (const [prNum, handle] of reviewHandles) {
+      handleToPr.set(handle, prNum);
+    }
+
+    for (const sessionResult of awaitResult.results) {
+      const prNum = handleToPr.get(sessionResult.handle);
+      if (prNum === undefined) continue;
+
+      const elapsedMs = sessionResult.durationMs;
+      const handle = sessionResult.handle;
+
+      // Get notes for this session
+      let notes: string | null = null;
+      if (sessionResult.outcome === 'success') {
+        notes = await deps.getAgentResult(handle);
+      }
+
+      // Parse findings
+      const findingsResult = parseFindingsFromNotes(notes);
+      const severity: ReviewSeverity = findingsResult.kind === 'ok'
+        ? findingsResult.value.severity
+        : 'unknown';
+
+      // Rule 5: write traceability JSON block before acting
+      const traceBlock = JSON.stringify({
+        childSessionId: handle,
+        outcome: sessionResult.outcome,
+        elapsedMs,
+        severity,
+      });
+      deps.stderr(`[TRACE] ${traceBlock}`);
+      reportLines.push(`\n<!-- TRACE: ${traceBlock} -->`);
+
+      const pr = prs.find((p) => p.number === prNum)!;
+      const severityLabel = severity.toUpperCase();
+      log(`      PR #${pr.number} ${pr.title}    done (${formatElapsed(elapsedMs)})  ${severityLabel}`);
+
+      const findings = findingsResult.kind === 'ok' ? findingsResult.value : null;
+      const outcome: PrOutcome = {
+        prNumber: prNum,
+        severity,
+        merged: false,
+        escalated: sessionResult.outcome !== 'success' || severity === 'blocking' || severity === 'unknown',
+        escalationReason: sessionResult.outcome !== 'success'
+          ? `session ${sessionResult.outcome}`
+          : severity === 'blocking' || severity === 'unknown'
+            ? `severity: ${severity}`
+            : null,
+        passCount: 0,
+        sessionHandles: [handle],
+      };
+
+      // Process minor PRs through fix-agent loop
+      if (severity === 'minor' && findings && sessionResult.outcome === 'success') {
+        const processedOutcome = await runFixAgentLoop(
+          deps,
+          opts,
+          pr,
+          findings,
+          outcome,
+          coordinatorStartMs,
+          log,
+        );
+        outcomes.set(prNum, processedOutcome);
+      } else {
+        outcomes.set(prNum, outcome);
+      }
+    }
+  }
+
+  // Add spawn-error PRs as escalated outcomes
+  for (const [prNum, errorMsg] of spawnErrors) {
+    outcomes.set(prNum, {
+      prNumber: prNum,
+      severity: 'unknown',
+      merged: false,
+      escalated: true,
+      escalationReason: `spawn error: ${errorMsg}`,
+      passCount: 0,
+      sessionHandles: [],
+    });
+  }
+
+  // ---- Stage 3: Process results ----
+  log('[3/3] Processing results...');
+
+  const mergeQueue: number[] = [];
+  const escalated: PrOutcome[] = [];
+
+  for (const outcome of outcomes.values()) {
+    if (!outcome.escalated && outcome.severity === 'clean') {
+      mergeQueue.push(outcome.prNumber);
+      log(`      PR #${outcome.prNumber}  ->  queued for merge`);
+    } else {
+      escalated.push(outcome);
+      const reason = outcome.escalationReason ?? outcome.severity;
+      log(`      PR #${outcome.prNumber}  ->  escalated (${reason})`);
+    }
+  }
+
+  // Serial merge: one at a time
+  const mergedPrs: number[] = [];
+  for (const prNum of mergeQueue) {
+    if (opts.dryRun) {
+      log(`      PR #${prNum}  ->  [dry-run] would merge`);
+      mergedPrs.push(prNum);
+      continue;
+    }
+
+    const mergeResult = await deps.mergePR(prNum, opts.workspace);
+    if (mergeResult.kind === 'ok') {
+      mergedPrs.push(prNum);
+      log(`      PR #${prNum}  ->  merged`);
+    } else {
+      log(`      PR #${prNum}  ->  merge failed: ${mergeResult.error} (escalated)`);
+      escalated.push({
+        prNumber: prNum,
+        severity: 'clean',
+        merged: false,
+        escalated: true,
+        escalationReason: `merge failed: ${mergeResult.error}`,
+        passCount: 0,
+        sessionHandles: [],
+      });
+    }
+  }
+
+  const result: CoordinatorResult = {
+    reviewed: prs.length,
+    approved: mergedPrs.length,
+    escalated: escalated.length,
+    mergedPrs,
+    reportPath,
+    hasErrors: spawnErrors.size > 0 || escalated.some((o) => o.escalationReason?.startsWith('spawn error') || o.escalationReason?.startsWith('session ') === true),
+  };
+
+  // Terminal summary
+  const mergedStr = mergedPrs.length > 0 ? `PR #${mergedPrs.join(', PR #')}` : 'none';
+  log('');
+  log(`RESULT: ${result.reviewed} PRs reviewed, ${result.approved} approved, ${result.escalated} escalated`);
+  log(`Merged: ${mergedStr}`);
+  log(`Full report: ${reportPath}`);
+
+  log(`\nTotal time: ${formatElapsed(deps.now() - reviewStart)}`);
+
+  await writeReport(deps, reportPath, reportLines, result);
+  return result;
+}
+
+/**
+ * Run the fix-agent loop for a PR with minor findings.
+ * Max MAX_FIX_PASSES passes; escalates if still minor after all passes.
+ *
+ * WHY passCount >= MAX_FIX_PASSES BEFORE spawning: prevents spawning a 4th agent
+ * when the loop has already run 3 times.
+ */
+async function runFixAgentLoop(
+  deps: CoordinatorDeps,
+  opts: PrReviewOpts,
+  pr: PrSummary,
+  initialFindings: ReviewFindings,
+  initialOutcome: PrOutcome,
+  coordinatorStartMs: number,
+  log: (line: string) => void,
+): Promise<PrOutcome> {
+  let passCount = 0;
+  let currentFindings = initialFindings;
+  let sessionHandles = [...initialOutcome.sessionHandles];
+
+  while (passCount < MAX_FIX_PASSES) {
+    // Rule 3: go/no-go time check before spawning
+    if (!opts.dryRun && deps.now() - coordinatorStartMs > COORDINATOR_SPAWN_CUTOFF_MS) {
+      log(`      PR #${pr.number}  ->  coordinator elapsed > 70 minutes, escalating`);
+      return {
+        ...initialOutcome,
+        passCount,
+        sessionHandles,
+        escalated: true,
+        escalationReason: 'coordinator elapsed > 70 minutes',
+      };
+    }
+
+    passCount++;
+    const fixGoal = buildFixGoal(pr.number, currentFindings);
+
+    if (opts.dryRun) {
+      log(`      PR #${pr.number}  ->  [dry-run] would spawn fix agent (pass ${passCount}): ${fixGoal}`);
+      return {
+        ...initialOutcome,
+        passCount,
+        sessionHandles,
+        severity: 'clean',
+        merged: false,
+        escalated: false,
+        escalationReason: null,
+      };
+    }
+
+    log(`      PR #${pr.number}  ->  spawning fix agent (pass ${passCount})...`);
+
+    const fixSpawnResult = await deps.spawnSession(
+      'coding-task-workflow-agentic',
+      fixGoal,
+      opts.workspace,
+    );
+
+    if (fixSpawnResult.kind === 'err') {
+      log(`      PR #${pr.number}  ->  fix agent spawn failed: ${fixSpawnResult.error}`);
+      return {
+        ...initialOutcome,
+        passCount,
+        sessionHandles,
+        escalated: true,
+        escalationReason: `fix agent spawn error (pass ${passCount}): ${fixSpawnResult.error}`,
+      };
+    }
+
+    const fixHandle = fixSpawnResult.value;
+    if (!fixHandle) {
+      // Rule 2: zombie detection
+      return {
+        ...initialOutcome,
+        passCount,
+        sessionHandles,
+        escalated: true,
+        escalationReason: `fix agent returned empty handle (zombie, pass ${passCount})`,
+      };
+    }
+
+    sessionHandles = [...sessionHandles, fixHandle];
+
+    // Await fix agent (child session timeout: 15 minutes, Rule 1)
+    const fixAwait = await deps.awaitSessions([fixHandle], CHILD_SESSION_TIMEOUT_MS);
+    const fixResult = fixAwait.results[0];
+
+    if (!fixResult || fixResult.outcome !== 'success') {
+      const outcome = fixResult?.outcome ?? 'not_found';
+      log(`      PR #${pr.number}  ->  fix agent ${outcome} (pass ${passCount})`);
+      return {
+        ...initialOutcome,
+        passCount,
+        sessionHandles,
+        escalated: true,
+        escalationReason: `fix agent ${outcome} (pass ${passCount})`,
+      };
+    }
+
+    log(`      PR #${pr.number}  ->  fix done (pass ${passCount}), re-reviewing...`);
+
+    // Re-review after fix
+    const reReviewGoal = `Re-review PR #${pr.number} after fixes (pass ${passCount})`;
+    const reReviewSpawnResult = await deps.spawnSession(
+      'mr-review-workflow-agentic',
+      reReviewGoal,
+      opts.workspace,
+    );
+
+    if (reReviewSpawnResult.kind === 'err') {
+      log(`      PR #${pr.number}  ->  re-review spawn failed: ${reReviewSpawnResult.error}`);
+      return {
+        ...initialOutcome,
+        passCount,
+        sessionHandles,
+        escalated: true,
+        escalationReason: `re-review spawn error (pass ${passCount}): ${reReviewSpawnResult.error}`,
+      };
+    }
+
+    const reReviewHandle = reReviewSpawnResult.value;
+    if (!reReviewHandle) {
+      return {
+        ...initialOutcome,
+        passCount,
+        sessionHandles,
+        escalated: true,
+        escalationReason: `re-review returned empty handle (zombie, pass ${passCount})`,
+      };
+    }
+
+    sessionHandles = [...sessionHandles, reReviewHandle];
+
+    const reReviewAwait = await deps.awaitSessions([reReviewHandle], REVIEW_AWAIT_TIMEOUT_MS);
+    const reReviewResult = reReviewAwait.results[0];
+
+    if (!reReviewResult || reReviewResult.outcome !== 'success') {
+      const outcome = reReviewResult?.outcome ?? 'not_found';
+      log(`      PR #${pr.number}  ->  re-review ${outcome} (pass ${passCount})`);
+      return {
+        ...initialOutcome,
+        passCount,
+        sessionHandles,
+        escalated: true,
+        escalationReason: `re-review ${outcome} (pass ${passCount})`,
+      };
+    }
+
+    const reNotes = await deps.getAgentResult(reReviewHandle);
+    const reFindingsResult = parseFindingsFromNotes(reNotes);
+    const reSeverity: ReviewSeverity = reFindingsResult.kind === 'ok'
+      ? reFindingsResult.value.severity
+      : 'unknown';
+
+    // Rule 5: traceability for re-review
+    const traceBlock = JSON.stringify({
+      childSessionId: reReviewHandle,
+      outcome: reReviewResult.outcome,
+      elapsedMs: reReviewResult.durationMs,
+      severity: reSeverity,
+    });
+    deps.stderr(`[TRACE] ${traceBlock}`);
+
+    log(`      PR #${pr.number}  ->  re-review result: ${reSeverity.toUpperCase()} (pass ${passCount})`);
+
+    if (reSeverity === 'clean') {
+      return {
+        prNumber: pr.number,
+        severity: 'clean',
+        merged: false,
+        escalated: false,
+        escalationReason: null,
+        passCount,
+        sessionHandles,
+      };
+    }
+
+    if (reSeverity === 'blocking' || reSeverity === 'unknown') {
+      return {
+        prNumber: pr.number,
+        severity: reSeverity,
+        merged: false,
+        escalated: true,
+        escalationReason: `severity: ${reSeverity} after fix (pass ${passCount})`,
+        passCount,
+        sessionHandles,
+      };
+    }
+
+    // Still minor -- continue loop
+    currentFindings = reFindingsResult.kind === 'ok'
+      ? reFindingsResult.value
+      : { severity: 'minor', findingSummaries: [], raw: reNotes ?? '' };
+  }
+
+  // Exhausted max passes
+  log(`      PR #${pr.number}  ->  ${MAX_FIX_PASSES} fix passes exhausted, escalating`);
+  return {
+    prNumber: pr.number,
+    severity: 'minor',
+    merged: false,
+    escalated: true,
+    escalationReason: `${MAX_FIX_PASSES} fix passes exhausted`,
+    passCount: MAX_FIX_PASSES,
+    sessionHandles,
+  };
+}
+
+/**
+ * Write the coordinator report markdown file.
+ */
+async function writeReport(
+  deps: CoordinatorDeps,
+  reportPath: string,
+  logLines: string[],
+  result: CoordinatorResult,
+): Promise<void> {
+  const today = new Date().toISOString().slice(0, 19).replace('T', ' ');
+  const content = [
+    `# PR Review Coordinator Report`,
+    ``,
+    `Generated: ${today}`,
+    ``,
+    `## Summary`,
+    ``,
+    `- PRs reviewed: ${result.reviewed}`,
+    `- Approved and merged: ${result.approved}`,
+    `- Escalated: ${result.escalated}`,
+    result.mergedPrs.length > 0 ? `- Merged PRs: ${result.mergedPrs.map((n) => `#${n}`).join(', ')}` : `- Merged PRs: none`,
+    ``,
+    `## Run Log`,
+    ``,
+    `\`\`\``,
+    ...logLines,
+    `\`\`\``,
+    ``,
+  ].join('\n');
+
+  try {
+    await deps.writeFile(reportPath, content);
+  } catch {
+    // Non-fatal -- coordinator result is still valid even if report write fails
+    deps.stderr(`Warning: could not write report to ${reportPath}`);
+  }
+}

--- a/tests/unit/coordinator-pr-review.test.ts
+++ b/tests/unit/coordinator-pr-review.test.ts
@@ -168,6 +168,28 @@ describe('parseFindingsFromNotes', () => {
     if (result.kind === 'ok') expect(result.value.severity).toBe('blocking');
   });
 
+  it('does NOT classify as blocking when "no request changes" appears', () => {
+    const result = parseFindingsFromNotes('There are no request changes needed. Good implementation.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.severity).not.toBe('blocking');
+    }
+  });
+
+  it('does NOT classify as blocking when "not request changes" appears', () => {
+    const result = parseFindingsFromNotes('This is not request changes territory -- looks good to me.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.severity).not.toBe('blocking');
+    }
+  });
+
+  it('DOES classify as blocking when "REQUEST CHANGES" appears without negation', () => {
+    const result = parseFindingsFromNotes('Final recommendation: REQUEST CHANGES -- fix the security issue first.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('blocking');
+  });
+
   // ---- Priority: blocking wins over clean ----
 
   it('blocking keywords win over clean keywords when both present', () => {

--- a/tests/unit/coordinator-pr-review.test.ts
+++ b/tests/unit/coordinator-pr-review.test.ts
@@ -198,6 +198,57 @@ describe('parseFindingsFromNotes', () => {
     expect(result.kind).toBe('ok');
     if (result.kind === 'ok') expect(result.value.severity).toBe('blocking');
   });
+
+  // ---- F1: CLEAN word boundary ----
+
+  it('classifies standalone CLEAN as clean', () => {
+    const result = parseFindingsFromNotes('Code review complete. CLEAN -- no issues found.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('clean');
+  });
+
+  it('does NOT classify CLEANED as clean (word boundary guard)', () => {
+    // "CLEANED" is a past-tense verb, not a severity signal
+    const result = parseFindingsFromNotes('The developer CLEANED up the code after feedback.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).not.toBe('clean');
+  });
+
+  it('does NOT classify CLEANER as clean (word boundary guard)', () => {
+    const result = parseFindingsFromNotes('This approach is CLEANER than the previous implementation.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).not.toBe('clean');
+  });
+
+  it('does NOT classify CLEANING as clean (word boundary guard)', () => {
+    const result = parseFindingsFromNotes('The PR focuses on CLEANING up dead code in the module.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).not.toBe('clean');
+  });
+
+  // ---- F2: clean+minor combination must return minor ----
+
+  it('returns minor when both clean and minor keywords are present (minor beats clean)', () => {
+    // A reviewer might write a mostly positive review but note a minor issue
+    const result = parseFindingsFromNotes('APPROVE the overall approach. MINOR: missing docstring on helper.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      // minor findings exist -- should go through fix-agent loop, NOT auto-merge
+      expect(result.value.severity).toBe('minor');
+    }
+  });
+
+  it('returns minor when LGTM and NIT both appear', () => {
+    const result = parseFindingsFromNotes('LGTM overall. NIT: variable name could be more descriptive.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('minor');
+  });
+
+  it('returns minor when CLEAN and SUGGESTION both appear', () => {
+    const result = parseFindingsFromNotes('CLEAN implementation. SUGGESTION: consider extracting this into a helper.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('minor');
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit/coordinator-pr-review.test.ts
+++ b/tests/unit/coordinator-pr-review.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Unit tests for src/coordinators/pr-review.ts
+ *
+ * Tests pure functions only. All I/O is injected via fake CoordinatorDeps.
+ * No HTTP calls, no exec calls, no filesystem access.
+ *
+ * Strategy: prefer fakes over mocks -- fake CoordinatorDeps objects implement
+ * the interface directly and record calls for assertion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseFindingsFromNotes,
+  buildFixGoal,
+  formatElapsed,
+  runPrReviewCoordinator,
+  type CoordinatorDeps,
+  type PrSummary,
+  type ReviewFindings,
+  type PrReviewOpts,
+} from '../../src/coordinators/pr-review.js';
+import type { AwaitResult } from '../../src/cli/commands/worktrain-await.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// parseFindingsFromNotes -- pure function tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('parseFindingsFromNotes', () => {
+  it('returns err when notes is null', () => {
+    const result = parseFindingsFromNotes(null);
+    expect(result.kind).toBe('err');
+  });
+
+  it('returns err when notes is empty string', () => {
+    const result = parseFindingsFromNotes('');
+    expect(result.kind).toBe('err');
+  });
+
+  it('returns err when notes is whitespace only', () => {
+    const result = parseFindingsFromNotes('   \n  ');
+    expect(result.kind).toBe('err');
+  });
+
+  // ---- JSON block (Tier 1) ----
+
+  it('parses clean from JSON block with recommendation: clean', () => {
+    const notes = `
+## COORDINATOR_OUTPUT
+\`\`\`json
+{ "recommendation": "clean", "findings": [] }
+\`\`\`
+`;
+    const result = parseFindingsFromNotes(notes);
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.severity).toBe('clean');
+      expect(result.value.findingSummaries).toHaveLength(0);
+    }
+  });
+
+  it('parses blocking from JSON block with recommendation: blocking', () => {
+    const notes = `
+\`\`\`json
+{ "recommendation": "blocking", "findings": [{ "severity": "critical", "summary": "auth bypass" }] }
+\`\`\`
+`;
+    const result = parseFindingsFromNotes(notes);
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.severity).toBe('blocking');
+      expect(result.value.findingSummaries[0]).toBe('auth bypass');
+    }
+  });
+
+  it('parses minor from JSON block with recommendation: minor', () => {
+    const notes = `
+\`\`\`json
+{ "recommendation": "minor", "findings": [{ "severity": "minor", "summary": "missing test" }] }
+\`\`\`
+`;
+    const result = parseFindingsFromNotes(notes);
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.severity).toBe('minor');
+    }
+  });
+
+  // ---- Keyword scan (Tier 2) ----
+
+  it('classifies APPROVE as clean', () => {
+    const result = parseFindingsFromNotes('**Final recommendation: APPROVE this change**\n\nLooks good.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('clean');
+  });
+
+  it('classifies LGTM as clean', () => {
+    const result = parseFindingsFromNotes('LGTM -- no issues found.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('clean');
+  });
+
+  it('classifies BLOCKING as blocking', () => {
+    const result = parseFindingsFromNotes('BLOCKING issue found: SQL injection risk in user input.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('blocking');
+  });
+
+  it('classifies CRITICAL as blocking', () => {
+    const result = parseFindingsFromNotes('CRITICAL severity: unvalidated redirect vulnerability.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('blocking');
+  });
+
+  it('classifies REQUEST CHANGES as blocking', () => {
+    const result = parseFindingsFromNotes('Final recommendation: REQUEST CHANGES before merge.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('blocking');
+  });
+
+  it('classifies MINOR as minor', () => {
+    const result = parseFindingsFromNotes('Overall looks good. One MINOR issue: missing docstring in helper function.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('minor');
+  });
+
+  it('classifies NIT as minor', () => {
+    const result = parseFindingsFromNotes('NIT: variable name could be more descriptive.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('minor');
+  });
+
+  it('returns unknown when no recognized keywords', () => {
+    const result = parseFindingsFromNotes('The code changes look reasonable. Some areas need attention.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('unknown');
+  });
+
+  // ---- Negation context check (critical safety invariant) ----
+
+  it('does NOT classify as blocking when "blocking" appears after "not"', () => {
+    const result = parseFindingsFromNotes('This is not technically blocking but could be improved.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.severity).not.toBe('blocking');
+    }
+  });
+
+  it('does NOT classify as blocking when "no blocking" appears', () => {
+    const result = parseFindingsFromNotes('There are no blocking issues. APPROVE.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      // "no blocking issues" + "APPROVE" -> clean
+      expect(result.value.severity).toBe('clean');
+    }
+  });
+
+  it('does NOT classify as blocking when "without blocking" appears', () => {
+    const result = parseFindingsFromNotes('Can merge without blocking concerns. Good to go.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.severity).not.toBe('blocking');
+    }
+  });
+
+  it('DOES classify as blocking when blocking keyword is present without negation', () => {
+    const result = parseFindingsFromNotes('Found a BLOCKING security issue: unescaped user input.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('blocking');
+  });
+
+  // ---- Priority: blocking wins over clean ----
+
+  it('blocking keywords win over clean keywords when both present', () => {
+    // A reviewer might say "approve the style changes, but BLOCKING on the security issue"
+    const result = parseFindingsFromNotes('APPROVE the formatting. BLOCKING: auth token exposed in logs.');
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value.severity).toBe('blocking');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// buildFixGoal -- pure function tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('buildFixGoal', () => {
+  it('includes PR number in goal', () => {
+    const findings: ReviewFindings = {
+      severity: 'minor',
+      findingSummaries: [],
+      raw: '',
+    };
+    const goal = buildFixGoal(419, findings);
+    expect(goal).toContain('PR #419');
+  });
+
+  it('includes finding summaries when available', () => {
+    const findings: ReviewFindings = {
+      severity: 'minor',
+      findingSummaries: ['missing test coverage', 'unclear variable name'],
+      raw: '',
+    };
+    const goal = buildFixGoal(406, findings);
+    expect(goal).toContain('missing test coverage');
+    expect(goal).toContain('PR #406');
+  });
+
+  it('produces valid goal when no findings', () => {
+    const findings: ReviewFindings = {
+      severity: 'minor',
+      findingSummaries: [],
+      raw: '',
+    };
+    const goal = buildFixGoal(100, findings);
+    expect(goal).toMatch(/Fix review findings in PR #100/);
+  });
+
+  it('limits to 3 findings in goal string', () => {
+    const findings: ReviewFindings = {
+      severity: 'minor',
+      findingSummaries: ['finding 1', 'finding 2', 'finding 3', 'finding 4', 'finding 5'],
+      raw: '',
+    };
+    const goal = buildFixGoal(1, findings);
+    expect(goal).toContain('finding 1');
+    expect(goal).toContain('finding 2');
+    expect(goal).toContain('finding 3');
+    // finding 4 and 5 should not appear (only first 3 included)
+    expect(goal).not.toContain('finding 4');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// formatElapsed -- pure function tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('formatElapsed', () => {
+  it('formats zero as 0:00', () => {
+    expect(formatElapsed(0)).toBe('0:00');
+  });
+
+  it('formats 30 seconds', () => {
+    expect(formatElapsed(30_000)).toBe('0:30');
+  });
+
+  it('formats 1 minute 8 seconds as 1:08', () => {
+    expect(formatElapsed(68_000)).toBe('1:08');
+  });
+
+  it('formats 8 minutes 31 seconds as 8:31', () => {
+    expect(formatElapsed(511_000)).toBe('8:31');
+  });
+
+  it('pads seconds with leading zero', () => {
+    expect(formatElapsed(61_000)).toBe('1:01');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runPrReviewCoordinator -- integration tests with fake deps
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Build a fake CoordinatorDeps object for testing.
+ * All I/O operations are recorded for assertion.
+ */
+function makeFakeDeps(overrides: Partial<CoordinatorDeps> = {}): CoordinatorDeps & {
+  spawnCalls: Array<{ workflowId: string; goal: string }>;
+  awaitCalls: Array<{ handles: readonly string[] }>;
+  mergeCalls: number[];
+  writtenFiles: Map<string, string>;
+  stderrLines: string[];
+} {
+  const spawnCalls: Array<{ workflowId: string; goal: string }> = [];
+  const awaitCalls: Array<{ handles: readonly string[] }> = [];
+  const mergeCalls: number[] = [];
+  const writtenFiles = new Map<string, string>();
+  const stderrLines: string[] = [];
+
+  const base: CoordinatorDeps = {
+    spawnSession: async (workflowId, goal) => {
+      spawnCalls.push({ workflowId, goal });
+      return { kind: 'ok', value: `handle-${spawnCalls.length}` };
+    },
+    awaitSessions: async (handles, _timeoutMs) => {
+      awaitCalls.push({ handles });
+      const results = [...handles].map((h) => ({
+        handle: h,
+        outcome: 'success' as const,
+        status: 'complete',
+        durationMs: 5_000,
+      }));
+      return { results, allSucceeded: true };
+    },
+    getAgentResult: async (_handle) => {
+      return 'APPROVE this change. No issues found.';
+    },
+    listOpenPRs: async (_workspace) => {
+      return [
+        { number: 419, title: 'feat: add new feature', headRef: 'feat/new-feature' },
+      ] satisfies PrSummary[];
+    },
+    mergePR: async (prNumber, _workspace) => {
+      mergeCalls.push(prNumber);
+      return { kind: 'ok', value: undefined };
+    },
+    writeFile: async (path, content) => {
+      writtenFiles.set(path, content);
+    },
+    stderr: (line) => {
+      stderrLines.push(line);
+    },
+    now: () => Date.now(),
+    port: 3456,
+    ...overrides,
+  };
+
+  return Object.assign(base, { spawnCalls, awaitCalls, mergeCalls, writtenFiles, stderrLines });
+}
+
+const defaultOpts: PrReviewOpts = {
+  workspace: '/test/workspace',
+  dryRun: false,
+};
+
+describe('runPrReviewCoordinator', () => {
+  it('returns 0 reviewed when no open PRs', async () => {
+    const deps = makeFakeDeps({
+      listOpenPRs: async () => [],
+    });
+    const result = await runPrReviewCoordinator(deps, defaultOpts);
+    expect(result.reviewed).toBe(0);
+    expect(result.approved).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(deps.spawnCalls).toHaveLength(0);
+    expect(deps.mergeCalls).toHaveLength(0);
+  });
+
+  it('merges clean PR', async () => {
+    const deps = makeFakeDeps({
+      getAgentResult: async () => 'APPROVE -- clean implementation, no issues.',
+    });
+    const result = await runPrReviewCoordinator(deps, defaultOpts);
+    expect(result.reviewed).toBe(1);
+    expect(result.approved).toBe(1);
+    expect(result.escalated).toBe(0);
+    expect(deps.mergeCalls).toContain(419);
+  });
+
+  it('escalates blocking PR without merging', async () => {
+    const deps = makeFakeDeps({
+      getAgentResult: async () => 'BLOCKING: critical security vulnerability found.',
+    });
+    const result = await runPrReviewCoordinator(deps, defaultOpts);
+    expect(result.reviewed).toBe(1);
+    expect(result.approved).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(deps.mergeCalls).toHaveLength(0);
+  });
+
+  it('escalates unknown severity without merging', async () => {
+    const deps = makeFakeDeps({
+      getAgentResult: async () => null,
+    });
+    const result = await runPrReviewCoordinator(deps, defaultOpts);
+    expect(result.reviewed).toBe(1);
+    expect(result.approved).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(deps.mergeCalls).toHaveLength(0);
+  });
+
+  it('does not merge on session failure (non-success outcome)', async () => {
+    const deps = makeFakeDeps({
+      awaitSessions: async (handles) => {
+        return {
+          results: [...handles].map((h) => ({
+            handle: h,
+            outcome: 'failed' as const,
+            status: 'blocked',
+            durationMs: 1_000,
+          })),
+          allSucceeded: false,
+        };
+      },
+    });
+    const result = await runPrReviewCoordinator(deps, defaultOpts);
+    expect(result.approved).toBe(0);
+    expect(deps.mergeCalls).toHaveLength(0);
+  });
+
+  it('does not merge on session timeout', async () => {
+    const deps = makeFakeDeps({
+      awaitSessions: async (handles) => {
+        return {
+          results: [...handles].map((h) => ({
+            handle: h,
+            outcome: 'timeout' as const,
+            status: null,
+            durationMs: 20 * 60 * 1000,
+          })),
+          allSucceeded: false,
+        };
+      },
+    });
+    const result = await runPrReviewCoordinator(deps, defaultOpts);
+    expect(result.approved).toBe(0);
+    expect(deps.mergeCalls).toHaveLength(0);
+  });
+
+  it('spawns fix agent for minor PR and merges after fix + clean re-review', async () => {
+    let reviewCallCount = 0;
+    const deps = makeFakeDeps({
+      getAgentResult: async (handle) => {
+        // First review: minor; re-review after fix: clean
+        if (handle.includes('handle-1')) {
+          reviewCallCount++;
+          return 'MINOR: missing test coverage for edge case.';
+        }
+        // Re-review after fix
+        return 'APPROVE -- all issues addressed.';
+      },
+    });
+    const result = await runPrReviewCoordinator(deps, defaultOpts);
+    expect(result.approved).toBe(1);
+    expect(result.escalated).toBe(0);
+    expect(deps.mergeCalls).toContain(419);
+    // Should have spawned: 1 review + 1 fix agent + 1 re-review = 3 spawns minimum
+    expect(deps.spawnCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('escalates after 3 fix passes with persistent minor findings', async () => {
+    const deps = makeFakeDeps({
+      getAgentResult: async () => {
+        // Always return minor -- never gets clean
+        return 'MINOR: this issue persists.';
+      },
+    });
+    const result = await runPrReviewCoordinator(deps, defaultOpts);
+    expect(result.approved).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(deps.mergeCalls).toHaveLength(0);
+  });
+
+  it('dry-run makes no spawn or merge calls', async () => {
+    const deps = makeFakeDeps();
+    const result = await runPrReviewCoordinator(deps, { ...defaultOpts, dryRun: true });
+    expect(deps.spawnCalls).toHaveLength(0);
+    expect(deps.mergeCalls).toHaveLength(0);
+    // Result is well-formed
+    expect(result.reviewed).toBeGreaterThanOrEqual(0);
+  });
+
+  it('writes report file to workspace', async () => {
+    const deps = makeFakeDeps({
+      getAgentResult: async () => 'APPROVE -- looks good.',
+    });
+    await runPrReviewCoordinator(deps, defaultOpts);
+    const reportKey = [...deps.writtenFiles.keys()].find((k) => k.includes('coordinator-pr-review'));
+    expect(reportKey).toBeDefined();
+    if (reportKey) {
+      const content = deps.writtenFiles.get(reportKey) ?? '';
+      expect(content).toContain('PR Review Coordinator Report');
+    }
+  });
+
+  it('handles spawn error gracefully without crashing', async () => {
+    const deps = makeFakeDeps({
+      spawnSession: async () => ({ kind: 'err', error: 'ECONNREFUSED' }),
+    });
+    const result = await runPrReviewCoordinator(deps, defaultOpts);
+    expect(result.reviewed).toBeGreaterThanOrEqual(0);
+    expect(deps.mergeCalls).toHaveLength(0);
+  });
+
+  it('uses specific PR numbers when --pr flag is provided', async () => {
+    const deps = makeFakeDeps({
+      getAgentResult: async () => 'APPROVE',
+    });
+    const result = await runPrReviewCoordinator(deps, { ...defaultOpts, prs: [123, 456] });
+    expect(result.reviewed).toBe(2);
+    // listOpenPRs should NOT have been called
+    // (PRs come from opts.prs, not from discovery)
+  });
+
+  it('escalates PR when merge fails', async () => {
+    const deps = makeFakeDeps({
+      getAgentResult: async () => 'APPROVE -- clean.',
+      mergePR: async () => ({ kind: 'err', error: 'merge conflict' }),
+    });
+    const result = await runPrReviewCoordinator(deps, defaultOpts);
+    expect(result.approved).toBe(0);
+    expect(result.escalated).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/coordinators/pr-review.ts`: first WorkTrain coordinator script with `CoordinatorDeps` interface, full pipeline (parallel review dispatch, finding extraction via 2-call HTTP, severity routing, fix-agent loop, serial merge), and 5 robustness rules
- Adds `worktrain run pr-review` CLI subcommand in `src/cli-worktrain.ts` with real HTTP/gh/fs deps wired
- Adds 41 unit tests covering all pure functions and routing behaviors (fake CoordinatorDeps, no network/exec)
- Adds design discovery docs in `docs/discovery/`

## Architecture

The coordinator follows the `WorktrainSpawnCommandDeps` DI pattern exactly. All I/O is injected via `CoordinatorDeps`. Pure functions (`parseFindingsFromNotes`, `classifySeverity`, `buildFixGoal`) are fully testable without live deps.

**Notes extraction:** after `worktrain await` returns a handle, a 2-call HTTP sequence retrieves findings: `GET /api/v2/sessions/:id` -> `preferredTipNodeId` -> `GET /api/v2/sessions/:id/nodes/:nodeId` -> `recapMarkdown`.

**Finding parser:** two-tier -- JSON block (`## COORDINATOR_OUTPUT`) first for future-proof structured output; keyword scan fallback for current mr-review free-form markdown. Blocking keywords take absolute precedence. Negation context (`not blocking`, `no blocking`) suppresses blocking classification.

**Five robustness rules:**
1. Child session timeout hardcoded to 15 minutes (never LLM-computed)
2. Zombie detection: empty/null session handle -> escalate
3. Wall-clock go/no-go: refuse new spawns if coordinator elapsed > 70 minutes
4. Two-tier parser with conservative defaults (unknown -> blocking)
5. Traceability JSON `{ childSessionId, outcome, elapsedMs, severity }` written before acting

## Test plan

- [ ] `npx vitest run tests/unit/coordinator-pr-review.test.ts` -- all 41 tests pass
- [ ] `npx tsc --noEmit` -- clean
- [ ] `npx vitest run tests/unit/` -- no regressions vs baseline (2 pre-existing failures in cli-validate/cli-version, both require compiled dist)
- [ ] Manual smoke: `worktrain run pr-review --workspace /path --dry-run` prints expected output

## Follow-ups

- Update `mr-review-workflow.agentic.v2.json` phase-6 to emit `## COORDINATOR_OUTPUT` JSON block for reliable machine parsing
- Add `worktrain run groom-prs` as second coordinator using same pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)