### PR TITLE
feat(console): add session tree view for coordinator sessions

### DIFF
--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -100,6 +100,8 @@ export interface ConsoleSessionSummary {
   /** True when the session is currently registered in DaemonRegistry with a recent heartbeat.
    * Ephemeral: always false when daemon is not running. */
   readonly isLive: boolean;
+  /** Session ID of the parent coordinator session. null for root sessions. */
+  readonly parentSessionId: string | null;
 }
 
 export interface ConsoleSessionListResponse {

--- a/console/src/hooks/__tests__/useSessionListViewModel.test.tsx
+++ b/console/src/hooks/__tests__/useSessionListViewModel.test.tsx
@@ -33,6 +33,7 @@ function makeSession(overrides: Partial<ConsoleSessionSummary> = {}): ConsoleSes
     lastModifiedMs: Date.now(),
     isAutonomous: false,
     isLive: false,
+    parentSessionId: null,
     ...overrides,
   };
 }

--- a/console/src/hooks/__tests__/useWorkspaceViewModel.test.tsx
+++ b/console/src/hooks/__tests__/useWorkspaceViewModel.test.tsx
@@ -58,6 +58,7 @@ const FAKE_REPO_READY = {
       lastModifiedMs: Date.now() - 1000,
       isAutonomous: false,
       isLive: false,
+      parentSessionId: null,
     },
   ],
   worktreeRepos: [

--- a/console/src/hooks/useSessionListViewModel.ts
+++ b/console/src/hooks/useSessionListViewModel.ts
@@ -48,10 +48,12 @@ import {
   sortSessions,
   groupSessions,
   computeStatusCounts,
+  buildSessionTree,
   PAGE_SIZE,
   type SortField,
   type GroupBy,
   type StatusFilter,
+  type SessionTree,
   SORT_AXES,
   GROUP_AXES,
   STATUS_FILTER_OPTIONS,
@@ -113,6 +115,8 @@ export type SessionListViewState =
       readonly groupAxes: typeof GROUP_AXES;
       /** Available status filter options. */
       readonly statusFilterOptions: typeof STATUS_FILTER_OPTIONS;
+      readonly viewMode: 'flat' | 'tree';
+      readonly sessionTree: SessionTree;
     };
 
 // ---------------------------------------------------------------------------
@@ -193,6 +197,12 @@ export function useSessionListViewModel({
     return { groups, total: sessions.length, filtered: filtered.length };
   }, [sessions, debouncedSearch, interactionState.statusFilter, interactionState.sort, interactionState.groupBy]);
 
+  // Tree built from full unfiltered session list.
+  const sessionTree = useMemo(() => {
+    if (!sessions) return buildSessionTree([]);
+    return buildSessionTree(sessions);
+  }, [sessions]);
+
   const isGrouped = interactionState.groupBy !== 'none';
   const totalPages = processed ? Math.ceil(processed.filtered / PAGE_SIZE) : 0;
   const pageStart = interactionState.page * PAGE_SIZE;
@@ -238,6 +248,8 @@ export function useSessionListViewModel({
       sortAxes: SORT_AXES,
       groupAxes: GROUP_AXES,
       statusFilterOptions: STATUS_FILTER_OPTIONS,
+      viewMode: interactionState.viewMode,
+      sessionTree,
     };
   }, [
     isLoading,
@@ -250,6 +262,7 @@ export function useSessionListViewModel({
     flatPageSessions,
     getSessionNavProps,
     sessionContainerProps,
+    sessionTree,
   ]);
 
   return { state, dispatch, onSelectSession };

--- a/console/src/views/SessionList.tsx
+++ b/console/src/views/SessionList.tsx
@@ -4,10 +4,12 @@ import { HealthBadge } from '../components/HealthBadge';
 import { BracketBadge } from '../components/BracketBadge';
 import { MetaChip } from '../components/MetaChip';
 import { ConsoleCard } from '../components/ConsoleCard';
+import { TreeLine } from '../components/TreeLine';
 import type { ConsoleSessionSummary } from '../api/types';
 import { formatRelativeTime } from '../utils/time';
 import type { UseGridKeyNavResult } from '../hooks/useGridKeyNav';
 import type { UseSessionListViewModelResult } from '../hooks/useSessionListViewModel';
+import type { SessionTree, SessionTreeNode } from './session-list-use-cases';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -57,7 +59,11 @@ export function SessionList({ viewModel }: Props) {
     sortAxes,
     groupAxes,
     statusFilterOptions,
+    viewMode,
+    sessionTree,
   } = state;
+
+  const isTreeMode = viewMode === 'tree';
 
   if (processed.total === 0) {
     return (
@@ -77,20 +83,33 @@ export function SessionList({ viewModel }: Props) {
         <h2 className="text-lg font-medium text-[var(--text-primary)]">
           Sessions
           <span className="text-[var(--text-muted)] font-normal ml-2 text-sm">
-            {processed.filtered === processed.total
-              ? processed.total
-              : `${processed.filtered} / ${processed.total}`}
+            {isTreeMode ? processed.total : processed.filtered === processed.total ? processed.total : `${processed.filtered} / ${processed.total}`}
           </span>
         </h2>
+        <div className="flex items-center gap-0 border border-[var(--border)] rounded-md overflow-hidden">
+          {(['flat', 'tree'] as const).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => dispatch({ type: 'view_mode_changed', viewMode: mode })}
+              className={`px-3 py-1.5 text-xs font-mono uppercase tracking-wider transition-colors cursor-pointer ${viewMode === mode ? 'bg-[var(--accent)] text-[#0f131f] font-bold' : 'bg-[var(--bg-secondary)] text-[var(--text-muted)] hover:text-[var(--text-primary)]'}`}
+              aria-pressed={viewMode === mode}
+            >
+              {mode}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Toolbar */}
-      <div className="flex flex-wrap items-center gap-3">
+      <div className={`flex flex-wrap items-center gap-3 ${isTreeMode ? 'opacity-40 pointer-events-none select-none' : ''}`}>
         {/* Search */}
         <div className="relative flex-1 min-w-[200px] max-w-[360px]">
           <input
             type="text"
             value={rawSearch}
+            disabled={isTreeMode}
+            aria-disabled={isTreeMode}
             onChange={(e) => dispatch({ type: 'search_changed', value: e.target.value })}
             placeholder="Search sessions..."
             className="w-full bg-[var(--bg-secondary)] border border-[var(--border)] rounded-md px-3 py-1.5 text-sm text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)] transition-colors"
@@ -122,6 +141,7 @@ export function SessionList({ viewModel }: Props) {
         />
       </div>
 
+      {isTreeMode && (<p className="text-[var(--text-muted)] text-xs font-mono">Tree view -- filters disabled</p>)}
       {/* Status filter pills */}
       <div className="flex flex-wrap gap-1.5">
         {statusFilterOptions.map((opt) => {
@@ -146,7 +166,9 @@ export function SessionList({ viewModel }: Props) {
       </div>
 
       {/* Session list */}
-      {processed.filtered === 0 ? (
+      {isTreeMode ? (
+        <SessionTreeView sessionTree={sessionTree} onSelectSession={onSelectSession} />
+      ) : processed.filtered === 0 ? (
         <div className="text-center py-12 text-[var(--text-muted)] text-sm">
           No sessions match the current filters
         </div>
@@ -431,5 +453,203 @@ function Chip({ children, icon }: { children: React.ReactNode; icon?: keyof type
       {icon && CHIP_ICONS[icon]}
       {children}
     </MetaChip>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Session tree view
+// ---------------------------------------------------------------------------
+
+function SessionTreeView({
+  sessionTree,
+  onSelectSession,
+}: {
+  readonly sessionTree: SessionTree;
+  readonly onSelectSession: (id: string) => void;
+}) {
+  const { roots } = sessionTree;
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() => {
+    const initial = new Set<string>();
+    for (const node of roots) {
+      if (node.children.length > 0 && node.session.status === 'in_progress') {
+        initial.add(node.session.sessionId);
+      }
+    }
+    return initial;
+  });
+
+  const toggleExpand = (sessionId: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(sessionId)) { next.delete(sessionId); } else { next.add(sessionId); }
+      return next;
+    });
+  };
+
+  if (roots.length === 0) {
+    return <div className="text-center py-12 text-[var(--text-muted)] text-sm">No sessions found</div>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {roots.map((node) => (
+        <SessionTreeRow
+          key={node.session.sessionId}
+          node={node}
+          isExpanded={expandedIds.has(node.session.sessionId)}
+          onToggle={() => toggleExpand(node.session.sessionId)}
+          onSelectSession={onSelectSession}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SessionTreeRow({
+  node,
+  isExpanded,
+  onToggle,
+  onSelectSession,
+}: {
+  readonly node: SessionTreeNode;
+  readonly isExpanded: boolean;
+  readonly onToggle: () => void;
+  readonly onSelectSession: (id: string) => void;
+}) {
+  const hasChildren = node.children.length > 0;
+
+  return (
+    <div>
+      <div className="flex items-start gap-1">
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={onToggle}
+            aria-expanded={isExpanded}
+            aria-label={`${isExpanded ? 'Collapse' : 'Expand'} children of ${node.session.sessionTitle ?? node.session.sessionId}`}
+            className="flex items-center justify-center w-11 h-11 shrink-0 text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-1 focus-visible:outline-none"
+          >
+            <span
+              className="text-xs transition-transform duration-150"
+              style={{ transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
+            >
+              &#x25b6;
+            </span>
+          </button>
+        ) : (
+          <div className="w-11 shrink-0" />
+        )}
+        <div className="flex-1 min-w-0">
+          <CoordinatorCard
+            session={node.session}
+            hasChildren={hasChildren}
+            isExpanded={isExpanded}
+            childCount={node.children.length}
+            onClick={() => onSelectSession(node.session.sessionId)}
+          />
+        </div>
+      </div>
+      {hasChildren && isExpanded && (
+        <div className="ml-11">
+          <TreeLine>
+            <div className="space-y-2 pt-1">
+              {node.children.map((child) => (
+                <ChildSessionCard
+                  key={child.sessionId}
+                  session={child}
+                  onClick={() => onSelectSession(child.sessionId)}
+                />
+              ))}
+            </div>
+          </TreeLine>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CoordinatorCard({
+  session,
+  hasChildren,
+  isExpanded,
+  childCount,
+  onClick,
+}: {
+  readonly session: ConsoleSessionSummary;
+  readonly hasChildren: boolean;
+  readonly isExpanded: boolean;
+  readonly childCount: number;
+  readonly onClick: () => void;
+}) {
+  const title = session.sessionTitle;
+  const workflowLabel = session.workflowName ?? session.workflowId;
+  const timeAgo = formatRelativeTime(session.lastModifiedMs);
+
+  return (
+    <ConsoleCard
+      variant="list"
+      onClick={onClick}
+      className="rounded-lg px-4 py-3"
+      style={{ borderLeft: '3px solid var(--accent)' }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-[var(--text-primary)] line-clamp-1 group-hover:text-[var(--accent)] transition-colors">
+            {title ?? workflowLabel ?? 'Unnamed session'}
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-[10px] text-[var(--text-muted)] tabular-nums">{timeAgo}</span>
+          {session.isAutonomous && session.isLive && (
+            <BracketBadge label="LIVE" pulse={true} color="#f4c430" />
+          )}
+          <BracketBadge label="COORD" color="var(--accent)" />
+          <StatusBadge status={session.status} />
+        </div>
+      </div>
+      <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+        {title && workflowLabel && (
+          <MetaChip className="rounded text-[var(--text-muted)] max-w-[200px] truncate">{workflowLabel}</MetaChip>
+        )}
+        {hasChildren && !isExpanded && (
+          <MetaChip className="rounded text-[var(--accent)]">{childCount} {childCount === 1 ? 'child' : 'children'}</MetaChip>
+        )}
+      </div>
+      <div className="mt-1.5 font-mono text-[10px] text-[var(--text-muted)] opacity-60 group-hover:opacity-100 transition-opacity truncate">
+        {session.sessionId}
+      </div>
+    </ConsoleCard>
+  );
+}
+
+function ChildSessionCard({
+  session,
+  onClick,
+}: {
+  readonly session: ConsoleSessionSummary;
+  readonly onClick: () => void;
+}) {
+  const title = session.sessionTitle;
+  const workflowLabel = session.workflowName ?? session.workflowId;
+  const timeAgo = formatRelativeTime(session.lastModifiedMs);
+
+  return (
+    <ConsoleCard variant="list" onClick={onClick} className="rounded-lg px-4 py-2.5">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-[var(--text-primary)] line-clamp-1 group-hover:text-[var(--accent)] transition-colors">
+            {title ?? workflowLabel ?? 'Unnamed session'}
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-[10px] text-[var(--text-muted)] tabular-nums">{timeAgo}</span>
+          <StatusBadge status={session.status} />
+        </div>
+      </div>
+      <div className="mt-1 font-mono text-[10px] text-[var(--text-muted)] opacity-60 truncate">
+        {session.sessionId}
+      </div>
+    </ConsoleCard>
   );
 }

--- a/console/src/views/SessionList.tsx
+++ b/console/src/views/SessionList.tsx
@@ -143,7 +143,7 @@ export function SessionList({ viewModel }: Props) {
 
       {isTreeMode && (<p className="text-[var(--text-muted)] text-xs font-mono">Tree view -- filters disabled</p>)}
       {/* Status filter pills */}
-      <div className="flex flex-wrap gap-1.5">
+      <div className={`flex flex-wrap gap-1.5 ${isTreeMode ? 'opacity-40 pointer-events-none select-none' : ''}`}>
         {statusFilterOptions.map((opt) => {
           const count = statusCounts[opt.value] ?? 0;
           if (opt.value !== 'all' && count === 0) return null;
@@ -469,15 +469,23 @@ function SessionTreeView({
   readonly onSelectSession: (id: string) => void;
 }) {
   const { roots } = sessionTree;
-  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() => {
-    const initial = new Set<string>();
-    for (const node of roots) {
-      if (node.children.length > 0 && node.session.status === 'in_progress') {
-        initial.add(node.session.sessionId);
-      }
-    }
-    return initial;
-  });
+  // Start empty -- sessions arrive asynchronously after mount, so the lazy
+  // initializer would always capture an empty roots array.
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(new Set());
+
+  // Additive only: seed auto-expansion for in-progress coordinators whenever
+  // roots changes (e.g. on each poll cycle). Existing IDs are never removed so
+  // user-toggled collapsed state is preserved across data refreshes.
+  useEffect(() => {
+    const toAdd = roots
+      .filter((n) => n.children.length > 0 && n.session.status === 'in_progress')
+      .map((n) => n.session.sessionId);
+    if (toAdd.length === 0) return;
+    setExpandedIds((prev) => {
+      if (toAdd.every((id) => prev.has(id))) return prev;
+      return new Set([...prev, ...toAdd]);
+    });
+  }, [roots]);
 
   const toggleExpand = (sessionId: string) => {
     setExpandedIds((prev) => {

--- a/console/src/views/session-list-reducer.test.ts
+++ b/console/src/views/session-list-reducer.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for session-list-reducer.ts.
+ *
+ * Covers view_mode_changed behavior, which has non-trivial field-clearing
+ * semantics: switching to tree clears rawSearch, statusFilter, and page;
+ * switching to flat only resets page.
+ */
+import { describe, it, expect } from 'vitest';
+import { sessionListReducer, createInitialSessionListState } from './session-list-reducer';
+
+describe('sessionListReducer -- view_mode_changed', () => {
+  it('switching to tree clears rawSearch, statusFilter, and page', () => {
+    const state = {
+      ...createInitialSessionListState(),
+      rawSearch: 'my-branch',
+      statusFilter: 'in_progress' as const,
+      page: 3,
+    };
+    const next = sessionListReducer(state, { type: 'view_mode_changed', viewMode: 'tree' });
+    expect(next.viewMode).toBe('tree');
+    expect(next.rawSearch).toBe('');
+    expect(next.statusFilter).toBe('all');
+    expect(next.page).toBe(0);
+  });
+
+  it('switching to flat only resets page, preserving rawSearch, sort, and groupBy', () => {
+    const state = {
+      ...createInitialSessionListState(),
+      rawSearch: 'my-branch',
+      sort: 'status' as const,
+      groupBy: 'workflow' as const,
+      page: 2,
+      viewMode: 'tree' as const,
+    };
+    const next = sessionListReducer(state, { type: 'view_mode_changed', viewMode: 'flat' });
+    expect(next.viewMode).toBe('flat');
+    expect(next.page).toBe(0);
+    // These fields must be preserved -- flat mode does not clear them.
+    expect(next.rawSearch).toBe('my-branch');
+    expect(next.sort).toBe('status');
+    expect(next.groupBy).toBe('workflow');
+  });
+
+  it('other events do not change viewMode', () => {
+    const state = { ...createInitialSessionListState(), viewMode: 'tree' as const };
+    const next = sessionListReducer(state, { type: 'search_changed', value: 'foo' });
+    expect(next.viewMode).toBe('tree');
+  });
+});

--- a/console/src/views/session-list-reducer.ts
+++ b/console/src/views/session-list-reducer.ts
@@ -28,6 +28,8 @@ export interface SessionListInteractionState {
   readonly groupBy: GroupBy;
   readonly statusFilter: StatusFilter;
   readonly page: number;
+  /** 'flat' = sorted/grouped list; 'tree' = coordinator tree. */
+  readonly viewMode: 'flat' | 'tree';
 }
 
 // ---------------------------------------------------------------------------
@@ -49,6 +51,7 @@ export function createInitialSessionListState(
     groupBy: 'none',
     statusFilter: 'all',
     page: 0,
+    viewMode: 'flat',
   };
 }
 
@@ -61,7 +64,8 @@ export type SessionListEvent =
   | { readonly type: 'sort_changed'; readonly sort: SortField }
   | { readonly type: 'group_changed'; readonly groupBy: GroupBy }
   | { readonly type: 'status_changed'; readonly statusFilter: StatusFilter }
-  | { readonly type: 'page_changed'; readonly page: number };
+  | { readonly type: 'page_changed'; readonly page: number }
+  | { readonly type: 'view_mode_changed'; readonly viewMode: 'flat' | 'tree' };
 
 // ---------------------------------------------------------------------------
 // Reducer
@@ -98,6 +102,12 @@ export function sessionListReducer(
     case 'page_changed':
       // page_changed is the only event that does NOT reset page to 0.
       return { ...state, page: event.page };
+
+    case 'view_mode_changed':
+      if (event.viewMode === 'tree') {
+        return { ...state, viewMode: 'tree', rawSearch: '', statusFilter: 'all', page: 0 };
+      }
+      return { ...state, viewMode: 'flat', page: 0 };
 
     default:
       return assertNever(event);

--- a/console/src/views/session-list-use-cases.test.ts
+++ b/console/src/views/session-list-use-cases.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for session-list-use-cases.ts -- buildSessionTree().
+ */
+import { describe, it, expect } from 'vitest';
+import { buildSessionTree } from './session-list-use-cases';
+import type { ConsoleSessionSummary } from '../api/types';
+
+function makeSession(overrides: Partial<ConsoleSessionSummary> = {}): ConsoleSessionSummary {
+  return {
+    sessionId: `sess-${Math.random().toString(36).slice(2, 10)}`,
+    sessionTitle: 'Test session',
+    workflowId: 'wf-coding',
+    workflowName: 'Coding Task',
+    workflowHash: null,
+    runId: null,
+    status: 'complete',
+    health: 'healthy',
+    nodeCount: 3,
+    edgeCount: 2,
+    tipCount: 1,
+    hasUnresolvedGaps: false,
+    recapSnippet: null,
+    gitBranch: 'main',
+    repoRoot: '/repos/myapp',
+    lastModifiedMs: Date.now(),
+    isAutonomous: false,
+    isLive: false,
+    parentSessionId: null,
+    ...overrides,
+  };
+}
+
+describe('buildSessionTree', () => {
+  it('empty input returns empty tree', () => {
+    const result = buildSessionTree([]);
+    expect(result.roots).toHaveLength(0);
+    expect(result.orphanChildIds.size).toBe(0);
+  });
+
+  it('all root sessions -- all appear as roots with no children', () => {
+    const sessions = [
+      makeSession({ sessionId: 'sess-a', parentSessionId: null }),
+      makeSession({ sessionId: 'sess-b', parentSessionId: null }),
+    ];
+    const result = buildSessionTree(sessions);
+    expect(result.roots).toHaveLength(2);
+    expect(result.roots.every((n) => n.children.length === 0)).toBe(true);
+  });
+
+  it('one coordinator with two children', () => {
+    const coordinator = makeSession({ sessionId: 'coord', parentSessionId: null });
+    const child1 = makeSession({ sessionId: 'child1', parentSessionId: 'coord' });
+    const child2 = makeSession({ sessionId: 'child2', parentSessionId: 'coord' });
+    const result = buildSessionTree([coordinator, child1, child2]);
+    expect(result.roots).toHaveLength(1);
+    expect(result.roots[0].session.sessionId).toBe('coord');
+    expect(result.roots[0].children).toHaveLength(2);
+  });
+
+  it('orphaned child appears as root', () => {
+    const child = makeSession({ sessionId: 'orphan', parentSessionId: 'missing-parent' });
+    const result = buildSessionTree([child]);
+    expect(result.roots).toHaveLength(1);
+    expect(result.orphanChildIds.has('orphan')).toBe(true);
+  });
+
+  it('cycle detection: self-parent treated as root', () => {
+    const cyclic = makeSession({ sessionId: 'cyclic', parentSessionId: 'cyclic' });
+    const result = buildSessionTree([cyclic]);
+    expect(result.roots).toHaveLength(1);
+    expect(result.roots[0].session.sessionId).toBe('cyclic');
+    expect(result.orphanChildIds.has('cyclic')).toBe(false);
+  });
+
+  it('multiple coordinators with independent children', () => {
+    const c1 = makeSession({ sessionId: 'c1' });
+    const c2 = makeSession({ sessionId: 'c2' });
+    const ch1 = makeSession({ sessionId: 'ch1', parentSessionId: 'c1' });
+    const ch2 = makeSession({ sessionId: 'ch2', parentSessionId: 'c2' });
+    const result = buildSessionTree([c1, c2, ch1, ch2]);
+    expect(result.roots).toHaveLength(2);
+    const rootMap = new Map(result.roots.map((n) => [n.session.sessionId, n]));
+    expect(rootMap.get('c1')?.children).toHaveLength(1);
+    expect(rootMap.get('c2')?.children).toHaveLength(1);
+  });
+
+  it('input order preserved for children', () => {
+    const coord = makeSession({ sessionId: 'coord' });
+    const ch1 = makeSession({ sessionId: 'ch1', parentSessionId: 'coord' });
+    const ch2 = makeSession({ sessionId: 'ch2', parentSessionId: 'coord' });
+    const result = buildSessionTree([coord, ch2, ch1]);
+    expect(result.roots[0].children.map((c) => c.sessionId)).toEqual(['ch2', 'ch1']);
+  });
+
+  it('mix of root, child, and orphan', () => {
+    const root = makeSession({ sessionId: 'root' });
+    const child = makeSession({ sessionId: 'child', parentSessionId: 'root' });
+    const orphan = makeSession({ sessionId: 'orphan', parentSessionId: 'missing' });
+    const result = buildSessionTree([root, child, orphan]);
+    expect(result.roots).toHaveLength(2);
+    expect(result.orphanChildIds.has('orphan')).toBe(true);
+  });
+});

--- a/console/src/views/session-list-use-cases.ts
+++ b/console/src/views/session-list-use-cases.ts
@@ -196,3 +196,48 @@ export function computeStatusCounts(
   }
   return counts as Record<StatusFilter, number>;
 }
+
+// ---------------------------------------------------------------------------
+// Session tree
+// ---------------------------------------------------------------------------
+
+export const TREE_MAX_DEPTH = 2;
+
+export interface SessionTreeNode {
+  readonly session: ConsoleSessionSummary;
+  readonly children: readonly ConsoleSessionSummary[];
+}
+
+export interface SessionTree {
+  readonly roots: readonly SessionTreeNode[];
+  readonly orphanChildIds: ReadonlySet<string>;
+}
+
+export function buildSessionTree(sessions: readonly ConsoleSessionSummary[]): SessionTree {
+  const sessionIdSet = new Set(sessions.map((s) => s.sessionId));
+  const childrenByParent = new Map<string, ConsoleSessionSummary[]>();
+  const orphanChildIds = new Set<string>();
+  const childSessionIds = new Set<string>();
+
+  for (const session of sessions) {
+    const parentId = session.parentSessionId;
+    if (!parentId) continue;
+    if (parentId === session.sessionId) continue;
+    if (!sessionIdSet.has(parentId)) {
+      orphanChildIds.add(session.sessionId);
+      continue;
+    }
+    childSessionIds.add(session.sessionId);
+    const siblings = childrenByParent.get(parentId) ?? [];
+    siblings.push(session);
+    childrenByParent.set(parentId, siblings);
+  }
+
+  const roots: SessionTreeNode[] = [];
+  for (const session of sessions) {
+    if (childSessionIds.has(session.sessionId)) continue;
+    roots.push({ session, children: childrenByParent.get(session.sessionId) ?? [] });
+  }
+
+  return { roots, orphanChildIds };
+}

--- a/docs/design/shaping-workflow-external-research.md
+++ b/docs/design/shaping-workflow-external-research.md
@@ -1,0 +1,119 @@
+# Shaping Workflow: External Research Synthesis
+# Date: Apr 18, 2026
+# Source: Deep research prompt answered by frontier model
+
+## TL;DR
+
+An 11-step prompt chain with two mandatory human gates, a self-refine loop with evaluator-optimizer split, sectioned solution divergence, and a hybrid JSON+markdown artifact. The single highest-leverage design decision: **generation and critique run on structurally different prompts (ideally different model families)** -- anchoring and self-preference bias are not mitigated by CoT or self-reflection alone (Lou & Sun 2025; Panickssery et al. 2024).
+
+## The 11-Step Skeleton
+
+| # | Step | Pattern | Output | Tokens |
+|---|---|---|---|---|
+| 1 | `ingest_and_extract` | Chain | Frame candidates, forces, open questions | 2–5k |
+| 2 | `frame_gate` | Interrupt | Confirmed problem + appetite | small | **MANDATORY HUMAN GATE** |
+| 3 | `diverge_solution_shapes` | Parallel ×4 | 4 candidate rough shapes | med ×4 |
+| 4 | `converge_pick` | Separate judge | Chosen shape + rationale | small-med |
+| 5 | `breadboard_and_elements` | Chain + 1 refine | Breadboard + fat-marker elements | 8–15k |
+| 6 | `rabbit_holes_nogos` | Adversarial | Risks, mitigations, no-gos, assumptions | 3–6k |
+| 7 | `context_pack_build` | Tool-augmented | File globs, utilities, conventions, related PRs | med-large |
+| 8 | `example_map_and_gherkin` | Chain | Rules, examples, Gherkin scenarios | 3–6k |
+| 9 | `draft_pitch` | Self-refine ×2, critic=separate prompt | Full pitch (markdown + JSON) | 8–15k ×critique |
+| 10 | `approval_gate` | Interrupt | Approved pitch | small | **MANDATORY HUMAN GATE** |
+| 11 | `finalize_and_handoff` | Deterministic + schema validate | Canonical artifact + pitch.md | <1k |
+
+Total budget: 50–200k tokens depending on divergence fan-out.
+
+## Key Empirical Findings
+
+### What actually mitigates LLM failure modes in shaping (ranked):
+1. **Generator ≠ Evaluator with authorship obfuscation** -- use different model families for generation vs critique. Beats anchoring, self-preference, and mode collapse simultaneously. CoT and self-reflection alone do NOT work (Lou & Sun 2025).
+2. **Verbalized Sampling + N-alternatives-before-selection** -- prompt for a distribution, not a single answer. 1.6–2.1× diversity gain (Zhang et al. arXiv 2510.01171).
+3. **Schema-constrained structured output** -- kills verbosity compensation, forces right abstraction level by construction.
+4. **ClarifyGPT-style consistency check** -- generate two independent interpretations; divergence triggers clarification.
+5. **Self-Refine with specific rubric**, bounded at 2–3 iterations (~20% absolute gain, Madaan et al. arXiv 2303.17651).
+6. **Red-team pass** with explicit "what's hallucinated / what's missing" prompts against a separate instance.
+
+### The right level of abstraction (encodable heuristic)
+**Interfaces and Invariants, Not Function Bodies.**
+
+Classify every sentence in the pitch as:
+- **(a) Interface** -- user-visible surfaces, data objects, integration points, touched modules
+- **(b) Invariant** -- declarative constraints (idempotency, auth model, consistency requirements, latency budgets)
+- **(c) Exclusion** -- explicitly excluded functionality
+- **(d) Implementation detail** -- over-specification, demote or cut
+- **(e) Vague** -- under-specification, replace with concrete interface/invariant or ask clarifying question
+
+A well-shaped pitch contains only (a), (b), (c).
+
+### Shaping for AI implementers vs humans (the key asymmetry)
+LLM implementers need:
+- **MORE explicit** than any human spec on: interfaces, invariants, conventions, no-gos, exact API versions, file boundaries (LLMs fabricate APIs, lack tacit codebase knowledge, lack scope-shame)
+- **LESS explicit** than junior-human spec on: standard implementation patterns (CRUD, routing, idiomatic error handling -- LLMs know these better)
+
+The dominant failure mode to design against: **confident architectural divergence** -- agent produces working, tested, reviewable PR that reinvents an existing utility or lands logic in the wrong layer. Looks plausible in review. Neither tests nor LLM sensors reliably catch it. Only a better spec prevents it.
+
+### Context Pack (Step 7) is the highest-leverage AI-specific addition
+But: **LLM-generated Context Packs are measurably inferior to human-curated ones** (ETH Zurich AGENTS.md study -- LLM-generated context reduced task success in 5 of 8 settings). Treat Step 7 output as a draft requiring spot-check.
+
+## The Artifact Schema
+
+```jsonc
+{
+  "shaping_run_id": "uuid",
+  "frame": {
+    "problem_story_md": "...",
+    "appetite": {
+      "calendar_weeks": 6,
+      "token_budget_est": 120000,
+      "agent_turns_est": 60,
+      "files_touched_est": 8,
+      "sizing_bucket": "small|medium|large"
+    },
+    "forces": { "push": [...], "pull": [...], "anxiety": [...], "habit": [...] }
+  },
+  "solution": {
+    "breadboard_md": "...",
+    "elements": [{ "name": "...", "description_md": "...", "classification": "interface|invariant|exclusion" }],
+    "alternatives_considered": [{ "sketch": "...", "rejected_because": "..." }]
+  },
+  "context_pack": {
+    "touch_globs": ["src/billing/**"],
+    "do_not_touch_globs": ["src/auth/**", "migrations/**"],
+    "reuse_utilities": [{ "path": "...", "symbol": "...", "signature": "...", "reason_to_reuse": "..." }],
+    "conventions_md": "...",
+    "related_prior_art": [{ "path_or_pr": "...", "relevance": "..." }]
+  },
+  "acceptance_criteria": {
+    "gherkin": "Feature: ...\n  Scenario: ...",
+    "verification_commands": ["pnpm test src/billing", "tsc --noEmit"],
+    "example_map": { "rules": [...], "examples": [...], "open_questions": [...] }
+  },
+  "rabbit_holes": [{ "risk": "...", "severity": "low|med|critical", "mitigation": "...", "patch_applied": true }],
+  "no_gos": ["..."],
+  "assumptions_log": [{ "step": "...", "assumption": "...", "confidence": 0.7, "rationale": "..." }],
+  "decomposition": {
+    "walking_skeleton": { "description": "thin end-to-end slice", "files": [...] },
+    "atomic_subtasks": [{ "id": "s1", "title": "...", "depends_on": [], "est_context_window": "single", "acceptance_scenario_refs": ["scenario-1"] }]
+  },
+  "pitch_md": "# Pitch: ...\n\n## Problem\n...",
+  "build_readiness_score": { "rubric_pass_count": 5, "critical_blockers": 0 }
+}
+```
+
+## What NOT to Build
+- Do NOT make this a dynamic autonomous agent -- shaping has a known skeleton (workflow, not agent)
+- Do NOT use tree-of-thoughts -- no cheap partial-goal verification signal in shaping
+- Do NOT build multi-agent role-plays -- single-voice judge with sectioning strictly dominates
+- Do NOT skip the frame gate on "small" tasks -- wrong frame on a small task still wastes the run
+
+## Failure Modes and Mitigations
+
+| Failure mode | Mitigation |
+|---|---|
+| Mode collapse on diverge step | Verbalized Sampling framing, explicit framing diversity, auto-retry at higher temperature if >70% overlap |
+| Self-preference on judge | Obfuscate authorship by rewriting all candidates into uniform voice; ideally different model family |
+| Verbosity compensation on pitch | Hard max-length on JSON fields; critic checks for vague modifiers without concrete nouns |
+| Hallucinated Context Pack entries | Tool-augment Step 7 with repo grep/AST scan; schema-validate all paths before Step 10 |
+| Over-decomposition | Minimum subtask size = single context window; maximum 8 subtasks per pitch; if more, appetite was wrong |
+| Silent architectural divergence | Include consistency-check sub-task: implementer lists every new file/symbol and justifies why it's not a duplicate |

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -6100,3 +6100,36 @@ Also consolidated from three workflow variants to one canonical file.
 6. **`spawn_agent` artifacts gap** -- add `artifacts?: readonly unknown[]` to the return value. `lastStepArtifacts` is already on `WorkflowRunSuccess`; wiring it through is ~30 LOC.
 7. **Knowledge graph wiring** -- move `ts-morph` and `@duckdb/node-api` to dependencies, add `query_knowledge_graph` MCP tool.
 8. **Artifact store foundation** -- `~/.workrail/artifacts/` directory, write path in `complete_step`.
+
+---
+
+### wr.shaping workflow: shape messy problems into implementation-ready specs (needs authoring, Apr 18, 2026)
+
+**Status:** Design complete. Ready to author as a WorkRail workflow JSON.
+
+**Design docs:**
+- `docs/design/shaping-workflow-discovery.md` -- WorkRail-internal discovery findings
+- `docs/design/shaping-workflow-external-research.md` -- External research synthesis (Shape Up, LLM failure modes, artifact schema)
+
+**The gap this fills:** WorkRail has `wr.discovery` (divergent) and `coding-task-workflow-agentic` (convergent). Shaping is the missing middle -- converting messy discovery output into a bounded, implementation-ready spec without mid-implementation rabbit holes.
+
+**The 11-step skeleton (see design doc for full detail):**
+1. ingest_and_extract -- extract problem frames, forces, open questions
+2. **frame_gate** -- MANDATORY HUMAN GATE: confirm problem + appetite
+3. diverge_solution_shapes -- 4 parallel rough shapes with varied framings
+4. converge_pick -- SEPARATE JUDGE (different model/prompt): pick best shape
+5. breadboard_and_elements -- fat-marker breadboard + Interface/Invariant/Exclusion classification
+6. rabbit_holes_nogos -- adversarial: risks, mitigations, no-gos, assumptions
+7. context_pack_build -- file globs, reuse_utilities, conventions, do-not-touch boundaries
+8. example_map_and_gherkin -- Given/When/Then acceptance criteria + verification commands
+9. draft_pitch -- self-refine ×2, SEPARATE CRITIC (obfuscated authorship)
+10. **approval_gate** -- MANDATORY HUMAN GATE: approve, edit, or restart
+11. finalize_and_handoff -- schema validation, emit shape.json + pitch.md
+
+**The single most important design decision:** generator and critic run on structurally different prompts (ideally different model families). CoT and self-reflection alone do NOT mitigate anchoring or self-preference bias (Lou & Sun 2025; Panickssery et al. 2024).
+
+**Output artifact:** `shape.json` -- contains problem story, appetite (multi-dimensional: calendar + tokens + turns + files), breadboard, elements, context_pack (file boundaries + reuse_utilities), Gherkin acceptance criteria, rabbit holes, no-gos, decomposition with walking skeleton, assumptions_log, build_readiness_score.
+
+**Key insight for AI implementers:** LLMs need MORE explicit specs than humans on interfaces/invariants/file boundaries (no tacit knowledge, no scope-shame), but LESS explicit than junior humans on standard patterns. The dominant failure mode is confident architectural divergence -- working code that reinvents an existing utility. Context Pack (Step 7) directly prevents this.
+
+**Next action:** author `wr.shaping` as a WorkRail workflow JSON using workflow-for-workflows, then update `coding-task-workflow-agentic` Phase 0 to detect and consume `shape.json` when present.

--- a/docs/ideas/design-candidates-console-session-tree-impl.md
+++ b/docs/ideas/design-candidates-console-session-tree-impl.md
@@ -1,0 +1,64 @@
+# Design Candidates: Console Session Tree Implementation (Phase 3)
+
+*2026-04-18 -- This document covers only the remaining Slice 5 (SessionTreeView UI component)*
+*Phase 1 and Phase 2 artifacts: see design-candidates-session-tree-view.md and design-review-findings-session-tree-view.md*
+
+## Problem Understanding
+
+Slices 1-4 are implemented. The remaining work is Slice 5: add a SessionTreeView rendering path to SessionList.tsx.
+
+**Tensions:**
+- Expand toggle vs card navigation: two click targets on the same logical row. Resolved by a flex row with separate button elements.
+- Per-coordinator expand state vs pure component: expand state lives in useState (UI state, not business logic -- correct placement).
+- Auto-expand for in_progress: requires checking status in state initialization.
+
+**Likely seam:** SessionList.tsx (presenter) + session-list-use-cases.ts (pure function buildSessionTree, already built).
+
+**What makes it hard:** The expand toggle must be keyboard-navigable separately from the card AND must not trigger card navigation on click.
+
+## Philosophy Constraints
+
+- Pure presenter: no business logic in the component
+- Immutability: expand state is a ReadonlyMap or regular Map in useState
+- Functional/declarative: map SessionTreeNode[] to JSX
+- Compose with small functions: SessionTreeView as a named function, separate from SessionList
+
+## Impact Surface
+
+- SessionList.tsx: adding viewMode branch
+- session-list-use-cases.ts: already has buildSessionTree exported
+- session-list-reducer.ts: already has viewMode + view_mode_changed
+
+## Candidates
+
+### Candidate A: SessionTreeView inline in SessionList.tsx (only candidate)
+
+**Summary:** A `SessionTreeView` function component in SessionList.tsx takes `SessionTreeNode[]`, initializes expand state as `Map<string, boolean>` (auto-expand in_progress), and renders a flex row with [expand-toggle, coordinator-card] and children in a TreeLine wrapper below when expanded.
+
+**Tensions resolved:** Expand/navigate separation (separate button elements). Accepts: expand state resets on navigation (transient UI state is acceptable).
+
+**Boundary:** SessionList.tsx presenter layer.
+
+**Failure mode:** Expand toggle accidentally triggers card navigation. Fixed by: expand toggle button is outside the coordinator ConsoleCard, not nested inside it.
+
+**Repo pattern:** Follows SessionGroup component pattern in SessionList.tsx exactly.
+
+**Gains:** Simple, pure, testable in isolation. **Loses:** Expand state resets when navigating away (transient).
+
+**Scope:** Best-fit.
+
+**Philosophy:** All principles honored.
+
+## Comparison and Recommendation
+
+Single candidate; no comparison needed. Candidate A is the correct approach.
+
+## Self-Critique
+
+Strongest counter-argument: expand state should be in the reducer (durable within page session). Counter-counter: expand state is UI state, not domain state. Reducer is for interaction state that needs to persist across renders (search, filter, sort, pagination). Expand state for individual coordinator rows is more like accordion state -- local useState is correct.
+
+Pivot condition: if user feedback shows expand state loss is disruptive, move to reducer with `expanded_coordinators: ReadonlySet<string>` field.
+
+## Open Questions for the Main Agent
+
+None. Implementation is fully specified in docs/ideas/design-candidates-session-tree-view.md and the Phase 2 design spec.

--- a/docs/ideas/design-candidates-session-tree-view.md
+++ b/docs/ideas/design-candidates-session-tree-view.md
@@ -1,0 +1,196 @@
+# Design Candidates: Session Tree View in Console
+
+*Discovery session: 2026-04-18*
+
+---
+
+## Problem Understanding
+
+### Core Tensions
+
+1. **Flat API vs tree UI**: `/api/v2/sessions` returns a flat array. The UI wants a tree grouped by parent-child relationships. Options: build tree client-side from parentSessionId index, or change the API. The existing repo pattern (flat projection DTOs, pure use-case functions) favors building the tree client-side.
+
+2. **Orphaned children vs tree integrity**: If a parent session is older than MAX_SESSIONS_TO_LOAD=500, its children have a dangling parentSessionId. Showing orphaned children as roots is the only safe fallback, but the tree is incomplete. Acceptable for MVP.
+
+3. **Filtering with tree structure**: When filtering by status or search, should the parent appear if only a child matches? Naive filtering breaks the tree. Better approach: include parent when any child matches. Adds complexity to filterSessions().
+
+4. **Type mirror sync**: ConsoleSessionSummary is duplicated between `src/v2/usecases/console-types.ts` (server) and `console/src/api/types.ts` (client mirror). Both must be updated in sync. This is an existing technical debt, not new -- adding parentSessionId just adds one more field to keep in sync.
+
+### Likely Seam
+
+The seam is between the flat sessions array and the tree render. The right place is a new pure function `buildSessionTree(sessions)` in `session-list-use-cases.ts`, not a new HTTP endpoint and not a modification to the GROUP_AXES grouping infrastructure.
+
+### What Makes This Hard
+
+The existing GROUP_AXES abstraction in `session-list-use-cases.ts` is flat -- each group has a string label. Tree grouping requires a fundamentally different rendering shape: a clickable coordinator SessionCard as the group header, with indented children below. Shoehorning tree rendering into GROUP_AXES produces an illegal state (coordinator appears as both a plain-text header label AND a card inside the group).
+
+The filter-with-tree interaction is the hardest sub-problem: when tree mode is active, a filter that excludes the parent but matches a child must still show the parent as context.
+
+---
+
+## Philosophy Constraints
+
+From CLAUDE.md and repo patterns:
+
+- **Immutability by default**: all new types use readonly fields
+- **Pure functions in use-cases**: business logic in `session-list-use-cases.ts`, not in React components
+- **Make illegal states unrepresentable**: coordinator session must not appear twice (as header AND as card)
+- **Errors are data**: orphaned children (parent not in loaded set) should degrade gracefully to root-level display, never throw
+- **YAGNI**: 2-level tree only for MVP; no recursive structure needed
+- **Compose with small pure functions**: `buildSessionTree()` should be pure and independently testable
+- **Validate at boundaries**: `extractParentSessionId()` happens in console-service.ts (the projection boundary); frontend trusts the value
+
+**No philosophy conflicts found.** CLAUDE.md principles and repo patterns are consistent for this problem.
+
+---
+
+## Impact Surface
+
+If `ConsoleSessionSummary` gains a `parentSessionId` field:
+- `src/v2/usecases/console-types.ts` -- server type definition
+- `console/src/api/types.ts` -- client type mirror (must stay in sync manually)
+- `projectSessionSummary()` in `console-service.ts` -- new field returned in the projection
+- `filterSessions()` in `session-list-use-cases.ts` -- needs parentIndex for tree-mode filtering
+- `SessionList.tsx` -- new tree rendering path
+- Any future codegen for the type mirror would pick this up automatically
+
+Existing consumers of the flat `/api/v2/sessions` endpoint are unaffected -- the new field is additive and optional for root sessions.
+
+---
+
+## Candidates
+
+### Candidate A -- Minimal: add parentSessionId, reuse GROUP_AXES with a 'tree' option
+
+**Summary:** Add `parentSessionId` to both type files. Add a 'tree' option to GROUP_AXES that groups children under their parent's sessionId as the group key. The existing SessionGroup component shows the parent sessionId as the group label; children are SessionCards inside.
+
+**Tensions resolved:** API stability (flat array unchanged). Type sync (one field added to both).
+
+**Tensions accepted:** GROUP_AXES abstraction is abused. SessionGroup renders a plain-text label (the parent sessionId string), not a clickable coordinator SessionCard.
+
+**Boundary solved at:** Frontend GROUP_AXES layer only.
+
+**Why that boundary:** Minimum viable change -- no new components, no new functions.
+
+**Failure mode:** Coordinator session appears BOTH as the group label text AND as a SessionCard inside the group (it's in the flat list). The group header is a non-navigable string, not a card. This is an illegal state: the coordinator is visible twice in different forms. Fixing this requires adding a custom node-renderer to SessionGroup -- at which point you've rebuilt Candidate B anyway.
+
+**Repo pattern:** Abuses GROUP_AXES -- designed for grouping by string key, not parent-child hierarchies.
+
+**Gains:** Zero new components. Minimal diff.
+
+**Losses:** Visual quality. Coordinator not navigable from group header. No tree connector lines. Duplication bug.
+
+**Scope:** Too narrow -- doesn't deliver the tree view quality described in the backlog.
+
+**Philosophy:** YAGNI honored. Make illegal states unrepresentable violated (coordinator appears twice).
+
+---
+
+### Candidate B -- Best-fit: new buildSessionTree() + dedicated SessionTreeView component
+
+**Summary:** Add `parentSessionId: string | null` to `ConsoleSessionSummary` on server and client. Implement `extractParentSessionId(events)` in `console-service.ts` (O(1), session_created is always eventIndex=0). Add a new pure function to `session-list-use-cases.ts`:
+
+```typescript
+interface SessionTreeNode {
+  readonly session: ConsoleSessionSummary;
+  readonly children: readonly ConsoleSessionSummary[];
+}
+
+interface SessionTree {
+  readonly roots: readonly SessionTreeNode[];
+  readonly orphanChildIds: ReadonlySet<string>;
+}
+
+function buildSessionTree(sessions: readonly ConsoleSessionSummary[]): SessionTree
+```
+
+Add a view mode toggle (tree/flat) to `SessionListState`. When tree mode is active, render a new `SessionTreeView` component: coordinator cards at root level, children indented 20px with a CSS `border-left` connector line on the wrapper div. Orphans (parent not loaded) appear as roots.
+
+Modify `filterSessions()` to accept an optional `parentIndex: ReadonlyMap<string, string>` parameter. When tree mode is active: if a child matches the filter, include its parent too (parent appears even if it doesn't match the filter text/status).
+
+**Tensions resolved:** API stability. Tree rendering quality (no duplication). Orphan handling (explicit orphanChildIds set). Filter+tree interaction (parent included when child matches).
+
+**Tensions accepted:** Type mirror sync remains manual.
+
+**Boundary solved at:** Frontend use-cases layer (`buildSessionTree()` is pure) + new presenter component.
+
+**Why that boundary:** `buildSessionTree()` is pure and testable without React. The tree is computed once per render cycle, not per-card. Follows the exact same pattern as the existing pure functions in `session-list-use-cases.ts`.
+
+**Failure mode:** Filter-with-tree is the hardest case. The `filterSessions()` modification adds complexity. If the logic is wrong, the parent could be shown when it shouldn't (e.g., filter=complete, parent is in_progress, child is complete -- should the in_progress parent appear?). Decision: include parent when any child matches, regardless of parent's own status. This is the most useful behavior for the tree view use case.
+
+**Repo pattern:** Follows the pure use-cases + presenter pattern exactly. New SessionTreeView component follows the same presenter shape as existing components.
+
+**Gains:** Clean tree rendering with visual connectors. Navigable coordinator cards. No duplication. Pure testable logic. Degrades gracefully for orphaned children.
+
+**Losses:** Slightly more code than Candidate A. Two components for the same view (flat list + tree view).
+
+**Scope:** Best-fit -- delivers the design described in the backlog without overbuilding.
+
+**Philosophy:** All principles honored. Immutability, explicit domain types, pure functions, YAGNI (2-level tree only).
+
+---
+
+### Candidate C -- Server-side tree: new `GET /api/v2/sessions/tree` endpoint
+
+**Summary:** Add a new server endpoint that returns `{ roots: ConsoleSessionSummaryWithChildren[], orphans: ConsoleSessionSummary[] }`. The flat `/api/v2/sessions` endpoint is unchanged. Server builds the tree from the loaded session set, embedding children under their parent in the response.
+
+**Tensions resolved:** Tree structure computed at the source of truth (server, with access to the full 500-session window). Client receives a ready-to-render tree.
+
+**Tensions accepted:** New endpoint means new React Query hook, new cache key, new loading state. Two overlapping endpoints that must be kept consistent.
+
+**Boundary solved at:** Server projection layer (`console-service.ts`).
+
+**Why that boundary:** Server has the full session set in scope; client doesn't need to rebuild the tree from a flat list.
+
+**Failure mode:** API surface grows. The flat endpoint and tree endpoint must stay consistent. Cache invalidation logic must be updated for both. If the tree endpoint is slow (500 sessions), the flat endpoint is still fast -- users may not understand why.
+
+**Repo pattern:** Departs from the existing pattern (all console endpoints return flat projection DTOs). Adds server complexity for a problem that client-side pure functions can solve with zero HTTP overhead.
+
+**Gains:** Tree is always consistent (parent and children computed together). Client rendering is simpler -- just map the tree response.
+
+**Losses:** API surface growth. Additional React Query hook. More complex cache invalidation. Server-side complexity for a problem solvable client-side.
+
+**Scope:** Too broad -- the flat list already contains all the data needed to build the tree client-side.
+
+**Philosophy:** Conflicts with YAGNI (new endpoint not needed). Conflicts with validate-at-boundaries (boundary moved to server when client can handle it).
+
+---
+
+## Comparison and Recommendation
+
+| Tension | A | B | C |
+|---|---|---|---|
+| API stability | Resolves | Resolves | Adds new endpoint |
+| Tree rendering quality | Fails (duplication) | Resolves | Resolves |
+| Orphan handling | None | Explicit | Server-side |
+| Filter+tree interaction | Broken | Manageable | Handled server-side |
+| Repo pattern fit | Abuses GROUP_AXES | Follows pure-function pattern | Departs from flat-DTO pattern |
+| Reversibility | Easy | Easy | Medium |
+| Philosophy fit | Partial | Full | Partial |
+
+**Recommendation: Candidate B.**
+
+B resolves all real tensions without overbuilding. It follows the existing pure-function/presenter split the repo already practices. `buildSessionTree()` is pure and testable independently of React. The filter-with-tree interaction is manageable with a contained change to `filterSessions()`. The 2-level tree constraint matches the backlog's examples exactly.
+
+---
+
+## Self-Critique
+
+**Strongest argument against B:** What if the Phase 2 UX design requires 3-level trees (coordinator → child coordinator → grandchild)? B explicitly excludes this by using `readonly children: readonly ConsoleSessionSummary[]` instead of `readonly children: readonly SessionTreeNode[]`. Changing to recursive SessionTreeNode later is a contained change, but it would require updating the SessionTreeView component too.
+
+**Pivot conditions:**
+- If Phase 2 UX requires >2 levels: change `SessionTreeNode.children` to `readonly SessionTreeNode[]` and make `SessionTreeView` recursive. The `buildSessionTree()` function would need to become recursive as well.
+- If filter+tree interaction proves too complex: ship tree view without filter support in tree mode, show a "tree view disabled while filtered" state.
+- If the type mirror sync problem grows: introduce codegen for the type mirror (separate from this feature).
+
+**Assumption that would invalidate B:** If the flat `/api/v2/sessions` endpoint doesn't return all sessions needed to build a complete tree (e.g., if sessions are paginated server-side before reaching the client). Currently MAX_SESSIONS_TO_LOAD=500 applies before the response; if a coordinator and its children are all within the 500-session window, the tree will be complete. If the coordinator is old but children are recent, the tree will be incomplete -- but this degrades gracefully (children show as roots).
+
+---
+
+## Open Questions for the Main Agent
+
+1. **Filter behavior in tree mode**: When filtering by status=in_progress and the coordinator is complete but has an in_progress child -- should the coordinator appear? Proposed: yes, include parent when any child matches. Is this the right UX?
+
+2. **Tree mode default or opt-in**: Should the tree view be the default mode, or should users opt in via a toggle? Given that zero sessions have parentSessionId today, defaulting to tree view would show an identical flat list -- tree mode only activates when coordinator sessions exist.
+
+3. **Connector line style**: Simple `border-left` CSS on the indented container, or tree-line SVG connectors like `TreeLine.tsx` (which already exists in `console/src/components/TreeLine.tsx`)? The existing component should be used if it fits.

--- a/docs/ideas/design-review-findings-console-session-tree-impl.md
+++ b/docs/ideas/design-review-findings-console-session-tree-impl.md
@@ -1,0 +1,75 @@
+# Design Review Findings: Console Session Tree Implementation (Phase 3)
+
+*2026-04-18 -- Covering Slice 5: SessionTreeView component*
+
+---
+
+## Tradeoff Review
+
+| Tradeoff | Acceptable? | Condition for Failure | Notes |
+|---|---|---|---|
+| Transient expand state (resets on navigation) | Yes | Never -- no acceptance criterion requires persistence | Acceptable for MVP |
+| Auto-expand only on initial render | Yes | User expects newly-in_progress coordinators to auto-expand during the page session | Known limitation, acceptable |
+| Expand toggle outside ConsoleCard | Yes | Layout mismatch -- toggle disconnected from card visually | WorkspaceView.tsx proves the flex-row pattern works |
+
+---
+
+## Failure Mode Review
+
+| Failure Mode | Handled? | Mitigation | Risk |
+|---|---|---|---|
+| Expand toggle triggers card navigation | Yes | Toggle is separate DOM button outside ConsoleCard | None |
+| Coordinator with no children shows toggle | Yes | Hide toggle when children.length === 0 | None |
+| cycle in parentSessionId | Yes | buildSessionTree() cycle guard | None |
+| Newly in_progress coordinator won't auto-expand after initial render | Partial | Accepted for MVP; useState init only covers initial render | Low |
+| TypeScript type errors | None expected | All types already defined in Slices 1-4 | None |
+
+---
+
+## Runner-Up / Simpler Alternative Review
+
+**Simpler variant adopted:** Skip auto-expand entirely, or keep auto-expand for initial render only. Decision: keep auto-expand on initial render (simple useState initializer), accept that mid-session state changes won't auto-expand. Avoids useEffect/useMemo complexity.
+
+---
+
+## Philosophy Alignment
+
+| Principle | Status |
+|---|---|
+| Pure functions in use-cases | Satisfied -- buildSessionTree() is pure |
+| Immutability | Satisfied -- readonly types throughout |
+| Compose with small functions | Satisfied -- SessionTreeView is a named function |
+| YAGNI | Satisfied -- auto-expand is minimal |
+| Functional/declarative | Acceptable tension -- useState Map is mutable but correct for React UI state |
+
+---
+
+## Findings
+
+### Red (must fix before implementation)
+
+None.
+
+### Orange (should address)
+
+**O1: Expand toggle placement requires specific layout**
+The expand toggle must be in a flex row with the coordinator card, but the coordinator card itself must not be a parent of the toggle (avoids nested interactive elements). The pattern from WorkspaceView.tsx is `<div className="flex items-start gap-2">` containing `[toggle button]` then `[coordinator card button]`.
+
+### Yellow (advisory)
+
+**Y1: Auto-expand fires only on initial render**
+If a coordinator transitions to in_progress after the component first renders, it will not auto-expand. This is acceptable for MVP.
+
+---
+
+## Recommended Revisions
+
+1. Use `flex items-start gap-2` wrapper row for [expand-toggle, coordinator-card] to avoid nested interactive elements.
+2. Initialize expand state with `useState(() => new Map(roots.filter(...).map(n => [n.session.sessionId, true])))` -- function initializer to avoid re-running on re-renders.
+
+---
+
+## Residual Concerns
+
+- Visual quality of the amber left border + [COORD] badge combination requires human visual review -- cannot be verified by TypeScript check.
+- No real coordinator sessions exist locally, so end-to-end visual testing requires either manual mock data or running a spawn_agent workflow.

--- a/docs/ideas/design-review-findings-session-tree-view.md
+++ b/docs/ideas/design-review-findings-session-tree-view.md
@@ -1,0 +1,88 @@
+# Design Review Findings: Session Tree View in Console
+
+*Discovery session: 2026-04-18*
+
+---
+
+## Tradeoff Review
+
+| Tradeoff | Violates Acceptance Criteria? | Conditions for Failure | Verdict |
+|---|---|---|---|
+| Manual type mirror sync | No -- TypeScript catches at build time | Developer forgets to update client mirror | Acceptable -- compiler enforces |
+| Incomplete tree when parent outside 500-session window | No -- degrades to orphan-as-root | Coordinator runs many children over days | Acceptable for MVP |
+| 2-level tree max | No -- engine depth limit aligns (maxSubagentDepth=2) | If maxSubagentDepth raised in config | Acceptable -- contained change to fix |
+| Tree mode opt-in (not default) | No -- flat view is current default | Users never discover toggle | Acceptable -- can add auto-suggest later |
+
+---
+
+## Failure Mode Review
+
+| Failure Mode | Handled? | Missing Mitigation | Risk |
+|---|---|---|---|
+| Cyclic parentSessionId (self-parent) | Partial | Explicit cycle guard in buildSessionTree(): `if (parentId === session.sessionId) treat as root` | Low -- easy to add, must add |
+| Orphaned child (parent outside window) | Yes | Optional: 'child session' badge. Low priority. | Low |
+| Filter shows no results in tree mode | Yes -- existing empty-state UI handles it | None needed | Low |
+| Tree toggle state lost on navigation | Not handled | Persist in sessionStorage or URL param. Low priority. | Low |
+| Client mirror type not updated | Yes -- TypeScript build fails | None needed | None at runtime |
+
+---
+
+## Runner-Up / Simpler Alternative Review
+
+**Runner-up (C, server-side tree):** No elements worth borrowing. Client already has all 500 sessions; server-side computation adds API surface with no benefit.
+
+**Simpler variant adopted:** Tree mode and filter mode are mutually exclusive for MVP. When tree mode is active, status/search filters are disabled (or auto-cleared). This eliminates the filter+tree parentIdIndex complexity from filterSessions() entirely. The more complex filter-aware tree can be added later when coordinator sessions are common enough to justify it.
+
+---
+
+## Philosophy Alignment
+
+**Satisfied:** Immutability, make illegal states unrepresentable, compose with small pure functions, validate at boundaries, errors as data, YAGNI.
+
+**Under tension (acceptable):**
+- Functional/declarative: buildSessionTree() is imperative-style but pure. Same-input/same-output invariant holds.
+- Type mirror sync: two copies of ConsoleSessionSummary can diverge, but TypeScript build catches this before runtime.
+
+**No risky philosophy tensions.**
+
+---
+
+## Findings
+
+### Red (must fix before implementation)
+
+None.
+
+### Orange (should fix before implementation)
+
+**O1: Cycle guard missing in design**
+buildSessionTree() must guard against `parentSessionId === session.sessionId`. Without this, a session appears both as a root and as its own child. Add explicitly to implementation.
+
+### Yellow (low priority, note for future)
+
+**Y1: Orphaned child has no visual indicator**
+Children with a dangling parentSessionId (parent outside 500-session window) show as roots with no indication they're children. A small 'child session' badge would improve UX for multi-day coordinator runs. Not needed for MVP.
+
+**Y2: Tree toggle state not persisted**
+Navigating to session detail and back resets tree/flat mode. Could be persisted in sessionStorage or URL param. Not needed for MVP.
+
+**Y3: Tree mode not auto-suggested when coordinator sessions exist**
+Users may not discover the tree mode toggle. When any session has `parentSessionId != null`, show a subtle prompt or auto-activate tree mode. Not needed for MVP.
+
+---
+
+## Recommended Revisions
+
+1. **Add cycle guard to buildSessionTree():** Before adding a session to a parent's children array, check `parentSessionId !== session.sessionId`. Treat self-parenting sessions as roots.
+
+2. **Make filter mode and tree mode mutually exclusive:** When tree mode is activated, clear active filters (or disable the filter controls). When a filter is applied, tree mode is disabled. Show a clear UI state for this (e.g., "Filters disabled in tree view").
+
+3. **Document 2-level max as explicit constant:** Define `TREE_MAX_DEPTH = 2` in session-list-use-cases.ts with a comment explaining the engine's maxSubagentDepth alignment.
+
+---
+
+## Residual Concerns
+
+1. **Untestable in real UI until coordinator sessions are run.** Zero sessions have parentSessionId today. The implementation can be verified only via manual testing with artificially constructed session data or by running an actual spawn_agent workflow. Recommendation: add a simple unit test for buildSessionTree() with mock ConsoleSessionSummary objects in session-list-use-cases.test.ts (if the test file exists -- check before implementing).
+
+2. **Filter+tree interaction deferred, not designed.** The current design explicitly excludes filtering while in tree mode. If a future sprint adds filter+tree, the parentIdIndex approach was analyzed and is the right path -- but it must be designed and tested carefully to avoid surprising UX (parent shown in 'complete' filter even though it's in_progress).

--- a/docs/ideas/implementation_plan_session_tree_view.md
+++ b/docs/ideas/implementation_plan_session_tree_view.md
@@ -1,0 +1,238 @@
+# Implementation Plan: Session Tree View in Console
+
+*Created: 2026-04-18*
+
+---
+
+## Problem Statement
+
+WorkRail creates a separate session for every workflow run. When spawn_agent is used, a coordinator session creates multiple child sessions. Today, all sessions appear as a flat list in the console -- there is no visual grouping that shows coordinator-child relationships. The `parentSessionId` field exists in the `session_created` event schema and is written by `makeSpawnAgentTool`, but it is not surfaced in `ConsoleSessionSummary` or rendered in the console UI.
+
+---
+
+## Acceptance Criteria
+
+1. `ConsoleSessionSummary` includes a `parentSessionId: string | null` field. Root sessions have `null`; child sessions have the parent's session ID.
+2. `/api/v2/sessions` response includes `parentSessionId` on each session summary.
+3. The console SessionList includes a tree view mode toggle.
+4. When tree view is active: coordinator sessions (sessions that have children) display their child sessions indented below them, separated by a `TreeLine` connector.
+5. When tree view is active: filter controls are disabled with a clear UI indicator.
+6. When tree view is active: sessions with no children display identically to the flat view.
+7. Orphaned children (parent session not in the loaded 500-session set) display as root sessions in tree view.
+8. `buildSessionTree()` handles the case where `parentSessionId === sessionId` (self-parent) by treating the session as a root.
+9. TypeScript build passes with no new errors.
+
+---
+
+## Non-Goals
+
+- No new HTTP endpoints (flat `/api/v2/sessions` is unchanged except for the new field).
+- No multi-level (depth > 2) tree rendering for MVP.
+- No filter+tree interaction for MVP (tree mode and filter mode are mutually exclusive).
+- No pagination changes.
+- No persistence of tree view toggle state.
+- No automatic activation of tree mode.
+
+---
+
+## Philosophy-Driven Constraints
+
+- **Immutability by default**: all new interfaces use `readonly`.
+- **Pure functions in use-cases**: `buildSessionTree()` is a pure function with no side effects, in `session-list-use-cases.ts`. No business logic in React components.
+- **Make illegal states unrepresentable**: coordinator session appears exactly once (as a root card). Cycle guard prevents self-parenting.
+- **Explicit domain types**: `SessionTree` and `SessionTreeNode` are named interfaces, not anonymous objects.
+- **YAGNI**: 2-level tree, mutually exclusive filter/tree modes, no new endpoints.
+- **Errors as data**: `buildSessionTree()` returns an `orphanChildIds` set; never throws on missing parents.
+
+---
+
+## Invariants
+
+1. `parentSessionId` is `null` for root sessions, a non-empty string for child sessions.
+2. `buildSessionTree()` is a pure function: same input always produces the same output.
+3. A session with `parentSessionId === sessionId` is treated as a root (cycle guard).
+4. An orphaned child (parent not in the input sessions array) is included in `orphanChildIds` and rendered as a root.
+5. The flat `/api/v2/sessions` endpoint response is backward-compatible: `parentSessionId` is a new additive field.
+6. `console/src/api/types.ts` mirrors `src/v2/usecases/console-types.ts` for `ConsoleSessionSummary` -- both must be updated together.
+
+---
+
+## Selected Approach
+
+**Candidate B: `buildSessionTree()` pure function + `SessionTreeView` presenter**
+
+See `design-candidates-session-tree-view.md` for full analysis. Summary: add `parentSessionId` to the type chain (server + client mirror), extract it at the projection boundary in `console-service.ts`, build the tree client-side in a pure function, and render it in a new presenter component using the existing `TreeLine` connector component.
+
+**Runner-up:** Candidate C (server-side tree endpoint) -- loses because the flat list already contains all data needed; a new endpoint adds API surface with no benefit.
+
+---
+
+## Vertical Slices
+
+### Slice 1: Add `parentSessionId` to server-side types and projection
+
+**Files changed:**
+- `src/v2/usecases/console-types.ts` -- add `readonly parentSessionId: string | null` to `ConsoleSessionSummary`
+- `src/v2/usecases/console-service.ts` -- add `extractParentSessionId(events)` function, include field in `projectSessionSummary()` return value
+
+**Acceptance criterion:** `GET /api/v2/sessions` response includes `parentSessionId: null` on all existing sessions. TypeScript build passes.
+
+**Pattern to follow:** `extractGitBranch(events)` / `extractRepoRoot(events)` in `console-service.ts` -- scan events for `session_created`, return `data.parentSessionId ?? null`.
+
+**Risk:** Low. Additive field, backward-compatible.
+
+---
+
+### Slice 2: Update client-side type mirror
+
+**Files changed:**
+- `console/src/api/types.ts` -- add `readonly parentSessionId: string | null` to `ConsoleSessionSummary`
+
+**Acceptance criterion:** TypeScript build of the console package passes. The new field is accessible in all React components that receive `ConsoleSessionSummary`.
+
+**Risk:** None. Compile-time only.
+
+---
+
+### Slice 3: Add `buildSessionTree()` to session-list-use-cases
+
+**Files changed:**
+- `console/src/views/session-list-use-cases.ts` -- add `SessionTreeNode`, `SessionTree` interfaces and `buildSessionTree()` function
+
+**Implementation:**
+```typescript
+export interface SessionTreeNode {
+  readonly session: ConsoleSessionSummary;
+  readonly children: readonly ConsoleSessionSummary[];
+}
+
+export interface SessionTree {
+  readonly roots: readonly SessionTreeNode[];
+  readonly orphanChildIds: ReadonlySet<string>;
+}
+
+export const TREE_MAX_DEPTH = 2; // aligns with engine's default maxSubagentDepth
+
+export function buildSessionTree(sessions: readonly ConsoleSessionSummary[]): SessionTree {
+  // Build parent -> children index
+  // Cycle guard: skip if parentSessionId === sessionId
+  // Orphan detection: if parent not in session set, add to orphanChildIds
+  // Return roots (sessions with no parent, plus orphaned children as roots) with children attached
+}
+```
+
+**Acceptance criterion:** Unit test in `console/src/views/session-list-use-cases.test.ts` (create if not exists) covers: empty input, all roots, parent-child pairs, cycle detection, orphaned children.
+
+**Risk:** Low. Pure function, no I/O.
+
+---
+
+### Slice 4: Add tree view mode to SessionList state and reducer
+
+**Files changed:**
+- `console/src/views/session-list-reducer.ts` -- add `viewMode: 'flat' | 'tree'` to state; add `view_mode_changed` action; when `view_mode_changed` to `tree`, clear filters
+- `console/src/hooks/useSessionListViewModel.ts` (or equivalent) -- expose `viewMode` and `dispatch` for tree toggle
+
+**Acceptance criterion:** Toggling to tree mode clears active status filter and search. State transitions are deterministic. TypeScript build passes.
+
+**Risk:** Low. Reducer is pure, state change is straightforward.
+
+---
+
+### Slice 5: Add `SessionTreeView` component and tree toggle UI
+
+**Files changed:**
+- `console/src/views/SessionList.tsx` -- add tree/flat mode toggle button; when `viewMode === 'tree'`, render `SessionTreeView` instead of the flat list; show "Filters disabled in tree view" when tree mode active and filters would normally show
+- New component `SessionTreeView` (inline in `SessionList.tsx` or in a new file) -- renders `SessionTreeNode[]` with `TreeLine` wrappers for indented children
+
+**Acceptance criterion:**
+- Toggle button visible in toolbar
+- Clicking toggle switches between tree and flat mode
+- In tree mode: coordinator sessions show children indented below using `TreeLine`
+- In tree mode: filter controls show a disabled state or a note
+- In tree mode with no coordinator sessions: renders identically to flat mode (no indentation)
+- `TreeLine` amber connector lines appear between coordinator card and child cards
+
+**Risk:** Medium. No real coordinator sessions exist for manual testing. Must use mock data or construct a test scenario.
+
+---
+
+## Test Design
+
+### Unit tests (`console/src/views/session-list-use-cases.test.ts`)
+
+Add a new `describe('buildSessionTree')` block:
+1. Empty input -> `{ roots: [], orphanChildIds: Set() }`
+2. All root sessions (no parentSessionId) -> all in roots, no orphans
+3. One coordinator with two children -> coordinator root with two children attached
+4. Orphaned child (parent not in input) -> child in roots, parentId in orphanChildIds
+5. Cycle detection (parentSessionId === sessionId) -> treated as root
+6. Multiple coordinators with overlapping children (edge case -- shouldn't occur but test graceful handling)
+
+### Build verification
+
+- `npm run build` (or equivalent) in both workrail root and console package must pass with no new TypeScript errors.
+
+### Manual verification
+
+- Create a test session data fixture (mock two sessions with parent-child relationship) and verify tree rendering visually.
+- Or: run a `spawn_agent` workflow in the daemon and observe the console.
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Cycle in parentSessionId causes infinite loop | Low | High | Cycle guard in buildSessionTree() (Slice 3) |
+| Client mirror not updated with server type | Low | Low | TypeScript build fails immediately |
+| No real coordinator sessions to test against | High | Medium | Unit tests cover the logic; manual test with mock data |
+| Phase 2 UX design requires depth-3 trees | Low | Medium | Change `children: readonly ConsoleSessionSummary[]` to `readonly SessionTreeNode[]`; contained change |
+| Tree mode breaks existing GROUP_AXES grouping | None | N/A | Tree mode is a separate view mode; GROUP_AXES unchanged |
+
+---
+
+## PR Packaging Strategy
+
+**Single PR: `feat/console-session-tree`**
+
+All 5 slices in one PR. Rationale:
+- Slices 1-2 (type changes) are tiny and safe but useless without the rendering
+- Slices 3-4 (logic) are testable independently but nothing to show
+- Slice 5 (UI) depends on all prior slices
+- The entire change is low-risk and additive -- no breaking changes
+- A single PR is easier to review as a coherent feature
+
+---
+
+## Philosophy Alignment Per Slice
+
+| Slice | Principle | Status |
+|---|---|---|
+| 1 (server type + extraction) | Validate at boundaries | Satisfied -- extraction at service boundary |
+| 1 | Compose with small pure functions | Satisfied -- extractParentSessionId follows extractRepoRoot pattern |
+| 1 | Immutability | Satisfied -- readonly field |
+| 2 (client mirror) | Make illegal states unrepresentable | Tension -- manual sync; TypeScript catches divergence at build time |
+| 3 (buildSessionTree) | Pure function composition | Satisfied |
+| 3 | Errors as data | Satisfied -- orphanChildIds, no throws |
+| 3 | Make illegal states unrepresentable | Satisfied -- cycle guard prevents self-parenting |
+| 4 (reducer) | Determinism over cleverness | Satisfied -- pure reducer |
+| 4 | Functional/declarative | Satisfied |
+| 5 (UI) | Compose with small pure functions | Satisfied -- SessionTreeView is a pure presenter |
+| 5 | YAGNI | Satisfied -- 2-level only, no filter+tree |
+
+---
+
+## Follow-Up Tickets
+
+- **Visual indicator on orphaned child sessions** (Y1): Add a small 'child session' badge to sessions in `orphanChildIds`. Low priority.
+- **Persist tree toggle state** (Y2): Save to sessionStorage or URL param. Low priority.
+- **Auto-suggest tree mode when coordinator sessions exist** (Y3): Detect `parentSessionId != null` in session list; show a subtle prompt. Low priority.
+- **Filter+tree interaction** (design exists): Add `parentIdIndex` to `filterSessions()` so tree mode and filter mode are compatible. Design is documented in `design-candidates-session-tree-view.md`.
+
+---
+
+## Plan Confidence
+
+- `unresolvedUnknownCount`: 1 (no real coordinator sessions to validate tree rendering end-to-end -- mitigated by unit tests)
+- `planConfidenceBand`: High

--- a/src/v2/usecases/console-service.ts
+++ b/src/v2/usecases/console-service.ts
@@ -959,6 +959,17 @@ function extractRepoRoot(events: readonly DomainEventV1[]): string | null {
 }
 
 
+function extractParentSessionId(events: readonly DomainEventV1[]): string | null {
+  for (const e of events) {
+    if (e.kind === EVENT_KIND.SESSION_CREATED) {
+      const parentId = e.data.parentSessionId;
+      if (typeof parentId === 'string' && parentId.length > 0) return parentId;
+      return null;
+    }
+  }
+  return null;
+}
+
 function truncateTitle(text: string, maxLen = 120): string {
   if (text.length <= maxLen) return text;
   return text.slice(0, maxLen - 1) + '…';
@@ -1005,6 +1016,7 @@ function projectSessionSummary(
   const sessionTitle = sortedEventsRes.isOk() ? deriveSessionTitle(sortedEventsRes.value) : null;
   const gitBranch = extractGitBranch(events);
   const repoRoot = extractRepoRoot(events);
+  const parentSessionId = extractParentSessionId(events);
 
   // Derive isAutonomous from context_set events. Checks all runs; true if any run has
   // is_autonomous: 'true' in its context. Gracefully degrades to false on projection error.
@@ -1041,6 +1053,7 @@ function projectSessionSummary(
       lastModifiedMs,
       isAutonomous,
       isLive,
+      parentSessionId,
     };
   }
 
@@ -1096,6 +1109,7 @@ function projectSessionSummary(
     lastModifiedMs,
     isAutonomous,
     isLive,
+    parentSessionId,
   };
 }
 

--- a/src/v2/usecases/console-types.ts
+++ b/src/v2/usecases/console-types.ts
@@ -49,6 +49,7 @@ export interface ConsoleSessionSummary {
    * session but no session_completed event. Derived from disk -- survives console restarts.
    * False on any read error (safe default). */
   readonly isLive: boolean;
+  readonly parentSessionId: string | null;
 }
 
 export interface ConsoleSessionListResponse {

--- a/tests/unit/console-session-list-reducer.test.ts
+++ b/tests/unit/console-session-list-reducer.test.ts
@@ -36,6 +36,7 @@ describe('sessionListReducer', () => {
         groupBy: 'none',
         statusFilter: 'all',
         page: 0,
+        viewMode: 'flat',
       });
     });
 
@@ -191,6 +192,7 @@ describe('sessionListReducer', () => {
         groupBy: 'workflow',
         statusFilter: 'in_progress',
         page: 0,
+        viewMode: 'flat',
       };
       const next = reduce(state, { type: 'page_changed', page: 5 });
       expect(next.rawSearch).toBe('foo');


### PR DESCRIPTION
## Summary

- Adds `parentSessionId: string | null` to `ConsoleSessionSummary` (server type + client mirror), extracted from the `session_created` event that `spawn_agent` already writes -- data was there, visualization was not
- Implements `buildSessionTree()` as a pure function in `session-list-use-cases.ts` with 7 unit tests (empty, parent-child, orphan, cycle, multiple coordinators)
- Adds a Flat/Tree view toggle to the SessionList toolbar; tree mode shows coordinator sessions (amber left border + `[COORD]` badge) with children nested below using the existing `TreeLine` amber connector component
- Tree mode and filter mode are mutually exclusive; coordinator cards auto-expand when `in_progress`

## Design rationale

Three candidates evaluated: always-expanded tree, collapsible coordinator cards, server-side tree endpoint. Collapsible selected -- initial view stays scannable when coordinators have many children. Full design artifacts in `docs/ideas/design-candidates-session-tree-view.md`.

## Test plan

- [ ] `cd console && npm run build` -- TypeScript and Vite build pass
- [ ] `cd console && npx vitest run` -- 153 tests pass including 7 new `buildSessionTree` unit tests
- [ ] `npx tsc --noEmit` at repo root -- server TypeScript clean
- [ ] Manual: Flat/Tree toggle appears in Sessions header
- [ ] Manual: with a `spawn_agent` workflow, coordinator shows amber left border + [COORD] badge, children nested with TreeLine connector
- [ ] Manual: filter controls disabled (opacity reduced) in tree mode

## Follow-up

- Orphaned child badge when parent outside 500-session window
- Persist toggle state in sessionStorage
- Auto-suggest tree mode when coordinators first appear
- Filter+tree interaction (include parent when child matches filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>