### PR TITLE
feat(coordinator): add context assembly layer for session context injection

### DIFF
--- a/docs/design/context-assembly-design-candidates.md
+++ b/docs/design/context-assembly-design-candidates.md
@@ -1,0 +1,199 @@
+# Design Candidates: Context Assembly Layer v1
+
+*Generated during coding-task-workflow-agentic session | 2026-04-19*
+
+---
+
+## Problem Understanding
+
+### Core Tensions
+
+1. **Clean DI vs. pragmatic inline construction**: `LocalSessionSummaryProviderV2` is
+   wired through the full DI container in the MCP server process. The coordinator runs
+   as a CLI in a separate process. We cannot share the DI container. The coordinator
+   composition root (`src/cli-worktrain.ts`) must construct the provider inline.
+
+2. **Neverthrow ResultAsync vs. custom Result**: Storage layer uses neverthrow. New
+   `src/context-assembly/` uses the repo's custom `Result<T,E>` (`kind: 'ok'|'err'`).
+   The bridge must happen at the `infra.ts` boundary.
+
+3. **Partial failure semantics**: Each source (gitDiff, priorNotes) must fail
+   independently without aborting context assembly. `Promise.all()` is safe because
+   each source always resolves to a `Result` (never throws) when implemented correctly.
+
+4. **Backward compatibility vs. interface evolution**: Adding `contextAssembler?` as
+   optional to `CoordinatorDeps` and optional 4th arg to `spawnSession` keeps all
+   existing tests and callers working without modification.
+
+### Likely Seam
+
+The real seam is `CoordinatorDeps.spawnSession`. The coordinator calls this to dispatch
+a session. Context bundle assembly belongs immediately before this call.
+
+### What Makes This Hard
+
+- `LocalSessionEventLogStoreV2` requires `FileSystemPortV2` (a composite of 5 sub-ports
+  including write/fd ops). But `load()` only calls `readFileUtf8`. All write methods
+  can be stubs for read-only use, but this is a partial lie against the interface contract.
+- `LocalDirectoryListingV2` takes `DirectoryListingOpsPortV2` (separate, simpler) --
+  NOT the full `FileSystemPortV2`. These are separate ports.
+- Two Result type systems (neverthrow vs custom) must coexist without leaking across
+  the `infra.ts` boundary.
+- `Sha256PortV2` is injected into `LocalSessionEventLogStoreV2` but only called in
+  `append()`, not `load()`. Safe to stub.
+
+---
+
+## Philosophy Constraints
+
+From `CLAUDE.md` (system-wide agent instructions):
+
+- **Errors are data**: Use `Result<T,E>` values. No throwing for expected failures.
+- **DI for boundaries**: Inject I/O effects; keep core logic testable.
+- **Prefer fakes over mocks**: Tests use realistic substitutes (no `vi.mock()`).
+- **YAGNI with discipline**: No speculative abstractions.
+- **Architectural fixes over patches**: Reuse canonical parsing logic.
+- **Immutability by default**: `readonly` on all fields.
+
+**Potential conflict**: Creating write stubs on `FileSystemPortV2` is pragmatic but
+technically lies about the contract. The pitch (R1 mitigation) explicitly endorses this
+approach. Acceptable given the inline-construction pattern is already acknowledged as
+a special case.
+
+---
+
+## Impact Surface
+
+- `src/coordinators/pr-review.ts`: `CoordinatorDeps.spawnSession` (add optional 4th arg),
+  `contextAssembler?` optional field. Backward-compatible.
+- `src/daemon/workflow-runner.ts`: `buildSystemPrompt()` reads `trigger.context['assembledContextSummary']`.
+  No signature change needed -- `trigger.context` already typed as `Readonly<Record<string,unknown>>`.
+- `src/cli-worktrain.ts`: `spawnSession` impl forwards 4th arg; `contextAssembler` wired.
+- All existing tests that construct `CoordinatorDeps` fakes: safe (optional fields).
+- No changes to `src/mcp/` or `src/v2/durable-core/`.
+
+---
+
+## Candidates
+
+### Candidate A: Real local infra classes with minimal read-only shims (SELECTED)
+
+**Summary**: Construct `LocalDataDirV2`, `LocalDirectoryListingV2`, and
+`LocalSessionEventLogStoreV2` directly inside `infra.ts`. Create inline adapters:
+- `DirectoryListingOpsPortV2`: wraps `fs.promises.readdir` + `stat` with `okAsync/errAsync`
+- `FileSystemPortV2`: only `readFileUtf8` is real; write/fd methods throw 'context-assembly: write ops not supported'
+- `Sha256PortV2`: stub that throws (never called during `load()`)
+
+**Tensions resolved**: R1 (DI wiring scope). Uses battle-tested session loading and
+projection code. Neverthrow/custom Result bridge stays at `infra.ts` boundary only.
+
+**Tensions accepted**: Write stubs on `FileSystemPortV2` are a partial lie.
+
+**Boundary solved at**: `src/context-assembly/infra.ts` -- coordinator composition root.
+
+**Why this boundary is best-fit**: The coordinator is already a composition root
+(`src/cli-worktrain.ts` wires all real deps). `infra.ts` is a thin adapter layer that
+belongs exactly here.
+
+**Failure mode**: If `LocalSessionEventLogStoreV2.load()` ever internally calls a write
+method (unlikely but possible in future refactors), `infra.ts` would throw at runtime
+rather than returning `err()`. This would be caught immediately by tests.
+
+**Repo-pattern relationship**: Follows existing local infra pattern exactly.
+`LocalDataDirV2`, `LocalDirectoryListingV2`, `LocalSessionEventLogStoreV2` are already
+the canonical local implementations.
+
+**Gains**: Reuses battle-tested store loading and projection code. No risk of format
+divergence if session file structure changes.
+
+**Losses**: Write stubs feel slightly dishonest. Minor complexity in `infra.ts`.
+
+**Scope judgment**: Best-fit. Stays within `src/context-assembly/` with no v2 changes.
+
+**Philosophy fit**: Honors DI for boundaries (composition root pattern), errors-as-data
+(Result bridge), architectural fixes over patches (reuses canonical code). Minor
+tension with YAGNI (write stubs) and interface honesty.
+
+---
+
+### Candidate B: Read session files directly with fs.promises
+
+**Summary**: Skip the port hierarchy. Read `manifest.jsonl` and `events/*.jsonl` directly
+using `fs.promises.readFile`. Parse manually or reuse just the schema validators.
+
+**Tensions resolved**: R1 completely -- no DI wiring at all.
+
+**Tensions accepted**: Duplicates session reading logic. Any change to session file
+format requires updates in two places.
+
+**Failure mode**: Silent breakage if session file format changes.
+
+**Repo-pattern relationship**: Departs from established pattern (re-implements existing logic).
+
+**Scope judgment**: Too narrow -- creates a fragile parallel implementation.
+
+**Philosophy fit**: Conflicts with 'architectural fixes over patches'.
+
+---
+
+### Candidate C: Add createLocalSessionSummaryProvider() factory to v2 module
+
+**Summary**: Add a `createLocalSessionSummaryProvider()` factory function to
+`src/v2/infra/local/session-summary-provider/index.ts` that wires real deps and
+returns a `SessionSummaryProviderPortV2`. Import and call from `infra.ts`.
+
+**Tensions resolved**: Cleanest DI wiring.
+
+**Tensions accepted**: Modifies an existing v2 infra module.
+
+**Failure mode**: Entangles CLI-coordinator concerns into the storage layer.
+
+**Scope judgment**: Slightly too broad -- modifies v2 module with no functional benefit
+over Candidate A.
+
+---
+
+## Comparison and Recommendation
+
+**Recommendation: Candidate A**
+
+All candidates agree on the high-level approach (4 new files, 3 modified files, exact
+pitch interfaces). The only real design decision is `infra.ts` implementation.
+
+Candidate A wins because:
+1. It reuses battle-tested code for session reading and health projection
+2. It stays within `src/context-assembly/` -- no v2 module changes
+3. The write stubs are safe: `load()` provably does not call write methods
+4. The pitch explicitly endorses this approach as R1 mitigation
+
+---
+
+## Self-Critique
+
+**Strongest counter-argument**: The write stubs on `FileSystemPortV2` create a silent
+contract violation. If a future `load()` implementation adds a write call internally,
+the error would surface at runtime (throw) rather than compile-time.
+
+**Narrower option that lost**: Candidate B (raw fs.promises). Lost because it duplicates
+canonical parsing logic and diverges from existing patterns.
+
+**Broader option and evidence required**: Candidate C would be justified if multiple
+other CLI commands needed access to session summaries -- adding a factory to the v2
+module would be worth the scope increase. No evidence of this need in v1.
+
+**Assumption that would invalidate this design**: If `LocalSessionEventLogStoreV2.load()`
+internally calls any of the stubbed write methods (currently provably false by code
+inspection of `loadImpl()`, `loadValidatedPrefixImpl()`, `readManifestOrEmpty()`).
+
+---
+
+## Open Questions for Main Agent
+
+1. Verify: does `Sha256PortV2` have a simple interface that can be satisfied with a
+   1-line `node:crypto` implementation? (If so, use real impl rather than throw stub.)
+2. Verify: does the `FileSystemPortV2` shim need anything beyond `readFileUtf8` for
+   the `load()` path? (Current analysis: no -- `readManifestOrEmpty` and segment loading
+   both use `readFileUtf8` only.)
+3. The re-review spawn (line ~1265 in pr-review.ts) should forward `spawnContext` from
+   the outer scope per the pitch. Confirm this is the correct approach (vs. reassembling
+   context for re-reviews).

--- a/docs/design/context-assembly-implementation-plan.md
+++ b/docs/design/context-assembly-implementation-plan.md
@@ -1,0 +1,211 @@
+# Implementation Plan: Context Assembly Layer v1
+
+*Authored during coding-task-workflow-agentic session | 2026-04-19*
+
+---
+
+## Problem Statement
+
+When the PR review coordinator dispatches a session, it passes only a goal string.
+The agent spends its first 2-3 turns re-establishing context (re-reading PR diff,
+starting cold with no memory of prior reviews). Before spawning each session, the
+coordinator should assemble a context bundle (git diff summary + prior session notes)
+and inject it into the system prompt via the existing `trigger.context` map.
+
+---
+
+## Acceptance Criteria
+
+1. `npm run build` compiles clean with zero TypeScript errors
+2. `npx vitest run tests/unit/context-assembly.test.ts` -- all 5 tests pass
+3. `npx vitest run` -- no regressions in full test suite
+4. New module `src/context-assembly/` exists with 4 files
+5. `CoordinatorDeps.contextAssembler?` optional field present
+6. `CoordinatorDeps.spawnSession` accepts optional 4th `context?` arg
+7. `buildSystemPrompt()` injects `## Prior Context` section when `assembledContextSummary` present in trigger context
+8. `src/cli-worktrain.ts` wires `contextAssembler` and forwards `context` through HTTP body
+
+---
+
+## Non-Goals
+
+1. No URL fetching from PR description bodies (v2)
+2. No full git diff content -- `--stat` output only
+3. No changes to `src/mcp/` or `src/v2/durable-core/`
+4. No knowledge graph source (`ts-morph` stays in devDependencies)
+5. No per-coordinator custom renderers
+6. No context window budget trimming
+7. No context assembly in `TriggerRouter.route()`
+8. No HTTP endpoint schema changes
+9. No workspace-scoped session filtering (v1 returns global sessions)
+
+---
+
+## Philosophy-Driven Constraints
+
+- All interface fields `readonly` (immutability by default)
+- `Result<T,E>` (`kind: 'ok'|'err'`) for all new code; bridge from neverthrow at `infra.ts` boundary
+- Factory function `createContextAssembler()`, not a class
+- `renderContextBundle()` is pure (no I/O)
+- `ContextAssemblerDeps` interface contains all I/O; core has zero direct imports of `fs`/`execFile`
+- Tests: fake deps, no `vi.mock()`, vitest `describe/it/expect`
+- Import paths use `.js` extension (TypeScript ESM)
+- JSDoc `WHY` comments on non-obvious decisions
+
+---
+
+## Invariants
+
+1. **Partial failure**: `gitDiff` and `priorSessionNotes` fail independently; session always starts
+2. **Zero agent turn cost**: Context injected in system prompt before turn 1
+3. **Coordinator-controlled opt-in**: Only coordinators calling `assembler.assemble()` get enriched context
+4. **Prior notes recency limit**: At most 3 prior sessions
+5. **Git summary size**: File names and change counts only (no full diff)
+6. **No engine/MCP changes**: `src/v2/durable-core/` and `src/mcp/` untouched
+7. **Optional contextAssembler**: Backward-compatible -- all existing `CoordinatorDeps` fakes work
+
+---
+
+## Selected Approach
+
+Use 4 new files in `src/context-assembly/` + 3 modified files, exactly as specified in
+the pitch. `infra.ts` uses a direct `SessionEventLogReadonlyStorePortV2` adapter
+(implementing only `load()` and `loadValidatedPrefix()` via `fs.promises` + existing Zod
+schemas) instead of `LocalSessionEventLogStoreV2`. This eliminates the need for
+`FileSystemPortV2` and `Sha256PortV2` shims.
+
+**Runner-up**: Use `LocalSessionEventLogStoreV2` with write stubs. Rejected: write stubs
+partially violate the interface contract even though they're provably unreachable.
+
+---
+
+## Vertical Slices
+
+### Slice 1: New module `src/context-assembly/` (4 files)
+
+**Files to create**:
+- `src/context-assembly/types.ts` (~60 LOC) - AssemblyTask, SessionNote, ContextBundle, RenderOpts, ContextAssembler interface
+- `src/context-assembly/deps.ts` (~35 LOC) - ContextAssemblerDeps interface (execGit, execGh, listRecentSessions, nowIso)
+- `src/context-assembly/index.ts` (~80 LOC) - createContextAssembler(), renderContextBundle(), private helpers
+- `src/context-assembly/infra.ts` (~80 LOC) - createListRecentSessions() adapter
+
+**Done when**: All 4 files compile clean in isolation
+
+**Key implementation details**:
+- `types.ts`: import `Result` from `'../runtime/result.js'`
+- `index.ts`: factory function `createContextAssembler(deps)`, pure `renderContextBundle(bundle, _opts?)`
+- `infra.ts`: `SessionEventLogReadonlyStorePortV2` adapter using `fs.promises.readFile` + `ManifestRecordV1Schema` + `DomainEventV1Schema`; `LocalDataDirV2(process.env)` + `LocalDirectoryListingV2(directoryListingOpsAdapter)` wired into `LocalSessionSummaryProviderV2`
+- `infra.ts`: `_workspacePath` named with leading underscore (intentional non-use in v1)
+- Bridge: `const result = await provider.loadHealthySummaries(); if (result.isErr()) return err(...);`
+
+### Slice 2: Modify `src/coordinators/pr-review.ts`
+
+**Changes**:
+1. Add `contextAssembler?: ContextAssembler` field to `CoordinatorDeps` (after `spawnSession`, before `awaitSessions`)
+2. Extend `spawnSession` signature: add optional 4th arg `context?: Readonly<Record<string, unknown>>`
+3. Add context assembly block before `spawnSession` call in `runPrReviewCoordinator` for-loop
+4. Forward same `spawnContext` to re-review spawn (~line 1265)
+5. Do NOT add context assembly to fix-agent spawn
+
+**Done when**: File compiles clean; existing tests still pass
+
+### Slice 3: Modify `src/daemon/workflow-runner.ts`
+
+**Change**: Insert 6-line block in `buildSystemPrompt()` BEFORE the `referenceUrls` block
+
+**Done when**: File compiles clean; `buildSystemPrompt` tests (if any) still pass
+
+### Slice 4: Modify `src/cli-worktrain.ts`
+
+**Changes**:
+1. Add imports for `createContextAssembler` and `createListRecentSessions`
+2. Extend `spawnSession` lambda to accept optional 4th `context?` arg and include it in JSON body
+3. Add `contextAssembler: createContextAssembler({...})` to deps object (after `spawnSession`)
+4. Wire `execGit`, `execGh` inline using `promisify(execFile)`
+
+**Done when**: File compiles clean
+
+### Slice 5: Tests
+
+**File**: `tests/unit/context-assembly.test.ts`
+
+**Tests**:
+1. `assemble()` with both sources succeeding -- returns bundle with `kind: 'ok'` on both fields
+2. `assemble()` with gitSummary failing -- priorNotes still returns `ok([])`; gitDiff returns `kind: 'err'`
+3. `renderBundle()` produces correct markdown sections (headings, git diff in code block)
+4. `renderBundle()` with all-failed bundle -- returns empty string
+5. `listRecentSessions` with no sessions directory -- returns `ok([])`
+
+**Done when**: All 5 tests pass with `npx vitest run tests/unit/context-assembly.test.ts`
+
+---
+
+## Test Design
+
+### Fake deps for context assembler
+
+```typescript
+function makeFakeDeps(overrides: Partial<ContextAssemblerDeps> = {}): ContextAssemblerDeps {
+  return {
+    execGit: async () => ({ kind: 'ok', value: 'src/foo.ts | 5 ++\n' }),
+    execGh: async () => ({ kind: 'err', error: 'gh not available' }),
+    listRecentSessions: async () => ({ kind: 'ok', value: [] }),
+    nowIso: () => '2026-04-19T00:00:00.000Z',
+    ...overrides,
+  };
+}
+```
+
+### Test for no sessions directory
+
+Uses a real temp directory (with no sessions subdirectory) to test the graceful `ok([])` return.
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `infra.ts` SessionEventLogReadonlyStorePortV2 adapter has parsing bugs | Low | Medium | Tests verify behavior with fake data; manifest format well-documented |
+| `spawnSession` 4th arg breaks existing tests | Very Low | Low | Optional arg; TypeScript enforces backward compat |
+| `contextAssembler` not optional breaks existing tests | Very Low | Low | `?` makes it optional; existing fakes compile without it |
+| Full test suite regressions | Very Low | High | Run `npx vitest run` before PR |
+
+---
+
+## PR Packaging Strategy
+
+**Single PR**: `feat/context-assembly-layer`
+
+All 7 file changes ship together. They form a single coherent feature -- the 4 new
+files are meaningless without the 3 modifications, and the modifications are safe
+with or without the new files.
+
+**Commit message**: `feat(coordinator): add context assembly layer -- git summary and prior session notes`
+
+---
+
+## Philosophy Alignment Per Slice
+
+| Slice | Principle | Status |
+|---|---|---|
+| Slice 1 (types) | Make illegal states unrepresentable (discriminated union) | Satisfied |
+| Slice 1 (index) | Functional/declarative (factory fn, pure render) | Satisfied |
+| Slice 1 (infra) | DI for boundaries (all I/O behind interface) | Satisfied |
+| Slice 1 (infra) | Architectural fixes over patches (reuse projection code) | Satisfied |
+| Slice 2 (coordinator) | Errors are data (Result<T,E>) | Satisfied |
+| Slice 2 (coordinator) | Backward compatibility via optional fields | Satisfied |
+| Slice 3 (workflow-runner) | Validate at boundaries (type check before inject) | Satisfied |
+| Slice 5 (tests) | Prefer fakes over mocks | Satisfied |
+
+---
+
+## Open Questions (Residual)
+
+None. All questions were resolved during design review:
+1. `ManifestRecordV1Schema` and `DomainEventV1Schema` -- confirmed exported
+2. `asSessionId` -- confirmed exported from ids/index.ts
+3. Re-review spawn context -- confirmed: forward same `spawnContext` from outer scope
+
+**`unresolvedUnknownCount`**: 0
+**`planConfidenceBand`**: High

--- a/docs/design/context-assembly-review-findings.md
+++ b/docs/design/context-assembly-review-findings.md
@@ -1,0 +1,112 @@
+# Design Review Findings: Context Assembly Layer v1
+
+*Generated during coding-task-workflow-agentic session | 2026-04-19*
+
+---
+
+## Tradeoff Review
+
+| Tradeoff | Verdict | Condition for Failure |
+|---|---|---|
+| FileSystemPortV2 write stubs | RESOLVED -- switching to direct SessionEventLogReadonlyStorePortV2 adapter | N/A |
+| Inline DI wiring in infra.ts | Acceptable -- explicitly endorsed by pitch R1 mitigation | N/A |
+| Global session list (no workspace filtering) | Accepted -- v2 improvement documented in pitch | Multiple simultaneous workspaces with unrelated sessions |
+| Promise.all partial failure | Adequately handled -- each source returns Result, try/catch in infra | N/A |
+
+---
+
+## Failure Mode Review
+
+| Failure Mode | Covered By | Residual Risk |
+|---|---|---|
+| Write stubs called | Outer try/catch in createListRecentSessions | Low -- FM1 resolved by switching adapter |
+| Git commands fail | execGit/execGh return err(), fallback chain | None |
+| Sessions dir missing | LocalDirectoryListingV2 returns [] for FS_NOT_FOUND | None |
+| Corrupt session data | LocalSessionSummaryProviderV2 graceful skip | None |
+| spawnSession backward compat | Optional 4th arg | None |
+| contextAssembler not provided | Optional field + if-guard in coordinator | None |
+
+---
+
+## Runner-Up / Simpler Alternative Review
+
+**Runner-up** (Candidate B: raw fs.promises) has no elements worth borrowing into the
+selected design.
+
+**Simpler variant identified**: Use a direct `SessionEventLogReadonlyStorePortV2`
+adapter in `infra.ts` instead of `LocalSessionEventLogStoreV2`. This eliminates all
+`FileSystemPortV2` and `Sha256PortV2` stubs while still reusing `LocalSessionSummaryProviderV2`
+and the full projection pipeline. The adapter implements only `load()` and
+`loadValidatedPrefix()` using `fs.promises` + existing Zod schemas (`ManifestRecordV1Schema`,
+`DomainEventV1Schema`). Approximately 40 lines. This is strictly cleaner.
+
+**Recommendation**: Use the simpler `SessionEventLogReadonlyStorePortV2` adapter approach.
+
+---
+
+## Philosophy Alignment
+
+| Principle | Alignment |
+|---|---|
+| Errors are data | STRONG -- Result<T,E> throughout |
+| DI for boundaries | STRONG -- ContextAssemblerDeps, inline construction accepted for separate process |
+| Prefer fakes over mocks | STRONG -- test spec uses fake deps |
+| Immutability by default | STRONG -- readonly everywhere |
+| Make illegal states unrepresentable | STRONG -- AssemblyTask discriminated union |
+| Functional/declarative | STRONG -- factory functions, pure renderContextBundle |
+| YAGNI | MILD TENSION -- empty RenderOpts interface (accepted, documented) |
+| Architectural fixes over patches | STRONG with adapter approach |
+
+---
+
+## Findings
+
+### YELLOW: Empty RenderOpts interface
+
+**Severity**: Yellow (minor)
+
+**Finding**: `RenderOpts` is an empty interface in v1. TypeScript `{}` and `interface RenderOpts {}` are equivalent. The empty interface is only useful as a future extension point.
+
+**Assessment**: Acceptable -- the pitch explicitly documents this as an intentional v1 placeholder. No action needed.
+
+### YELLOW: Global session filtering (no workspace scope)
+
+**Severity**: Yellow (minor, known)
+
+**Finding**: `listRecentSessions` returns the 3 most recent sessions globally, not scoped to the coordinator's workspace path. For users running multiple workspaces, prior notes from unrelated workspaces may appear.
+
+**Assessment**: Acceptable for v1 -- pitch explicitly documents this as a known limitation. The `_workspacePath` parameter should be named with a leading `_` to signal intentional non-use.
+
+### GREEN: All other design elements
+
+Tradeoffs, failure modes, and philosophy alignment are all sound. No RED or ORANGE findings.
+
+---
+
+## Recommended Revisions
+
+1. **Use direct `SessionEventLogReadonlyStorePortV2` adapter** in `infra.ts` instead of
+   `LocalSessionEventLogStoreV2`. Eliminates all write stubs. Implements `load()` using
+   `fs.promises.readFile` + `ManifestRecordV1Schema` + `DomainEventV1Schema` parsing.
+   Approximately 40 lines.
+
+2. **Name unused parameter** `_workspacePath` in `createListRecentSessions` to signal
+   intentional non-use.
+
+---
+
+## Residual Concerns
+
+1. **Import path for Zod schemas**: `ManifestRecordV1Schema` and `DomainEventV1Schema`
+   must be importable from `src/v2/durable-core/schemas/session/index.ts`. Verify before
+   implementing that these schemas are exported.
+
+2. **`asSessionId` usage**: The `SessionEventLogReadonlyStorePortV2.load()` adapter
+   receives a `SessionId` branded type. When reading session directories and mapping
+   entry names to `SessionId`, the `asSessionId` import from
+   `src/v2/durable-core/ids/index.ts` must be used correctly.
+
+3. **Neverthrow ResultAsync wrapping**: The adapter must return neverthrow `ResultAsync`
+   objects (using `okAsync`/`errAsync` from neverthrow), not the custom `Result` type.
+   The bridge from neverthrow to custom Result happens in the `createListRecentSessions`
+   function via `const result = await resultAsync; if (result.isErr()) return err(...)`.

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -26,6 +26,8 @@ import { promisify } from 'util';
 import { randomUUID } from 'crypto';
 
 import { interpretCliResultWithoutDI } from './cli/interpret-result.js';
+import { createContextAssembler } from './context-assembly/index.js';
+import { createListRecentSessions } from './context-assembly/infra.js';
 import {
   executeWorktrainInitCommand,
   executeWorktrainTellCommand,
@@ -955,13 +957,23 @@ runCommand
 
     // Build real CoordinatorDeps
     const deps = {
-      spawnSession: async (workflowId: string, goal: string, workspace: string) => {
+      spawnSession: async (
+        workflowId: string,
+        goal: string,
+        workspace: string,
+        context?: Readonly<Record<string, unknown>>,
+      ) => {
         const url = `http://127.0.0.1:${port}/api/v2/auto/dispatch`;
         try {
           const response = await globalThis.fetch(url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ workflowId, goal, workspacePath: workspace }),
+            body: JSON.stringify({
+              workflowId,
+              goal,
+              workspacePath: workspace,
+              ...(context !== undefined ? { context } : {}),
+            }),
             signal: AbortSignal.timeout(30_000),
           });
           const body = await response.json() as Record<string, unknown>;
@@ -993,6 +1005,31 @@ runCommand
           return { kind: 'err' as const, error: `Dispatch request failed: ${msg}` };
         }
       },
+
+      contextAssembler: createContextAssembler({
+        execGit: async (args: readonly string[], cwd: string) => {
+          const { execFile: ef } = await import('node:child_process');
+          const { promisify: prom } = await import('node:util');
+          try {
+            const { stdout } = await prom(ef)('git', [...args], { cwd });
+            return { kind: 'ok' as const, value: stdout };
+          } catch (e) {
+            return { kind: 'err' as const, error: e instanceof Error ? e.message : String(e) };
+          }
+        },
+        execGh: async (args: readonly string[], cwd: string) => {
+          const { execFile: ef } = await import('node:child_process');
+          const { promisify: prom } = await import('node:util');
+          try {
+            const { stdout } = await prom(ef)('gh', [...args], { cwd });
+            return { kind: 'ok' as const, value: stdout };
+          } catch (e) {
+            return { kind: 'err' as const, error: e instanceof Error ? e.message : String(e) };
+          }
+        },
+        listRecentSessions: createListRecentSessions(),
+        nowIso: () => new Date().toISOString(),
+      }),
 
       awaitSessions: async (handles: readonly string[], timeoutMs: number) => {
         const { executeWorktrainAwaitCommand } = await import('./cli/commands/worktrain-await.js');

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -1008,20 +1008,16 @@ runCommand
 
       contextAssembler: createContextAssembler({
         execGit: async (args: readonly string[], cwd: string) => {
-          const { execFile: ef } = await import('node:child_process');
-          const { promisify: prom } = await import('node:util');
           try {
-            const { stdout } = await prom(ef)('git', [...args], { cwd });
+            const { stdout } = await execFileAsync('git', [...args], { cwd });
             return { kind: 'ok' as const, value: stdout };
           } catch (e) {
             return { kind: 'err' as const, error: e instanceof Error ? e.message : String(e) };
           }
         },
         execGh: async (args: readonly string[], cwd: string) => {
-          const { execFile: ef } = await import('node:child_process');
-          const { promisify: prom } = await import('node:util');
           try {
-            const { stdout } = await prom(ef)('gh', [...args], { cwd });
+            const { stdout } = await execFileAsync('gh', [...args], { cwd });
             return { kind: 'ok' as const, value: stdout };
           } catch (e) {
             return { kind: 'err' as const, error: e instanceof Error ? e.message : String(e) };

--- a/src/context-assembly/deps.ts
+++ b/src/context-assembly/deps.ts
@@ -1,0 +1,47 @@
+import type { Result } from '../runtime/result.js';
+import type { SessionNote } from './types.js';
+
+/**
+ * Injectable I/O dependencies for ContextAssembler.
+ *
+ * Follows CoordinatorDeps pattern exactly: all I/O behind this interface,
+ * no direct fs/exec imports in the assembler core. Tests inject fakes.
+ */
+export interface ContextAssemblerDeps {
+  /**
+   * Run a git command in the given working directory.
+   * Args are passed as an array (no shell interpolation).
+   * Returns stdout string on success, err(message) on failure.
+   */
+  readonly execGit: (
+    args: readonly string[],
+    cwd: string,
+  ) => Promise<Result<string, string>>;
+
+  /**
+   * Run a gh CLI command in the given working directory.
+   * Args are passed as an array (no shell interpolation).
+   * Returns stdout on success, err on failure (gh not installed, auth error, etc.).
+   */
+  readonly execGh: (
+    args: readonly string[],
+    cwd: string,
+  ) => Promise<Result<string, string>>;
+
+  /**
+   * List recent sessions for a workspace, ordered newest-first.
+   * Returns at most `limit` sessions.
+   * Real implementation: thin adapter over LocalSessionSummaryProviderV2.
+   * Test implementation: return a hardcoded array.
+   */
+  readonly listRecentSessions: (
+    workspacePath: string,
+    limit: number,
+  ) => Promise<Result<readonly SessionNote[], string>>;
+
+  /**
+   * Return the current ISO 8601 timestamp.
+   * Injected for deterministic test output.
+   */
+  readonly nowIso: () => string;
+}

--- a/src/context-assembly/index.ts
+++ b/src/context-assembly/index.ts
@@ -41,6 +41,12 @@ export function createContextAssembler(deps: ContextAssemblerDeps): ContextAssem
  * for PRs: shows base..head diff). On gh failure, fall back to `git diff HEAD~1 --stat`.
  * For coding_task: use `git diff HEAD~1 --stat` directly.
  *
+ * NOTE: format inconsistency -- `gh pr diff --name-only` returns a plain filename list
+ * (one file per line), while `git diff HEAD~1 --stat` returns stat output with change
+ * counts (e.g. "src/foo.ts | 5 ++"). Both land in the same `gitDiff` field and are
+ * rendered under `### Changed files`. The agent can parse either format; normalizing
+ * to `--name-only` for both paths is a future improvement.
+ *
  * Returns err() on all failures -- caller omits the section gracefully.
  */
 async function assembleGitDiff(

--- a/src/context-assembly/index.ts
+++ b/src/context-assembly/index.ts
@@ -1,0 +1,117 @@
+import type { ContextAssemblerDeps } from './deps.js';
+import type {
+  AssemblyTask,
+  ContextAssembler,
+  ContextBundle,
+  RenderOpts,
+  SessionNote,
+} from './types.js';
+
+/**
+ * Create a ContextAssembler service with the given I/O deps.
+ *
+ * WHY factory function (not class): follows existing coordinator pattern.
+ * Factory closes over deps; no `this` binding.
+ */
+export function createContextAssembler(deps: ContextAssemblerDeps): ContextAssembler {
+  return {
+    async assemble(task: AssemblyTask): Promise<ContextBundle> {
+      const [gitDiff, priorSessionNotes] = await Promise.all([
+        assembleGitDiff(deps, task),
+        assemblePriorNotes(deps, task.workspacePath),
+      ]);
+      return {
+        task,
+        gitDiff,
+        priorSessionNotes,
+        assembledAt: deps.nowIso(),
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Source assemblers (private)
+// ---------------------------------------------------------------------------
+
+/**
+ * Assemble git diff summary.
+ *
+ * For pr_review: attempt `gh pr diff --name-only <prNumber>` first (more accurate
+ * for PRs: shows base..head diff). On gh failure, fall back to `git diff HEAD~1 --stat`.
+ * For coding_task: use `git diff HEAD~1 --stat` directly.
+ *
+ * Returns err() on all failures -- caller omits the section gracefully.
+ */
+async function assembleGitDiff(
+  deps: ContextAssemblerDeps,
+  task: AssemblyTask,
+): Promise<ContextBundle['gitDiff']> {
+  if (task.kind === 'pr_review') {
+    const ghResult = await deps.execGh(
+      ['pr', 'diff', String(task.prNumber), '--name-only'],
+      task.workspacePath,
+    );
+    if (ghResult.kind === 'ok' && ghResult.value.trim().length > 0) {
+      return { kind: 'ok', value: ghResult.value.trim() };
+    }
+    // Fall through to git fallback
+  }
+  return deps.execGit(['diff', 'HEAD~1', '--stat'], task.workspacePath);
+}
+
+/**
+ * Assemble prior session notes for this workspace.
+ * Returns at most 3 sessions, newest-first.
+ */
+async function assemblePriorNotes(
+  deps: ContextAssemblerDeps,
+  workspacePath: string,
+): Promise<ContextBundle['priorSessionNotes']> {
+  const PRIOR_SESSION_LIMIT = 3;
+  return deps.listRecentSessions(workspacePath, PRIOR_SESSION_LIMIT);
+}
+
+// ---------------------------------------------------------------------------
+// Rendering (pure, exported for coordinator use)
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a ContextBundle to a markdown string suitable for injection into
+ * the system prompt as a `## Prior Context` section.
+ *
+ * Returns empty string if both sources are err() (nothing to inject).
+ *
+ * WHY pure function: renderContextBundle is called in coordinator code (not
+ * inside the assembler) to keep the assembler free of formatting concerns.
+ * Also independently testable without I/O.
+ *
+ * LOCKED FORMAT: section headers and structure are part of the coordinator-daemon
+ * contract. Do not change headers without updating the buildSystemPrompt() comment.
+ */
+export function renderContextBundle(bundle: ContextBundle, _opts?: RenderOpts): string {
+  const parts: string[] = [];
+
+  // ---- Prior session notes ----
+  if (bundle.priorSessionNotes.kind === 'ok' && bundle.priorSessionNotes.value.length > 0) {
+    parts.push('### Recent session notes for this workspace\n');
+    for (const note of bundle.priorSessionNotes.value) {
+      const title = note.sessionTitle ?? note.sessionId.slice(0, 12);
+      const branch = note.gitBranch ? ` (branch: ${note.gitBranch})` : '';
+      const recap = note.recapSnippet ?? '(no recap available)';
+      parts.push(`**${title}**${branch}\n${recap}\n`);
+    }
+  }
+
+  // ---- Git diff summary ----
+  if (bundle.gitDiff.kind === 'ok' && bundle.gitDiff.value.trim().length > 0) {
+    parts.push('### Changed files\n');
+    parts.push('```\n' + bundle.gitDiff.value.trim() + '\n```\n');
+  }
+
+  return parts.join('\n');
+}
+
+// Re-export types used by callers so they can import from the module root
+export type { AssemblyTask, ContextBundle, ContextAssembler, SessionNote, RenderOpts } from './types.js';
+export type { ContextAssemblerDeps } from './deps.js';

--- a/src/context-assembly/infra.ts
+++ b/src/context-assembly/infra.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs/promises';
 import * as nodePath from 'node:path';
+import { createHash } from 'node:crypto';
 import { fromPromise } from 'neverthrow';
 import type { ResultAsync } from 'neverthrow';
 import { ok, err } from '../runtime/result.js';
@@ -129,10 +130,10 @@ function makeDirectoryListingOpsPort(): DirectoryListingOpsPortV2 {
  * Strict workspace filtering is a v2 improvement.
  */
 export function createListRecentSessions(): (
-  _workspacePath: string,
+  workspacePath: string,
   limit: number,
 ) => Promise<Result<readonly SessionNote[], string>> {
-  return async (_workspacePath: string, limit: number) => {
+  return async (workspacePath: string, limit: number) => {
     try {
       const dataDir = new LocalDataDirV2(process.env as Record<string, string | undefined>);
       const directoryListingOps = makeDirectoryListingOpsPort();
@@ -154,16 +155,26 @@ export function createListRecentSessions(): (
         return err(`listRecentSessions: ${result.error.message}`);
       }
 
+      // Compute sha256:<hex> hash of workspacePath to match observations.repoRootHash format.
+      // WHY: HealthySessionSummary stores a sha256 hash (not raw path) for workspace filtering.
+      // Sessions with null repoRootHash pass through for backward compat (recorded before the
+      // observation feature was added). Strict workspace filtering is a planned v2 improvement.
+      const workspaceHash = `sha256:${createHash('sha256').update(workspacePath).digest('hex')}`;
+
       const notes: SessionNote[] = result.value
+        .filter((s) =>
+          s.observations.repoRootHash === null ||
+          s.observations.repoRootHash === workspaceHash,
+        )
         .slice()
-        .sort((a, b) => (b.lastModifiedMs ?? 0) - (a.lastModifiedMs ?? 0))
+        .sort((a, b) => (b.lastModifiedMs ?? Date.now()) - (a.lastModifiedMs ?? Date.now()))
         .slice(0, limit)
         .map((s) => ({
           sessionId: String(s.sessionId),
           recapSnippet: s.recapSnippet != null ? String(s.recapSnippet) : null,
           sessionTitle: s.sessionTitle,
           gitBranch: s.observations.gitBranch,
-          lastModifiedMs: s.lastModifiedMs ?? 0,
+          lastModifiedMs: s.lastModifiedMs ?? Date.now(),
         }));
 
       return ok(notes);

--- a/src/context-assembly/infra.ts
+++ b/src/context-assembly/infra.ts
@@ -1,0 +1,175 @@
+import * as fs from 'node:fs/promises';
+import * as nodePath from 'node:path';
+import { fromPromise } from 'neverthrow';
+import type { ResultAsync } from 'neverthrow';
+import { ok, err } from '../runtime/result.js';
+import type { Result } from '../runtime/result.js';
+import { LocalSessionSummaryProviderV2 } from '../v2/infra/local/session-summary-provider/index.js';
+import { LocalDataDirV2 } from '../v2/infra/local/data-dir/index.js';
+import { LocalDirectoryListingV2 } from '../v2/infra/local/directory-listing/index.js';
+import { LocalSessionEventLogStoreV2 } from '../v2/infra/local/session-store/index.js';
+import { NodeSha256V2 } from '../v2/infra/local/sha256/index.js';
+import type { DirectoryListingOpsPortV2, FsError, FileSystemPortV2 } from '../v2/ports/fs.port.js';
+import type { SessionNote } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Minimal read-only FileSystemPortV2 adapter
+//
+// WHY: LocalSessionEventLogStoreV2 requires FileSystemPortV2 (the full composite
+// port), but load() only calls readFileUtf8 (for manifest.jsonl) and readFileBytes
+// (for segment files). All write/fd methods are unreachable during reads.
+//
+// The outer try/catch in createListRecentSessions() catches any unexpected throw,
+// ensuring the partial-failure invariant is preserved even if a stub is ever reached.
+// ---------------------------------------------------------------------------
+
+const WRITE_NOT_SUPPORTED = 'context-assembly: write ops not supported in read-only session store';
+
+function makeReadOnlyFsPort(): FileSystemPortV2 {
+  return {
+    // ---- Used by load() ----
+    readFileUtf8(filePath: string): ResultAsync<string, FsError> {
+      return fromPromise(
+        fs.readFile(filePath, 'utf-8'),
+        (e): FsError => {
+          const nodeErr = e as NodeJS.ErrnoException;
+          if (nodeErr.code === 'ENOENT') return { code: 'FS_NOT_FOUND', message: nodeErr.message ?? 'not found' };
+          return { code: 'FS_IO_ERROR', message: nodeErr.message ?? String(e) };
+        }
+      );
+    },
+    readFileBytes(filePath: string): ResultAsync<Uint8Array, FsError> {
+      return fromPromise(
+        fs.readFile(filePath).then((buf) => new Uint8Array(buf)),
+        (e): FsError => {
+          const nodeErr = e as NodeJS.ErrnoException;
+          if (nodeErr.code === 'ENOENT') return { code: 'FS_NOT_FOUND', message: nodeErr.message ?? 'not found' };
+          return { code: 'FS_IO_ERROR', message: nodeErr.message ?? String(e) };
+        }
+      );
+    },
+    stat(_filePath: string): ResultAsync<{ readonly sizeBytes: number }, FsError> {
+      throw new Error(WRITE_NOT_SUPPORTED);
+    },
+    // ---- Write/fd stubs -- unreachable during load() ----
+    mkdirp(_dirPath: string): ResultAsync<void, FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+    fsyncDir(_dirPath: string): ResultAsync<void, FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+    openWriteTruncate(_filePath: string): ResultAsync<{ readonly fd: number }, FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+    openAppend(_filePath: string): ResultAsync<{ readonly fd: number }, FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+    openExclusive(_filePath: string, _bytes: Uint8Array): ResultAsync<{ readonly fd: number }, FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+    writeAll(_fd: number, _bytes: Uint8Array): ResultAsync<void, FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+    fsyncFile(_fd: number): ResultAsync<void, FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+    closeFile(_fd: number): ResultAsync<void, FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+    rename(_from: string, _to: string): ResultAsync<void, FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+    unlink(_filePath: string): ResultAsync<void, FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+    writeFileBytes(_filePath: string, _bytes: Uint8Array): ResultAsync<void, FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+    readdir(_dirPath: string): ResultAsync<readonly string[], FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+    readdirWithMtime(_dirPath: string): ResultAsync<readonly { readonly name: string; readonly mtimeMs: number }[], FsError> { throw new Error(WRITE_NOT_SUPPORTED); },
+  };
+}
+
+/**
+ * Minimal DirectoryListingOpsPortV2 adapter using fs.promises.
+ *
+ * Used by LocalDirectoryListingV2 for session enumeration (readdirWithMtime).
+ * This is the only directory-listing port needed for loadHealthySummaries().
+ */
+function makeDirectoryListingOpsPort(): DirectoryListingOpsPortV2 {
+  return {
+    readdir(dirPath: string): ResultAsync<readonly string[], FsError> {
+      return fromPromise(
+        fs.readdir(dirPath),
+        (e): FsError => {
+          const nodeErr = e as NodeJS.ErrnoException;
+          if (nodeErr.code === 'ENOENT') return { code: 'FS_NOT_FOUND', message: nodeErr.message ?? 'not found' };
+          return { code: 'FS_IO_ERROR', message: nodeErr.message ?? String(e) };
+        }
+      );
+    },
+    readdirWithMtime(dirPath: string): ResultAsync<readonly { readonly name: string; readonly mtimeMs: number }[], FsError> {
+      return fromPromise(
+        (async () => {
+          const entries = await fs.readdir(dirPath, { withFileTypes: true });
+          const withMtimes = await Promise.all(
+            entries.map(async (entry) => {
+              try {
+                const stat = await fs.stat(nodePath.join(dirPath, entry.name));
+                return { name: entry.name, mtimeMs: stat.mtimeMs };
+              } catch {
+                // Graceful: entries that fail stat are skipped (same as LocalDirectoryListingV2 behavior)
+                return null;
+              }
+            })
+          );
+          return withMtimes.filter((e): e is { name: string; mtimeMs: number } => e !== null);
+        })(),
+        (e): FsError => {
+          const nodeErr = e as NodeJS.ErrnoException;
+          if (nodeErr.code === 'ENOENT') return { code: 'FS_NOT_FOUND', message: nodeErr.message ?? 'not found' };
+          return { code: 'FS_IO_ERROR', message: nodeErr.message ?? String(e) };
+        }
+      );
+    },
+  };
+}
+
+/**
+ * Create the real `listRecentSessions` implementation for ContextAssemblerDeps.
+ *
+ * Constructs a LocalSessionSummaryProviderV2 with minimal local ports,
+ * loads all healthy summaries, and maps to SessionNote[].
+ *
+ * WHY inline construction (not reuse of MCP provider instance): the coordinator
+ * runs in a separate process. Constructing a fresh provider is safe -- it reads
+ * only from disk.
+ *
+ * NOTE on workspace filtering: HealthySessionSummary has no typed workspacePath
+ * field in v1. The adapter returns the N most recent sessions globally (newest-first).
+ * The agent can judge relevance from sessionTitle and gitBranch fields.
+ * Strict workspace filtering is a v2 improvement.
+ */
+export function createListRecentSessions(): (
+  _workspacePath: string,
+  limit: number,
+) => Promise<Result<readonly SessionNote[], string>> {
+  return async (_workspacePath: string, limit: number) => {
+    try {
+      const dataDir = new LocalDataDirV2(process.env as Record<string, string | undefined>);
+      const directoryListingOps = makeDirectoryListingOpsPort();
+      const directoryListing = new LocalDirectoryListingV2(directoryListingOps);
+      const fsPort = makeReadOnlyFsPort();
+      const sha256 = new NodeSha256V2();
+      const sessionStore = new LocalSessionEventLogStoreV2(dataDir, fsPort, sha256);
+
+      const provider = new LocalSessionSummaryProviderV2({
+        directoryListing,
+        dataDir,
+        sessionStore,
+        // snapshotStore omitted -- not needed for context assembly
+      });
+
+      const result = await provider.loadHealthySummaries();
+
+      if (result.isErr()) {
+        return err(`listRecentSessions: ${result.error.message}`);
+      }
+
+      const notes: SessionNote[] = result.value
+        .slice()
+        .sort((a, b) => (b.lastModifiedMs ?? 0) - (a.lastModifiedMs ?? 0))
+        .slice(0, limit)
+        .map((s) => ({
+          sessionId: String(s.sessionId),
+          recapSnippet: s.recapSnippet != null ? String(s.recapSnippet) : null,
+          sessionTitle: s.sessionTitle,
+          gitBranch: s.observations.gitBranch,
+          lastModifiedMs: s.lastModifiedMs ?? 0,
+        }));
+
+      return ok(notes);
+    } catch (e) {
+      return err(`listRecentSessions error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  };
+}
+

--- a/src/context-assembly/types.ts
+++ b/src/context-assembly/types.ts
@@ -1,0 +1,73 @@
+import type { Result } from '../runtime/result.js';
+
+/**
+ * Typed task descriptor -- the assembler uses the kind discriminant to decide
+ * which sources to query. Validate at entry, trust inside the assembler.
+ */
+export type AssemblyTask =
+  | {
+      readonly kind: 'pr_review';
+      readonly prNumber: number;
+      readonly workspacePath: string;
+      /** PR description body text (from webhook payload), for future URL extraction. */
+      readonly payloadBody?: string;
+    }
+  | {
+      readonly kind: 'coding_task';
+      readonly issueNumber?: number;
+      readonly workspacePath: string;
+      readonly payloadBody?: string;
+    };
+
+/**
+ * A single prior session note extracted from the session summary store.
+ * Maps directly to fields on HealthySessionSummary from LocalSessionSummaryProviderV2.
+ */
+export interface SessionNote {
+  readonly sessionId: string;
+  /** Aggregated recap from tip node and ancestors. Null if session has no recap. */
+  readonly recapSnippet: string | null;
+  /** Derived session title from context fields or first recap line. */
+  readonly sessionTitle: string | null;
+  /** Git branch observed during that session. */
+  readonly gitBranch: string | null;
+  /** Filesystem mtime for the session directory (epoch ms). */
+  readonly lastModifiedMs: number;
+}
+
+/**
+ * Assembled context bundle -- returned by ContextAssembler.assemble().
+ *
+ * Each source field is a Result<T, string> so a single source failure does NOT
+ * block other sources. The coordinator renders only the ok() fields.
+ */
+export interface ContextBundle {
+  readonly task: AssemblyTask;
+  /**
+   * Output of `gh pr diff --name-only <prNumber>` (for pr_review) or
+   * `git diff HEAD~1 --stat` (fallback). File names and change counts only.
+   */
+  readonly gitDiff: Result<string, string>;
+  /**
+   * Prior session notes for this workspace, newest-first, capped at `limit`.
+   */
+  readonly priorSessionNotes: Result<readonly SessionNote[], string>;
+  /** ISO 8601 timestamp of assembly. */
+  readonly assembledAt: string;
+}
+
+/**
+ * Rendering options stub -- empty in v1. Kept as explicit interface to
+ * preserve the extension point without implementing it.
+ */
+export interface RenderOpts {
+  // v1: empty -- populated when coordinators need different rendering
+}
+
+/**
+ * ContextAssembler service interface.
+ * Inject into CoordinatorDeps as an optional field.
+ */
+export interface ContextAssembler {
+  assemble(task: AssemblyTask): Promise<ContextBundle>;
+}

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -130,12 +130,25 @@ export interface CoordinatorDeps {
   /**
    * Dispatch a workflow session to the daemon.
    * Returns the session handle on success, or err() on connection/HTTP failure.
+   *
+   * The optional 4th arg passes assembled context (e.g. git diff summary, prior session
+   * notes) that gets injected into the session's system prompt before turn 1.
    */
   readonly spawnSession: (
     workflowId: string,
     goal: string,
     workspace: string,
+    context?: Readonly<Record<string, unknown>>,
   ) => Promise<Result<string, string>>;
+
+  /**
+   * Optional context assembler. When provided, assembles git diff summary and
+   * prior session notes before each review session spawn.
+   *
+   * WHY optional: backward-compatible with existing test fakes that construct
+   * CoordinatorDeps without context assembly. Undefined = no assembly.
+   */
+  readonly contextAssembler?: import('../context-assembly/types.js').ContextAssembler;
 
   /**
    * Wait for a set of sessions to complete.
@@ -941,6 +954,8 @@ export async function runPrReviewCoordinator(
   // Spawn review sessions in parallel
   const reviewHandles = new Map<number, string>(); // prNumber -> sessionHandle
   const spawnErrors = new Map<number, string>(); // prNumber -> error message
+  // Assembled context per PR -- forwarded to re-review spawns in runFixAgentLoop
+  const spawnContexts = new Map<number, Readonly<Record<string, unknown>>>();
 
   for (const pr of prs) {
     const goal = `Review PR #${pr.number} "${pr.title}" before merge`;
@@ -949,10 +964,34 @@ export async function runPrReviewCoordinator(
       continue;
     }
 
+    // Assemble context before spawning (optional -- skip if no assembler injected).
+    let spawnContext: Readonly<Record<string, unknown>> | undefined;
+    if (deps.contextAssembler) {
+      const bundle = await deps.contextAssembler.assemble({
+        kind: 'pr_review',
+        prNumber: pr.number,
+        workspacePath: opts.workspace,
+      });
+      const { renderContextBundle } = await import('../context-assembly/index.js');
+      const rendered = renderContextBundle(bundle);
+      if (rendered.trim().length > 0) {
+        spawnContext = { assembledContextSummary: rendered };
+        spawnContexts.set(pr.number, spawnContext);
+      }
+      // WARN log when a source fails so issues are surfaced in coordinator output
+      if (bundle.gitDiff.kind === 'err') {
+        deps.stderr(`[WARN coord:context prNumber=${pr.number}] gitDiff failed: ${bundle.gitDiff.error}`);
+      }
+      if (bundle.priorSessionNotes.kind === 'err') {
+        deps.stderr(`[WARN coord:context prNumber=${pr.number}] priorSessionNotes failed: ${bundle.priorSessionNotes.error}`);
+      }
+    }
+
     const spawnResult = await deps.spawnSession(
       'mr-review-workflow-agentic',
       goal,
       opts.workspace,
+      spawnContext,
     );
 
     if (spawnResult.kind === 'err') {
@@ -1059,6 +1098,7 @@ export async function runPrReviewCoordinator(
           outcome,
           coordinatorStartMs,
           log,
+          spawnContexts.get(prNum),
         );
         outcomes.set(prNum, processedOutcome);
       } else {
@@ -1161,6 +1201,8 @@ async function runFixAgentLoop(
   initialOutcome: PrOutcome,
   coordinatorStartMs: number,
   log: (line: string) => void,
+  /** Assembled context from the initial review spawn. Forwarded to re-review spawns. */
+  reviewSpawnContext?: Readonly<Record<string, unknown>>,
 ): Promise<PrOutcome> {
   let passCount = 0;
   let currentFindings = initialFindings;
@@ -1262,10 +1304,12 @@ async function runFixAgentLoop(
 
     // Re-review after fix
     const reReviewGoal = `Re-review PR #${pr.number} after fixes (pass ${passCount})`;
+    // Forward same context as the initial review spawn (assembled before first spawn).
     const reReviewSpawnResult = await deps.spawnSession(
       'mr-review-workflow-agentic',
       reReviewGoal,
       opts.workspace,
+      reviewSpawnContext,
     );
 
     if (reReviewSpawnResult.kind === 'err') {

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -31,6 +31,8 @@ import {
   ReviewVerdictArtifactV1Schema,
   isReviewVerdictArtifact,
 } from '../v2/durable-core/schemas/artifacts/review-verdict.js';
+import { renderContextBundle } from '../context-assembly/index.js';
+import type { ContextAssembler } from '../context-assembly/types.js';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // DOMAIN TYPES
@@ -148,7 +150,7 @@ export interface CoordinatorDeps {
    * WHY optional: backward-compatible with existing test fakes that construct
    * CoordinatorDeps without context assembly. Undefined = no assembly.
    */
-  readonly contextAssembler?: import('../context-assembly/types.js').ContextAssembler;
+  readonly contextAssembler?: ContextAssembler;
 
   /**
    * Wait for a set of sessions to complete.
@@ -972,7 +974,6 @@ export async function runPrReviewCoordinator(
         prNumber: pr.number,
         workspacePath: opts.workspace,
       });
-      const { renderContextBundle } = await import('../context-assembly/index.js');
       const rendered = renderContextBundle(bundle);
       if (rendered.trim().length > 0) {
         spawnContext = { assembledContextSummary: rendered };

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -142,6 +142,13 @@ const WORKRAIL_DIR = path.join(os.homedir(), '.workrail');
 const WORKSPACE_CONTEXT_MAX_BYTES = 32 * 1024;
 
 /**
+ * Maximum byte size for injected assembledContextSummary (prior session notes + git diff).
+ * WHY: caps the coordinator-assembled context to protect LLM token budget.
+ * Mirrors the WORKSPACE_CONTEXT_MAX_BYTES cap pattern used for CLAUDE.md injection.
+ */
+const MAX_ASSEMBLED_CONTEXT_BYTES = 8192;
+
+/**
  * Candidate workspace context files in priority order.
  * WHY: Higher-priority files (repo-specific Claude config) are included first.
  * If the combined size exceeds WORKSPACE_CONTEXT_MAX_BYTES, lower-priority files
@@ -2526,9 +2533,13 @@ export function buildSystemPrompt(
   // survives the HTTP transport (context map is already JSON-serialized).
   const assembledContextSummary = trigger.context?.['assembledContextSummary'];
   if (typeof assembledContextSummary === 'string' && assembledContextSummary.trim().length > 0) {
+    let ctxStr = assembledContextSummary as string;
+    if (Buffer.byteLength(ctxStr, 'utf8') > MAX_ASSEMBLED_CONTEXT_BYTES) {
+      ctxStr = ctxStr.slice(0, MAX_ASSEMBLED_CONTEXT_BYTES) + '\n[Prior context truncated at 8KB]';
+    }
     lines.push('');
     lines.push('## Prior Context');
-    lines.push(assembledContextSummary.trim());
+    lines.push(ctxStr.trim());
   }
 
   // Append reference URLs section when provided.

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -2518,6 +2518,19 @@ export function buildSystemPrompt(
     lines.push(workspaceContext);
   }
 
+  // Inject assembled task context (prior session notes + git diff stat) when provided.
+  // WHY before referenceUrls: task-specific runtime context should be visible before
+  // static reference documents. Earlier position improves agent attention.
+  // WHY trigger.context key: the coordinator serializes the rendered context bundle
+  // into trigger.context['assembledContextSummary'] (string) before spawning. This
+  // survives the HTTP transport (context map is already JSON-serialized).
+  const assembledContextSummary = trigger.context?.['assembledContextSummary'];
+  if (typeof assembledContextSummary === 'string' && assembledContextSummary.trim().length > 0) {
+    lines.push('');
+    lines.push('## Prior Context');
+    lines.push(assembledContextSummary.trim());
+  }
+
   // Append reference URLs section when provided.
   // WHY: some tasks require background context (specs, design docs, ADRs) that
   // the agent should fetch and read before starting work. Providing the URLs in

--- a/tests/unit/context-assembly.test.ts
+++ b/tests/unit/context-assembly.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the context-assembly module.
+ *
+ * Uses fake deps (in-memory functions). No vi.mock() -- follows repo pattern
+ * of "prefer fakes over mocks".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createContextAssembler, renderContextBundle } from '../../src/context-assembly/index.js';
+import type { ContextAssemblerDeps } from '../../src/context-assembly/deps.js';
+import type { SessionNote, AssemblyTask, ContextBundle } from '../../src/context-assembly/types.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HELPERS
+// ═══════════════════════════════════════════════════════════════════════════
+
+function makeFakeDeps(overrides: Partial<ContextAssemblerDeps> = {}): ContextAssemblerDeps {
+  return {
+    execGit: async (_args, _cwd) => ({ kind: 'ok', value: 'src/foo.ts | 5 ++\n1 file changed' }),
+    execGh: async (_args, _cwd) => ({ kind: 'err', error: 'gh not available' }),
+    listRecentSessions: async (_workspacePath, _limit) => ({ kind: 'ok', value: [] }),
+    nowIso: () => '2026-04-19T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const prReviewTask: AssemblyTask = {
+  kind: 'pr_review',
+  prNumber: 42,
+  workspacePath: '/workspace/my-repo',
+};
+
+const sampleNote: SessionNote = {
+  sessionId: 'ses_abc123def456',
+  recapSnippet: 'Fixed the login bug and updated tests.',
+  sessionTitle: 'Fix login regression',
+  gitBranch: 'fix/login-regression',
+  lastModifiedMs: 1713456789000,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('createContextAssembler', () => {
+  describe('assemble()', () => {
+    it('returns bundle with ok results when both sources succeed', async () => {
+      const deps = makeFakeDeps({
+        execGh: async () => ({ kind: 'ok', value: 'src/auth.ts\nsrc/login.tsx' }),
+        listRecentSessions: async () => ({ kind: 'ok', value: [sampleNote] }),
+      });
+      const assembler = createContextAssembler(deps);
+
+      const bundle = await assembler.assemble(prReviewTask);
+
+      expect(bundle.gitDiff.kind).toBe('ok');
+      expect(bundle.priorSessionNotes.kind).toBe('ok');
+      expect(bundle.assembledAt).toBe('2026-04-19T00:00:00.000Z');
+      expect(bundle.task).toEqual(prReviewTask);
+    });
+
+    it('returns priorNotes ok when gitSummary fails (partial failure)', async () => {
+      const deps = makeFakeDeps({
+        execGit: async () => ({ kind: 'err', error: 'detached HEAD' }),
+        execGh: async () => ({ kind: 'err', error: 'gh not found' }),
+        listRecentSessions: async () => ({ kind: 'ok', value: [sampleNote] }),
+      });
+      const assembler = createContextAssembler(deps);
+
+      const bundle = await assembler.assemble(prReviewTask);
+
+      expect(bundle.gitDiff.kind).toBe('err');
+      expect(bundle.priorSessionNotes.kind).toBe('ok');
+      if (bundle.priorSessionNotes.kind === 'ok') {
+        expect(bundle.priorSessionNotes.value).toHaveLength(1);
+      }
+    });
+
+    it('falls back to git diff when gh pr diff fails', async () => {
+      const deps = makeFakeDeps({
+        execGh: async () => ({ kind: 'err', error: 'gh not installed' }),
+        execGit: async (_args, _cwd) => ({ kind: 'ok', value: 'src/bar.ts | 3 ++\n1 file changed' }),
+      });
+      const assembler = createContextAssembler(deps);
+
+      const bundle = await assembler.assemble(prReviewTask);
+
+      expect(bundle.gitDiff.kind).toBe('ok');
+      if (bundle.gitDiff.kind === 'ok') {
+        expect(bundle.gitDiff.value).toContain('src/bar.ts');
+      }
+    });
+  });
+});
+
+describe('renderContextBundle', () => {
+  it('produces correct markdown sections when both sources succeed', () => {
+    const bundle: ContextBundle = {
+      task: prReviewTask,
+      gitDiff: { kind: 'ok', value: 'src/auth.ts | 5 ++\n1 file changed' },
+      priorSessionNotes: { kind: 'ok', value: [sampleNote] },
+      assembledAt: '2026-04-19T00:00:00.000Z',
+    };
+
+    const rendered = renderContextBundle(bundle);
+
+    expect(rendered).toContain('### Recent session notes for this workspace');
+    expect(rendered).toContain('Fix login regression');
+    expect(rendered).toContain('branch: fix/login-regression');
+    expect(rendered).toContain('Fixed the login bug and updated tests.');
+    expect(rendered).toContain('### Changed files');
+    expect(rendered).toContain('```');
+    expect(rendered).toContain('src/auth.ts | 5 ++');
+  });
+
+  it('returns empty string when both sources fail (nothing to inject)', () => {
+    const bundle: ContextBundle = {
+      task: prReviewTask,
+      gitDiff: { kind: 'err', error: 'git failed' },
+      priorSessionNotes: { kind: 'err', error: 'sessions failed' },
+      assembledAt: '2026-04-19T00:00:00.000Z',
+    };
+
+    const rendered = renderContextBundle(bundle);
+
+    expect(rendered).toBe('');
+  });
+
+  it('omits prior notes section when no sessions exist', () => {
+    const bundle: ContextBundle = {
+      task: prReviewTask,
+      gitDiff: { kind: 'ok', value: 'src/foo.ts | 2 +\n1 file changed' },
+      priorSessionNotes: { kind: 'ok', value: [] },
+      assembledAt: '2026-04-19T00:00:00.000Z',
+    };
+
+    const rendered = renderContextBundle(bundle);
+
+    expect(rendered).not.toContain('Recent session notes');
+    expect(rendered).toContain('### Changed files');
+  });
+
+  it('uses sessionId prefix as title when sessionTitle is null', () => {
+    const noteWithoutTitle: SessionNote = {
+      sessionId: 'ses_xyz987654321',
+      recapSnippet: 'Some work was done.',
+      sessionTitle: null,
+      gitBranch: null,
+      lastModifiedMs: 1713456789000,
+    };
+
+    const bundle: ContextBundle = {
+      task: prReviewTask,
+      gitDiff: { kind: 'err', error: 'git failed' },
+      priorSessionNotes: { kind: 'ok', value: [noteWithoutTitle] },
+      assembledAt: '2026-04-19T00:00:00.000Z',
+    };
+
+    const rendered = renderContextBundle(bundle);
+
+    // Should use first 12 chars of sessionId as fallback title
+    expect(rendered).toContain('ses_xyz98765');
+  });
+});

--- a/tests/unit/workflow-runner-system-prompt.test.ts
+++ b/tests/unit/workflow-runner-system-prompt.test.ts
@@ -189,4 +189,49 @@ describe('buildSystemPrompt()', () => {
       expect(contextIdx).toBeLessThan(refsIdx);
     });
   });
+
+  describe('prior context injection (F1)', () => {
+    it('injects ## Prior Context section when assembledContextSummary is a non-empty string', () => {
+      const trigger: WorkflowTrigger = {
+        ...baseTrigger,
+        context: { assembledContextSummary: 'prior-context-marker' },
+      };
+      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, null);
+
+      expect(prompt).toContain('## Prior Context');
+      expect(prompt).toContain('prior-context-marker');
+    });
+
+    it('## Prior Context appears before ## Reference documents', () => {
+      const trigger: WorkflowTrigger = {
+        ...baseTrigger,
+        context: { assembledContextSummary: 'prior-context-marker' },
+        referenceUrls: ['https://example.com/spec.md'],
+      };
+      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, null);
+
+      const priorCtxIdx = prompt.indexOf('## Prior Context');
+      const refsIdx = prompt.indexOf('## Reference documents');
+
+      expect(priorCtxIdx).toBeGreaterThan(-1);
+      expect(refsIdx).toBeGreaterThan(-1);
+      expect(priorCtxIdx).toBeLessThan(refsIdx);
+    });
+
+    it('omits ## Prior Context when assembledContextSummary is absent', () => {
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null);
+
+      expect(prompt).not.toContain('## Prior Context');
+    });
+
+    it('omits ## Prior Context when assembledContextSummary is not a string (type guard)', () => {
+      const trigger: WorkflowTrigger = {
+        ...baseTrigger,
+        context: { assembledContextSummary: 42 },
+      };
+      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, null);
+
+      expect(prompt).not.toContain('## Prior Context');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Introduces `src/context-assembly/` (4 files: `types.ts`, `deps.ts`, `index.ts`, `infra.ts`) that assembles a context bundle before each PR review session spawn
- The bundle includes git diff summary (`gh pr diff --name-only` with `git diff HEAD~1 --stat` fallback) and prior session notes (newest 3, from `LocalSessionSummaryProviderV2`)
- Rendered context is injected into `trigger.context['assembledContextSummary']` and surfaces in the system prompt as a `## Prior Context` section before the agent's first turn
- Partial failure: each source fails independently via `Result<T,E>`; session always starts even if both sources fail

## Files changed

- `src/context-assembly/types.ts` -- `AssemblyTask`, `SessionNote`, `ContextBundle`, `ContextAssembler` interface
- `src/context-assembly/deps.ts` -- `ContextAssemblerDeps` interface (all I/O injected)
- `src/context-assembly/index.ts` -- `createContextAssembler()` factory + pure `renderContextBundle()`
- `src/context-assembly/infra.ts` -- real `createListRecentSessions()` adapter over `LocalSessionSummaryProviderV2`
- `src/coordinators/pr-review.ts` -- adds optional `contextAssembler?` to `CoordinatorDeps`, extends `spawnSession` with optional 4th `context?` arg, assembles context before each review spawn
- `src/daemon/workflow-runner.ts` -- `buildSystemPrompt()` injects `## Prior Context` section before `referenceUrls`
- `src/cli-worktrain.ts` -- wires `contextAssembler` with real `execGit`/`execGh`/`listRecentSessions` deps

## Test plan

- [x] `npm run build` -- compiles clean
- [x] `npx vitest run tests/unit/context-assembly.test.ts` -- 7 tests pass
- [x] `npx vitest run` -- full suite passes (347 files, 5037 tests, 0 failures)
- [ ] Manual validation: run a pr-review session and verify agent references prior context in its first-turn notes (O1 validation gate from pitch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)