### PR TITLE
feat(schema): add wr.coordinator_signal typed artifact schema

### DIFF
--- a/src/v2/durable-core/domain/artifact-contract-validator.ts
+++ b/src/v2/durable-core/domain/artifact-contract-validator.ts
@@ -7,6 +7,9 @@ import {
   isLoopControlArtifact,
   isValidContractRef,
   type LoopControlArtifactV1,
+  COORDINATOR_SIGNAL_CONTRACT_REF,
+  CoordinatorSignalArtifactV1Schema,
+  isCoordinatorSignalArtifact,
 } from '../schemas/artifacts/index.js';
 
 /**
@@ -61,7 +64,10 @@ export function validateArtifactContract(
   switch (contractRef) {
     case LOOP_CONTROL_CONTRACT_REF:
       return validateLoopControlContract(artifacts, contractRef, required);
-    
+
+    case COORDINATOR_SIGNAL_CONTRACT_REF:
+      return validateCoordinatorSignalContract(artifacts, contractRef, required);
+
     default:
       // Type system should prevent this, but fail-fast just in case
       return {
@@ -124,8 +130,56 @@ function validateLoopControlContract(
 }
 
 /**
+ * Validate coordinator signal artifact contract.
+ */
+function validateCoordinatorSignalContract(
+  artifacts: readonly unknown[],
+  contractRef: string,
+  required: boolean
+): ArtifactContractValidationResult {
+  // Find coordinator signal artifacts by kind discriminant
+  const signalArtifacts = artifacts.filter(isCoordinatorSignalArtifact);
+
+  if (signalArtifacts.length === 0) {
+    if (required) {
+      return {
+        valid: false,
+        error: {
+          code: 'MISSING_REQUIRED_ARTIFACT',
+          contractRef,
+          message: `Required artifact missing: ${contractRef}. Agent must provide an artifact with kind='wr.coordinator_signal'.`,
+        },
+      };
+    }
+    // Not required and not present -- valid (no artifact returned)
+    return { valid: true, artifact: null };
+  }
+
+  // Validate the first matching artifact
+  const artifact = signalArtifacts[0]!;
+  const parseResult = CoordinatorSignalArtifactV1Schema.safeParse(artifact);
+
+  if (!parseResult.success) {
+    const issues = parseResult.error.issues.map(
+      (issue) => `${issue.path.join('.')}: ${issue.message}`
+    );
+    return {
+      valid: false,
+      error: {
+        code: 'INVALID_ARTIFACT_SCHEMA',
+        contractRef,
+        message: `Artifact schema validation failed for ${contractRef}`,
+        issues,
+      },
+    };
+  }
+
+  return { valid: true, artifact: parseResult.data };
+}
+
+/**
  * Check if step has an output contract that requires validation.
- * 
+ *
  * @param outputContract - The step's output contract (optional)
  * @returns True if validation is required
  */

--- a/src/v2/durable-core/schemas/artifacts/coordinator-signal.ts
+++ b/src/v2/durable-core/schemas/artifacts/coordinator-signal.ts
@@ -1,0 +1,144 @@
+import { z } from 'zod';
+
+/**
+ * Coordinator Signal Artifact Schema (v1)
+ *
+ * Typed artifact for mid-session signaling from an agent to its coordinator.
+ * Agents emit this artifact to surface progress updates, intermediate findings,
+ * data requests, approval requests, or blocking conditions without stopping
+ * the session.
+ *
+ * NOTE on naming:
+ *   - `kind: 'wr.coordinator_signal'` is the discriminator field in the artifact object.
+ *   - `COORDINATOR_SIGNAL_CONTRACT_REF = 'wr.contracts.coordinator_signal'` is the
+ *     contract reference used in workflow YAML (`output.contractRef`) and in
+ *     `ARTIFACT_CONTRACT_REFS`. These are distinct identifiers that serve different roles.
+ *
+ * Lock: §19 Evidence-based validation - typed artifacts over prose validation
+ * Related: docs/ideas/design-mid-session-signaling.md (Selected Direction: D + A)
+ *
+ * Example usage in workflow:
+ * ```json
+ * {
+ *   "id": "signal-step",
+ *   "prompt": "Signal your coordinator with findings.",
+ *   "output": {
+ *     "contractRef": "wr.contracts.coordinator_signal"
+ *   }
+ * }
+ * ```
+ *
+ * Agent provides:
+ * ```json
+ * {
+ *   "artifacts": [{
+ *     "kind": "wr.coordinator_signal",
+ *     "signalKind": "finding",
+ *     "payload": { "summary": "Found 3 critical issues in module A" }
+ *   }]
+ * }
+ * ```
+ */
+
+/**
+ * Contract reference for coordinator signal artifacts.
+ * Used in workflow step definitions to declare the required output contract.
+ */
+export const COORDINATOR_SIGNAL_CONTRACT_REF = 'wr.contracts.coordinator_signal' as const;
+
+/**
+ * Valid signal kinds for coordinator signal artifacts.
+ *
+ * - 'progress': Fire-and-observe heartbeat; no data required. Pass `payload: {}`.
+ * - 'finding': Intermediate result or discovery worth surfacing now.
+ * - 'data_needed': Agent requests external data from coordinator before continuing.
+ * - 'approval_needed': Agent requests coordinator approval before proceeding.
+ * - 'blocked': Agent has hit a blocking condition and cannot continue without intervention.
+ */
+export const CoordinatorSignalKindSchema = z.enum([
+  'progress',
+  'finding',
+  'data_needed',
+  'approval_needed',
+  'blocked',
+]);
+
+export type CoordinatorSignalKind = z.infer<typeof CoordinatorSignalKindSchema>;
+
+/**
+ * Coordinator Signal Artifact V1 Schema
+ *
+ * Machine-checkable artifact for mid-session agent-to-coordinator communication.
+ * Validated against this schema when a step declares
+ * `output.contractRef: 'wr.contracts.coordinator_signal'`.
+ *
+ * The `signal_coordinator` tool (future work) emits artifacts of this shape.
+ */
+export const CoordinatorSignalArtifactV1Schema = z
+  .object({
+    /** Artifact kind discriminator (must be 'wr.coordinator_signal') */
+    kind: z.literal('wr.coordinator_signal'),
+
+    /**
+     * The signal kind.
+     * Closed enum -- only the five defined kinds are valid.
+     */
+    signalKind: CoordinatorSignalKindSchema,
+
+    /**
+     * Structured payload accompanying the signal.
+     *
+     * For signals with no data to attach (e.g. progress updates), pass `{}`.
+     * For findings, include structured data the coordinator needs to act on.
+     *
+     * NOTE: The `signal_coordinator` tool (future work) will default this to `{}`
+     * when the agent omits it, so agents using the tool do not need to pass `{}` manually.
+     */
+    payload: z.record(z.unknown()),
+
+    /**
+     * Optional session identifier.
+     * The engine already knows the session; include this for coordinator log correlation
+     * when the artifact is read out-of-band via the node detail API.
+     */
+    sessionId: z.string().optional(),
+  })
+  .strict();
+
+export type CoordinatorSignalArtifactV1 = z.infer<typeof CoordinatorSignalArtifactV1Schema>;
+
+/**
+ * Type guard to check if an unknown artifact is a coordinator signal artifact.
+ *
+ * Checks the kind discriminant only -- does not validate the full schema.
+ * Use `parseCoordinatorSignalArtifact()` for full validation.
+ *
+ * @param artifact - Unknown artifact to check
+ * @returns True if artifact has the coordinator signal kind
+ */
+export function isCoordinatorSignalArtifact(
+  artifact: unknown,
+): artifact is { readonly kind: 'wr.coordinator_signal' } {
+  return (
+    typeof artifact === 'object' &&
+    artifact !== null &&
+    (artifact as Record<string, unknown>).kind === 'wr.coordinator_signal'
+  );
+}
+
+/**
+ * Parse and validate an unknown artifact as a coordinator signal artifact.
+ *
+ * Returns the parsed artifact on success, null on validation failure.
+ * Use `isCoordinatorSignalArtifact()` to check kind before calling this
+ * if you want to distinguish "wrong kind" from "wrong schema".
+ *
+ * @param artifact - Unknown artifact to validate
+ * @returns Parsed artifact or null if validation fails
+ */
+export function parseCoordinatorSignalArtifact(
+  artifact: unknown,
+): CoordinatorSignalArtifactV1 | null {
+  const result = CoordinatorSignalArtifactV1Schema.safeParse(artifact);
+  return result.success ? result.data : null;
+}

--- a/src/v2/durable-core/schemas/artifacts/index.ts
+++ b/src/v2/durable-core/schemas/artifacts/index.ts
@@ -32,6 +32,17 @@ export {
   type LoopControlArtifactV1,
 } from './loop-control.js';
 
+export {
+  // Coordinator Signal
+  COORDINATOR_SIGNAL_CONTRACT_REF,
+  CoordinatorSignalKindSchema,
+  CoordinatorSignalArtifactV1Schema,
+  isCoordinatorSignalArtifact,
+  parseCoordinatorSignalArtifact,
+  type CoordinatorSignalKind,
+  type CoordinatorSignalArtifactV1,
+} from './coordinator-signal.js';
+
 /**
  * Registry of all artifact contract references.
  * Used for validation and documentation.
@@ -39,6 +50,7 @@ export {
 export const ARTIFACT_CONTRACT_REFS = [
   'wr.contracts.assessment',
   'wr.contracts.loop_control',
+  'wr.contracts.coordinator_signal',
 ] as const;
 
 export type ArtifactContractRef = (typeof ARTIFACT_CONTRACT_REFS)[number];

--- a/tests/unit/artifact-schema-coordinator-signal.test.ts
+++ b/tests/unit/artifact-schema-coordinator-signal.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for the wr.coordinator_signal artifact schema.
+ *
+ * Verifies:
+ * - Valid artifacts for all 5 signal kinds parse correctly
+ * - Required fields (signalKind, payload) are enforced
+ * - Extra fields are rejected by .strict()
+ * - isCoordinatorSignalArtifact() checks kind only
+ * - parseCoordinatorSignalArtifact() does full schema validation
+ * - validateArtifactContract() happy-path returns valid: true
+ * - validateArtifactContract() missing required artifact returns MISSING_REQUIRED_ARTIFACT
+ *
+ * WHY no mocks: these are pure function tests -- Zod schemas and the validator
+ * are deterministic functions with no I/O or external dependencies.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isCoordinatorSignalArtifact,
+  parseCoordinatorSignalArtifact,
+  COORDINATOR_SIGNAL_CONTRACT_REF,
+} from '../../src/v2/durable-core/schemas/artifacts/coordinator-signal.js';
+import { validateArtifactContract } from '../../src/v2/durable-core/domain/artifact-contract-validator.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const VALID_PROGRESS = {
+  kind: 'wr.coordinator_signal',
+  signalKind: 'progress',
+  payload: {},
+} as const;
+
+const VALID_FINDING = {
+  kind: 'wr.coordinator_signal',
+  signalKind: 'finding',
+  payload: { summary: 'Found 3 critical issues in module A' },
+} as const;
+
+const VALID_DATA_NEEDED = {
+  kind: 'wr.coordinator_signal',
+  signalKind: 'data_needed',
+  payload: { request: 'Need full diff of PR #456' },
+} as const;
+
+const VALID_APPROVAL_NEEDED = {
+  kind: 'wr.coordinator_signal',
+  signalKind: 'approval_needed',
+  payload: { action: 'delete production table users_v1' },
+} as const;
+
+const VALID_BLOCKED = {
+  kind: 'wr.coordinator_signal',
+  signalKind: 'blocked',
+  payload: { reason: 'Cannot access external API -- credentials not in context' },
+} as const;
+
+const VALID_WITH_SESSION_ID = {
+  kind: 'wr.coordinator_signal',
+  signalKind: 'progress',
+  payload: {},
+  sessionId: 'abc-123-session',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Tests: isCoordinatorSignalArtifact()
+// ---------------------------------------------------------------------------
+
+describe('isCoordinatorSignalArtifact()', () => {
+  it('returns true for artifact with kind wr.coordinator_signal', () => {
+    expect(isCoordinatorSignalArtifact(VALID_PROGRESS)).toBe(true);
+  });
+
+  it('returns false for artifact with a different kind', () => {
+    expect(isCoordinatorSignalArtifact({ kind: 'wr.loop_control', decision: 'stop' })).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isCoordinatorSignalArtifact(null)).toBe(false);
+  });
+
+  it('returns false for non-object', () => {
+    expect(isCoordinatorSignalArtifact('wr.coordinator_signal')).toBe(false);
+  });
+
+  it('returns false for object with no kind field', () => {
+    expect(isCoordinatorSignalArtifact({ signalKind: 'progress', payload: {} })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: parseCoordinatorSignalArtifact() -- valid inputs
+// ---------------------------------------------------------------------------
+
+describe('parseCoordinatorSignalArtifact() -- valid inputs', () => {
+  it('TC1: parses progress signal with empty payload', () => {
+    const result = parseCoordinatorSignalArtifact(VALID_PROGRESS);
+    expect(result).not.toBeNull();
+    expect(result?.kind).toBe('wr.coordinator_signal');
+    expect(result?.signalKind).toBe('progress');
+    expect(result?.payload).toEqual({});
+  });
+
+  it('TC2: parses finding signal with non-empty payload', () => {
+    const result = parseCoordinatorSignalArtifact(VALID_FINDING);
+    expect(result).not.toBeNull();
+    expect(result?.signalKind).toBe('finding');
+    expect(result?.payload).toEqual({ summary: 'Found 3 critical issues in module A' });
+  });
+
+  it('TC3: parses data_needed signal', () => {
+    const result = parseCoordinatorSignalArtifact(VALID_DATA_NEEDED);
+    expect(result).not.toBeNull();
+    expect(result?.signalKind).toBe('data_needed');
+  });
+
+  it('TC4: parses approval_needed signal', () => {
+    const result = parseCoordinatorSignalArtifact(VALID_APPROVAL_NEEDED);
+    expect(result).not.toBeNull();
+    expect(result?.signalKind).toBe('approval_needed');
+  });
+
+  it('TC5: parses blocked signal', () => {
+    const result = parseCoordinatorSignalArtifact(VALID_BLOCKED);
+    expect(result).not.toBeNull();
+    expect(result?.signalKind).toBe('blocked');
+  });
+
+  it('TC6: parses artifact with optional sessionId', () => {
+    const result = parseCoordinatorSignalArtifact(VALID_WITH_SESSION_ID);
+    expect(result).not.toBeNull();
+    expect(result?.sessionId).toBe('abc-123-session');
+  });
+
+  it('TC7: parses artifact without optional sessionId (undefined)', () => {
+    const result = parseCoordinatorSignalArtifact(VALID_PROGRESS);
+    expect(result).not.toBeNull();
+    expect(result?.sessionId).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: parseCoordinatorSignalArtifact() -- invalid inputs
+// ---------------------------------------------------------------------------
+
+describe('parseCoordinatorSignalArtifact() -- invalid inputs', () => {
+  it('TC8: returns null when signalKind is missing', () => {
+    const result = parseCoordinatorSignalArtifact({
+      kind: 'wr.coordinator_signal',
+      payload: {},
+    });
+    expect(result).toBeNull();
+  });
+
+  it('TC9: returns null when signalKind is an unknown value', () => {
+    const result = parseCoordinatorSignalArtifact({
+      kind: 'wr.coordinator_signal',
+      signalKind: 'unknown_kind',
+      payload: {},
+    });
+    expect(result).toBeNull();
+  });
+
+  it('TC10: returns null when payload is missing (required field)', () => {
+    const result = parseCoordinatorSignalArtifact({
+      kind: 'wr.coordinator_signal',
+      signalKind: 'progress',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('TC11: returns null when extra field is present (.strict() enforcement)', () => {
+    const result = parseCoordinatorSignalArtifact({
+      kind: 'wr.coordinator_signal',
+      signalKind: 'progress',
+      payload: {},
+      unknownExtraField: 'should be rejected',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('TC12: returns null for null input', () => {
+    expect(parseCoordinatorSignalArtifact(null)).toBeNull();
+  });
+
+  it('TC13: returns null for non-object input', () => {
+    expect(parseCoordinatorSignalArtifact('not an artifact')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: validateArtifactContract()
+// ---------------------------------------------------------------------------
+
+describe('validateArtifactContract() with wr.contracts.coordinator_signal', () => {
+  it('TC9-happy: valid artifact returns valid: true with parsed artifact', () => {
+    const result = validateArtifactContract(
+      [VALID_PROGRESS],
+      { contractRef: COORDINATOR_SIGNAL_CONTRACT_REF },
+    );
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect((result.artifact as { kind: string }).kind).toBe('wr.coordinator_signal');
+    }
+  });
+
+  it('TC9-finding: valid finding artifact with payload returns valid: true', () => {
+    const result = validateArtifactContract(
+      [VALID_FINDING],
+      { contractRef: COORDINATOR_SIGNAL_CONTRACT_REF },
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('TC10-missing: empty artifacts with required:true returns MISSING_REQUIRED_ARTIFACT', () => {
+    const result = validateArtifactContract(
+      [],
+      { contractRef: COORDINATOR_SIGNAL_CONTRACT_REF, required: true },
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error.code).toBe('MISSING_REQUIRED_ARTIFACT');
+      expect(result.error.contractRef).toBe(COORDINATOR_SIGNAL_CONTRACT_REF);
+    }
+  });
+
+  it('TC10-optional: empty artifacts with required:false returns valid: true', () => {
+    const result = validateArtifactContract(
+      [],
+      { contractRef: COORDINATOR_SIGNAL_CONTRACT_REF, required: false },
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('TC11-invalid-schema: artifact with extra field returns INVALID_ARTIFACT_SCHEMA', () => {
+    const result = validateArtifactContract(
+      [{ kind: 'wr.coordinator_signal', signalKind: 'progress', payload: {}, extra: 'field' }],
+      { contractRef: COORDINATOR_SIGNAL_CONTRACT_REF },
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error.code).toBe('INVALID_ARTIFACT_SCHEMA');
+    }
+  });
+
+  it('TC12-unknown-ref: unknown contract ref returns UNKNOWN_CONTRACT_REF', () => {
+    const result = validateArtifactContract(
+      [VALID_PROGRESS],
+      { contractRef: 'wr.contracts.nonexistent' as never },
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error.code).toBe('UNKNOWN_CONTRACT_REF');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/v2/durable-core/schemas/artifacts/coordinator-signal.ts` -- a new typed artifact kind for mid-session signaling from agent to coordinator
- Schema: `{ kind: 'wr.coordinator_signal', signalKind: 'progress' | 'finding' | 'data_needed' | 'approval_needed' | 'blocked', payload: Record<string, unknown>, sessionId?: string }` with `.strict()` enforcement
- Registers `'wr.contracts.coordinator_signal'` in `ARTIFACT_CONTRACT_REFS` and adds a switch case in `validateArtifactContract()`
- 24 unit tests covering all 5 signal kinds, required field enforcement, `.strict()` extra-field rejection, and the `validateArtifactContract()` happy path

## Context

This is a standalone schema addition from the mid-session signaling design (`docs/ideas/design-mid-session-signaling.md`, Selected Direction: D + A). It does not depend on #594 or any mid-session injection infrastructure. The `signal_coordinator` tool that will emit this artifact will be built separately.

## Test plan

- [x] `npm run build` -- clean build, no TS errors
- [x] `npx vitest run tests/unit/artifact-schema-coordinator-signal.test.ts` -- 24/24 pass
- [x] `npx vitest run tests/unit/workflow-interpreter-loop-artifacts.test.ts tests/unit/workflow-runner-artifacts.test.ts` -- 33/33 pass (no regressions on existing artifact tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)