### PR TITLE
feat(trigger): GitHub issue queue poll trigger with maturity inference and idempotency

### DIFF
--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -3289,6 +3289,10 @@ export async function runWorkflow(
     const limitDescription = timeoutReason === 'wall_clock'
       ? `${trigger.agentConfig?.maxSessionMinutes ?? DEFAULT_SESSION_TIMEOUT_MINUTES} minutes`
       : `${trigger.agentConfig?.maxTurns ?? DEFAULT_MAX_TURNS} turns`;
+    // Clean up session file on timeout -- same pattern as success path.
+    // WHY: a timed-out session is no longer in-flight. Leaving the file causes
+    // countActiveSessions() to permanently inflate until daemon restart.
+    await fs.unlink(path.join(DAEMON_SESSIONS_DIR, `${sessionId}.json`)).catch(() => {});
     return {
       _tag: 'timeout',
       workflowId: trigger.workflowId,
@@ -3318,6 +3322,10 @@ export async function runWorkflow(
       ...(lastToolCalled !== null && { lastToolCalled }),
       ...(issueSummaries.length > 0 && { issueSummaries }),
     })}`;
+    // Clean up session file on error -- same pattern as success path.
+    // WHY: an errored session is no longer in-flight. Leaving the file causes
+    // countActiveSessions() to permanently inflate until daemon restart.
+    await fs.unlink(path.join(DAEMON_SESSIONS_DIR, `${sessionId}.json`)).catch(() => {});
     return {
       _tag: 'error',
       workflowId: trigger.workflowId,

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -290,6 +290,25 @@ export interface WorkflowTrigger {
    * Kept here so workflow-runner.ts remains decoupled from trigger system types.
    */
   readonly soulFile?: string;
+
+  /**
+   * Optional bot identity for git commit attribution in autonomous sessions.
+   * Set by queue-poll dispatch (polling-scheduler.ts doPollGitHubQueue).
+   *
+   * When present, workflow-runner.ts runs:
+   *   git -C <workspacePath> config user.name <name>
+   *   git -C <workspacePath> config user.email <email>
+   * after session initialization, before the agent loop begins.
+   *
+   * WHY deterministic (not delegated to LLM): git attribution is infra, not agent work.
+   * WHY non-fatal: if git config fails, session continues with default git config.
+   *
+   * Default: undefined (no identity override).
+   */
+  readonly botIdentity?: {
+    readonly name: string;
+    readonly email: string;
+  };
 }
 
 /** Successful completion of a workflow run. */
@@ -2843,6 +2862,26 @@ export async function runWorkflow(
   // this point and the first continue_workflow call leaves a recoverable state file.
   if (startContinueToken) {
     await persistTokens(sessionId, startContinueToken, startCheckpointToken);
+  }
+
+  // Bot identity: if trigger.botIdentity is set, configure git user.name/email on the
+  // workspace so commits from autonomous sessions use the bot account rather than the
+  // operator's personal git identity. Non-fatal: failure logs a warning and continues.
+  if (trigger.botIdentity) {
+    try {
+      await execFileAsync('git', ['-C', trigger.workspacePath, 'config', 'user.name', trigger.botIdentity.name]);
+      await execFileAsync('git', ['-C', trigger.workspacePath, 'config', 'user.email', trigger.botIdentity.email]);
+      console.log(
+        `[WorkflowRunner] Bot identity set: sessionId=${sessionId} ` +
+        `name=${trigger.botIdentity.name} email=${trigger.botIdentity.email}`,
+      );
+    } catch (identityErr) {
+      console.warn(
+        `[WorkflowRunner] WARNING: Failed to set bot identity for sessionId=${sessionId}: ` +
+        `${identityErr instanceof Error ? identityErr.message : String(identityErr)}. ` +
+        `Commits will use default git config.`,
+      );
+    }
   }
 
   // Edge case: workflow completes immediately on start (single-step workflow with

--- a/src/trigger/adapters/github-queue-poller.ts
+++ b/src/trigger/adapters/github-queue-poller.ts
@@ -18,9 +18,10 @@
  *
  * Maturity inference (3 deterministic heuristics -- SCOPE LOCK, no LLM):
  * - H1 (ready): body contains upstream_spec: line with http/https URL, OR a http/https
- *   URL in the first paragraph
- * - H2 (specced): body contains `- [ ]` checklist items OR heading matching
- *   /acceptance criteria|test plan|implementation checklist/i OR `### Implementation`
+ *   URL with a spec-implying path segment (/pitch|prd|spec|brd|rfc|design/) in the first
+ *   paragraph (plain issue/PR URLs do NOT trigger ready)
+ * - H2 (specced): body contains `- [ ]` checklist items OR an exact heading line of
+ *   `## Acceptance Criteria` or `## Implementation Plan` (case-insensitive)
  * - Default: 'idea'
  * Note: H3 (active/skip) is applied in polling-scheduler.ts before calling inferMaturity().
  *
@@ -213,10 +214,12 @@ export async function pollGitHubQueueIssues(
  * Infer the maturity of an issue from its body.
  *
  * Heuristics (applied in order, first match wins):
- * H1 (ready): body has upstream_spec: line with http/https URL, OR any http/https URL
- *   in the first paragraph
- * H2 (specced): body has `- [ ]` checklist items, OR heading matching
- *   /acceptance criteria|test plan|implementation checklist/i, OR `### Implementation`
+ * H1 (ready): body has upstream_spec: line with http/https URL, OR a http/https URL
+ *   containing a spec-implying path segment (/pitch|prd|spec|brd|rfc|design/) in the
+ *   first paragraph. WHY path segment: avoids plain issue/PR URLs triggering 'ready'.
+ * H2 (specced): body has `- [ ]` checklist items, OR an exact heading line matching
+ *   `## Acceptance Criteria` or `## Implementation Plan` (any level, case-insensitive).
+ *   WHY exact: loose match on 'implementation' catches non-spec sentences.
  * Default: 'idea'
  *
  * Note: H3 (active/in-progress exclusion) is NOT a maturity level -- it is applied
@@ -225,16 +228,21 @@ export async function pollGitHubQueueIssues(
  * SCOPE LOCK: exactly 3 heuristics (H1, H2, default). Do not add more without a new pitch.
  */
 export function inferMaturity(body: string): 'idea' | 'specced' | 'ready' {
-  // H1: ready -- upstream_spec: line with URL, OR http/https URL in first paragraph
+  // H1: ready -- upstream_spec: line with http/https URL (any URL), OR http/https URL
+  // with a spec-implying path segment in the first paragraph.
+  // WHY path segment requirement on first-para: prevents plain GitHub issue links,
+  // PR links, and other non-spec URLs from falsely triggering 'ready'.
   const specLineMatch = /upstream_spec:\s*(https?:\/\/\S+)/i.exec(body);
   if (specLineMatch) return 'ready';
 
   const firstPara = body.split(/\n\s*\n/)[0] ?? '';
-  if (/(https?:\/\/\S+)/.test(firstPara)) return 'ready';
+  if (/https?:\/\/\S*\/(?:pitch|prd|spec|brd|rfc|design)\b/i.test(firstPara)) return 'ready';
 
-  // H2: specced -- checklist items OR acceptance criteria heading OR ### Implementation
+  // H2: specced -- checklist items OR exact headings (Acceptance Criteria / Implementation Plan)
+  // WHY exact headings: loose matching on 'implementation' would catch sentences like
+  // "implementation details are TBD" and falsely elevate issues to 'specced'.
   if (/- \[ \]/.test(body)) return 'specced';
-  if (/#{1,6}\s*(acceptance criteria|test plan|implementation checklist|implementation)/i.test(body)) return 'specced';
+  if (/^#{1,6}\s*(Acceptance Criteria|Implementation Plan)\s*$/im.test(body)) return 'specced';
 
   // Default: idea
   return 'idea';
@@ -253,12 +261,19 @@ export function inferMaturity(body: string): 'idea' | 'specced' | 'ready' {
  *   - Parse the file as JSON
  *   - Check if context.taskCandidate.issueNumber === issueNumber
  *   - If match: return 'active'
- *   - On ANY error (ENOENT, parse, missing field): return 'active' (conservative)
+ *   - If file has no context or no taskCandidate: return 'clear'
+ *     WHY: real session files written by persistTokens() contain only
+ *     { continueToken, checkpointToken, ts } -- no context field. A file
+ *     without taskCandidate cannot claim ownership of any issue.
+ *   - On any read/parse error: return 'active' (conservative)
+ *     WHY: if we cannot read the file we cannot trust its content is safe.
+ *     Double-dispatch is worse than a missed dispatch.
  *
- * Returns 'clear' only if no session file claims this issue number.
+ * Returns 'clear' if no session file explicitly claims this issue number.
  *
- * INVARIANT: Conservative default -- any error = 'active', not 'clear'.
- * Double-dispatch is worse than missed dispatch.
+ * INVARIANT: 'active' ONLY when (a) the file is unreadable/unparseable, OR
+ * (b) context.taskCandidate.issueNumber === issueNumber.
+ * 'clear' when the file exists but has no context/taskCandidate field.
  *
  * @param issueNumber - The GitHub issue number to check
  * @param sessionsDir - Path to daemon-sessions directory (injectable for testing)
@@ -278,29 +293,29 @@ export async function checkIdempotency(
   const jsonFiles = files.filter(f => f.endsWith('.json'));
 
   for (const filename of jsonFiles) {
-    // Outer try/catch: conservative default -- any error for this file = treat as active
     try {
       const content = await fs.readFile(path.join(sessionsDir, filename), 'utf8');
       const parsed: unknown = JSON.parse(content);
 
       if (typeof parsed !== 'object' || parsed === null) {
-        // Malformed session file -- treat as active (conservative)
+        // Malformed session file -- cannot trust it, conservative default: treat as active
         return 'active';
       }
 
       const session = parsed as Record<string, unknown>;
       const context = session['context'];
       if (typeof context !== 'object' || context === null) {
-        // No context -- can't determine if this session owns the issue
-        // Conservative default: treat as active
-        return 'active';
+        // No context field -- this is a normal persistTokens() session file that does not
+        // own any issue. Cannot block dispatch. Return 'clear' for this file.
+        continue;
       }
 
       const ctx = context as Record<string, unknown>;
       const taskCandidate = ctx['taskCandidate'];
       if (typeof taskCandidate !== 'object' || taskCandidate === null) {
-        // No taskCandidate in context -- conservative default: treat as active
-        return 'active';
+        // Context exists but no taskCandidate -- not a queue-originated session.
+        // Cannot claim issue ownership. Return 'clear' for this file.
+        continue;
       }
 
       const tc = taskCandidate as Record<string, unknown>;
@@ -309,6 +324,7 @@ export async function checkIdempotency(
       }
     } catch {
       // Any read/parse error -- conservative default: treat as active
+      // WHY: we cannot determine whether this file owns the issue.
       return 'active';
     }
   }

--- a/src/trigger/adapters/github-queue-poller.ts
+++ b/src/trigger/adapters/github-queue-poller.ts
@@ -1,0 +1,360 @@
+/**
+ * WorkRail Auto: GitHub Queue Issues Adapter
+ *
+ * Fetches open GitHub issues for the queue poller. Unlike github-poller.ts (which
+ * fetches issues updated since a timestamp for deduplication), this adapter fetches
+ * ALL open issues matching the queue config filter (e.g. assigned to a user).
+ *
+ * API used:
+ *   GET /repos/:owner/:repo/issues?state=open&assignee=<user>&per_page=100
+ *   Header: Authorization: Bearer <token>
+ *
+ * Design notes:
+ * - fetchFn is injectable for testing without real HTTP. Defaults to globalThis.fetch.
+ * - Returns Result<GitHubQueueIssue[], GitHubQueuePollError> -- no throws at boundary.
+ * - Rate limit: if X-RateLimit-Remaining < 100, returns ok([]) and logs warning.
+ * - On any HTTP error (non-2xx), returns err(). Caller skips the cycle.
+ * - Pagination: only first page (per_page=100). Per pitch: accepted limitation.
+ *
+ * Maturity inference (3 deterministic heuristics -- SCOPE LOCK, no LLM):
+ * - H1 (ready): body contains upstream_spec: line with http/https URL, OR a http/https
+ *   URL in the first paragraph
+ * - H2 (specced): body contains `- [ ]` checklist items OR heading matching
+ *   /acceptance criteria|test plan|implementation checklist/i OR `### Implementation`
+ * - Default: 'idea'
+ * Note: H3 (active/skip) is applied in polling-scheduler.ts before calling inferMaturity().
+ *
+ * Idempotency check:
+ * - Scans sessionsDir (default: ~/.workrail/daemon-sessions/) for JSON files
+ * - For each file: parse context.taskCandidate.issueNumber
+ * - If matching issueNumber found: return 'active'
+ * - On ANY error (ENOENT, parse error, missing field): return 'active' (conservative default)
+ * - WHY conservative: double-dispatch is worse than missed dispatch
+ */
+
+import type { GitHubQueuePollingSource } from '../types.js';
+import type { GitHubQueueConfig } from '../github-queue-config.js';
+import type { Result } from '../../runtime/result.js';
+import { ok, err } from '../../runtime/result.js';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Label shape from GitHub API */
+export interface GitHubQueueLabel {
+  readonly name: string;
+}
+
+/**
+ * A GitHub Issue as returned by the queue issues list API.
+ * Contains only the fields needed by the queue poller.
+ */
+export interface GitHubQueueIssue {
+  /** Globally unique issue ID (across all repos). */
+  readonly id: number;
+  /** Repository-scoped issue number (the #123 number). */
+  readonly number: number;
+  readonly title: string;
+  readonly body: string;
+  readonly url: string;
+  readonly labels: readonly GitHubQueueLabel[];
+  readonly createdAt: string;
+}
+
+export type GitHubQueuePollError =
+  | { readonly kind: 'http_error'; readonly status: number; readonly message: string }
+  | { readonly kind: 'network_error'; readonly message: string }
+  | { readonly kind: 'parse_error'; readonly message: string }
+  | { readonly kind: 'not_implemented'; readonly message: string };
+
+/**
+ * Injectable fetch function type. Matches the global fetch signature.
+ * Default: globalThis.fetch (Node 18+).
+ */
+export type FetchFn = (url: string, init: RequestInit) => Promise<Response>;
+
+// ---------------------------------------------------------------------------
+// Default sessions directory
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_SESSIONS_DIR = path.join(os.homedir(), '.workrail', 'daemon-sessions');
+
+// ---------------------------------------------------------------------------
+// Rate limit check (same pattern as github-poller.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check the GitHub API rate limit headers on a successful response.
+ * Returns true if healthy (>= 100 remaining).
+ * Returns false and logs a warning if remaining < 100.
+ */
+function checkRateLimit(response: Response): boolean {
+  const remainingHeader = response.headers.get('X-RateLimit-Remaining');
+  const resetHeader = response.headers.get('X-RateLimit-Reset');
+  if (remainingHeader === null) return true;
+
+  const remaining = parseInt(remainingHeader, 10);
+  if (isNaN(remaining) || remaining >= 100) return true;
+
+  const resetTs = parseInt(resetHeader ?? '0', 10);
+  const resetAt = resetTs > 0 ? new Date(resetTs * 1000).toISOString() : 'unknown';
+  console.warn(
+    `[GitHubQueuePoller] Rate limit low: remaining=${remaining}, resets at ${resetAt}. ` +
+    `Skipping poll cycle to avoid exhaustion.`,
+  );
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// pollGitHubQueueIssues: fetch open issues matching the queue config filter
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch open GitHub issues matching the queue config filter.
+ *
+ * For type === 'assignee': fetches issues with assignee=<config.user>.
+ * For other types: returns err({ kind: 'not_implemented' }) -- caller skips cycle.
+ *
+ * @param source - Queue polling source configuration (repo, token, pollInterval)
+ * @param config - Queue filter configuration loaded from ~/.workrail/config.json
+ * @param fetchFn - Optional injectable fetch function (default: globalThis.fetch)
+ * @returns Result<GitHubQueueIssue[], GitHubQueuePollError>
+ */
+export async function pollGitHubQueueIssues(
+  source: GitHubQueuePollingSource,
+  config: GitHubQueueConfig,
+  fetchFn: FetchFn = globalThis.fetch,
+): Promise<Result<GitHubQueueIssue[], GitHubQueuePollError>> {
+  // Only 'assignee' type is implemented -- other types throw not_implemented at runtime
+  if (config.type !== 'assignee') {
+    return err({
+      kind: 'not_implemented',
+      message: `Queue type '${config.type}' is not implemented. Only 'assignee' is supported.`,
+    });
+  }
+
+  const [owner, repo] = source.repo.split('/');
+  const url = new URL(`https://api.github.com/repos/${owner}/${repo}/issues`);
+  url.searchParams.set('state', 'open');
+  url.searchParams.set('per_page', '100');
+
+  // Apply assignee filter
+  if (config.user) {
+    url.searchParams.set('assignee', config.user);
+  }
+
+  let response: Response;
+  try {
+    response = await fetchFn(url.toString(), {
+      headers: {
+        'Authorization': `Bearer ${source.token}`,
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+  } catch (e) {
+    return err({
+      kind: 'network_error',
+      message: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  if (!response.ok) {
+    return err({
+      kind: 'http_error',
+      status: response.status,
+      message: `GitHub API returned HTTP ${response.status}: ${response.statusText}`,
+    });
+  }
+
+  if (!checkRateLimit(response)) {
+    return ok([]);
+  }
+
+  let raw: unknown;
+  try {
+    raw = await response.json();
+  } catch (e) {
+    return err({
+      kind: 'parse_error',
+      message: `Failed to parse GitHub Issues API response: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  if (!Array.isArray(raw)) {
+    return err({
+      kind: 'parse_error',
+      message: `Expected array from GitHub Issues API, got: ${typeof raw}`,
+    });
+  }
+
+  const issues: GitHubQueueIssue[] = [];
+  for (const item of raw) {
+    const shaped = toGitHubQueueIssue(item);
+    if (shaped !== null) {
+      issues.push(shaped);
+    }
+  }
+
+  return ok(issues);
+}
+
+// ---------------------------------------------------------------------------
+// inferMaturity: 3 deterministic heuristics (SCOPE LOCK -- do not add a 4th)
+//
+// SCOPE LOCK: exactly 3 heuristics. Adding a 4th requires a new pitch.
+// ---------------------------------------------------------------------------
+
+/**
+ * Infer the maturity of an issue from its body.
+ *
+ * Heuristics (applied in order, first match wins):
+ * H1 (ready): body has upstream_spec: line with http/https URL, OR any http/https URL
+ *   in the first paragraph
+ * H2 (specced): body has `- [ ]` checklist items, OR heading matching
+ *   /acceptance criteria|test plan|implementation checklist/i, OR `### Implementation`
+ * Default: 'idea'
+ *
+ * Note: H3 (active/in-progress exclusion) is NOT a maturity level -- it is applied
+ * as an exclusion BEFORE inferMaturity() is called (in polling-scheduler.ts).
+ *
+ * SCOPE LOCK: exactly 3 heuristics (H1, H2, default). Do not add more without a new pitch.
+ */
+export function inferMaturity(body: string): 'idea' | 'specced' | 'ready' {
+  // H1: ready -- upstream_spec: line with URL, OR http/https URL in first paragraph
+  const specLineMatch = /upstream_spec:\s*(https?:\/\/\S+)/i.exec(body);
+  if (specLineMatch) return 'ready';
+
+  const firstPara = body.split(/\n\s*\n/)[0] ?? '';
+  if (/(https?:\/\/\S+)/.test(firstPara)) return 'ready';
+
+  // H2: specced -- checklist items OR acceptance criteria heading OR ### Implementation
+  if (/- \[ \]/.test(body)) return 'specced';
+  if (/#{1,6}\s*(acceptance criteria|test plan|implementation checklist|implementation)/i.test(body)) return 'specced';
+
+  // Default: idea
+  return 'idea';
+}
+
+// ---------------------------------------------------------------------------
+// checkIdempotency: per-issue idempotency check via session file scan
+//
+// Conservative default: any parse error -> 'active' (never dispatch on uncertainty)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if an issue already has an active session.
+ *
+ * Scans all JSON files in sessionsDir. For each file:
+ *   - Parse the file as JSON
+ *   - Check if context.taskCandidate.issueNumber === issueNumber
+ *   - If match: return 'active'
+ *   - On ANY error (ENOENT, parse, missing field): return 'active' (conservative)
+ *
+ * Returns 'clear' only if no session file claims this issue number.
+ *
+ * INVARIANT: Conservative default -- any error = 'active', not 'clear'.
+ * Double-dispatch is worse than missed dispatch.
+ *
+ * @param issueNumber - The GitHub issue number to check
+ * @param sessionsDir - Path to daemon-sessions directory (injectable for testing)
+ */
+export async function checkIdempotency(
+  issueNumber: number,
+  sessionsDir: string = DEFAULT_SESSIONS_DIR,
+): Promise<'clear' | 'active'> {
+  let files: string[];
+  try {
+    files = await fs.readdir(sessionsDir);
+  } catch {
+    // Sessions dir absent or unreadable -- no active sessions
+    return 'clear';
+  }
+
+  const jsonFiles = files.filter(f => f.endsWith('.json'));
+
+  for (const filename of jsonFiles) {
+    // Outer try/catch: conservative default -- any error for this file = treat as active
+    try {
+      const content = await fs.readFile(path.join(sessionsDir, filename), 'utf8');
+      const parsed: unknown = JSON.parse(content);
+
+      if (typeof parsed !== 'object' || parsed === null) {
+        // Malformed session file -- treat as active (conservative)
+        return 'active';
+      }
+
+      const session = parsed as Record<string, unknown>;
+      const context = session['context'];
+      if (typeof context !== 'object' || context === null) {
+        // No context -- can't determine if this session owns the issue
+        // Conservative default: treat as active
+        return 'active';
+      }
+
+      const ctx = context as Record<string, unknown>;
+      const taskCandidate = ctx['taskCandidate'];
+      if (typeof taskCandidate !== 'object' || taskCandidate === null) {
+        // No taskCandidate in context -- conservative default: treat as active
+        return 'active';
+      }
+
+      const tc = taskCandidate as Record<string, unknown>;
+      if (tc['issueNumber'] === issueNumber) {
+        return 'active';
+      }
+    } catch {
+      // Any read/parse error -- conservative default: treat as active
+      return 'active';
+    }
+  }
+
+  return 'clear';
+}
+
+// ---------------------------------------------------------------------------
+// Type guard / mapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a raw GitHub API issue object to GitHubQueueIssue.
+ * Returns null if the item does not have the required shape.
+ */
+function toGitHubQueueIssue(item: unknown): GitHubQueueIssue | null {
+  if (typeof item !== 'object' || item === null) return null;
+  const obj = item as Record<string, unknown>;
+
+  if (
+    typeof obj['id'] !== 'number' ||
+    typeof obj['number'] !== 'number' ||
+    typeof obj['title'] !== 'string' ||
+    typeof obj['html_url'] !== 'string'
+  ) {
+    return null;
+  }
+
+  // body can be null in GitHub API (no body set)
+  const body = typeof obj['body'] === 'string' ? obj['body'] : '';
+  const createdAt = typeof obj['created_at'] === 'string' ? obj['created_at'] : '';
+
+  // Labels: array of objects with name field
+  const rawLabels = Array.isArray(obj['labels']) ? obj['labels'] : [];
+  const labels: GitHubQueueLabel[] = rawLabels
+    .filter((l): l is Record<string, unknown> => typeof l === 'object' && l !== null)
+    .filter((l) => typeof l['name'] === 'string')
+    .map((l) => ({ name: l['name'] as string }));
+
+  return {
+    id: obj['id'] as number,
+    number: obj['number'] as number,
+    title: obj['title'] as string,
+    body,
+    url: obj['html_url'] as string,
+    labels,
+    createdAt,
+  };
+}

--- a/src/trigger/github-queue-config.ts
+++ b/src/trigger/github-queue-config.ts
@@ -1,0 +1,244 @@
+/**
+ * WorkRail Auto: GitHub Queue Configuration
+ *
+ * Loads and validates the `queue` key from ~/.workrail/config.json.
+ * Returns the parsed GitHubQueueConfig or null when no queue config is present.
+ *
+ * Design notes:
+ * - Returns Result<GitHubQueueConfig | null, string>:
+ *     null when config.json exists but has no `queue` key, OR when config.json is absent.
+ *     err when the `queue` key is present but malformed or missing required fields.
+ * - Token resolution: if token starts with '$', resolve from process.env.
+ *   Returns err if the env var is unset or empty.
+ * - The type field is validated against the allowed union values.
+ *   Only 'assignee' is implemented -- other types parse fine but throw not_implemented
+ *   at dispatch time in polling-scheduler.ts.
+ * - repo is required. pollIntervalSeconds, maxConcurrentSelf, excludeLabels are optional
+ *   with documented defaults.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { Result } from '../runtime/result.js';
+import { ok, err } from '../runtime/result.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Queue filter configuration from ~/.workrail/config.json `queue` key.
+ *
+ * Invariants:
+ * - token is already resolved from environment when returned from loadQueueConfig().
+ *   The raw config may contain a '$ENV_VAR' reference; loadQueueConfig() resolves it.
+ * - type === 'assignee' is the only implemented filter at runtime.
+ *   Other types are accepted by the type system but throw not_implemented at dispatch.
+ * - repo is in "owner/repo" format.
+ * - pollIntervalSeconds: default 300 if absent.
+ * - maxConcurrentSelf: default 1 if absent.
+ * - excludeLabels: default [] if absent.
+ */
+export interface GitHubQueueConfig {
+  /**
+   * Opt-in mechanism. MVP: only "assignee" is implemented.
+   * Other types are defined in the type but throw 'not_implemented' at runtime.
+   */
+  readonly type: 'assignee' | 'label' | 'mention' | 'query';
+  /** Required when type === 'assignee'. The GitHub login to poll for. */
+  readonly user?: string;
+  /** Required when type === 'label'. The label name to match. */
+  readonly name?: string;
+  /** Required when type === 'mention'. The handle (with @) to match. */
+  readonly handle?: string;
+  /** Required when type === 'query'. Free-form GitHub issue search query. */
+  readonly search?: string;
+  /**
+   * If true, process any open issue regardless of assignment/label filter.
+   * Default: false. Use with extreme care.
+   */
+  readonly workOnAll?: boolean;
+  /**
+   * Poll interval in seconds. Default: 300 (5 min).
+   */
+  readonly pollIntervalSeconds: number;
+  /**
+   * Maximum concurrent self-improvement sessions.
+   * Poller skips dispatch when active sessions >= this value.
+   * Default: 1.
+   */
+  readonly maxConcurrentSelf: number;
+  /**
+   * Issues with ANY of these labels are skipped by the poller.
+   * Default: [].
+   */
+  readonly excludeLabels: readonly string[];
+  /**
+   * GitHub repository in "owner/repo" format. Required.
+   */
+  readonly repo: string;
+  /**
+   * GitHub PAT for the bot account. Already resolved from env.
+   * Requires repo:read scope.
+   */
+  readonly token: string;
+}
+
+// ---------------------------------------------------------------------------
+// Default config path
+// ---------------------------------------------------------------------------
+
+export const WORKRAIL_CONFIG_PATH = path.join(os.homedir(), '.workrail', 'config.json');
+
+// ---------------------------------------------------------------------------
+// loadQueueConfig
+// ---------------------------------------------------------------------------
+
+/**
+ * Load and validate the `queue` key from ~/.workrail/config.json.
+ *
+ * Returns:
+ * - ok(null) when config.json does not exist or has no `queue` key
+ * - ok(GitHubQueueConfig) when the queue config is present and valid
+ * - err(string) when the queue key is present but invalid
+ *
+ * @param configPath - Injectable path to config.json (default: ~/.workrail/config.json)
+ * @param env - Injectable environment map for $SECRET resolution (default: process.env)
+ */
+export async function loadQueueConfig(
+  configPath: string = WORKRAIL_CONFIG_PATH,
+  env: Record<string, string | undefined> = process.env,
+): Promise<Result<GitHubQueueConfig | null, string>> {
+  // Read config.json
+  let raw: string;
+  try {
+    raw = await fs.readFile(configPath, 'utf8');
+  } catch (e) {
+    const error = e as NodeJS.ErrnoException;
+    if (error.code === 'ENOENT') {
+      // Config file absent -- no queue config
+      return ok(null);
+    }
+    return err(`Failed to read config file at ${configPath}: ${error.message ?? String(e)}`);
+  }
+
+  // Parse JSON
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    return err(`Failed to parse config JSON at ${configPath}: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return err(`Config at ${configPath} is not a JSON object`);
+  }
+
+  const config = parsed as Record<string, unknown>;
+
+  // No queue key -- null result
+  if (!('queue' in config)) {
+    return ok(null);
+  }
+
+  const queue = config['queue'];
+  if (typeof queue !== 'object' || queue === null) {
+    return err('config.queue is not an object');
+  }
+
+  const q = queue as Record<string, unknown>;
+
+  // Validate required fields
+  const rawType = q['type'];
+  if (typeof rawType !== 'string') {
+    return err('config.queue.type is required and must be a string');
+  }
+
+  const VALID_TYPES = new Set<string>(['assignee', 'label', 'mention', 'query']);
+  if (!VALID_TYPES.has(rawType)) {
+    return err(`config.queue.type must be one of: assignee, label, mention, query. Got: "${rawType}"`);
+  }
+
+  const rawRepo = q['repo'];
+  if (typeof rawRepo !== 'string' || !rawRepo.trim()) {
+    return err('config.queue.repo is required and must be a non-empty string');
+  }
+
+  const rawToken = q['token'];
+  if (typeof rawToken !== 'string' || !rawToken.trim()) {
+    return err('config.queue.token is required and must be a non-empty string');
+  }
+
+  // Resolve token from env if it starts with '$'
+  let resolvedToken: string;
+  if (rawToken.startsWith('$')) {
+    const envVarName = rawToken.slice(1);
+    const envValue = env[envVarName];
+    if (!envValue) {
+      return err(`config.queue.token references env var $${envVarName} which is unset or empty`);
+    }
+    resolvedToken = envValue;
+  } else {
+    resolvedToken = rawToken.trim();
+  }
+
+  // Optional numeric fields
+  const rawPollInterval = q['pollIntervalSeconds'];
+  let pollIntervalSeconds = 300;
+  if (rawPollInterval !== undefined) {
+    if (typeof rawPollInterval !== 'number' || !Number.isInteger(rawPollInterval) || rawPollInterval <= 0) {
+      return err('config.queue.pollIntervalSeconds must be a positive integer');
+    }
+    pollIntervalSeconds = rawPollInterval;
+  }
+
+  const rawMaxConcurrent = q['maxConcurrentSelf'];
+  let maxConcurrentSelf = 1;
+  if (rawMaxConcurrent !== undefined) {
+    if (typeof rawMaxConcurrent !== 'number' || !Number.isInteger(rawMaxConcurrent) || rawMaxConcurrent <= 0) {
+      return err('config.queue.maxConcurrentSelf must be a positive integer');
+    }
+    maxConcurrentSelf = rawMaxConcurrent;
+  }
+
+  // Optional array fields
+  const rawExcludeLabels = q['excludeLabels'];
+  let excludeLabels: readonly string[] = [];
+  if (rawExcludeLabels !== undefined) {
+    if (!Array.isArray(rawExcludeLabels) || !rawExcludeLabels.every(l => typeof l === 'string')) {
+      return err('config.queue.excludeLabels must be an array of strings');
+    }
+    excludeLabels = rawExcludeLabels as string[];
+  }
+
+  // Optional string fields
+  const rawUser = q['user'];
+  const user = typeof rawUser === 'string' && rawUser.trim() ? rawUser.trim() : undefined;
+
+  const rawName = q['name'];
+  const labelName = typeof rawName === 'string' && rawName.trim() ? rawName.trim() : undefined;
+
+  const rawHandle = q['handle'];
+  const handle = typeof rawHandle === 'string' && rawHandle.trim() ? rawHandle.trim() : undefined;
+
+  const rawSearch = q['search'];
+  const search = typeof rawSearch === 'string' && rawSearch.trim() ? rawSearch.trim() : undefined;
+
+  const rawWorkOnAll = q['workOnAll'];
+  const workOnAll = rawWorkOnAll === true;
+
+  return ok({
+    type: rawType as 'assignee' | 'label' | 'mention' | 'query',
+    ...(user !== undefined ? { user } : {}),
+    ...(labelName !== undefined ? { name: labelName } : {}),
+    ...(handle !== undefined ? { handle } : {}),
+    ...(search !== undefined ? { search } : {}),
+    ...(workOnAll ? { workOnAll } : {}),
+    pollIntervalSeconds,
+    maxConcurrentSelf,
+    excludeLabels,
+    repo: rawRepo.trim(),
+    token: resolvedToken,
+  });
+}

--- a/src/trigger/github-queue-config.ts
+++ b/src/trigger/github-queue-config.ts
@@ -13,7 +13,7 @@
  * - The type field is validated against the allowed union values.
  *   Only 'assignee' is implemented -- other types parse fine but throw not_implemented
  *   at dispatch time in polling-scheduler.ts.
- * - repo is required. pollIntervalSeconds, maxConcurrentSelf, excludeLabels are optional
+ * - repo is required. pollIntervalSeconds, maxTotalConcurrentSessions, excludeLabels are optional
  *   with documented defaults.
  */
 
@@ -37,7 +37,7 @@ import { ok, err } from '../runtime/result.js';
  *   Other types are accepted by the type system but throw not_implemented at dispatch.
  * - repo is in "owner/repo" format.
  * - pollIntervalSeconds: default 300 if absent.
- * - maxConcurrentSelf: default 1 if absent.
+ * - maxTotalConcurrentSessions: default 1 if absent.
  * - excludeLabels: default [] if absent.
  */
 export interface GitHubQueueConfig {
@@ -64,11 +64,11 @@ export interface GitHubQueueConfig {
    */
   readonly pollIntervalSeconds: number;
   /**
-   * Maximum concurrent self-improvement sessions.
+   * Maximum total concurrent sessions (across all triggers).
    * Poller skips dispatch when active sessions >= this value.
    * Default: 1.
    */
-  readonly maxConcurrentSelf: number;
+  readonly maxTotalConcurrentSessions: number;
   /**
    * Issues with ANY of these labels are skipped by the poller.
    * Default: [].
@@ -83,6 +83,16 @@ export interface GitHubQueueConfig {
    * Requires repo:read scope.
    */
   readonly token: string;
+  /**
+   * Display name for the bot account used when committing from queue sessions.
+   * Defaults to 'worktrain' when absent.
+   */
+  readonly botName?: string;
+  /**
+   * Email for the bot account used when committing from queue sessions.
+   * Defaults to 'worktrain@users.noreply.github.com' when absent.
+   */
+  readonly botEmail?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -193,13 +203,15 @@ export async function loadQueueConfig(
     pollIntervalSeconds = rawPollInterval;
   }
 
-  const rawMaxConcurrent = q['maxConcurrentSelf'];
-  let maxConcurrentSelf = 1;
+  // Support both old name (maxConcurrentSelf) and new name (maxTotalConcurrentSessions)
+  // for backward compatibility with existing config files.
+  const rawMaxConcurrent = q['maxTotalConcurrentSessions'] ?? q['maxConcurrentSelf'];
+  let maxTotalConcurrentSessions = 1;
   if (rawMaxConcurrent !== undefined) {
     if (typeof rawMaxConcurrent !== 'number' || !Number.isInteger(rawMaxConcurrent) || rawMaxConcurrent <= 0) {
-      return err('config.queue.maxConcurrentSelf must be a positive integer');
+      return err('config.queue.maxTotalConcurrentSessions must be a positive integer');
     }
-    maxConcurrentSelf = rawMaxConcurrent;
+    maxTotalConcurrentSessions = rawMaxConcurrent;
   }
 
   // Optional array fields
@@ -228,6 +240,12 @@ export async function loadQueueConfig(
   const rawWorkOnAll = q['workOnAll'];
   const workOnAll = rawWorkOnAll === true;
 
+  const rawBotName = q['botName'];
+  const botName = typeof rawBotName === 'string' && rawBotName.trim() ? rawBotName.trim() : undefined;
+
+  const rawBotEmail = q['botEmail'];
+  const botEmail = typeof rawBotEmail === 'string' && rawBotEmail.trim() ? rawBotEmail.trim() : undefined;
+
   return ok({
     type: rawType as 'assignee' | 'label' | 'mention' | 'query',
     ...(user !== undefined ? { user } : {}),
@@ -236,9 +254,11 @@ export async function loadQueueConfig(
     ...(search !== undefined ? { search } : {}),
     ...(workOnAll ? { workOnAll } : {}),
     pollIntervalSeconds,
-    maxConcurrentSelf,
+    maxTotalConcurrentSessions,
     excludeLabels,
     repo: rawRepo.trim(),
     token: resolvedToken,
+    ...(botName !== undefined ? { botName } : {}),
+    ...(botEmail !== undefined ? { botEmail } : {}),
   });
 }

--- a/src/trigger/polling-scheduler.ts
+++ b/src/trigger/polling-scheduler.ts
@@ -25,12 +25,17 @@
  *   These are available to goalTemplate interpolation and workflow context.
  */
 
-import type { TriggerDefinition, PollingSource, TriggerId } from './types.js';
+import type { TriggerDefinition, PollingSource, TriggerId, TaskCandidate } from './types.js';
 import type { TriggerRouter } from './trigger-router.js';
 import type { PolledEventStore } from './polled-event-store.js';
 import { pollGitLabMRs, type FetchFn, type GitLabMR } from './adapters/gitlab-poller.js';
 import { pollGitHubIssues, pollGitHubPRs, type GitHubIssue, type GitHubPR } from './adapters/github-poller.js';
+import { pollGitHubQueueIssues, inferMaturity, checkIdempotency, type GitHubQueueIssue, type FetchFn as QueueFetchFn } from './adapters/github-queue-poller.js';
+import { loadQueueConfig } from './github-queue-config.js';
 import type { WorkflowTrigger } from '../daemon/workflow-runner.js';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -211,6 +216,9 @@ export class PollingScheduler {
       case 'github_prs_poll':
         await this.doPollGitHub(trigger, triggerId, pollStartAt, lastPollAt, trigger.pollingSource, 'prs');
         break;
+      case 'github_queue_poll':
+        await this.doPollGitHubQueue(trigger, triggerId, trigger.pollingSource);
+        break;
       default: {
         // TypeScript exhaustiveness: if a new provider is added to the PollingSource union
         // without a case here, this line becomes unreachable and the compiler warns.
@@ -357,6 +365,142 @@ export class PollingScheduler {
       );
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // doPollGitHubQueue: one poll cycle for a github_queue_poll trigger
+  //
+  // Does NOT use PolledEventStore (queue-poll semantics differ from event-poll).
+  // At most one session dispatched per cycle.
+  // Cycle order is fixed and critical -- see implementation_plan.md.
+  // ---------------------------------------------------------------------------
+
+  private async doPollGitHubQueue(
+    trigger: PollingTriggerDefinition,
+    triggerId: TriggerId,
+    source: Extract<PollingSource, { readonly provider: 'github_queue_poll' }>,
+  ): Promise<void> {
+    const cycleStart = Date.now();
+
+    const configResult = await loadQueueConfig();
+    if (configResult.kind === 'err') {
+      console.warn(`[QueuePoll] Failed to load queue config for trigger '${triggerId}': ${configResult.error}. Skipping cycle.`);
+      return;
+    }
+
+    const queueConfig = configResult.value;
+    if (queueConfig === null) return;
+
+    if (queueConfig.type !== 'assignee') {
+      console.error(`[QueuePoll] Queue type '${queueConfig.type}' is not implemented. Only 'assignee' is supported. Skipping cycle.`);
+      await appendQueuePollLog({ event: 'poll_cycle_error', triggerId, reason: `not_implemented: queue type '${queueConfig.type}'`, ts: new Date().toISOString() });
+      return;
+    }
+
+    // Concurrency cap check BEFORE per-issue evaluation (INVARIANT per pitch)
+    const sessionsDir = path.join(os.homedir(), '.workrail', 'daemon-sessions');
+    const activeSessions = await countActiveSessions(sessionsDir);
+    if (activeSessions >= queueConfig.maxConcurrentSelf) {
+      console.log(`[QueuePoll] Skipping cycle: active sessions (${activeSessions}) >= maxConcurrentSelf (${queueConfig.maxConcurrentSelf}).`);
+      await appendQueuePollLog({ event: 'poll_cycle_skipped', triggerId, reason: 'max_concurrency_reached', activeSessions, maxConcurrentSelf: queueConfig.maxConcurrentSelf, ts: new Date().toISOString() });
+      return;
+    }
+
+    const fetchResult = await pollGitHubQueueIssues(source, queueConfig, this.fetchFn as QueueFetchFn | undefined);
+    if (fetchResult.kind === 'err') {
+      console.warn(`[QueuePoll] GitHub API error for trigger '${triggerId}': ${fetchResult.error.kind}. Skipping cycle.`);
+      return;
+    }
+
+    const issues = fetchResult.value;
+    console.log(`[QueuePoll] cycle start repo=${source.repo} issues_fetched=${issues.length}`);
+
+    type ScoredIssue = { issue: GitHubQueueIssue; maturity: 'idea' | 'specced' | 'ready' };
+    const candidates: ScoredIssue[] = [];
+    const skipped: Array<{ issue: GitHubQueueIssue; reason: string }> = [];
+
+    for (const issue of issues) {
+      const issueLabels = issue.labels.map((l) => l.name);
+
+      const excludedLabel = queueConfig.excludeLabels.find((el) => issueLabels.includes(el));
+      if (excludedLabel) { skipped.push({ issue, reason: `excluded_label: ${excludedLabel}` }); continue; }
+
+      // H3: worktrain:in-progress label (active/skip -- not a maturity level)
+      if (issueLabels.includes('worktrain:in-progress')) { skipped.push({ issue, reason: 'active_session_or_in_progress' }); continue; }
+
+      // H3: session ID pattern in body (active/skip)
+      if (/sess_[a-z0-9]+/.test(issue.body)) { skipped.push({ issue, reason: 'active_session_or_in_progress' }); continue; }
+
+      // Per-issue idempotency (conservative: any parse error = active)
+      const idempotencyStatus = await checkIdempotency(issue.number, sessionsDir);
+      if (idempotencyStatus === 'active') { skipped.push({ issue, reason: 'active_session' }); continue; }
+
+      // Infer maturity (exactly 3 heuristics -- SCOPE LOCK)
+      const maturity = inferMaturity(issue.body);
+      candidates.push({ issue, maturity });
+    }
+
+    // Rank: ready > specced > idea, ties by issue number ascending
+    const MATURITY_RANK: Record<string, number> = { ready: 0, specced: 1, idea: 2 };
+    candidates.sort((a, b) => {
+      const rankDiff = (MATURITY_RANK[a.maturity] ?? 2) - (MATURITY_RANK[b.maturity] ?? 2);
+      return rankDiff !== 0 ? rankDiff : a.issue.number - b.issue.number;
+    });
+
+    for (const { issue, reason } of skipped) {
+      console.log(`[QueuePoll] skipped #${issue.number} "${issue.title}" reason=${reason}`);
+      await appendQueuePollLog({ event: 'task_skipped', issueNumber: issue.number, title: issue.title, reason, ts: new Date().toISOString() });
+    }
+
+    if (candidates.length === 0) {
+      console.log('[QueuePoll] No actionable issues found in this poll cycle.');
+      await appendQueuePollLog({ event: 'poll_cycle_complete', selected: 0, skipped: skipped.length, elapsed: Date.now() - cycleStart, ts: new Date().toISOString() });
+      return;
+    }
+
+    const top = candidates[0]!;
+    const upstreamSpecUrl = extractUpstreamSpecUrl(top.issue.body);
+
+    const taskCandidate: TaskCandidate = {
+      issueNumber: top.issue.number,
+      title: top.issue.title,
+      body: top.issue.body,
+      url: top.issue.url,
+      inferredMaturity: top.maturity,
+      ...(upstreamSpecUrl !== undefined ? { upstreamSpecUrl } : {}),
+      queueConfigType: queueConfig.type,
+    };
+
+    const workflowTrigger: WorkflowTrigger = {
+      workflowId: trigger.workflowId,
+      goal: top.issue.title,
+      workspacePath: trigger.workspacePath,
+      context: { taskCandidate },
+      ...(trigger.referenceUrls !== undefined ? { referenceUrls: trigger.referenceUrls } : {}),
+      ...(trigger.agentConfig !== undefined ? { agentConfig: trigger.agentConfig } : {}),
+      ...(trigger.soulFile !== undefined ? { soulFile: trigger.soulFile } : {}),
+      // Bot identity for queue-poll sessions: autonomous commits use bot account.
+      botIdentity: {
+        name: 'worktrain-etienneb',
+        email: 'worktrain-etienneb@users.noreply.github.com',
+      },
+    };
+
+    const maturityReason = describeMaturityReason(top.maturity);
+    console.log(`[QueuePoll] selected #${top.issue.number} "${top.issue.title}" maturity=${top.maturity} reason="${maturityReason}"`);
+    await appendQueuePollLog({ event: 'task_selected', issueNumber: top.issue.number, title: top.issue.title, maturity: top.maturity, reason: maturityReason, ts: new Date().toISOString() });
+
+    this.router.dispatch(workflowTrigger);
+
+    for (let i = 1; i < candidates.length; i++) {
+      const { issue, maturity } = candidates[i]!;
+      console.log(`[QueuePoll] skipped #${issue.number} "${issue.title}" reason=lower_priority_${maturity}`);
+      await appendQueuePollLog({ event: 'task_skipped', issueNumber: issue.number, title: issue.title, inferredMaturity: maturity, reason: `lower_priority_${maturity}`, ts: new Date().toISOString() });
+    }
+
+    const elapsed = Date.now() - cycleStart;
+    console.log(`[QueuePoll] cycle complete selected=1 skipped=${skipped.length + candidates.length - 1} elapsed=${elapsed}ms`);
+    await appendQueuePollLog({ event: 'poll_cycle_complete', selected: 1, skipped: skipped.length + candidates.length - 1, elapsed, ts: new Date().toISOString() });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -492,11 +636,11 @@ function interpolateGoalFromPayload(
  * Returns undefined for missing paths or array-indexed paths.
  */
 function extractDotPath(obj: Record<string, unknown>, rawPath: string): unknown {
-  let path = rawPath.trim();
-  if (path.startsWith('$.')) path = path.slice(2);
-  else if (path.startsWith('$')) path = path.slice(1);
+  let dotPath = rawPath.trim();
+  if (dotPath.startsWith('$.')) dotPath = dotPath.slice(2);
+  else if (dotPath.startsWith('$')) dotPath = dotPath.slice(1);
 
-  const segments = path.split('.');
+  const segments = dotPath.split('.');
   let current: unknown = obj;
   for (const segment of segments) {
     if (segment.includes('[') || current === null || typeof current !== 'object') {
@@ -505,4 +649,42 @@ function extractDotPath(obj: Record<string, unknown>, rawPath: string): unknown 
     current = (current as Record<string, unknown>)[segment];
   }
   return current;
+}
+
+// ---------------------------------------------------------------------------
+// Queue poll helper functions
+// ---------------------------------------------------------------------------
+
+async function countActiveSessions(sessionsDir: string): Promise<number> {
+  try {
+    const files = await fs.readdir(sessionsDir);
+    return files.filter((f) => f.endsWith('.json')).length;
+  } catch {
+    return 0;
+  }
+}
+
+async function appendQueuePollLog(entry: Record<string, unknown>): Promise<void> {
+  const logPath = path.join(os.homedir(), '.workrail', 'queue-poll.jsonl');
+  try {
+    await fs.appendFile(logPath, JSON.stringify(entry) + '\n', 'utf8');
+  } catch (e) {
+    console.warn(`[QueuePoll] Failed to write queue-poll.jsonl: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+function extractUpstreamSpecUrl(body: string): string | undefined {
+  const specLineMatch = /upstream_spec:\s*(https?:\/\/\S+)/i.exec(body);
+  if (specLineMatch?.[1]) return specLineMatch[1];
+  const firstPara = body.split(/\n\s*\n/)[0] ?? '';
+  const urlMatch = /(https?:\/\/\S+)/.exec(firstPara);
+  return urlMatch?.[1];
+}
+
+function describeMaturityReason(maturity: 'idea' | 'specced' | 'ready'): string {
+  switch (maturity) {
+    case 'ready': return 'has upstream spec URL';
+    case 'specced': return 'has acceptance criteria or checklist';
+    case 'idea': return 'maturity=idea, no upstream spec';
+  }
 }

--- a/src/trigger/polling-scheduler.ts
+++ b/src/trigger/polling-scheduler.ts
@@ -392,16 +392,17 @@ export class PollingScheduler {
 
     if (queueConfig.type !== 'assignee') {
       console.error(`[QueuePoll] Queue type '${queueConfig.type}' is not implemented. Only 'assignee' is supported. Skipping cycle.`);
-      await appendQueuePollLog({ event: 'poll_cycle_error', triggerId, reason: `not_implemented: queue type '${queueConfig.type}'`, ts: new Date().toISOString() });
+      // N2: write poll_cycle_complete (not poll_cycle_error) so operators can grep a uniform event name.
+      await appendQueuePollLog({ event: 'poll_cycle_complete', triggerId, reason: 'not_implemented', queueType: queueConfig.type, ts: new Date().toISOString() });
       return;
     }
 
     // Concurrency cap check BEFORE per-issue evaluation (INVARIANT per pitch)
     const sessionsDir = path.join(os.homedir(), '.workrail', 'daemon-sessions');
     const activeSessions = await countActiveSessions(sessionsDir);
-    if (activeSessions >= queueConfig.maxConcurrentSelf) {
-      console.log(`[QueuePoll] Skipping cycle: active sessions (${activeSessions}) >= maxConcurrentSelf (${queueConfig.maxConcurrentSelf}).`);
-      await appendQueuePollLog({ event: 'poll_cycle_skipped', triggerId, reason: 'max_concurrency_reached', activeSessions, maxConcurrentSelf: queueConfig.maxConcurrentSelf, ts: new Date().toISOString() });
+    if (activeSessions >= queueConfig.maxTotalConcurrentSessions) {
+      console.log(`[QueuePoll] Skipping cycle: active sessions (${activeSessions}) >= maxTotalConcurrentSessions (${queueConfig.maxTotalConcurrentSessions}).`);
+      await appendQueuePollLog({ event: 'poll_cycle_skipped', triggerId, reason: 'max_concurrency_reached', activeSessions, maxTotalConcurrentSessions: queueConfig.maxTotalConcurrentSessions, ts: new Date().toISOString() });
       return;
     }
 
@@ -479,9 +480,10 @@ export class PollingScheduler {
       ...(trigger.agentConfig !== undefined ? { agentConfig: trigger.agentConfig } : {}),
       ...(trigger.soulFile !== undefined ? { soulFile: trigger.soulFile } : {}),
       // Bot identity for queue-poll sessions: autonomous commits use bot account.
+      // Read from queue config when present; fall back to generic defaults.
       botIdentity: {
-        name: 'worktrain-etienneb',
-        email: 'worktrain-etienneb@users.noreply.github.com',
+        name: queueConfig.botName ?? 'worktrain',
+        email: queueConfig.botEmail ?? 'worktrain@users.noreply.github.com',
       },
     };
 

--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -64,7 +64,7 @@ export type TriggerStoreError =
 // Supported providers (extensible: add post-MVP providers here)
 // ---------------------------------------------------------------------------
 
-const SUPPORTED_PROVIDERS = new Set(['generic', 'gitlab_poll', 'github_issues_poll', 'github_prs_poll']);
+const SUPPORTED_PROVIDERS = new Set(['generic', 'gitlab_poll', 'github_issues_poll', 'github_prs_poll', 'github_queue_poll']);
 
 // ---------------------------------------------------------------------------
 // Narrow YAML parser
@@ -993,13 +993,52 @@ function validateAndResolveTrigger(
         labelFilter,
       };
     }
+  } else if (provider === 'github_queue_poll') {
+    // github_queue_poll does NOT require 'events'. Only repo, token, pollIntervalSeconds.
+    // Queue filter (assignee, excludeLabels) comes from ~/.workrail/config.json at runtime.
+    // pollIntervalSeconds defaults to 300 (not 60) per pitch design.
+    if (!raw.source) {
+      return err({ kind: 'missing_field', field: 'source', triggerId: rawId });
+    }
+
+    const queueSrc = raw.source;
+
+    if (!queueSrc.repo?.trim()) {
+      return err({ kind: 'missing_field', field: 'source.repo', triggerId: rawId });
+    }
+
+    if (!queueSrc.token?.trim()) {
+      return err({ kind: 'missing_field', field: 'source.token', triggerId: rawId });
+    }
+    const queueTokenResult = resolveSecret(queueSrc.token.trim(), rawId, env);
+    if (queueTokenResult.kind === 'err') return queueTokenResult;
+
+    let queuePollIntervalSeconds = 300;
+    if (queueSrc.pollIntervalSeconds?.trim()) {
+      const asNumber = Number(queueSrc.pollIntervalSeconds.trim());
+      if (!Number.isInteger(asNumber) || asNumber <= 0) {
+        return err({
+          kind: 'invalid_field_value',
+          field: `source.pollIntervalSeconds (must be a positive integer, got: ${queueSrc.pollIntervalSeconds})`,
+          triggerId: rawId,
+        });
+      }
+      queuePollIntervalSeconds = asNumber;
+    }
+
+    pollingSource = {
+      provider: 'github_queue_poll',
+      repo: queueSrc.repo.trim(),
+      token: queueTokenResult.value,
+      pollIntervalSeconds: queuePollIntervalSeconds,
+    };
   } else if (raw.source) {
     // provider === 'generic' but source: is present -- warn, do not error.
     // The source: block is only meaningful for polling providers.
     console.warn(
       `[TriggerStore] WARNING: trigger '${rawId}' has provider='${provider}' but also ` +
       `defines a source: block. The source: block is only used for polling providers ` +
-      `(gitlab_poll, github_issues_poll, github_prs_poll). It will be ignored for this trigger.`,
+      `(gitlab_poll, github_issues_poll, github_prs_poll, github_queue_poll). It will be ignored for this trigger.`,
     );
   }
 

--- a/src/trigger/types.ts
+++ b/src/trigger/types.ts
@@ -222,6 +222,31 @@ export interface GitHubPollingSource {
 }
 
 // ---------------------------------------------------------------------------
+// GitHubQueuePollingSource: configuration for GitHub queue-poll triggers.
+// ---------------------------------------------------------------------------
+
+export interface GitHubQueuePollingSource {
+  readonly repo: string;
+  readonly token: string;
+  readonly pollIntervalSeconds: number;
+}
+
+// ---------------------------------------------------------------------------
+// TaskCandidate: the structured output of the queue picker, injected into
+// the dispatched session as context.taskCandidate.
+// ---------------------------------------------------------------------------
+
+export interface TaskCandidate {
+  readonly issueNumber: number;
+  readonly title: string;
+  readonly body: string;
+  readonly url: string;
+  readonly inferredMaturity: 'idea' | 'specced' | 'ready';
+  readonly upstreamSpecUrl?: string;
+  readonly queueConfigType: 'assignee' | 'label' | 'mention' | 'query';
+}
+
+// ---------------------------------------------------------------------------
 // PollingSource: discriminated union of all polling source configurations
 //
 // Tagged by provider so the polling scheduler can narrow to the correct source
@@ -229,16 +254,18 @@ export interface GitHubPollingSource {
 //
 // Usage in polling-scheduler.ts:
 //   switch (trigger.pollingSource.provider) {
-//     case 'gitlab_poll':       /* trigger.pollingSource is GitLabPollingSource */ break;
-//     case 'github_issues_poll': /* trigger.pollingSource is GitHubPollingSource */ break;
-//     case 'github_prs_poll':   /* trigger.pollingSource is GitHubPollingSource */ break;
+//     case 'gitlab_poll':        /* GitLabPollingSource */ break;
+//     case 'github_issues_poll': /* GitHubPollingSource */ break;
+//     case 'github_prs_poll':    /* GitHubPollingSource */ break;
+//     case 'github_queue_poll':  /* GitHubQueuePollingSource */ break;
 //   }
 // ---------------------------------------------------------------------------
 
 export type PollingSource =
   | (GitLabPollingSource & { readonly provider: 'gitlab_poll' })
   | (GitHubPollingSource & { readonly provider: 'github_issues_poll' })
-  | (GitHubPollingSource & { readonly provider: 'github_prs_poll' });
+  | (GitHubPollingSource & { readonly provider: 'github_prs_poll' })
+  | (GitHubQueuePollingSource & { readonly provider: 'github_queue_poll' });
 
 // ---------------------------------------------------------------------------
 // TriggerDefinition: a single configured trigger loaded from triggers.yml

--- a/tests/unit/github-queue-poller.test.ts
+++ b/tests/unit/github-queue-poller.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Tests for src/trigger/adapters/github-queue-poller.ts
+ *
+ * Covers:
+ * - Fetches issues matching assignee filter (assignee query param set)
+ * - Returns not_implemented for non-assignee queue types
+ * - Skips cycle on GitHub API error (network error, HTTP error)
+ * - Idempotency: skips issue with matching active session file
+ * - Idempotency: returns 'clear' when no matching session
+ * - Idempotency: returns 'active' on any parse error (conservative default)
+ * - Maturity H1: spec URL in upstream_spec line -> 'ready'
+ * - Maturity H1: http URL in first paragraph -> 'ready'
+ * - Maturity H2: checklist items -> 'specced'
+ * - Maturity H2: acceptance criteria heading -> 'specced'
+ * - Maturity default: plain body -> 'idea'
+ * - H3 exclusion: worktrain:in-progress label (in scheduler, not inferMaturity)
+ * - Rate limit skip: X-RateLimit-Remaining < 100 -> ok([])
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  pollGitHubQueueIssues,
+  inferMaturity,
+  checkIdempotency,
+  type FetchFn,
+  type GitHubQueueIssue,
+} from '../../src/trigger/adapters/github-queue-poller.js';
+import type { GitHubQueuePollingSource } from '../../src/trigger/types.js';
+import type { GitHubQueueConfig } from '../../src/trigger/github-queue-config.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSource(overrides: Partial<GitHubQueuePollingSource> = {}): GitHubQueuePollingSource {
+  return {
+    repo: 'acme/my-project',
+    token: 'test-token',
+    pollIntervalSeconds: 300,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<GitHubQueueConfig> = {}): GitHubQueueConfig {
+  return {
+    type: 'assignee',
+    user: 'worktrain-etienneb',
+    repo: 'acme/my-project',
+    token: 'test-token',
+    pollIntervalSeconds: 300,
+    maxConcurrentSelf: 1,
+    excludeLabels: [],
+    ...overrides,
+  };
+}
+
+function makeIssue(overrides: Partial<{
+  id: number;
+  number: number;
+  title: string;
+  body: string;
+  html_url: string;
+  labels: Array<{ name: string }>;
+  created_at: string;
+}> = {}): object {
+  return {
+    id: 1001,
+    number: 42,
+    title: 'Test issue',
+    body: 'A plain issue body.',
+    html_url: 'https://github.com/acme/my-project/issues/42',
+    labels: [],
+    created_at: '2026-04-19T00:00:00Z',
+    state: 'open',
+    ...overrides,
+  };
+}
+
+function makeFetch(response: {
+  ok: boolean;
+  status?: number;
+  statusText?: string;
+  json?: () => Promise<unknown>;
+  headers?: Record<string, string>;
+}): FetchFn {
+  return vi.fn().mockResolvedValue({
+    ok: response.ok,
+    status: response.status ?? (response.ok ? 200 : 400),
+    statusText: response.statusText ?? (response.ok ? 'OK' : 'Error'),
+    json: response.json ?? (() => Promise.resolve([])),
+    headers: {
+      get: (key: string) => response.headers?.[key] ?? null,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// pollGitHubQueueIssues tests
+// ---------------------------------------------------------------------------
+
+describe('pollGitHubQueueIssues', () => {
+  it('fetches issues matching assignee filter', async () => {
+    const issue = makeIssue({ number: 42, title: 'Add Glob tool', body: 'Simple body' });
+    const fetchFn = makeFetch({
+      ok: true,
+      json: () => Promise.resolve([issue]),
+    });
+
+    const result = await pollGitHubQueueIssues(makeSource(), makeConfig({ user: 'bob' }), fetchFn);
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]?.number).toBe(42);
+      expect(result.value[0]?.title).toBe('Add Glob tool');
+    }
+
+    // Verify assignee query param was set
+    const fetchCall = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(fetchCall?.[0]).toContain('assignee=bob');
+  });
+
+  it('returns not_implemented for non-assignee queue type', async () => {
+    const fetchFn = makeFetch({ ok: true });
+
+    const result = await pollGitHubQueueIssues(
+      makeSource(),
+      makeConfig({ type: 'label', name: 'my-label' }),
+      fetchFn,
+    );
+
+    expect(result.kind).toBe('err');
+    if (result.kind === 'err') {
+      expect(result.error.kind).toBe('not_implemented');
+    }
+    // fetchFn should NOT be called for not_implemented types
+    expect((fetchFn as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+  });
+
+  it('returns network_error on fetch throw', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await pollGitHubQueueIssues(makeSource(), makeConfig(), fetchFn as FetchFn);
+
+    expect(result.kind).toBe('err');
+    if (result.kind === 'err') {
+      expect(result.error.kind).toBe('network_error');
+    }
+  });
+
+  it('returns http_error on non-2xx response', async () => {
+    const fetchFn = makeFetch({ ok: false, status: 401, statusText: 'Unauthorized' });
+
+    const result = await pollGitHubQueueIssues(makeSource(), makeConfig(), fetchFn);
+
+    expect(result.kind).toBe('err');
+    if (result.kind === 'err') {
+      expect(result.error.kind).toBe('http_error');
+    }
+  });
+
+  it('returns ok([]) on rate limit exceeded (X-RateLimit-Remaining < 100)', async () => {
+    const issue = makeIssue({ number: 42 });
+    const fetchFn = makeFetch({
+      ok: true,
+      json: () => Promise.resolve([issue]),
+      headers: { 'X-RateLimit-Remaining': '50', 'X-RateLimit-Reset': '9999999999' },
+    });
+
+    const result = await pollGitHubQueueIssues(makeSource(), makeConfig(), fetchFn);
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value).toHaveLength(0); // Rate limit skip returns empty array
+    }
+  });
+
+  it('returns ok([]) on parse error (non-JSON response)', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.reject(new SyntaxError('Unexpected token')),
+      headers: { get: () => null },
+    });
+
+    const result = await pollGitHubQueueIssues(makeSource(), makeConfig(), fetchFn as FetchFn);
+
+    expect(result.kind).toBe('err');
+    if (result.kind === 'err') {
+      expect(result.error.kind).toBe('parse_error');
+    }
+  });
+
+  it('maps GitHub API issue fields to GitHubQueueIssue', async () => {
+    const issue = makeIssue({
+      id: 9999,
+      number: 7,
+      title: 'Fix the bug',
+      body: 'This is the body.',
+      html_url: 'https://github.com/acme/my-project/issues/7',
+      labels: [{ name: 'bug' }, { name: 'worktrain' }],
+      created_at: '2026-01-01T00:00:00Z',
+    });
+    const fetchFn = makeFetch({ ok: true, json: () => Promise.resolve([issue]) });
+
+    const result = await pollGitHubQueueIssues(makeSource(), makeConfig(), fetchFn);
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      const mapped = result.value[0];
+      expect(mapped?.id).toBe(9999);
+      expect(mapped?.number).toBe(7);
+      expect(mapped?.title).toBe('Fix the bug');
+      expect(mapped?.body).toBe('This is the body.');
+      expect(mapped?.url).toBe('https://github.com/acme/my-project/issues/7');
+      expect(mapped?.labels).toEqual([{ name: 'bug' }, { name: 'worktrain' }]);
+      expect(mapped?.createdAt).toBe('2026-01-01T00:00:00Z');
+    }
+  });
+
+  it('handles null body from GitHub API (empty string result)', async () => {
+    const issue = { ...makeIssue(), body: null };
+    const fetchFn = makeFetch({ ok: true, json: () => Promise.resolve([issue]) });
+
+    const result = await pollGitHubQueueIssues(makeSource(), makeConfig(), fetchFn);
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value[0]?.body).toBe('');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferMaturity tests (3 heuristics -- SCOPE LOCK)
+// ---------------------------------------------------------------------------
+
+describe('inferMaturity', () => {
+  it('H1: body with upstream_spec: line -> ready', () => {
+    const body = `## WorkTrain\nupstream_spec: https://example.com/pitch.md\n\nSome details.`;
+    expect(inferMaturity(body)).toBe('ready');
+  });
+
+  it('H1: body with http URL in first paragraph -> ready', () => {
+    const body = `See https://github.com/acme/my-project/issues/1 for the full spec.\n\nDetails here.`;
+    expect(inferMaturity(body)).toBe('ready');
+  });
+
+  it('H1: URL in second paragraph does NOT trigger ready', () => {
+    // Second paragraph means no URL in first paragraph -> falls through to H2
+    const body = `Plain first paragraph.\n\nSee https://example.com for details.`;
+    // Should be 'idea' since no checklist and no heading match
+    expect(inferMaturity(body)).toBe('idea');
+  });
+
+  it('H2: checklist items -> specced', () => {
+    const body = `## Task\n- [ ] Write tests\n- [ ] Update docs\n`;
+    expect(inferMaturity(body)).toBe('specced');
+  });
+
+  it('H2: Acceptance Criteria heading -> specced', () => {
+    const body = `## Acceptance Criteria\n- Must do X\n- Must do Y\n`;
+    expect(inferMaturity(body)).toBe('specced');
+  });
+
+  it('H2: Test Plan heading -> specced', () => {
+    const body = `## Test Plan\n1. Run unit tests\n2. Check integration`;
+    expect(inferMaturity(body)).toBe('specced');
+  });
+
+  it('H2: Implementation heading -> specced', () => {
+    const body = `### Implementation\nDo this then that.`;
+    expect(inferMaturity(body)).toBe('specced');
+  });
+
+  it('Default: plain body -> idea', () => {
+    const body = `This is a vague issue with no spec, no checklist, and no URL.`;
+    expect(inferMaturity(body)).toBe('idea');
+  });
+
+  it('Default: empty body -> idea', () => {
+    expect(inferMaturity('')).toBe('idea');
+  });
+
+  it('H1 takes precedence over H2 when both present', () => {
+    const body = `See https://example.com/pitch\n\n- [ ] Implement\n- [ ] Test`;
+    // H1 matches first -> 'ready'
+    expect(inferMaturity(body)).toBe('ready');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkIdempotency tests
+// ---------------------------------------------------------------------------
+
+describe('checkIdempotency', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wt-idempotency-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns clear when sessions directory is empty', async () => {
+    const status = await checkIdempotency(42, tmpDir);
+    expect(status).toBe('clear');
+  });
+
+  it('returns clear when no session file has matching issueNumber', async () => {
+    const sessionFile = {
+      continueToken: 'ct_abc',
+      checkpointToken: null,
+      ts: Date.now(),
+      context: { taskCandidate: { issueNumber: 99, title: 'Other issue' } },
+    };
+    await fs.writeFile(path.join(tmpDir, 'sess_abc.json'), JSON.stringify(sessionFile), 'utf8');
+
+    const status = await checkIdempotency(42, tmpDir);
+    expect(status).toBe('clear');
+  });
+
+  it('returns active when session file has matching issueNumber', async () => {
+    const sessionFile = {
+      continueToken: 'ct_abc',
+      checkpointToken: null,
+      ts: Date.now(),
+      context: { taskCandidate: { issueNumber: 42, title: 'Add Glob tool' } },
+    };
+    await fs.writeFile(path.join(tmpDir, 'sess_abc.json'), JSON.stringify(sessionFile), 'utf8');
+
+    const status = await checkIdempotency(42, tmpDir);
+    expect(status).toBe('active');
+  });
+
+  it('returns active (conservative) on malformed JSON', async () => {
+    await fs.writeFile(path.join(tmpDir, 'sess_bad.json'), '{ invalid json }', 'utf8');
+
+    const status = await checkIdempotency(42, tmpDir);
+    expect(status).toBe('active');
+  });
+
+  it('returns active (conservative) when session file has no context field', async () => {
+    const sessionFile = { continueToken: 'ct_abc', checkpointToken: null, ts: Date.now() };
+    await fs.writeFile(path.join(tmpDir, 'sess_nocontext.json'), JSON.stringify(sessionFile), 'utf8');
+
+    const status = await checkIdempotency(42, tmpDir);
+    expect(status).toBe('active');
+  });
+
+  it('returns active (conservative) when context has no taskCandidate', async () => {
+    const sessionFile = {
+      continueToken: 'ct_abc',
+      context: { someOtherField: 'value' },
+    };
+    await fs.writeFile(path.join(tmpDir, 'sess_notask.json'), JSON.stringify(sessionFile), 'utf8');
+
+    const status = await checkIdempotency(42, tmpDir);
+    expect(status).toBe('active');
+  });
+
+  it('returns clear when sessions dir does not exist', async () => {
+    const nonExistentDir = path.join(tmpDir, 'does-not-exist');
+    const status = await checkIdempotency(42, nonExistentDir);
+    expect(status).toBe('clear');
+  });
+
+  it('ignores non-JSON files in sessions dir', async () => {
+    await fs.writeFile(path.join(tmpDir, 'readme.txt'), 'not a session', 'utf8');
+    await fs.writeFile(path.join(tmpDir, '.gitkeep'), '', 'utf8');
+
+    const status = await checkIdempotency(42, tmpDir);
+    expect(status).toBe('clear');
+  });
+});

--- a/tests/unit/github-queue-poller.test.ts
+++ b/tests/unit/github-queue-poller.test.ts
@@ -51,7 +51,7 @@ function makeConfig(overrides: Partial<GitHubQueueConfig> = {}): GitHubQueueConf
     repo: 'acme/my-project',
     token: 'test-token',
     pollIntervalSeconds: 300,
-    maxConcurrentSelf: 1,
+    maxTotalConcurrentSessions: 1,
     excludeLabels: [],
     ...overrides,
   };
@@ -245,9 +245,20 @@ describe('inferMaturity', () => {
     expect(inferMaturity(body)).toBe('ready');
   });
 
-  it('H1: body with http URL in first paragraph -> ready', () => {
-    const body = `See https://github.com/acme/my-project/issues/1 for the full spec.\n\nDetails here.`;
+  it('H1: body with spec-implying URL (/spec path) in first paragraph -> ready', () => {
+    const body = `See https://example.com/spec/my-feature for the full spec.\n\nDetails here.`;
     expect(inferMaturity(body)).toBe('ready');
+  });
+
+  it('H1: body with spec-implying URL (/prd path) in first paragraph -> ready', () => {
+    const body = `Spec: https://docs.example.com/prd/feature-123\n\nDetails here.`;
+    expect(inferMaturity(body)).toBe('ready');
+  });
+
+  it('H1: plain GitHub issue URL in first paragraph does NOT trigger ready (no spec path)', () => {
+    // A plain issue link has no spec-implying path segment -> falls through to H2/default
+    const body = `See https://github.com/acme/my-project/issues/1 for context.\n\nDetails here.`;
+    expect(inferMaturity(body)).toBe('idea');
   });
 
   it('H1: URL in second paragraph does NOT trigger ready', () => {
@@ -267,14 +278,21 @@ describe('inferMaturity', () => {
     expect(inferMaturity(body)).toBe('specced');
   });
 
-  it('H2: Test Plan heading -> specced', () => {
-    const body = `## Test Plan\n1. Run unit tests\n2. Check integration`;
+  it('H2: Implementation Plan heading -> specced', () => {
+    const body = `## Implementation Plan\nDo this then that.`;
     expect(inferMaturity(body)).toBe('specced');
   });
 
-  it('H2: Implementation heading -> specced', () => {
+  it('H2: loose implementation mention does NOT trigger specced (N1 tightening)', () => {
+    // "### Implementation" and "Test Plan" no longer match -- only exact headings do.
     const body = `### Implementation\nDo this then that.`;
-    expect(inferMaturity(body)).toBe('specced');
+    expect(inferMaturity(body)).toBe('idea');
+  });
+
+  it('H2: Test Plan heading does NOT trigger specced after N1 tightening', () => {
+    // Only "Acceptance Criteria" and "Implementation Plan" are exact matches.
+    const body = `## Test Plan\n1. Run unit tests\n2. Check integration`;
+    expect(inferMaturity(body)).toBe('idea');
   });
 
   it('Default: plain body -> idea', () => {
@@ -346,15 +364,19 @@ describe('checkIdempotency', () => {
     expect(status).toBe('active');
   });
 
-  it('returns active (conservative) when session file has no context field', async () => {
+  it('returns clear when session file has no context field (real persistTokens format)', async () => {
+    // Real session files written by persistTokens() contain only { continueToken, checkpointToken, ts }.
+    // A file without context cannot claim ownership of any issue.
     const sessionFile = { continueToken: 'ct_abc', checkpointToken: null, ts: Date.now() };
     await fs.writeFile(path.join(tmpDir, 'sess_nocontext.json'), JSON.stringify(sessionFile), 'utf8');
 
     const status = await checkIdempotency(42, tmpDir);
-    expect(status).toBe('active');
+    expect(status).toBe('clear');
   });
 
-  it('returns active (conservative) when context has no taskCandidate', async () => {
+  it('returns clear when context has no taskCandidate (non-queue session)', async () => {
+    // A session file with context but no taskCandidate is not a queue-originated session.
+    // It cannot claim ownership of any issue.
     const sessionFile = {
       continueToken: 'ct_abc',
       context: { someOtherField: 'value' },
@@ -362,7 +384,17 @@ describe('checkIdempotency', () => {
     await fs.writeFile(path.join(tmpDir, 'sess_notask.json'), JSON.stringify(sessionFile), 'utf8');
 
     const status = await checkIdempotency(42, tmpDir);
-    expect(status).toBe('active');
+    expect(status).toBe('clear');
+  });
+
+  it('regression C1: real-format session file {continueToken, checkpointToken, ts} returns clear', async () => {
+    // Regression test for C1: persistTokens() writes this format -- no context field.
+    // Before the C1 fix, this would return 'active' and permanently block queue dispatch.
+    const sessionFile = { continueToken: 'ct_xxx', checkpointToken: 'cp_xxx', ts: 123 };
+    await fs.writeFile(path.join(tmpDir, 'sess_real.json'), JSON.stringify(sessionFile), 'utf8');
+
+    const status = await checkIdempotency(42, tmpDir);
+    expect(status).toBe('clear');
   });
 
   it('returns clear when sessions dir does not exist', async () => {


### PR DESCRIPTION
## Summary

- Adds a new `github_queue_poll` polling trigger that fetches open GitHub issues on a configurable interval, infers maturity from issue body content using 3 deterministic heuristics (H1: spec URL, H2: acceptance criteria, H3: active/skip), checks per-issue idempotency by scanning active daemon sessions, ranks candidates (ready > specced > idea, ties by issue number ascending), and dispatches the top candidate as a WorkTrain session with a structured `TaskCandidate` payload
- Adds `GitHubQueueConfig` loading from `~/.workrail/config.json` at runtime, JSONL decision logging to `~/.workrail/queue-poll.jsonl`, and stdout logging per cycle (selected/skipped/complete)
- Adds `WorkflowTrigger.botIdentity` optional field consumed by `workflow-runner.ts` to set `git config user.name/email` deterministically for autonomous sessions, preventing personal git identity from appearing in bot-dispatched commits

## New files

- `src/trigger/adapters/github-queue-poller.ts` -- fetch adapter with `inferMaturity` (3 heuristics, scope-locked) and `checkIdempotency` (conservative: any parse error = active)
- `src/trigger/github-queue-config.ts` -- `GitHubQueueConfig` type + `loadQueueConfig()` with `$ENV_VAR` token resolution
- `tests/unit/github-queue-poller.test.ts` -- 26 unit tests covering all acceptance criteria

## Modified files

- `src/trigger/types.ts` -- `GitHubQueuePollingSource`, `TaskCandidate`, new `PollingSource` union arm
- `src/trigger/trigger-store.ts` -- `SUPPORTED_PROVIDERS` + dedicated assembly branch (no `events` required, 300s default interval)
- `src/trigger/polling-scheduler.ts` -- `case 'github_queue_poll'` + `doPollGitHubQueue()` with full cycle logic
- `src/daemon/workflow-runner.ts` -- `WorkflowTrigger.botIdentity` field + git config block

## Test plan

- [x] `npm run build` -- clean build
- [x] `npx vitest run tests/unit/github-queue-poller.test.ts` -- 26/26 pass
- [x] `npx vitest run tests/unit/` -- all pass (2 integration test failures are pre-existing Anthropic API overload, unrelated)

## Key design decisions

- `not_implemented` error for `type: 'label' | 'mention' | 'query'` at runtime (not parse time) -- config parses fine, dispatch rejects
- Conservative idempotency default: any session file parse error = treat as active (never dispatch on uncertainty)
- Concurrency cap check BEFORE per-issue iteration (pitch invariant)
- No `PolledEventStore` -- queue poll semantics (select-one-per-cycle) differ from event-poll (at-least-once-per-event)
- Exactly 3 maturity heuristics, marked `// SCOPE LOCK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)