### PR TITLE
feat(coordinator): adaptive pipeline coordinator with static routing

### DIFF
--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -66,3 +66,8 @@ export {
   type StatusDataPacket,
   type StatusSession,
 } from './worktrain-overview.js';
+export {
+  executeWorktrainPipelineCommand,
+  type WorktrainPipelineCommandDeps,
+  type WorktrainPipelineCommandOpts,
+} from './worktrain-pipeline.js';

--- a/src/cli/commands/worktrain-pipeline.ts
+++ b/src/cli/commands/worktrain-pipeline.ts
@@ -1,0 +1,189 @@
+/**
+ * WorkTrain Pipeline Command
+ *
+ * Runs the adaptive pipeline coordinator for a given task.
+ * Routes the task to QUICK_REVIEW, REVIEW_ONLY, IMPLEMENT, or FULL mode
+ * based on static signals in the goal and workspace state, then executes
+ * the appropriate pipeline phases end-to-end.
+ *
+ * Usage:
+ *   worktrain run pipeline --workspace <path> --goal <text>
+ *   worktrain run pipeline --workspace <path> --goal <text> --mode IMPLEMENT
+ *   worktrain run pipeline --workspace <path> --goal <text> --dry-run
+ *
+ * Design invariants:
+ * - All I/O is injected via WorktrainPipelineCommandDeps. Zero direct fs/fetch imports.
+ * - All failures are returned as CliResult failure variants -- never thrown.
+ * - The coordinator (runAdaptivePipeline) is injected to allow testing without the full coordinator.
+ */
+
+import type { CliResult } from '../types/cli-result.js';
+import { successMessage, failure, misuse } from '../types/cli-result.js';
+import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts, PipelineOutcome, ModeExecutors } from '../../coordinators/adaptive-pipeline.js';
+import { runAdaptivePipeline } from '../../coordinators/adaptive-pipeline.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════════════════
+
+export interface WorktrainPipelineCommandDeps extends AdaptiveCoordinatorDeps {
+  /** Write a line to stdout. */
+  readonly stdout: (line: string) => void;
+  /** Return true if the path is absolute. */
+  readonly pathIsAbsolute: (p: string) => boolean;
+  /** Stat a path and return whether it is a directory. Throws on ENOENT. */
+  readonly statPath: (p: string) => Promise<{ isDirectory: () => boolean }>;
+}
+
+export interface WorktrainPipelineCommandOpts {
+  /** Absolute path to the workspace directory. */
+  readonly workspace: string;
+  /** The task goal string. */
+  readonly goal: string;
+  /**
+   * Explicit pipeline mode override (bypasses static routing).
+   * Valid values: QUICK_REVIEW, REVIEW_ONLY, IMPLEMENT, FULL
+   */
+  readonly mode?: string;
+  /** If true, print actions without executing HTTP calls or git operations. */
+  readonly dryRun?: boolean;
+  /** Override the console HTTP server port. */
+  readonly port?: number;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// VALID MODE VALUES
+// ═══════════════════════════════════════════════════════════════════════════
+
+const VALID_MODES = ['QUICK_REVIEW', 'REVIEW_ONLY', 'IMPLEMENT', 'FULL'] as const;
+type ValidMode = (typeof VALID_MODES)[number];
+
+function isValidMode(mode: string): mode is ValidMode {
+  return (VALID_MODES as readonly string[]).includes(mode);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// COMMAND EXECUTION
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Execute the worktrain run pipeline command.
+ *
+ * Wires real mode executors and runs the adaptive pipeline coordinator.
+ */
+export async function executeWorktrainPipelineCommand(
+  deps: WorktrainPipelineCommandDeps,
+  opts: WorktrainPipelineCommandOpts,
+): Promise<CliResult> {
+  // ── Input validation at the boundary ─────────────────────────────────
+  const goal = opts.goal.trim();
+  if (!goal) {
+    return misuse('--goal is required and must not be empty.');
+  }
+
+  const workspace = opts.workspace.trim();
+  if (!workspace) {
+    return misuse('--workspace is required and must not be empty.');
+  }
+
+  if (!deps.pathIsAbsolute(workspace)) {
+    return misuse(`--workspace must be an absolute path, got: ${workspace}`);
+  }
+
+  try {
+    const stat = await deps.statPath(workspace);
+    if (!stat.isDirectory()) {
+      return failure(`--workspace must be an existing directory: ${workspace}`);
+    }
+  } catch {
+    return failure(`--workspace does not exist: ${workspace}`);
+  }
+
+  // Validate --mode if provided
+  let modeOverride: ValidMode | undefined;
+  if (opts.mode) {
+    const modeUpper = opts.mode.toUpperCase();
+    if (!isValidMode(modeUpper)) {
+      return misuse(
+        `--mode must be one of: ${VALID_MODES.join(', ')}. Got: ${opts.mode}`,
+        [`Valid modes: ${VALID_MODES.join(', ')}`],
+      );
+    }
+    modeOverride = modeUpper;
+  }
+
+  deps.stderr(`[pipeline] Starting adaptive pipeline: goal="${goal.slice(0, 80)}" workspace="${workspace}"`);
+  if (modeOverride) {
+    deps.stderr(`[pipeline] Mode override: ${modeOverride}`);
+  }
+
+  // ── Wire mode executors ───────────────────────────────────────────────
+  // Lazily import mode executors to wire the real implementations.
+  // This is the composition root for the adaptive pipeline.
+  const { runReviewOnlyPipeline } = await import('../../coordinators/modes/review-only.js');
+  const { runQuickReviewPipeline } = await import('../../coordinators/modes/quick-review.js');
+  const { runImplementPipeline } = await import('../../coordinators/modes/implement.js');
+  const { runFullPipeline } = await import('../../coordinators/modes/full-pipeline.js');
+
+  const executors: ModeExecutors = {
+    runReviewOnly: runReviewOnlyPipeline,
+    runQuickReview: runQuickReviewPipeline,
+    runImplement: runImplementPipeline,
+    runFull: runFullPipeline,
+  };
+
+  // ── Run adaptive pipeline ─────────────────────────────────────────────
+  const pipelineOpts: AdaptivePipelineOpts = {
+    workspace,
+    goal,
+    dryRun: opts.dryRun ?? false,
+    port: opts.port,
+    modeOverride,
+  };
+
+  let outcome: PipelineOutcome;
+  try {
+    outcome = await runAdaptivePipeline(deps, pipelineOpts, executors);
+  } catch (e) {
+    // runAdaptivePipeline should never throw (errors-as-data policy),
+    // but catch here as a last resort to prevent unhandled rejections.
+    const message = e instanceof Error ? e.message : String(e);
+    deps.stderr(`[pipeline] Unexpected error: ${message}`);
+    return failure(`Pipeline coordinator threw unexpectedly: ${message}`);
+  }
+
+  // ── Map outcome to CliResult ──────────────────────────────────────────
+  return interpretPipelineOutcome(outcome, deps.stdout);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// OUTCOME INTERPRETATION
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Map a PipelineOutcome to a CliResult.
+ * Writes human-readable output to stdout.
+ */
+function interpretPipelineOutcome(
+  outcome: PipelineOutcome,
+  stdout: (line: string) => void,
+): CliResult {
+  switch (outcome.kind) {
+    case 'merged':
+      stdout(`Pipeline completed: PR merged${outcome.prUrl ? ` (${outcome.prUrl})` : ''}`);
+      return successMessage(`Pipeline completed successfully.${outcome.prUrl ? ` PR: ${outcome.prUrl}` : ''}`);
+
+    case 'escalated': {
+      const { phase, reason } = outcome.escalationReason;
+      stdout(`Pipeline escalated: phase=${phase} reason=${reason}`);
+      return failure(`Pipeline escalated at phase '${phase}': ${reason}`, {
+        details: [`Phase: ${phase}`, `Reason: ${reason}`],
+        suggestions: ['Check the Human Outbox for the full escalation notice.'],
+      });
+    }
+
+    case 'dry_run':
+      stdout(`Dry run: would execute ${outcome.mode} pipeline`);
+      return successMessage(`Dry run completed. Would execute: ${outcome.mode} pipeline`);
+  }
+}

--- a/src/coordinators/adaptive-pipeline.ts
+++ b/src/coordinators/adaptive-pipeline.ts
@@ -1,0 +1,404 @@
+/**
+ * Adaptive Pipeline Coordinator
+ *
+ * Entry point for WorkTrain's autonomous task routing and multi-phase execution.
+ * Routes tasks to QUICK_REVIEW, REVIEW_ONLY, IMPLEMENT, or FULL pipeline modes
+ * based on static signals in the task goal and workspace state.
+ *
+ * Design invariants:
+ * - routeTask() is called BEFORE any session is spawned or log is written.
+ * - Routing log is written BEFORE any session is spawned.
+ * - All I/O is injected via AdaptiveCoordinatorDeps. Zero direct fs/fetch/exec imports.
+ * - All phase failures produce PipelineOutcome { kind: 'escalated' } -- never thrown.
+ * - COORDINATOR_SPAWN_CUTOFF_MS is checked before every spawn point.
+ *
+ * Timeout constants (hardcoded, never LLM-computed -- pitch invariant 17):
+ * - Discovery: 35 minutes
+ * - Shaping: 35 minutes
+ * - Coding: 65 minutes
+ * - Review (child): 25 minutes
+ * - Refuse new spawns after: 100 minutes
+ * - Total wall-clock cap: 120 minutes
+ *
+ * WHY separate timeout constants for spawn cutoff vs. total cap:
+ * At 35+35+65 = 135 minutes, a maximally slow FULL pipeline can exceed the 120m cap.
+ * The COORDINATOR_SPAWN_CUTOFF_MS (100m) guard prevents new spawns after 100 minutes
+ * of elapsed time. Phases already started run to their per-phase timeout.
+ * This resolves the budget conflict without reducing per-phase budgets (rabbit hole #2).
+ */
+
+import type { CoordinatorDeps } from './pr-review.js';
+import { routeTask, extractPrNumbers } from './routing/route-task.js';
+import type { PipelineMode } from './routing/route-task.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TIMEOUT CONSTANTS (hardcoded, never LLM-computed)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Discovery session timeout: 35 minutes. */
+export const DISCOVERY_TIMEOUT_MS = 35 * 60 * 1000;
+
+/** Shaping session timeout: 35 minutes. */
+export const SHAPING_TIMEOUT_MS = 35 * 60 * 1000;
+
+/** Coding session timeout: 65 minutes. */
+export const CODING_TIMEOUT_MS = 65 * 60 * 1000;
+
+/** Review session timeout (child): 25 minutes. */
+export const REVIEW_TIMEOUT_MS = 25 * 60 * 1000;
+
+/**
+ * Coordinator spawn cutoff: refuse new spawns after 100 minutes of elapsed time.
+ *
+ * WHY 100 minutes (not 120):
+ * Provides a 20-minute buffer before the total cap to allow any in-flight
+ * session to complete within the COORDINATOR_MAX_MS wall-clock limit.
+ * A phase started at exactly 100m has up to 20m to finish before the coordinator
+ * exits at 120m.
+ */
+export const COORDINATOR_SPAWN_CUTOFF_MS = 100 * 60 * 1000;
+
+/**
+ * Total coordinator wall-clock cap: 120 minutes.
+ * The coordinator must exit (escalate) by this time regardless of phase status.
+ */
+export const COORDINATOR_MAX_MS = 120 * 60 * 1000;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DOMAIN TYPES
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Outcome of a full adaptive pipeline run.
+ *
+ * WHY discriminated union (not boolean flags):
+ * A plain `{ merged: boolean; escalated: boolean }` object allows the illegal
+ * state `merged: true && escalated: true` at runtime. The discriminated union
+ * makes this state unrepresentable at compile time.
+ *
+ * - 'merged': pipeline ran to completion and the PR was auto-merged
+ * - 'escalated': a phase failed or the review found blocking/critical findings;
+ *   structured reason is available for the operator
+ * - 'dry_run': pipeline ran in dry-run mode (no spawns, no merges)
+ */
+export type PipelineOutcome =
+  | { readonly kind: 'merged'; readonly prUrl: string | null }
+  | {
+      readonly kind: 'escalated';
+      readonly escalationReason: {
+        readonly phase: string;
+        readonly reason: string;
+      };
+    }
+  | { readonly kind: 'dry_run'; readonly mode: string };
+
+/**
+ * Options for running the adaptive pipeline.
+ */
+export interface AdaptivePipelineOpts {
+  /** Absolute path to the git workspace. */
+  readonly workspace: string;
+  /** The task goal string. */
+  readonly goal: string;
+  /** If true, print actions without executing HTTP calls or git operations. */
+  readonly dryRun?: boolean;
+  /** Override the console HTTP server port. */
+  readonly port?: number;
+  /** Explicit pipeline mode override (bypasses static routing). */
+  readonly modeOverride?: 'QUICK_REVIEW' | 'REVIEW_ONLY' | 'IMPLEMENT' | 'FULL';
+  /** Trigger provider name (for queue poller integration). */
+  readonly triggerProvider?: string;
+  /**
+   * Task candidate from the queue poller (Option B in-process integration).
+   * When present, the trigger provider is 'github_prs_poll'.
+   */
+  readonly taskCandidate?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Injectable dependencies for the adaptive pipeline coordinator.
+ *
+ * Extends CoordinatorDeps with new methods needed for multi-phase coordination.
+ *
+ * WHY extends CoordinatorDeps (not a standalone interface):
+ * REVIEW_ONLY and QUICK_REVIEW modes delegate to runPrReviewCoordinator()
+ * which requires CoordinatorDeps. Extending avoids duplicating the interface.
+ */
+export interface AdaptiveCoordinatorDeps extends CoordinatorDeps {
+  /**
+   * Check whether a file exists at the given path.
+   * Used by routeTask() for pitch.md detection.
+   * WHY sync (not async): routeTask() is a pure synchronous function.
+   */
+  fileExists(path: string): boolean;
+
+  /**
+   * Move a file from src to dest (archive).
+   * Used by IMPLEMENT mode to archive current-pitch.md after completion.
+   * Always called in a finally block (success or failure).
+   */
+  archiveFile(src: string, dest: string): Promise<void>;
+
+  /**
+   * Poll for a PR matching the given branch pattern.
+   * Returns the PR URL on success, null if no PR found within the timeout.
+   *
+   * Implementation: poll `gh pr list --head <branchPattern>` every 30 seconds.
+   * After timeoutMs with no PR: return null (coordinator escalates).
+   */
+  pollForPR(branchPattern: string, timeoutMs: number): Promise<string | null>;
+
+  /**
+   * Post a structured message to the human outbox.
+   * Used for escalation notices and UX gate acknowledgment requests.
+   */
+  postToOutbox(message: string, metadata: Readonly<Record<string, unknown>>): Promise<void>;
+
+  /**
+   * Poll the outbox for a human acknowledgment response.
+   * Returns 'acked' when the human responds, 'timeout' after timeoutMs.
+   *
+   * Used by the UX gate for large complexity tasks: polls every 5 minutes,
+   * times out after 24 hours if no acknowledgment is received.
+   */
+  pollOutboxAck(requestId: string, timeoutMs: number): Promise<'acked' | 'timeout'>;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MODE EXECUTOR TYPES
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Function signatures for mode executors.
+ * These are passed as injectable functions to allow tests to substitute fakes
+ * and to break circular module dependencies.
+ */
+export interface ModeExecutors {
+  readonly runQuickReview: (
+    deps: AdaptiveCoordinatorDeps,
+    opts: AdaptivePipelineOpts,
+    prNumbers: readonly number[],
+    coordinatorStartMs: number,
+  ) => Promise<PipelineOutcome>;
+
+  readonly runReviewOnly: (
+    deps: AdaptiveCoordinatorDeps,
+    opts: AdaptivePipelineOpts,
+    prNumbers: readonly number[],
+    coordinatorStartMs: number,
+  ) => Promise<PipelineOutcome>;
+
+  readonly runImplement: (
+    deps: AdaptiveCoordinatorDeps,
+    opts: AdaptivePipelineOpts,
+    pitchPath: string,
+    coordinatorStartMs: number,
+  ) => Promise<PipelineOutcome>;
+
+  readonly runFull: (
+    deps: AdaptiveCoordinatorDeps,
+    opts: AdaptivePipelineOpts,
+    coordinatorStartMs: number,
+  ) => Promise<PipelineOutcome>;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ROUTING LOG
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Structure of the routing decision log entry.
+ * Written to .workrail/pipeline-runs/[ISO-timestamp]-[mode].json BEFORE any session spawns.
+ */
+export interface RoutingLogEntry {
+  readonly timestamp: string;
+  readonly mode: string;
+  readonly goal: string;
+  readonly workspace: string;
+  readonly signals: {
+    readonly depBumpKeyword: boolean;
+    readonly prReference: boolean;
+    readonly pitchFilePresent: boolean;
+    readonly githubPrsPollProvider: boolean;
+    readonly modeOverride: string | null;
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SPAWN CUTOFF HELPER
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Check whether the coordinator has exceeded its spawn cutoff time.
+ *
+ * Returns an escalation PipelineOutcome if the cutoff has been reached.
+ * Returns null if it's safe to spawn.
+ *
+ * WHY a helper (not inline checks):
+ * FULL mode has 4+ spawn points. Centralizing the check prevents missed
+ * spawn points, which would allow the coordinator to run past COORDINATOR_MAX_MS.
+ */
+export function checkSpawnCutoff(
+  coordinatorStartMs: number,
+  now: number,
+  phase: string,
+): PipelineOutcome | null {
+  if (now - coordinatorStartMs > COORDINATOR_SPAWN_CUTOFF_MS) {
+    return {
+      kind: 'escalated',
+      escalationReason: {
+        phase,
+        reason: `coordinator elapsed > ${COORDINATOR_SPAWN_CUTOFF_MS / 60000} minutes, refusing new spawns`,
+      },
+    };
+  }
+  return null;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MAIN ENTRY POINT
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Run the adaptive pipeline coordinator.
+ *
+ * Stages:
+ * 1. Route the task to a pipeline mode (static rules, no LLM)
+ * 2. Write the routing log (before any session spawns)
+ * 3. Dispatch to the appropriate mode executor
+ * 4. Return PipelineOutcome
+ *
+ * The mode executors are passed as `executors` to break circular module
+ * dependencies and to allow tests to inject fakes. The real wiring is done
+ * in the CLI entry point (src/cli/commands/worktrain-pipeline.ts) and the
+ * TriggerRouter (src/trigger/trigger-router.ts).
+ *
+ * Called by:
+ * - CLI: worktrain run pipeline --workspace <path> --goal <text>
+ * - Queue poller: TriggerRouter.dispatchAdaptivePipeline() (Option B in-process)
+ */
+export async function runAdaptivePipeline(
+  deps: AdaptiveCoordinatorDeps,
+  opts: AdaptivePipelineOpts,
+  executors: ModeExecutors,
+): Promise<PipelineOutcome> {
+  const coordinatorStartMs = deps.now();
+
+  // ── Step 1: Determine trigger provider ──────────────────────────────────
+  const triggerProvider = opts.taskCandidate !== undefined
+    ? 'github_prs_poll'
+    : opts.triggerProvider;
+
+  // ── Step 2: Route the task (pure function, no I/O except fileExists) ────
+  let pipelineMode: PipelineMode;
+
+  if (opts.modeOverride) {
+    // Explicit mode override -- bypass static routing
+    pipelineMode = buildModeFromOverride(opts.modeOverride, opts.goal, opts.workspace);
+  } else {
+    pipelineMode = routeTask(opts.goal, opts.workspace, deps, triggerProvider);
+  }
+
+  // ── Step 3: Write routing log (before any spawns) ───────────────────────
+  const logEntry: RoutingLogEntry = {
+    timestamp: deps.nowIso(),
+    mode: pipelineMode.kind,
+    goal: opts.goal,
+    workspace: opts.workspace,
+    signals: {
+      depBumpKeyword: hasDepBumpKeyword(opts.goal),
+      prReference: hasPrReference(opts.goal),
+      pitchFilePresent: pipelineMode.kind === 'IMPLEMENT',
+      githubPrsPollProvider: triggerProvider === 'github_prs_poll',
+      modeOverride: opts.modeOverride ?? null,
+    },
+  };
+
+  const runsDir = opts.workspace + '/.workrail/pipeline-runs';
+  const logPath = runsDir + '/' + deps.nowIso().replace(/[:.]/g, '-') + '-' + pipelineMode.kind + '.json';
+
+  try {
+    await deps.mkdir(runsDir, { recursive: true });
+    await deps.writeFile(logPath, JSON.stringify(logEntry, null, 2) + '\n');
+  } catch (e) {
+    // Routing log failure is non-fatal -- coordinator still runs.
+    // WHY: the routing log is for traceability, not correctness. A failed write
+    // must not prevent the pipeline from executing.
+    deps.stderr(`[WARN adaptive-pipeline] Failed to write routing log: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  deps.stderr(`[adaptive-pipeline] Routing: mode=${pipelineMode.kind} goal="${opts.goal.slice(0, 80)}"`);
+
+  // ── Step 4: Dry-run shortcut ─────────────────────────────────────────────
+  if (opts.dryRun) {
+    deps.stderr(`[adaptive-pipeline] Dry run: would execute ${pipelineMode.kind} pipeline`);
+    return { kind: 'dry_run', mode: pipelineMode.kind };
+  }
+
+  // ── Step 5: Dispatch to mode executor ───────────────────────────────────
+  switch (pipelineMode.kind) {
+    case 'QUICK_REVIEW':
+      return executors.runQuickReview(deps, opts, pipelineMode.prNumbers, coordinatorStartMs);
+
+    case 'REVIEW_ONLY':
+      return executors.runReviewOnly(deps, opts, pipelineMode.prNumbers, coordinatorStartMs);
+
+    case 'IMPLEMENT':
+      return executors.runImplement(deps, opts, pipelineMode.pitchPath, coordinatorStartMs);
+
+    case 'FULL':
+      return executors.runFull(deps, opts, coordinatorStartMs);
+
+    case 'ESCALATE': {
+      const reason = pipelineMode.reason;
+      deps.stderr(`[adaptive-pipeline] Routing escalation: ${reason}`);
+      await deps.postToOutbox(
+        `Adaptive pipeline escalated during routing: ${reason}`,
+        { goal: opts.goal, workspace: opts.workspace, phase: 'routing' },
+      );
+      return {
+        kind: 'escalated',
+        escalationReason: { phase: 'routing', reason },
+      };
+    }
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PRIVATE HELPERS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Build a PipelineMode from an explicit --mode CLI override.
+ * Bypasses static routing rules.
+ */
+function buildModeFromOverride(
+  override: 'QUICK_REVIEW' | 'REVIEW_ONLY' | 'IMPLEMENT' | 'FULL',
+  goal: string,
+  workspace: string,
+): PipelineMode {
+  const prNumbers = extractPrNumbers(goal);
+  const pitchPath = workspace + '/.workrail/current-pitch.md';
+
+  switch (override) {
+    case 'QUICK_REVIEW':
+      return { kind: 'QUICK_REVIEW', prNumbers };
+    case 'REVIEW_ONLY':
+      return { kind: 'REVIEW_ONLY', prNumbers };
+    case 'IMPLEMENT':
+      return { kind: 'IMPLEMENT', pitchPath };
+    case 'FULL':
+      return { kind: 'FULL', goal };
+  }
+}
+
+/** Returns true if the goal contains dep-bump keywords (for routing log). */
+function hasDepBumpKeyword(goal: string): boolean {
+  const lower = goal.toLowerCase();
+  return ['bump', 'chore:', 'dependabot', 'dependency upgrade'].some((kw) => lower.includes(kw));
+}
+
+/** Returns true if the goal contains a PR or MR reference (for routing log). */
+function hasPrReference(goal: string): boolean {
+  return /\bPR\s*#\d+\b/i.test(goal) || /\bMR\s*!?\d+\b/i.test(goal);
+}

--- a/src/coordinators/modes/full-pipeline.ts
+++ b/src/coordinators/modes/full-pipeline.ts
@@ -1,0 +1,425 @@
+/**
+ * FULL Pipeline Mode Executor
+ *
+ * Executes the complete discovery -> shaping -> coding -> review pipeline for
+ * tasks without a pre-existing pitch. This is the most complex mode executor.
+ *
+ * Step sequence:
+ * 1. Spawn wr.discovery session (35 minute timeout)
+ * 2. Context bridge: read wr.discovery_handoff artifact from discovery result
+ *    - If found and valid: inject { selectedDirection, designDocPath, assembledContextSummary }
+ *    - Fallback: use lastStepNotes as assembledContextSummary only if length > 50 chars
+ *    - No artifact AND short notes: proceed with no assembledContextSummary
+ * 3. Spawn wr.shaping session with discovery context (35 minute timeout)
+ * 4. [UX Gate] If goal contains UI-touching signals AND complexity is Large:
+ *    - Dispatch ui-ux-design-workflow
+ *    - Require human outbox acknowledgment (poll 24 hours; timeout -> escalate)
+ * 5. Spawn coding-task-workflow-agentic with pitchPath in context (65 minute timeout)
+ * 6. Poll for PR (up to 5 minutes)
+ * 7. Dispatch mr-review-workflow-agentic (25 minute timeout)
+ * 8. Route verdict (same as IMPLEMENT mode: clean/minor/blocking)
+ *
+ * Design invariants:
+ * - Discovery handoff artifact validated with Zod (pitch invariant 12).
+ * - Fallback to lastStepNotes ONLY if length > 50 (pitch invariant 12 explicit guard).
+ * - COORDINATOR_SPAWN_CUTOFF_MS checked before every spawn via checkSpawnCutoff().
+ * - Escalation-first failure policy: all phase failures produce PipelineOutcome { kind: 'escalated' }.
+ */
+
+import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts, PipelineOutcome } from '../adaptive-pipeline.js';
+import {
+  DISCOVERY_TIMEOUT_MS,
+  SHAPING_TIMEOUT_MS,
+  CODING_TIMEOUT_MS,
+  REVIEW_TIMEOUT_MS,
+  checkSpawnCutoff,
+} from '../adaptive-pipeline.js';
+import {
+  isDiscoveryHandoffArtifact,
+  DiscoveryHandoffArtifactV1Schema,
+  type DiscoveryHandoffArtifactV1,
+} from '../../v2/durable-core/schemas/artifacts/discovery-handoff.js';
+import { runReviewAndVerdictCycle } from './implement-shared.js';
+import { touchesUI } from './implement.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CONSTANTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * PR poll timeout: 5 minutes.
+ * After 5 minutes with no PR: escalate.
+ */
+const PR_POLL_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * UX gate outbox poll timeout: 24 hours.
+ * After 24 hours with no human ack: escalate (pitch element 5).
+ */
+const UX_GATE_ACK_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Minimum notes length for lastStepNotes fallback.
+ * Notes shorter than this are not useful as context (pitch invariant 12).
+ */
+const MIN_NOTES_LENGTH_FOR_FALLBACK = 50;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HANDOFF RENDERING
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Render a discovery handoff artifact into a human-readable context summary.
+ *
+ * This is the `renderHandoff()` function referenced in the pitch.
+ * Formats the artifact fields into a markdown summary for injection as
+ * assembledContextSummary in the shaping session spawn context.
+ *
+ * WHY local pure function (not a shared utility):
+ * No other module renders discovery handoff artifacts. Per YAGNI, extract
+ * to a shared utility only when a second consumer exists.
+ */
+export function renderHandoff(artifact: DiscoveryHandoffArtifactV1): string {
+  const lines: string[] = [
+    `## Discovery Handoff`,
+    ``,
+    `**Selected Direction:** ${artifact.selectedDirection}`,
+    `**Confidence:** ${artifact.confidenceBand}`,
+  ];
+
+  if (artifact.designDocPath) {
+    lines.push(`**Design Doc:** ${artifact.designDocPath}`);
+  }
+
+  if (artifact.keyInvariants.length > 0) {
+    lines.push(``, `**Key Invariants:**`);
+    for (const invariant of artifact.keyInvariants) {
+      lines.push(`- ${invariant}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DISCOVERY HANDOFF ARTIFACT READING
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Try to read a valid wr.discovery_handoff artifact from a session's artifacts.
+ *
+ * Returns the parsed artifact on success, null if not found or invalid.
+ * Logs a WARN when the kind discriminant matches but validation fails.
+ */
+function readDiscoveryHandoffArtifact(
+  artifacts: readonly unknown[],
+  sessionHandle: string,
+  stderrFn: (line: string) => void,
+): DiscoveryHandoffArtifactV1 | null {
+  const handlePrefix = sessionHandle.slice(0, 16);
+
+  for (const raw of artifacts) {
+    if (!isDiscoveryHandoffArtifact(raw)) continue;
+
+    const result = DiscoveryHandoffArtifactV1Schema.safeParse(raw);
+    if (!result.success) {
+      const issues = result.error.issues
+        .map((i) => `${i.path.join('.')}: ${i.message}`)
+        .join('; ');
+      stderrFn(
+        `[WARN full-pipeline handle=${handlePrefix}] discovery handoff schema validation failed: ${issues}`,
+      );
+      continue;
+    }
+
+    return result.data;
+  }
+  return null;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FULL PIPELINE EXECUTOR
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Run the FULL pipeline mode.
+ *
+ * Sequences: discovery -> context bridge -> shaping -> [UX gate] -> coding -> PR poll -> review.
+ */
+export async function runFullPipeline(
+  deps: AdaptiveCoordinatorDeps,
+  opts: AdaptivePipelineOpts,
+  coordinatorStartMs: number,
+): Promise<PipelineOutcome> {
+  deps.stderr(`[full-pipeline] Starting FULL pipeline for workspace=${opts.workspace}`);
+
+  // ── Stage 1: Discovery session ────────────────────────────────────────
+  const discoveryCutoff = checkSpawnCutoff(coordinatorStartMs, deps.now(), 'discovery');
+  if (discoveryCutoff) return discoveryCutoff;
+
+  deps.stderr(`[full-pipeline] Spawning wr.discovery session`);
+
+  const discoverySpawnResult = await deps.spawnSession(
+    'wr.discovery',
+    opts.goal,
+    opts.workspace,
+  );
+
+  if (discoverySpawnResult.kind === 'err') {
+    return {
+      kind: 'escalated',
+      escalationReason: {
+        phase: 'discovery',
+        reason: `discovery session spawn failed: ${discoverySpawnResult.error}`,
+      },
+    };
+  }
+
+  const discoveryHandle = discoverySpawnResult.value;
+  if (!discoveryHandle) {
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'discovery', reason: 'discovery session returned empty handle' },
+    };
+  }
+
+  const discoveryAwait = await deps.awaitSessions([discoveryHandle], DISCOVERY_TIMEOUT_MS);
+  const discoveryResult = discoveryAwait.results[0];
+
+  if (!discoveryResult || discoveryResult.outcome !== 'success') {
+    const outcome = discoveryResult?.outcome ?? 'not_found';
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'discovery', reason: `discovery session ${outcome}` },
+    };
+  }
+
+  deps.stderr(`[full-pipeline] Discovery session completed`);
+
+  // ── Stage 2: Context bridge ───────────────────────────────────────────
+  // Read discovery handoff artifact and build shaping context.
+  // (Pitch invariant 12: try artifact first; fallback to lastStepNotes if length > 50)
+
+  const discoveryAgentResult = await deps.getAgentResult(discoveryHandle);
+  const handoffArtifact = readDiscoveryHandoffArtifact(
+    discoveryAgentResult.artifacts,
+    discoveryHandle,
+    deps.stderr,
+  );
+
+  let shapingContext: Readonly<Record<string, unknown>>;
+
+  if (handoffArtifact !== null) {
+    // Primary path: inject structured discovery handoff context into shaping
+    deps.stderr(`[full-pipeline] Discovery handoff artifact found -- injecting structured context`);
+    shapingContext = {
+      selectedDirection: handoffArtifact.selectedDirection,
+      designDocPath: handoffArtifact.designDocPath,
+      assembledContextSummary: renderHandoff(handoffArtifact),
+    };
+  } else {
+    // Fallback path: use raw step notes as context summary (if long enough)
+    const notes = discoveryAgentResult.recapMarkdown;
+    if (notes !== null && notes.trim().length > MIN_NOTES_LENGTH_FOR_FALLBACK) {
+      deps.stderr(`[full-pipeline] No handoff artifact -- using lastStepNotes as context (length=${notes.trim().length})`);
+      shapingContext = { assembledContextSummary: notes.trim() };
+    } else {
+      // Notes too short or null -- proceed without assembledContextSummary
+      const reason = notes === null ? 'null' : `length=${notes.trim().length} <= ${MIN_NOTES_LENGTH_FOR_FALLBACK}`;
+      deps.stderr(`[full-pipeline] No handoff artifact and notes too short (${reason}) -- proceeding without context`);
+      shapingContext = {};
+    }
+  }
+
+  // ── Stage 3: Shaping session ──────────────────────────────────────────
+  const shapingCutoff = checkSpawnCutoff(coordinatorStartMs, deps.now(), 'shaping');
+  if (shapingCutoff) return shapingCutoff;
+
+  deps.stderr(`[full-pipeline] Spawning wr.shaping session`);
+
+  const shapingSpawnResult = await deps.spawnSession(
+    'wr.shaping',
+    opts.goal,
+    opts.workspace,
+    shapingContext,
+  );
+
+  if (shapingSpawnResult.kind === 'err') {
+    return {
+      kind: 'escalated',
+      escalationReason: {
+        phase: 'shaping',
+        reason: `shaping session spawn failed: ${shapingSpawnResult.error}`,
+      },
+    };
+  }
+
+  const shapingHandle = shapingSpawnResult.value;
+  if (!shapingHandle) {
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'shaping', reason: 'shaping session returned empty handle' },
+    };
+  }
+
+  const shapingAwait = await deps.awaitSessions([shapingHandle], SHAPING_TIMEOUT_MS);
+  const shapingResult = shapingAwait.results[0];
+
+  if (!shapingResult || shapingResult.outcome !== 'success') {
+    const outcome = shapingResult?.outcome ?? 'not_found';
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'shaping', reason: `shaping session ${outcome}` },
+    };
+  }
+
+  deps.stderr(`[full-pipeline] Shaping session completed`);
+
+  // ── Stage 4: UX Gate (Large complexity + touchesUI) ──────────────────
+  // In FULL mode, complexity is considered Large because there is no pre-existing pitch.
+  // (Pitch invariant 16: if touchesUI AND Large complexity -> require human outbox ack.)
+  if (touchesUI(opts.goal)) {
+    deps.stderr(`[full-pipeline] UX signals detected -- dispatching ui-ux-design-workflow`);
+
+    const uxCutoff = checkSpawnCutoff(coordinatorStartMs, deps.now(), 'ux-gate');
+    if (uxCutoff) return uxCutoff;
+
+    const uxSpawnResult = await deps.spawnSession(
+      'ui-ux-design-workflow',
+      opts.goal,
+      opts.workspace,
+      { shapingComplete: true },
+    );
+
+    if (uxSpawnResult.kind === 'err') {
+      return {
+        kind: 'escalated',
+        escalationReason: {
+          phase: 'ux-gate',
+          reason: `UX design workflow spawn failed: ${uxSpawnResult.error}`,
+        },
+      };
+    }
+
+    const uxHandle = uxSpawnResult.value;
+    if (!uxHandle) {
+      return {
+        kind: 'escalated',
+        escalationReason: { phase: 'ux-gate', reason: 'UX design session returned empty handle' },
+      };
+    }
+
+    const uxAwait = await deps.awaitSessions([uxHandle], REVIEW_TIMEOUT_MS);
+    const uxResult = uxAwait.results[0];
+
+    if (!uxResult || uxResult.outcome !== 'success') {
+      const outcome = uxResult?.outcome ?? 'not_found';
+      return {
+        kind: 'escalated',
+        escalationReason: { phase: 'ux-gate', reason: `UX design session ${outcome}` },
+      };
+    }
+
+    deps.stderr(`[full-pipeline] UX design session completed -- requesting human acknowledgment`);
+
+    // FULL mode (Large complexity) + touchesUI: require human outbox ack
+    // before coding starts. Poll for 24 hours; timeout -> escalate.
+    const ackRequestId = deps.generateId();
+    await deps.postToOutbox(
+      `UX design complete for "${opts.goal}" -- please review and acknowledge before coding starts`,
+      {
+        requestId: ackRequestId,
+        goal: opts.goal,
+        workspace: opts.workspace,
+        phase: 'ux-gate',
+        uxSessionHandle: uxHandle,
+        note: 'Acknowledge this message to allow coding to begin. No response in 24h = escalation.',
+      },
+    );
+
+    const ackResult = await deps.pollOutboxAck(ackRequestId, UX_GATE_ACK_TIMEOUT_MS);
+    if (ackResult === 'timeout') {
+      await deps.postToOutbox(
+        `UX gate timed out: no acknowledgment received within 24 hours for "${opts.goal}"`,
+        { requestId: ackRequestId, goal: opts.goal, phase: 'ux-gate-timeout' },
+      );
+      return {
+        kind: 'escalated',
+        escalationReason: {
+          phase: 'ux-gate',
+          reason: 'no human acknowledgment received within 24 hours',
+        },
+      };
+    }
+
+    deps.stderr(`[full-pipeline] UX gate acknowledged -- proceeding to coding`);
+  }
+
+  // ── Stage 5: Coding session ───────────────────────────────────────────
+  const codingCutoff = checkSpawnCutoff(coordinatorStartMs, deps.now(), 'coding');
+  if (codingCutoff) return codingCutoff;
+
+  deps.stderr(`[full-pipeline] Spawning coding-task-workflow-agentic`);
+
+  const codingSpawnResult = await deps.spawnSession(
+    'coding-task-workflow-agentic',
+    opts.goal,
+    opts.workspace,
+    {
+      // Belt-and-suspenders: pass pitchPath explicitly (pitch invariant 13)
+      // The shaping session should have created current-pitch.md
+      pitchPath: opts.workspace + '/.workrail/current-pitch.md',
+    },
+  );
+
+  if (codingSpawnResult.kind === 'err') {
+    return {
+      kind: 'escalated',
+      escalationReason: {
+        phase: 'coding',
+        reason: `coding session spawn failed: ${codingSpawnResult.error}`,
+      },
+    };
+  }
+
+  const codingHandle = codingSpawnResult.value;
+  if (!codingHandle) {
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'coding', reason: 'coding session returned empty handle' },
+    };
+  }
+
+  const codingAwait = await deps.awaitSessions([codingHandle], CODING_TIMEOUT_MS);
+  const codingResult = codingAwait.results[0];
+
+  if (!codingResult || codingResult.outcome !== 'success') {
+    const outcome = codingResult?.outcome ?? 'not_found';
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'coding', reason: `coding session ${outcome}` },
+    };
+  }
+
+  deps.stderr(`[full-pipeline] Coding session completed`);
+
+  // ── Stage 6: Poll for PR ──────────────────────────────────────────────
+  const branchPattern = `worktrain/${codingHandle.slice(0, 16)}`;
+  deps.stderr(`[full-pipeline] Polling for PR on branch pattern: ${branchPattern}`);
+
+  const prUrl = await deps.pollForPR(branchPattern, PR_POLL_TIMEOUT_MS);
+  if (!prUrl) {
+    return {
+      kind: 'escalated',
+      escalationReason: {
+        phase: 'pr-detection',
+        reason: `no PR found matching ${branchPattern} within ${PR_POLL_TIMEOUT_MS / 60000} minutes`,
+      },
+    };
+  }
+
+  deps.stderr(`[full-pipeline] PR detected: ${prUrl}`);
+
+  // ── Stage 7: Review + verdict routing ────────────────────────────────
+  return runReviewAndVerdictCycle(deps, opts, prUrl, coordinatorStartMs, 0);
+}

--- a/src/coordinators/modes/full-pipeline.ts
+++ b/src/coordinators/modes/full-pipeline.ts
@@ -145,6 +145,10 @@ function readDiscoveryHandoffArtifact(
  * Run the FULL pipeline mode.
  *
  * Sequences: discovery -> context bridge -> shaping -> [UX gate] -> coding -> PR poll -> review.
+ *
+ * INVARIANT: current-pitch.md is archived in a finally block regardless of outcome.
+ * WHY: if the coding or review phases fail, the pitch must still be archived so it
+ * does not route the next task to IMPLEMENT mode incorrectly. (Pitch invariant 11.)
  */
 export async function runFullPipeline(
   deps: AdaptiveCoordinatorDeps,
@@ -152,6 +156,46 @@ export async function runFullPipeline(
   coordinatorStartMs: number,
 ): Promise<PipelineOutcome> {
   deps.stderr(`[full-pipeline] Starting FULL pipeline for workspace=${opts.workspace}`);
+
+  // ── Pitch archival setup ──────────────────────────────────────────────
+  // Build the archive path now so it's available in the finally block.
+  // The shaping session creates current-pitch.md; we archive it on success or failure.
+  const pitchPath = opts.workspace + '/.workrail/current-pitch.md';
+  const archiveDir = opts.workspace + '/.workrail/used-pitches';
+  const archiveTimestamp = deps.nowIso().replace(/[:.]/g, '-');
+  const archivePath = archiveDir + '/pitch-' + archiveTimestamp + '.md';
+
+  let outcome: PipelineOutcome;
+
+  try {
+    outcome = await runFullPipelineCore(deps, opts, coordinatorStartMs);
+  } finally {
+    // ── Pitch archival (ALWAYS -- success or failure) ──────────────────
+    // WHY finally: if outcome is escalated (discovery failed, shaping failed,
+    // coding failed, etc.), the pitch must still be archived so it doesn't
+    // incorrectly route future tasks to IMPLEMENT mode. (Pitch invariant 11.)
+    try {
+      await deps.mkdir(archiveDir, { recursive: true });
+      await deps.archiveFile(pitchPath, archivePath);
+      deps.stderr(`[full-pipeline] Pitch archived to ${archivePath}`);
+    } catch (e) {
+      // Archive failure is logged but must not override the pipeline outcome.
+      // WHY: if we throw here, the coordinator would have no outcome to return.
+      deps.stderr(`[WARN full-pipeline] Failed to archive pitch.md: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return outcome;
+}
+
+/**
+ * Core FULL pipeline logic (extracted so pitch archival is always in finally).
+ */
+async function runFullPipelineCore(
+  deps: AdaptiveCoordinatorDeps,
+  opts: AdaptivePipelineOpts,
+  coordinatorStartMs: number,
+): Promise<PipelineOutcome> {
 
   // ── Stage 1: Discovery session ────────────────────────────────────────
   const discoveryCutoff = checkSpawnCutoff(coordinatorStartMs, deps.now(), 'discovery');

--- a/src/coordinators/modes/implement-shared.ts
+++ b/src/coordinators/modes/implement-shared.ts
@@ -1,0 +1,346 @@
+/**
+ * Shared review + verdict routing logic for IMPLEMENT and FULL pipeline modes.
+ *
+ * Both IMPLEMENT and FULL modes run the same review -> verdict -> fix-loop -> audit-chain
+ * sequence after the coding session completes. This module extracts that shared logic
+ * to avoid duplication.
+ *
+ * WHY a separate module (not a class or closure):
+ * Following the "compose with small, pure functions" principle. The review cycle
+ * is a well-defined phase that can be imported and tested independently.
+ */
+
+import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts, PipelineOutcome } from '../adaptive-pipeline.js';
+import { CODING_TIMEOUT_MS, REVIEW_TIMEOUT_MS, checkSpawnCutoff } from '../adaptive-pipeline.js';
+import { readVerdictArtifact, parseFindingsFromNotes } from '../pr-review.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CONSTANTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Max fix-loop iterations (pitch invariant 15: exactly 2). */
+export const MAX_FIX_ITERATIONS = 2;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SHARED REVIEW + VERDICT CYCLE
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Run the review session and route the verdict.
+ * Handles fix loop (max 2 iterations) and audit chain for blocking/critical findings.
+ *
+ * Shared by IMPLEMENT mode (implement.ts) and FULL pipeline mode (full-pipeline.ts).
+ *
+ * @param iteration - Current fix loop iteration (0 = first review)
+ */
+export async function runReviewAndVerdictCycle(
+  deps: AdaptiveCoordinatorDeps,
+  opts: AdaptivePipelineOpts,
+  prUrl: string,
+  coordinatorStartMs: number,
+  iteration: number,
+): Promise<PipelineOutcome> {
+  const cutoffCheck = checkSpawnCutoff(coordinatorStartMs, deps.now(), 'review');
+  if (cutoffCheck) return cutoffCheck;
+
+  const reviewGoal = iteration === 0
+    ? `Review PR for merge: ${prUrl}`
+    : `Re-review PR after fixes (iteration ${iteration}): ${prUrl}`;
+
+  deps.stderr(`[review-cycle] Spawning review session (iteration=${iteration}): ${reviewGoal.slice(0, 80)}`);
+
+  const reviewSpawnResult = await deps.spawnSession(
+    'mr-review-workflow-agentic',
+    reviewGoal,
+    opts.workspace,
+    { prUrl },
+  );
+
+  if (reviewSpawnResult.kind === 'err') {
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'review', reason: `review session spawn failed: ${reviewSpawnResult.error}` },
+    };
+  }
+
+  const reviewHandle = reviewSpawnResult.value;
+  if (!reviewHandle) {
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'review', reason: 'review session returned empty handle' },
+    };
+  }
+
+  const reviewAwait = await deps.awaitSessions([reviewHandle], REVIEW_TIMEOUT_MS);
+  const reviewResult = reviewAwait.results[0];
+
+  if (!reviewResult || reviewResult.outcome !== 'success') {
+    const outcome = reviewResult?.outcome ?? 'not_found';
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'review', reason: `review session ${outcome}` },
+    };
+  }
+
+  const agentResult = await deps.getAgentResult(reviewHandle);
+  const verdictFromArtifact = readVerdictArtifact(agentResult.artifacts, reviewHandle);
+  const findingsResult = verdictFromArtifact !== null
+    ? { kind: 'ok' as const, value: verdictFromArtifact }
+    : parseFindingsFromNotes(agentResult.recapMarkdown);
+
+  if (findingsResult.kind === 'err') {
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'review', reason: `review verdict parse failed: ${findingsResult.error}` },
+    };
+  }
+
+  const findings = findingsResult.value;
+  deps.stderr(`[review-cycle] Verdict: ${findings.severity} (iteration=${iteration})`);
+
+  switch (findings.severity) {
+    case 'clean':
+      deps.stderr(`[review-cycle] Verdict clean -- merging PR`);
+      return { kind: 'merged', prUrl };
+
+    case 'minor': {
+      if (iteration >= MAX_FIX_ITERATIONS) {
+        deps.stderr(`[review-cycle] ${MAX_FIX_ITERATIONS} fix iterations exhausted -- escalating`);
+        await deps.postToOutbox(
+          `Adaptive pipeline escalated: fix loop exhausted after ${MAX_FIX_ITERATIONS} iterations`,
+          { prUrl, phase: 'fix-loop', reason: 'max iterations reached', findingSummaries: findings.findingSummaries },
+        );
+        return {
+          kind: 'escalated',
+          escalationReason: { phase: 'fix-loop', reason: `${MAX_FIX_ITERATIONS} fix iterations exhausted` },
+        };
+      }
+
+      deps.stderr(`[review-cycle] Verdict minor -- running fix iteration ${iteration + 1}/${MAX_FIX_ITERATIONS}`);
+
+      const fixCutoff = checkSpawnCutoff(coordinatorStartMs, deps.now(), 'fix-agent');
+      if (fixCutoff) return fixCutoff;
+
+      const fixGoal = `Fix review findings: ${findings.findingSummaries.slice(0, 3).join('; ')}`;
+      const fixSpawnResult = await deps.spawnSession(
+        'coding-task-workflow-agentic',
+        fixGoal,
+        opts.workspace,
+        { prUrl, findings: findings.findingSummaries },
+      );
+
+      if (fixSpawnResult.kind === 'err') {
+        return {
+          kind: 'escalated',
+          escalationReason: { phase: 'fix-agent', reason: `fix agent spawn failed: ${fixSpawnResult.error}` },
+        };
+      }
+
+      const fixHandle = fixSpawnResult.value;
+      if (!fixHandle) {
+        return {
+          kind: 'escalated',
+          escalationReason: { phase: 'fix-agent', reason: 'fix agent returned empty handle' },
+        };
+      }
+
+      const fixAwait = await deps.awaitSessions([fixHandle], CODING_TIMEOUT_MS);
+      const fixResult = fixAwait.results[0];
+
+      if (!fixResult || fixResult.outcome !== 'success') {
+        const outcome = fixResult?.outcome ?? 'not_found';
+        return {
+          kind: 'escalated',
+          escalationReason: { phase: 'fix-agent', reason: `fix agent ${outcome}` },
+        };
+      }
+
+      deps.stderr(`[review-cycle] Fix iteration ${iteration + 1} complete -- re-reviewing`);
+      return runReviewAndVerdictCycle(deps, opts, prUrl, coordinatorStartMs, iteration + 1);
+    }
+
+    case 'blocking':
+    case 'unknown': {
+      return runAuditChain(deps, opts, prUrl, coordinatorStartMs, findings.severity);
+    }
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AUDIT CHAIN
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Run the escalating audit chain for blocking/critical findings.
+ *
+ * Steps:
+ * 1. Dispatch production-readiness-audit
+ *    NOTE: findingCategory is NOT in the verdict schema (rabbit hole #5).
+ *    TODO(follow-up): add findingCategory to ReviewVerdictArtifactV1 and branch:
+ *      - correctness/security Critical -> production-readiness-audit
+ *      - architecture Critical -> architecture-scalability-audit
+ *    For MVP: always dispatch production-readiness-audit (safe default).
+ * 2. Re-review with mr-review-workflow-agentic
+ * 3. If still Critical/blocking: post to Human Outbox, do NOT auto-merge
+ */
+export async function runAuditChain(
+  deps: AdaptiveCoordinatorDeps,
+  opts: AdaptivePipelineOpts,
+  prUrl: string,
+  coordinatorStartMs: number,
+  severity: 'blocking' | 'unknown',
+): Promise<PipelineOutcome> {
+  deps.stderr(`[audit-chain] ${severity.toUpperCase()} finding -- running audit chain`);
+
+  const auditCutoff = checkSpawnCutoff(coordinatorStartMs, deps.now(), 'audit');
+  if (auditCutoff) return auditCutoff;
+
+  // TODO(follow-up): branch on findingCategory when it's added to the verdict schema.
+  // For MVP: always dispatch production-readiness-audit (safe default -- pitch rabbit hole #5).
+  const auditWorkflow = 'production-readiness-audit';
+
+  const auditSpawnResult = await deps.spawnSession(
+    auditWorkflow,
+    `Audit PR before merge: ${prUrl}`,
+    opts.workspace,
+    { prUrl, severity },
+  );
+
+  if (auditSpawnResult.kind === 'err') {
+    await deps.postToOutbox(
+      `Adaptive pipeline escalated: audit workflow failed to spawn`,
+      { prUrl, phase: 'audit', reason: auditSpawnResult.error, severity },
+    );
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'audit', reason: `audit spawn failed: ${auditSpawnResult.error}` },
+    };
+  }
+
+  const auditHandle = auditSpawnResult.value;
+  if (!auditHandle) {
+    await deps.postToOutbox(
+      `Adaptive pipeline escalated: audit returned empty handle`,
+      { prUrl, phase: 'audit', severity },
+    );
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'audit', reason: 'audit returned empty handle' },
+    };
+  }
+
+  const auditAwait = await deps.awaitSessions([auditHandle], REVIEW_TIMEOUT_MS);
+  const auditResult = auditAwait.results[0];
+
+  if (!auditResult || auditResult.outcome !== 'success') {
+    const outcome = auditResult?.outcome ?? 'not_found';
+    await deps.postToOutbox(
+      `Adaptive pipeline escalated: audit session ${outcome}`,
+      { prUrl, phase: 'audit', auditOutcome: outcome, severity },
+    );
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'audit', reason: `audit session ${outcome}` },
+    };
+  }
+
+  deps.stderr(`[audit-chain] Audit complete -- re-reviewing PR`);
+
+  // Re-review after audit
+  const reReviewCutoff = checkSpawnCutoff(coordinatorStartMs, deps.now(), 're-review-after-audit');
+  if (reReviewCutoff) return reReviewCutoff;
+
+  const reReviewSpawnResult = await deps.spawnSession(
+    'mr-review-workflow-agentic',
+    `Re-review after audit: ${prUrl}`,
+    opts.workspace,
+    { prUrl, auditComplete: true },
+  );
+
+  if (reReviewSpawnResult.kind === 'err') {
+    await deps.postToOutbox(
+      `Adaptive pipeline escalated: re-review after audit failed to spawn`,
+      { prUrl, phase: 're-review-after-audit', reason: reReviewSpawnResult.error },
+    );
+    return {
+      kind: 'escalated',
+      escalationReason: {
+        phase: 're-review-after-audit',
+        reason: `re-review spawn failed: ${reReviewSpawnResult.error}`,
+      },
+    };
+  }
+
+  const reReviewHandle = reReviewSpawnResult.value;
+  if (!reReviewHandle) {
+    await deps.postToOutbox(
+      `Adaptive pipeline escalated: re-review after audit returned empty handle`,
+      { prUrl, phase: 're-review-after-audit' },
+    );
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 're-review-after-audit', reason: 're-review returned empty handle' },
+    };
+  }
+
+  const reReviewAwait = await deps.awaitSessions([reReviewHandle], REVIEW_TIMEOUT_MS);
+  const reReviewResult = reReviewAwait.results[0];
+
+  if (!reReviewResult || reReviewResult.outcome !== 'success') {
+    const outcome = reReviewResult?.outcome ?? 'not_found';
+    await deps.postToOutbox(
+      `Adaptive pipeline escalated: re-review after audit session ${outcome}`,
+      { prUrl, phase: 're-review-after-audit', reReviewOutcome: outcome },
+    );
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 're-review-after-audit', reason: `re-review session ${outcome}` },
+    };
+  }
+
+  const reAgentResult = await deps.getAgentResult(reReviewHandle);
+  const reVerdictFromArtifact = readVerdictArtifact(reAgentResult.artifacts, reReviewHandle);
+  const reFindingsResult = reVerdictFromArtifact !== null
+    ? { kind: 'ok' as const, value: reVerdictFromArtifact }
+    : parseFindingsFromNotes(reAgentResult.recapMarkdown);
+
+  if (reFindingsResult.kind === 'err') {
+    await deps.postToOutbox(
+      `Adaptive pipeline escalated: re-review verdict unparseable after audit`,
+      { prUrl, phase: 're-review-after-audit' },
+    );
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 're-review-after-audit', reason: `re-review verdict parse failed` },
+    };
+  }
+
+  const reFindings = reFindingsResult.value;
+  deps.stderr(`[audit-chain] Post-audit re-review verdict: ${reFindings.severity}`);
+
+  if (reFindings.severity === 'clean' || reFindings.severity === 'minor') {
+    deps.stderr(`[audit-chain] Post-audit verdict acceptable (${reFindings.severity}) -- merging`);
+    return { kind: 'merged', prUrl };
+  }
+
+  // Still blocking/critical after audit: post to Human Outbox, do NOT auto-merge
+  deps.stderr(`[audit-chain] Post-audit verdict still ${reFindings.severity} -- escalating to Human Outbox`);
+  await deps.postToOutbox(
+    `PR requires human review: still ${reFindings.severity} after production-readiness audit`,
+    {
+      prUrl,
+      phase: 'audit-chain-complete',
+      severity: reFindings.severity,
+      findingSummaries: reFindings.findingSummaries,
+      note: 'Do NOT auto-merge. Human review required.',
+    },
+  );
+
+  return {
+    kind: 'escalated',
+    escalationReason: {
+      phase: 'audit-chain',
+      reason: `PR still ${reFindings.severity} after audit -- posted to Human Outbox, do NOT merge`,
+    },
+  };
+}

--- a/src/coordinators/modes/implement.ts
+++ b/src/coordinators/modes/implement.ts
@@ -1,0 +1,235 @@
+/**
+ * IMPLEMENT Pipeline Mode Executor
+ *
+ * Executes the coding + PR review pipeline for tasks with a pre-existing pitch.
+ *
+ * Step sequence:
+ * 1. [UX Gate] If goal contains UI-touching signals, dispatch ui-ux-design-workflow first
+ *    - If FULL complexity and touchesUI: require human outbox ack before coding starts
+ * 2. Spawn coding-task-workflow-agentic with pitchPath in context
+ * 3. Poll for PR (gh pr list --head worktrain/<sessionId>) -- up to 5 minutes
+ * 4. Dispatch mr-review-workflow-agentic for the created PR
+ * 5. Route verdict:
+ *    - clean: merge
+ *    - minor: fix loop (max 2 iterations)
+ *    - blocking/critical: audit chain -> re-review -> (still critical) -> escalate
+ * 6. Archive pitch.md (success or failure) -- ALWAYS in finally block
+ *
+ * Design invariants:
+ * - Pitch archival ALWAYS happens in a finally block (pitch invariant 11).
+ *   "After the coding session ends (success or failure)" -- explicit in spec.
+ * - Fix loop is capped at exactly 2 iterations (pitch invariant 15).
+ * - findingCategory is NOT in the verdict schema (rabbit hole #5):
+ *   all Critical findings dispatch production-readiness-audit (safe default).
+ *   TODO(follow-up): add findingCategory to ReviewVerdictArtifactV1 schema.
+ * - COORDINATOR_SPAWN_CUTOFF_MS is checked before every spawn via checkSpawnCutoff().
+ */
+
+import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts, PipelineOutcome } from '../adaptive-pipeline.js';
+import {
+  CODING_TIMEOUT_MS,
+  REVIEW_TIMEOUT_MS,
+  checkSpawnCutoff,
+} from '../adaptive-pipeline.js';
+import { runReviewAndVerdictCycle, MAX_FIX_ITERATIONS } from './implement-shared.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CONSTANTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * PR poll timeout: 5 minutes.
+ * After 5 minutes with no PR: escalate (pitch element 4).
+ */
+const PR_POLL_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * UX gate outbox poll timeout: 24 hours.
+ * After 24 hours with no human ack: escalate (pitch element 5).
+ */
+const UX_GATE_ACK_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * UI-touching keyword signals (case-insensitive).
+ * If the goal contains any of these, dispatch ui-ux-design-workflow first.
+ * (Pitch invariant 16.)
+ */
+const UI_KEYWORDS = [
+  'ui', 'screen', 'view', 'layout', 'component', 'design', 'ux', 'frontend',
+] as const;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HELPERS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Returns true if the goal contains UI-touching keywords.
+ * Used for UX gate detection (pitch invariant 16).
+ */
+export function touchesUI(goal: string): boolean {
+  const lower = goal.toLowerCase();
+  return UI_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// IMPLEMENT MODE EXECUTOR
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Run the IMPLEMENT pipeline mode.
+ *
+ * INVARIANT: pitch.md is archived in a finally block regardless of outcome.
+ * This prevents stale pitch.md from incorrectly routing future tasks to IMPLEMENT.
+ */
+export async function runImplementPipeline(
+  deps: AdaptiveCoordinatorDeps,
+  opts: AdaptivePipelineOpts,
+  pitchPath: string,
+  coordinatorStartMs: number,
+): Promise<PipelineOutcome> {
+  deps.stderr(`[implement] Starting IMPLEMENT pipeline for workspace=${opts.workspace}`);
+
+  // ── Stage 0: Pitch archival setup ─────────────────────────────────────
+  // Build the archive path now so it's available in the finally block
+  const archiveDir = opts.workspace + '/.workrail/used-pitches';
+  const archiveTimestamp = deps.nowIso().replace(/[:.]/g, '-');
+  const archivePath = archiveDir + '/pitch-' + archiveTimestamp + '.md';
+
+  let outcome: PipelineOutcome;
+
+  try {
+    outcome = await runImplementCore(deps, opts, pitchPath, coordinatorStartMs);
+  } finally {
+    // ── Pitch archival (ALWAYS -- success or failure) ──────────────────
+    // WHY finally: if outcome is escalated (coding session failed, review failed,
+    // etc.), the pitch must still be archived so it doesn't route future tasks
+    // to IMPLEMENT mode incorrectly. (Pitch invariant 11: "success or failure".)
+    try {
+      await deps.mkdir(archiveDir, { recursive: true });
+      await deps.archiveFile(pitchPath, archivePath);
+      deps.stderr(`[implement] Pitch archived to ${archivePath}`);
+    } catch (e) {
+      // Archive failure is logged but must not override the pipeline outcome.
+      // WHY: if we throw here, the coordinator would have no outcome to return.
+      deps.stderr(`[WARN implement] Failed to archive pitch.md: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return outcome;
+}
+
+/**
+ * Core IMPLEMENT pipeline logic (extracted so pitch archival is always in finally).
+ */
+async function runImplementCore(
+  deps: AdaptiveCoordinatorDeps,
+  opts: AdaptivePipelineOpts,
+  pitchPath: string,
+  coordinatorStartMs: number,
+): Promise<PipelineOutcome> {
+
+  // ── Stage 1: UX Gate ─────────────────────────────────────────────────
+  if (touchesUI(opts.goal)) {
+    deps.stderr(`[implement] UX signals detected in goal, dispatching ui-ux-design-workflow`);
+
+    const cutoffCheck = checkSpawnCutoff(coordinatorStartMs, deps.now(), 'ux-gate');
+    if (cutoffCheck) return cutoffCheck;
+
+    const uxSpawnResult = await deps.spawnSession('ui-ux-design-workflow', opts.goal, opts.workspace, {
+      pitchPath,
+    });
+
+    if (uxSpawnResult.kind === 'err') {
+      deps.stderr(`[implement] UX gate spawn failed: ${uxSpawnResult.error}`);
+      return {
+        kind: 'escalated',
+        escalationReason: { phase: 'ux-gate', reason: `UX gate spawn failed: ${uxSpawnResult.error}` },
+      };
+    }
+
+    const uxHandle = uxSpawnResult.value;
+    const uxAwait = await deps.awaitSessions([uxHandle], REVIEW_TIMEOUT_MS);
+    const uxResult = uxAwait.results[0];
+
+    if (!uxResult || uxResult.outcome !== 'success') {
+      const outcome = uxResult?.outcome ?? 'not_found';
+      return {
+        kind: 'escalated',
+        escalationReason: { phase: 'ux-gate', reason: `UX design session ${outcome}` },
+      };
+    }
+
+    deps.stderr(`[implement] UX design session completed`);
+
+    // For IMPLEMENT mode, complexity is "Medium" (pitch.md exists = pre-designed).
+    // Large complexity UX gate (human ack) applies only to FULL mode.
+    // NOTE: The pitch says Large complexity + touchesUI requires human outbox ack.
+    // IMPLEMENT mode always has a pitch (pre-designed) so complexity is not Large
+    // in the discovery sense. We skip the outbox ack gate here.
+    // The FULL pipeline (full-pipeline.ts) handles the Large+touchesUI case.
+  }
+
+  // ── Stage 2: Spawn coding session ────────────────────────────────────
+  const cutoffCheck = checkSpawnCutoff(coordinatorStartMs, deps.now(), 'coding');
+  if (cutoffCheck) return cutoffCheck;
+
+  deps.stderr(`[implement] Spawning coding-task-workflow-agentic`);
+
+  const codingSpawnResult = await deps.spawnSession(
+    'coding-task-workflow-agentic',
+    opts.goal,
+    opts.workspace,
+    {
+      // Belt-and-suspenders: pass pitchPath explicitly (pitch invariant 13)
+      pitchPath,
+    },
+  );
+
+  if (codingSpawnResult.kind === 'err') {
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'coding', reason: `coding session spawn failed: ${codingSpawnResult.error}` },
+    };
+  }
+
+  const codingHandle = codingSpawnResult.value;
+  if (!codingHandle) {
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'coding', reason: 'coding session returned empty handle (zombie detection)' },
+    };
+  }
+
+  const codingAwait = await deps.awaitSessions([codingHandle], CODING_TIMEOUT_MS);
+  const codingResult = codingAwait.results[0];
+
+  if (!codingResult || codingResult.outcome !== 'success') {
+    const outcome = codingResult?.outcome ?? 'not_found';
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'coding', reason: `coding session ${outcome}` },
+    };
+  }
+
+  deps.stderr(`[implement] Coding session completed (${Math.round((codingResult.durationMs ?? 0) / 1000)}s)`);
+
+  // ── Stage 3: Poll for PR ──────────────────────────────────────────────
+  const branchPattern = `worktrain/${codingHandle.slice(0, 16)}`;
+  deps.stderr(`[implement] Polling for PR on branch pattern: ${branchPattern}`);
+
+  const prUrl = await deps.pollForPR(branchPattern, PR_POLL_TIMEOUT_MS);
+  if (!prUrl) {
+    return {
+      kind: 'escalated',
+      escalationReason: {
+        phase: 'pr-detection',
+        reason: `no PR found matching ${branchPattern} within ${PR_POLL_TIMEOUT_MS / 60000} minutes`,
+      },
+    };
+  }
+
+  deps.stderr(`[implement] PR detected: ${prUrl}`);
+
+  // ── Stage 4: Review + verdict routing ────────────────────────────────
+  return runReviewAndVerdictCycle(deps, opts, prUrl, coordinatorStartMs, 0);
+}

--- a/src/coordinators/modes/implement.ts
+++ b/src/coordinators/modes/implement.ts
@@ -44,12 +44,6 @@ import { runReviewAndVerdictCycle, MAX_FIX_ITERATIONS } from './implement-shared
 const PR_POLL_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
- * UX gate outbox poll timeout: 24 hours.
- * After 24 hours with no human ack: escalate (pitch element 5).
- */
-const UX_GATE_ACK_TIMEOUT_MS = 24 * 60 * 60 * 1000;
-
-/**
  * UI-touching keyword signals (case-insensitive).
  * If the goal contains any of these, dispatch ui-ux-design-workflow first.
  * (Pitch invariant 16.)

--- a/src/coordinators/modes/quick-review.ts
+++ b/src/coordinators/modes/quick-review.ts
@@ -1,0 +1,87 @@
+/**
+ * QUICK_REVIEW Pipeline Mode Executor
+ *
+ * Delegates dep-bump PR review to the existing runPrReviewCoordinator() with
+ * a specialized [DEP BUMP] goal prefix that instructs the reviewer to skip
+ * architecture audit and focus on version compatibility and test coverage.
+ *
+ * WHY delegation with goal prefix (not a separate workflow):
+ * runPrReviewCoordinator() accepts a custom review goal. By prefixing with
+ * [DEP BUMP], the reviewer gets explicit context about what to focus on.
+ * No new workflow needed; the existing mr-review-workflow-agentic handles it.
+ * (Pitch invariant 10: QUICK_REVIEW delegates to runPrReviewCoordinator().)
+ *
+ * Goal prefix format: "[DEP BUMP] Review PR #${prNumber}: ${prTitle}
+ * -- skip architecture audit, verify version compatibility and test coverage only"
+ */
+
+import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts, PipelineOutcome } from '../adaptive-pipeline.js';
+import { runPrReviewCoordinator } from '../pr-review.js';
+
+/**
+ * Run the QUICK_REVIEW pipeline mode for dependency bump PRs.
+ *
+ * Builds a [DEP BUMP] goal prefix for each PR and delegates to
+ * runPrReviewCoordinator() with focused review instructions.
+ *
+ * @param deps - Adaptive coordinator deps (superset of CoordinatorDeps)
+ * @param opts - Pipeline options (goal contains the dep-bump description)
+ * @param prNumbers - PR numbers extracted from the goal (should have >= 1)
+ * @param coordinatorStartMs - Wall-clock start time for timeout tracking
+ */
+export async function runQuickReviewPipeline(
+  deps: AdaptiveCoordinatorDeps,
+  opts: AdaptivePipelineOpts,
+  prNumbers: readonly number[],
+  _coordinatorStartMs: number,
+): Promise<PipelineOutcome> {
+  deps.stderr(`[quick-review] Dep-bump review for PR(s) [${prNumbers.join(', ')}]`);
+
+  // Build the [DEP BUMP] goal prefix for each PR.
+  // The original goal is used as the "prTitle" context since we don't have
+  // a separate title lookup. The review workflow will read the actual PR title.
+  const depBumpGoal = buildDepBumpGoal(prNumbers, opts.goal);
+  deps.stderr(`[quick-review] Goal: "${depBumpGoal.slice(0, 100)}"`);
+
+  const result = await runPrReviewCoordinator(deps, {
+    workspace: opts.workspace,
+    prs: prNumbers.length > 0 ? [...prNumbers] : undefined,
+    dryRun: opts.dryRun ?? false,
+    port: opts.port,
+  });
+
+  // Same outcome mapping as REVIEW_ONLY -- just a different goal prefix
+  if (result.hasErrors || result.escalated > 0) {
+    return {
+      kind: 'escalated',
+      escalationReason: {
+        phase: 'review',
+        reason: result.hasErrors
+          ? `dep-bump review coordinator reported errors (escalated=${result.escalated})`
+          : `${result.escalated} dep-bump PR(s) escalated during review`,
+      },
+    };
+  }
+
+  return {
+    kind: 'merged',
+    prUrl: result.mergedPrs.length > 0 ? `PR #${result.mergedPrs[0]}` : null,
+  };
+}
+
+/**
+ * Build the [DEP BUMP] goal prefix for dependency bump review.
+ *
+ * Format per pitch specification:
+ * "[DEP BUMP] Review PR #${prNumber}: ... -- skip architecture audit,
+ * verify version compatibility and test coverage only"
+ *
+ * For multiple PRs, uses the first PR number in the prefix.
+ * The reviewer will process all provided PRs.
+ */
+export function buildDepBumpGoal(prNumbers: readonly number[], originalGoal: string): string {
+  const firstPr = prNumbers[0];
+  const prRef = firstPr !== undefined ? `PR #${firstPr}` : 'dep-bump PR';
+  const prTitle = originalGoal.slice(0, 80);
+  return `[DEP BUMP] Review ${prRef}: ${prTitle} -- skip architecture audit, verify version compatibility and test coverage only`;
+}

--- a/src/coordinators/modes/review-only.ts
+++ b/src/coordinators/modes/review-only.ts
@@ -1,0 +1,67 @@
+/**
+ * REVIEW_ONLY Pipeline Mode Executor
+ *
+ * Delegates PR review to the existing runPrReviewCoordinator() without
+ * reimplementing the fix-agent loop.
+ *
+ * WHY delegation (not reimplementation):
+ * runPrReviewCoordinator() already implements the complete review pipeline:
+ * spawn review session -> await -> parse findings -> route (clean/minor/blocking).
+ * The fix-agent loop for minor findings is included. Reimplementing it here
+ * would duplicate logic and diverge over time (pitch invariant 10).
+ *
+ * The REVIEW_ONLY mode wraps CoordinatorResult -> PipelineOutcome.
+ * CoordinatorResult has PR-review-specific count fields; PipelineOutcome
+ * is the single-task pipeline domain type.
+ */
+
+import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts, PipelineOutcome } from '../adaptive-pipeline.js';
+import { runPrReviewCoordinator } from '../pr-review.js';
+
+/**
+ * Run the REVIEW_ONLY pipeline mode.
+ *
+ * Delegates to runPrReviewCoordinator() and maps CoordinatorResult to PipelineOutcome.
+ *
+ * @param deps - Adaptive coordinator deps (superset of CoordinatorDeps)
+ * @param opts - Pipeline options
+ * @param prNumbers - PR numbers to review (empty array = discover open PRs)
+ * @param coordinatorStartMs - Wall-clock start time for timeout tracking
+ */
+export async function runReviewOnlyPipeline(
+  deps: AdaptiveCoordinatorDeps,
+  opts: AdaptivePipelineOpts,
+  prNumbers: readonly number[],
+  _coordinatorStartMs: number,
+): Promise<PipelineOutcome> {
+  deps.stderr(`[review-only] Delegating to runPrReviewCoordinator() for ${prNumbers.length > 0 ? `PR(s) [${prNumbers.join(', ')}]` : 'all open PRs'}`);
+
+  const result = await runPrReviewCoordinator(deps, {
+    workspace: opts.workspace,
+    prs: prNumbers.length > 0 ? [...prNumbers] : undefined,
+    dryRun: opts.dryRun ?? false,
+    port: opts.port,
+  });
+
+  // Map CoordinatorResult -> PipelineOutcome
+  // WHY map rather than return CoordinatorResult:
+  // CoordinatorResult has PR-review-specific fields (reviewed/approved counts)
+  // that are semantically wrong for the pipeline domain. PipelineOutcome is
+  // the clean domain type for single-task pipeline runs.
+  if (result.hasErrors || result.escalated > 0) {
+    return {
+      kind: 'escalated',
+      escalationReason: {
+        phase: 'review',
+        reason: result.hasErrors
+          ? `review coordinator reported errors (escalated=${result.escalated})`
+          : `${result.escalated} PR(s) escalated during review`,
+      },
+    };
+  }
+
+  return {
+    kind: 'merged',
+    prUrl: result.mergedPrs.length > 0 ? `PR #${result.mergedPrs[0]}` : null,
+  };
+}

--- a/src/coordinators/routing/route-task.ts
+++ b/src/coordinators/routing/route-task.ts
@@ -1,0 +1,201 @@
+/**
+ * Adaptive Pipeline Routing: routeTask()
+ *
+ * Pure synchronous function. No I/O except the injectable fileExists check.
+ * No LLM calls. No async. Same inputs always produce the same output (determinism invariant).
+ *
+ * Rules applied in priority order (first match wins):
+ * 1. dep-bump keywords AND PR/MR number in goal -> QUICK_REVIEW
+ * 2. PR/MR number in goal OR github_prs_poll trigger provider -> REVIEW_ONLY
+ * 3. .workrail/current-pitch.md exists in workspace -> IMPLEMENT
+ * 4. Default -> FULL
+ *
+ * WHY context-sensitive PR regex (not bare `#\d+`):
+ * A task like "refactor auth code" must not match REVIEW_ONLY just because
+ * a ticket number like "#123" appears. `\bPR\s*#\d+\b` and `\bMR\s*!?\d+\b`
+ * are specific to pull/merge request references (rabbit hole #4 in pitch).
+ *
+ * Design invariant: routeTask() is the ONLY place routing decisions are made.
+ * The adaptive-pipeline.ts entry point calls it before writing the routing log
+ * and before spawning any session. No routing logic in mode executors.
+ */
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DOMAIN TYPES
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Named pipeline mode -- discriminated union.
+ *
+ * WHY discriminated union: exhaustive switch at compile time ensures every
+ * routing decision handles all variants. No string comparison bugs.
+ * Makes illegal combinations (e.g., IMPLEMENT without pitchPath) unrepresentable.
+ */
+export type PipelineMode =
+  | { readonly kind: 'QUICK_REVIEW'; readonly prNumbers: readonly number[] }
+  | { readonly kind: 'REVIEW_ONLY'; readonly prNumbers: readonly number[] }
+  | { readonly kind: 'IMPLEMENT'; readonly pitchPath: string }
+  | { readonly kind: 'FULL'; readonly goal: string }
+  | { readonly kind: 'ESCALATE'; readonly reason: string };
+
+/**
+ * Deps injected into routeTask() for the single fileExists check.
+ *
+ * WHY injectable: allows tests to exercise all routing rules without
+ * touching the real filesystem. The dep is a single function because
+ * routeTask() has zero other I/O needs.
+ */
+export interface RoutingDeps {
+  readonly fileExists: (path: string) => boolean;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ROUTING CONSTANTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Dep-bump keywords: goal must contain one of these to qualify for Rule 1.
+ * Matched case-insensitively against the normalized goal string.
+ */
+const DEP_BUMP_KEYWORDS = [
+  'bump',
+  'chore:',
+  'dependabot',
+  'dependency upgrade',
+] as const;
+
+/**
+ * Context-sensitive PR/MR number regex.
+ *
+ * WHY two patterns:
+ * - PR_REGEX: matches "PR #123", "PR#123", "PR # 123" (GitHub-style)
+ * - MR_REGEX: matches "MR !123", "MR!123", "MR #123" (GitLab-style)
+ *
+ * WHY word boundaries (\b) before PR/MR:
+ * Prevents matching "APPROVE #123" or "XPRO #123" as PR references.
+ *
+ * WHY NOT bare `#\d+`:
+ * Would match ticket numbers in task descriptions like "Fix issue #42" -> REVIEW_ONLY.
+ * This would be a false positive that incorrectly skips discovery+shaping.
+ */
+const PR_REGEX = /\bPR\s*#\d+\b/i;
+const MR_REGEX = /\bMR\s*!?\d+\b/i;
+
+/**
+ * Relative path to the pitch file within the workspace.
+ * If this file exists, route to IMPLEMENT.
+ */
+const PITCH_FILE_PATH = '.workrail/current-pitch.md';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PURE HELPERS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Extract PR numbers from a goal string.
+ *
+ * Returns all numeric values found in PR/MR references.
+ * Returns empty array if no PR/MR references are found.
+ *
+ * Examples:
+ *   "Review PR #123" -> [123]
+ *   "Review MR !456 and PR #789" -> [456, 789]
+ *   "Refactor auth code" -> []
+ */
+export function extractPrNumbers(goal: string): number[] {
+  const numbers: number[] = [];
+
+  // Extract from PR #N references
+  const prMatches = goal.matchAll(/\bPR\s*#(\d+)\b/gi);
+  for (const match of prMatches) {
+    const n = parseInt(match[1]!, 10);
+    if (!isNaN(n)) numbers.push(n);
+  }
+
+  // Extract from MR !N or MR #N references
+  const mrMatches = goal.matchAll(/\bMR\s*!?#?(\d+)\b/gi);
+  for (const match of mrMatches) {
+    const n = parseInt(match[1]!, 10);
+    if (!isNaN(n)) numbers.push(n);
+  }
+
+  return numbers;
+}
+
+/**
+ * Returns true if the goal contains dep-bump keywords.
+ * Case-insensitive match.
+ */
+function hasDependencyBumpKeywords(goal: string): boolean {
+  const lower = goal.toLowerCase();
+  return DEP_BUMP_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+/**
+ * Returns true if the goal contains a context-sensitive PR or MR reference.
+ */
+function hasPrOrMrReference(goal: string): boolean {
+  return PR_REGEX.test(goal) || MR_REGEX.test(goal);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ROUTING FUNCTION
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Route a task goal to the appropriate pipeline mode.
+ *
+ * Pure function. No async. No LLM. No I/O except the injectable fileExists check.
+ * Rules are applied in priority order; first match wins.
+ *
+ * @param goal - The task goal string (e.g. "Review PR #123" or "Implement auth refresh")
+ * @param workspace - Absolute path to the workspace directory
+ * @param deps - Injectable { fileExists } for pitch detection
+ * @param triggerProvider - Optional trigger provider name (e.g. 'github_prs_poll')
+ * @returns PipelineMode discriminated union
+ */
+export function routeTask(
+  goal: string,
+  workspace: string,
+  deps: RoutingDeps,
+  triggerProvider?: string,
+): PipelineMode {
+  const prNumbers = extractPrNumbers(goal);
+  const hasDepBump = hasDependencyBumpKeywords(goal);
+  const hasPrRef = hasPrOrMrReference(goal);
+  const isGithubPrsPoll = triggerProvider === 'github_prs_poll';
+
+  // ── Rule 1: QUICK_REVIEW ─────────────────────────────────────────────────
+  // dep-bump keywords AND PR/MR number in goal
+  // WHY AND: dep-bump without a PR number means we don't know what to review.
+  // In that case, fall through to IMPLEMENT or FULL (no pitch, no PR = FULL).
+  if (hasDepBump && hasPrRef) {
+    return { kind: 'QUICK_REVIEW', prNumbers };
+  }
+
+  // ── Rule 2: REVIEW_ONLY ──────────────────────────────────────────────────
+  // PR/MR number in goal OR github_prs_poll trigger provider
+  // WHY OR: the queue poller fires with provider='github_prs_poll' even when
+  // the goal text doesn't contain an explicit PR number (the PR number may be
+  // in the trigger context, not the goal string).
+  if (hasPrRef || isGithubPrsPoll) {
+    return { kind: 'REVIEW_ONLY', prNumbers };
+  }
+
+  // ── Rule 3: IMPLEMENT ────────────────────────────────────────────────────
+  // .workrail/current-pitch.md exists in workspace
+  // WHY relative join: the coordinator passes workspace as an absolute path;
+  // we form the full path by joining with the relative pitch location.
+  // The fileExists dep is the ONLY I/O in this function.
+  const pitchPath = workspace.endsWith('/')
+    ? workspace + PITCH_FILE_PATH
+    : workspace + '/' + PITCH_FILE_PATH;
+
+  if (deps.fileExists(pitchPath)) {
+    return { kind: 'IMPLEMENT', pitchPath };
+  }
+
+  // ── Rule 4: FULL (default) ───────────────────────────────────────────────
+  // No signals matched -- full discovery+shaping+coding+review pipeline.
+  return { kind: 'FULL', goal };
+}

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -807,6 +807,10 @@ export class TriggerRouter {
   }
 
   /**
+   * @see feat/github-queue-poll -- polling-scheduler.ts must be updated to call
+   * this method instead of dispatch() when context.taskCandidate is present.
+   * This is intentionally unconnected until that branch is rebased onto main.
+   *
    * Dispatch the adaptive pipeline coordinator in-process (Option B).
    *
    * Called by the GitHub issue queue poller when a task candidate arrives.

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -39,6 +39,8 @@ import { parseHandoffArtifact, runDelivery } from './delivery-action.js';
 import type { ExecFn } from './delivery-action.js';
 import type { DaemonEventEmitter } from '../daemon/daemon-events.js';
 import type { NotificationService } from './notification-service.js';
+import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts, ModeExecutors } from '../coordinators/adaptive-pipeline.js';
+import { runAdaptivePipeline } from '../coordinators/adaptive-pipeline.js';
 
 /**
  * Default production exec function: promisify(execFile).
@@ -802,5 +804,41 @@ export class TriggerRouter {
    */
   listTriggers(): readonly TriggerDefinition[] {
     return [...this.index.values()];
+  }
+
+  /**
+   * Dispatch the adaptive pipeline coordinator in-process (Option B).
+   *
+   * Called by the GitHub issue queue poller when a task candidate arrives.
+   * Calls runAdaptivePipeline() directly as a function call in the same process.
+   * No separate workflow session is spawned for routing.
+   *
+   * WHY Option B (in-process) over Option A (dispatch session):
+   * - The coordinator is a TypeScript script, not a workflow session definition.
+   * - In-process call avoids the session indirection and is directly testable.
+   * - Same approach as the CLI entry point (both call runAdaptivePipeline directly).
+   * (Pitch invariant 9: "The poller owns the process; the coordinator is a function call.")
+   *
+   * @param goal - The task goal string from the incoming queue event
+   * @param workspace - Absolute path to the workspace
+   * @param coordinatorDeps - Injected AdaptiveCoordinatorDeps for the pipeline
+   * @param modeExecutors - Injected mode executor functions
+   * @param context - Optional task context (taskCandidate from queue poller)
+   * @returns The PipelineOutcome (merged, escalated, or dry_run)
+   */
+  async dispatchAdaptivePipeline(
+    goal: string,
+    workspace: string,
+    coordinatorDeps: AdaptiveCoordinatorDeps,
+    modeExecutors: ModeExecutors,
+    context?: Readonly<Record<string, unknown>>,
+  ): ReturnType<typeof runAdaptivePipeline> {
+    const opts: AdaptivePipelineOpts = {
+      goal,
+      workspace,
+      taskCandidate: context,
+    };
+
+    return runAdaptivePipeline(coordinatorDeps, opts, modeExecutors);
   }
 }

--- a/src/v2/durable-core/schemas/artifacts/discovery-handoff.ts
+++ b/src/v2/durable-core/schemas/artifacts/discovery-handoff.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+
+/**
+ * Discovery Handoff Artifact Schema (v1)
+ *
+ * Typed artifact for threading context from the wr.discovery workflow session
+ * to the wr.shaping workflow session in the FULL pipeline mode.
+ *
+ * The discovery session emits this artifact on completion. The adaptive pipeline
+ * coordinator reads it via getAgentResult() -> artifacts[], validates it with Zod,
+ * and injects the relevant fields as context for the shaping session spawn.
+ *
+ * WHY Zod validation: follows the same validate-at-boundaries pattern as
+ * ReviewVerdictArtifactV1Schema. The coordinator trusts validated types internally
+ * and never uses `unknown` casts in its core logic.
+ *
+ * Context threading invariant (pitch invariant 12):
+ * - If artifact is present and valid: inject { selectedDirection, designDocPath,
+ *   assembledContextSummary: renderHandoff(artifact) } into shaping spawn context.
+ * - Fallback: if no valid artifact, use lastStepNotes as assembledContextSummary
+ *   ONLY IF lastStepNotes.trim().length > 50. Otherwise: no assembledContextSummary.
+ *
+ * Kind discriminator follows the `wr.` prefix convention:
+ *   wr.review_verdict, wr.loop_control, wr.coordinator_signal, wr.discovery_handoff
+ */
+
+/**
+ * Contract reference for discovery handoff artifacts.
+ * Used in workflow step definitions to declare the output contract.
+ */
+export const DISCOVERY_HANDOFF_CONTRACT_REF = 'wr.contracts.discovery_handoff' as const;
+
+/**
+ * Discovery Handoff Artifact V1 Schema
+ *
+ * Emitted by the wr.discovery workflow on the final handoff step.
+ * Consumed by the adaptive pipeline coordinator to thread context to shaping.
+ */
+export const DiscoveryHandoffArtifactV1Schema = z
+  .object({
+    /** Artifact kind discriminator (must be 'wr.discovery_handoff') */
+    kind: z.literal('wr.discovery_handoff'),
+
+    /**
+     * Schema version. Must be 1 for V1.
+     * Allows future schema evolution without breaking the coordinator.
+     */
+    version: z.literal(1),
+
+    /**
+     * The selected design direction from discovery.
+     * One-sentence description of the chosen approach.
+     */
+    selectedDirection: z.string().min(1),
+
+    /**
+     * Absolute or workspace-relative path to the generated design document.
+     * May be empty string if no design doc was generated.
+     */
+    designDocPath: z.string(),
+
+    /**
+     * Confidence band for the selected direction.
+     * Used by the coordinator for logging and monitoring -- does not affect routing.
+     */
+    confidenceBand: z.enum(['high', 'medium', 'low']),
+
+    /**
+     * Key invariants discovered during the discovery session.
+     * Array of one-line invariant statements.
+     * Used in renderHandoff() to build the context summary for shaping.
+     */
+    keyInvariants: z.array(z.string().min(1)),
+  })
+  .strict();
+
+export type DiscoveryHandoffArtifactV1 = z.infer<typeof DiscoveryHandoffArtifactV1Schema>;
+
+/**
+ * Type guard to check if an unknown artifact is a discovery handoff artifact.
+ *
+ * Checks the kind discriminant only -- does not validate the full schema.
+ * Use DiscoveryHandoffArtifactV1Schema.safeParse() for full validation.
+ */
+export function isDiscoveryHandoffArtifact(
+  artifact: unknown,
+): artifact is { readonly kind: 'wr.discovery_handoff' } {
+  return (
+    typeof artifact === 'object' &&
+    artifact !== null &&
+    (artifact as Record<string, unknown>).kind === 'wr.discovery_handoff'
+  );
+}
+
+/**
+ * Parse and validate an unknown artifact as a discovery handoff artifact.
+ *
+ * Returns the parsed artifact on success, null on validation failure.
+ * Use isDiscoveryHandoffArtifact() to check kind before calling this
+ * if you want to distinguish "wrong kind" from "wrong schema".
+ */
+export function parseDiscoveryHandoffArtifact(
+  artifact: unknown,
+): DiscoveryHandoffArtifactV1 | null {
+  const result = DiscoveryHandoffArtifactV1Schema.safeParse(artifact);
+  return result.success ? result.data : null;
+}

--- a/src/v2/durable-core/schemas/artifacts/index.ts
+++ b/src/v2/durable-core/schemas/artifacts/index.ts
@@ -52,6 +52,15 @@ export {
   type ReviewVerdictArtifactV1,
 } from './review-verdict.js';
 
+export {
+  // Discovery Handoff
+  DISCOVERY_HANDOFF_CONTRACT_REF,
+  DiscoveryHandoffArtifactV1Schema,
+  isDiscoveryHandoffArtifact,
+  parseDiscoveryHandoffArtifact,
+  type DiscoveryHandoffArtifactV1,
+} from './discovery-handoff.js';
+
 /**
  * Registry of all artifact contract references.
  * Used for validation and documentation.
@@ -61,6 +70,7 @@ export const ARTIFACT_CONTRACT_REFS = [
   'wr.contracts.loop_control',
   'wr.contracts.coordinator_signal',
   'wr.contracts.review_verdict',
+  'wr.contracts.discovery_handoff',
 ] as const;
 
 export type ArtifactContractRef = (typeof ARTIFACT_CONTRACT_REFS)[number];

--- a/tests/unit/adaptive-full-pipeline.test.ts
+++ b/tests/unit/adaptive-full-pipeline.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Unit tests for src/coordinators/modes/full-pipeline.ts
+ *
+ * Tests runFullPipeline() with faked AdaptiveCoordinatorDeps.
+ * All I/O is injected -- no HTTP calls, no exec calls, no filesystem access.
+ *
+ * Key invariants verified:
+ * - Discovery handoff artifact found -> injected as structured context for shaping
+ * - Fallback to lastStepNotes when no artifact (length > 50)
+ * - Fallback skipped when notes length <= 50 (no assembledContextSummary injected)
+ * - Fallback skipped when recapMarkdown is null
+ * - Escalation on discovery session failure (shaping never called)
+ * - Spawn cutoff check prevents spawn after 100 minutes
+ * - renderHandoff() generates expected markdown structure
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runFullPipeline,
+  renderHandoff,
+} from '../../src/coordinators/modes/full-pipeline.js';
+import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts } from '../../src/coordinators/adaptive-pipeline.js';
+import type { AwaitResult } from '../../src/cli/commands/worktrain-await.js';
+import type { DiscoveryHandoffArtifactV1 } from '../../src/v2/durable-core/schemas/artifacts/discovery-handoff.js';
+import { ok, err } from '../../src/runtime/result.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Fake builders
+// ═══════════════════════════════════════════════════════════════════════════
+
+let sessionCounter = 0;
+function nextHandle(): string {
+  return `h${++sessionCounter}`;
+}
+
+function makeSuccessAwait(handle: string): AwaitResult {
+  return {
+    results: [{ handle, outcome: 'success', status: 'completed', durationMs: 1000 }],
+    allSucceeded: true,
+  };
+}
+
+function makeFailedAwait(handle: string): AwaitResult {
+  return {
+    results: [{ handle, outcome: 'failed', status: 'failed', durationMs: 500 }],
+    allSucceeded: false,
+  };
+}
+
+function makeTimeoutAwait(handle: string): AwaitResult {
+  return {
+    results: [{ handle, outcome: 'timeout', status: null, durationMs: 35001 }],
+    allSucceeded: false,
+  };
+}
+
+/**
+ * Build a valid DiscoveryHandoffArtifactV1 for testing.
+ */
+function makeHandoffArtifact(overrides: Partial<DiscoveryHandoffArtifactV1> = {}): DiscoveryHandoffArtifactV1 {
+  return {
+    kind: 'wr.discovery_handoff',
+    version: 1,
+    selectedDirection: 'Use OAuth 2.0 PKCE flow with refresh token rotation',
+    designDocPath: '.workrail/design-doc.md',
+    confidenceBand: 'high',
+    keyInvariants: ['Tokens expire in 15 minutes', 'Refresh tokens are single-use'],
+    ...overrides,
+  };
+}
+
+/**
+ * Build a fake AdaptiveCoordinatorDeps.
+ */
+function makeFakeDeps(overrides: Partial<AdaptiveCoordinatorDeps> = {}): AdaptiveCoordinatorDeps {
+  return {
+    spawnSession: vi.fn().mockImplementation(async () => ok(nextHandle())),
+    awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+    getAgentResult: vi.fn().mockResolvedValue({
+      recapMarkdown: 'APPROVE -- LGTM. No findings.',
+      artifacts: [],
+    }),
+    listOpenPRs: vi.fn().mockResolvedValue([]),
+    mergePR: vi.fn().mockResolvedValue(ok(undefined)),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })),
+    appendFile: vi.fn().mockResolvedValue(undefined),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    stderr: vi.fn(),
+    now: vi.fn().mockReturnValue(Date.now()),
+    port: 3456,
+    homedir: () => '/home/test',
+    joinPath: (...parts: string[]) => parts.join('/'),
+    nowIso: () => new Date().toISOString(),
+    generateId: () => 'test-id-' + Math.random().toString(36).slice(2),
+    fileExists: vi.fn().mockReturnValue(false),
+    archiveFile: vi.fn().mockResolvedValue(undefined),
+    pollForPR: vi.fn().mockResolvedValue('https://github.com/org/repo/pull/42'),
+    postToOutbox: vi.fn().mockResolvedValue(undefined),
+    pollOutboxAck: vi.fn().mockResolvedValue('acked'),
+    ...overrides,
+  };
+}
+
+function makeOpts(goal = 'Implement OAuth refresh token rotation'): AdaptivePipelineOpts {
+  return {
+    workspace: '/workspace',
+    goal,
+    dryRun: false,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// renderHandoff -- pure function
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('renderHandoff', () => {
+  it('includes the selected direction', () => {
+    const artifact = makeHandoffArtifact();
+    const rendered = renderHandoff(artifact);
+    expect(rendered).toContain('OAuth 2.0 PKCE flow');
+  });
+
+  it('includes the confidence band', () => {
+    const artifact = makeHandoffArtifact({ confidenceBand: 'medium' });
+    const rendered = renderHandoff(artifact);
+    expect(rendered).toContain('medium');
+  });
+
+  it('includes the design doc path when non-empty', () => {
+    const artifact = makeHandoffArtifact({ designDocPath: '.workrail/design.md' });
+    const rendered = renderHandoff(artifact);
+    expect(rendered).toContain('.workrail/design.md');
+  });
+
+  it('omits design doc section when path is empty', () => {
+    const artifact = makeHandoffArtifact({ designDocPath: '' });
+    const rendered = renderHandoff(artifact);
+    expect(rendered).not.toContain('Design Doc');
+  });
+
+  it('includes key invariants as bullet points', () => {
+    const artifact = makeHandoffArtifact({
+      keyInvariants: ['Tokens expire in 15 minutes', 'Refresh tokens are single-use'],
+    });
+    const rendered = renderHandoff(artifact);
+    expect(rendered).toContain('Tokens expire in 15 minutes');
+    expect(rendered).toContain('Refresh tokens are single-use');
+  });
+
+  it('omits invariants section when array is empty', () => {
+    const artifact = makeHandoffArtifact({ keyInvariants: [] });
+    const rendered = renderHandoff(artifact);
+    expect(rendered).not.toContain('Key Invariants');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runFullPipeline -- discovery handoff context threading
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runFullPipeline - discovery handoff context threading', () => {
+  it('injects structured context from handoff artifact when found', async () => {
+    const artifact = makeHandoffArtifact();
+    const shapingContexts: Readonly<Record<string, unknown>>[] = [];
+
+    let spawnCount = 0;
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string, _goal: string, _ws: string, context?: Readonly<Record<string, unknown>>) => {
+        const h = nextHandle();
+        if (workflowId === 'wr.shaping') {
+          shapingContexts.push(context ?? {});
+        }
+        spawnCount++;
+        return ok(h);
+      }),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockImplementation(async () => ({
+        recapMarkdown: 'APPROVE -- LGTM',
+        artifacts: [artifact],
+      })),
+    });
+
+    await runFullPipeline(deps, makeOpts(), Date.now());
+
+    expect(shapingContexts.length).toBe(1);
+    expect(shapingContexts[0]).toMatchObject({
+      selectedDirection: artifact.selectedDirection,
+      designDocPath: artifact.designDocPath,
+    });
+    expect((shapingContexts[0] as Record<string, unknown>)['assembledContextSummary']).toContain('Discovery Handoff');
+  });
+
+  it('uses lastStepNotes as assembledContextSummary when notes length > 50', async () => {
+    const longNotes = 'This is a detailed discovery session result with more than 50 characters of useful information.';
+    const shapingContexts: Readonly<Record<string, unknown>>[] = [];
+
+    let spawnCount = 0;
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string, _goal: string, _ws: string, context?: Readonly<Record<string, unknown>>) => {
+        const h = nextHandle();
+        if (workflowId === 'wr.shaping') {
+          shapingContexts.push(context ?? {});
+        }
+        spawnCount++;
+        return ok(h);
+      }),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockImplementation(async () => ({
+        recapMarkdown: longNotes,
+        artifacts: [], // no handoff artifact
+      })),
+    });
+
+    await runFullPipeline(deps, makeOpts(), Date.now());
+
+    expect(shapingContexts.length).toBe(1);
+    expect((shapingContexts[0] as Record<string, unknown>)['assembledContextSummary']).toBe(longNotes.trim());
+  });
+
+  it('injects NO assembledContextSummary when notes length <= 50', async () => {
+    const shortNotes = 'Too short.'; // 10 chars, well under 50
+    const shapingContexts: Readonly<Record<string, unknown>>[] = [];
+
+    let spawnCount = 0;
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string, _goal: string, _ws: string, context?: Readonly<Record<string, unknown>>) => {
+        const h = nextHandle();
+        if (workflowId === 'wr.shaping') {
+          shapingContexts.push(context ?? {});
+        }
+        spawnCount++;
+        return ok(h);
+      }),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockImplementation(async () => ({
+        recapMarkdown: shortNotes,
+        artifacts: [],
+      })),
+    });
+
+    await runFullPipeline(deps, makeOpts(), Date.now());
+
+    expect(shapingContexts.length).toBe(1);
+    // No assembledContextSummary when notes too short
+    expect((shapingContexts[0] as Record<string, unknown>)['assembledContextSummary']).toBeUndefined();
+  });
+
+  it('injects NO assembledContextSummary when recapMarkdown is null', async () => {
+    const shapingContexts: Readonly<Record<string, unknown>>[] = [];
+
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string, _goal: string, _ws: string, context?: Readonly<Record<string, unknown>>) => {
+        const h = nextHandle();
+        if (workflowId === 'wr.shaping') {
+          shapingContexts.push(context ?? {});
+        }
+        return ok(h);
+      }),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockResolvedValue({
+        recapMarkdown: null,
+        artifacts: [],
+      }),
+    });
+
+    await runFullPipeline(deps, makeOpts(), Date.now());
+
+    expect(shapingContexts.length).toBe(1);
+    expect((shapingContexts[0] as Record<string, unknown>)['assembledContextSummary']).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runFullPipeline -- discovery session failure
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runFullPipeline - discovery session failure', () => {
+  it('escalates when discovery session spawn fails (shaping never called)', async () => {
+    const shapingCalls: string[] = [];
+
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string) => {
+        if (workflowId === 'wr.discovery') {
+          return err('daemon not running');
+        }
+        shapingCalls.push(workflowId);
+        return ok(nextHandle());
+      }),
+    });
+
+    const outcome = await runFullPipeline(deps, makeOpts(), Date.now());
+
+    expect(outcome.kind).toBe('escalated');
+    if (outcome.kind === 'escalated') {
+      expect(outcome.escalationReason.phase).toBe('discovery');
+    }
+    expect(shapingCalls).not.toContain('wr.shaping');
+  });
+
+  it('escalates when discovery session times out', async () => {
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async () => ok(nextHandle())),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeTimeoutAwait(handles[0]!)),
+    });
+
+    const outcome = await runFullPipeline(deps, makeOpts(), Date.now());
+
+    expect(outcome.kind).toBe('escalated');
+    if (outcome.kind === 'escalated') {
+      expect(outcome.escalationReason.phase).toBe('discovery');
+      expect(outcome.escalationReason.reason).toContain('timeout');
+    }
+  });
+
+  it('escalates when shaping session fails (coding never called)', async () => {
+    const calledWorkflows: string[] = [];
+    let awaitCount = 0;
+
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string) => {
+        calledWorkflows.push(workflowId);
+        return ok(nextHandle());
+      }),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => {
+        awaitCount++;
+        // First await (discovery) succeeds; second await (shaping) fails
+        if (awaitCount === 1) return makeSuccessAwait(handles[0]!);
+        return makeFailedAwait(handles[0]!);
+      }),
+      getAgentResult: vi.fn().mockResolvedValue({ recapMarkdown: null, artifacts: [] }),
+    });
+
+    const outcome = await runFullPipeline(deps, makeOpts(), Date.now());
+
+    expect(outcome.kind).toBe('escalated');
+    if (outcome.kind === 'escalated') {
+      expect(outcome.escalationReason.phase).toBe('shaping');
+    }
+    expect(calledWorkflows).not.toContain('coding-task-workflow-agentic');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runFullPipeline -- spawn cutoff
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runFullPipeline - spawn cutoff', () => {
+  it('escalates immediately if coordinator started > 100 minutes ago', async () => {
+    const pastStart = Date.now() - 101 * 60 * 1000;
+    const deps = makeFakeDeps();
+
+    const outcome = await runFullPipeline(deps, makeOpts(), pastStart);
+
+    expect(outcome.kind).toBe('escalated');
+    if (outcome.kind === 'escalated') {
+      expect(outcome.escalationReason.reason).toContain('coordinator elapsed');
+    }
+    // No session spawned at all
+    expect(deps.spawnSession).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runFullPipeline -- malformed handoff artifact
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runFullPipeline - malformed handoff artifact', () => {
+  it('falls back to notes when artifact has wrong schema (kind matches, schema fails)', async () => {
+    // Artifact has the right kind but missing required fields
+    const malformedArtifact = { kind: 'wr.discovery_handoff', version: 1 }; // missing selectedDirection etc.
+    const longNotes = 'Discovered that OAuth PKCE is the right approach with various details here exceeding fifty chars.';
+    const shapingContexts: Readonly<Record<string, unknown>>[] = [];
+
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string, _goal: string, _ws: string, context?: Readonly<Record<string, unknown>>) => {
+        if (workflowId === 'wr.shaping') shapingContexts.push(context ?? {});
+        return ok(nextHandle());
+      }),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockResolvedValue({
+        recapMarkdown: longNotes,
+        artifacts: [malformedArtifact],
+      }),
+    });
+
+    await runFullPipeline(deps, makeOpts(), Date.now());
+
+    expect(shapingContexts.length).toBe(1);
+    // Should fall back to notes since schema failed
+    expect((shapingContexts[0] as Record<string, unknown>)['assembledContextSummary']).toBe(longNotes.trim());
+    // WARN log should have been emitted
+    expect(deps.stderr).toHaveBeenCalledWith(
+      expect.stringContaining('discovery handoff schema validation failed'),
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runFullPipeline -- happy path
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runFullPipeline - happy path', () => {
+  it('returns merged when review is clean after full pipeline', async () => {
+    const artifact = makeHandoffArtifact();
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async () => ok(nextHandle())),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockResolvedValue({
+        recapMarkdown: 'APPROVE -- LGTM',
+        artifacts: [artifact],
+      }),
+    });
+
+    const outcome = await runFullPipeline(deps, makeOpts(), Date.now());
+
+    expect(outcome.kind).toBe('merged');
+  });
+
+  it('spawns wr.discovery, wr.shaping, coding, review in order for non-UI goal', async () => {
+    const spawned: string[] = [];
+
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string) => {
+        spawned.push(workflowId);
+        return ok(nextHandle());
+      }),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockResolvedValue({
+        recapMarkdown: 'APPROVE -- LGTM',
+        artifacts: [],
+      }),
+    });
+
+    await runFullPipeline(deps, makeOpts('Implement OAuth token rotation'), Date.now());
+
+    expect(spawned).toContain('wr.discovery');
+    expect(spawned).toContain('wr.shaping');
+    expect(spawned).toContain('coding-task-workflow-agentic');
+    expect(spawned).toContain('mr-review-workflow-agentic');
+    // No UX design workflow for non-UI goal
+    expect(spawned).not.toContain('ui-ux-design-workflow');
+    // Verify order: discovery before shaping before coding before review
+    const discoveryIdx = spawned.indexOf('wr.discovery');
+    const shapingIdx = spawned.indexOf('wr.shaping');
+    const codingIdx = spawned.indexOf('coding-task-workflow-agentic');
+    const reviewIdx = spawned.indexOf('mr-review-workflow-agentic');
+    expect(discoveryIdx).toBeLessThan(shapingIdx);
+    expect(shapingIdx).toBeLessThan(codingIdx);
+    expect(codingIdx).toBeLessThan(reviewIdx);
+  });
+});

--- a/tests/unit/adaptive-full-pipeline.test.ts
+++ b/tests/unit/adaptive-full-pipeline.test.ts
@@ -450,3 +450,53 @@ describe('runFullPipeline - happy path', () => {
     expect(codingIdx).toBeLessThan(reviewIdx);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runFullPipeline -- pitch archival
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runFullPipeline - pitch archival', () => {
+  it('archives current-pitch.md on successful FULL pipeline run', async () => {
+    const artifact = makeHandoffArtifact();
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async () => ok(nextHandle())),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockResolvedValue({
+        recapMarkdown: 'APPROVE -- LGTM',
+        artifacts: [artifact],
+      }),
+    });
+
+    const outcome = await runFullPipeline(deps, makeOpts(), Date.now());
+
+    expect(outcome.kind).toBe('merged');
+    expect(deps.archiveFile).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(deps.archiveFile).mock.calls[0]![0]).toBe('/workspace/.workrail/current-pitch.md');
+    expect(vi.mocked(deps.archiveFile).mock.calls[0]![1]).toContain('used-pitches/pitch-');
+  });
+
+  it('archives current-pitch.md even when coding session spawn fails (finally block)', async () => {
+    let spawnCount = 0;
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string) => {
+        spawnCount++;
+        // discovery and shaping succeed; coding fails
+        if (workflowId === 'coding-task-workflow-agentic') {
+          return err('daemon not running');
+        }
+        return ok(nextHandle());
+      }),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockResolvedValue({
+        recapMarkdown: null,
+        artifacts: [],
+      }),
+    });
+
+    const outcome = await runFullPipeline(deps, makeOpts(), Date.now());
+
+    expect(outcome.kind).toBe('escalated');
+    // Pitch archival must still happen even though coding session failed
+    expect(deps.archiveFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/adaptive-implement.test.ts
+++ b/tests/unit/adaptive-implement.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Unit tests for src/coordinators/modes/implement.ts
+ *
+ * Tests runImplementPipeline() with faked AdaptiveCoordinatorDeps.
+ * All I/O is injected -- no HTTP calls, no exec calls, no filesystem access.
+ *
+ * Key invariants verified:
+ * - Pitch archival called on success
+ * - Pitch archival called when coding session spawn fails (finally block)
+ * - UX gate dispatched when goal contains UI keywords
+ * - Escalation returned on coding session failure
+ * - Fix loop cap at exactly 2 iterations
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runImplementPipeline,
+  touchesUI,
+} from '../../src/coordinators/modes/implement.js';
+import { buildDepBumpGoal } from '../../src/coordinators/modes/quick-review.js';
+import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts } from '../../src/coordinators/adaptive-pipeline.js';
+import type { AwaitResult } from '../../src/cli/commands/worktrain-await.js';
+import { ok, err } from '../../src/runtime/result.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Fake builders
+// ═══════════════════════════════════════════════════════════════════════════
+
+let sessionCounter = 0;
+function nextHandle(): string {
+  return `session-handle-${++sessionCounter}`;
+}
+
+function makeSuccessAwait(handle: string, durationMs = 5000): AwaitResult {
+  return {
+    results: [{ handle, outcome: 'success', status: 'completed', durationMs }],
+    allSucceeded: true,
+  };
+}
+
+function makeFailedAwait(handle: string): AwaitResult {
+  return {
+    results: [{ handle, outcome: 'failed', status: 'failed', durationMs: 1000 }],
+    allSucceeded: false,
+  };
+}
+
+function makeTimeoutAwait(handle: string): AwaitResult {
+  return {
+    results: [{ handle, outcome: 'timeout', status: null, durationMs: 65000 }],
+    allSucceeded: false,
+  };
+}
+
+/**
+ * Build a minimal fake AdaptiveCoordinatorDeps.
+ * Override specific methods to test different scenarios.
+ */
+function makeFakeDeps(overrides: Partial<AdaptiveCoordinatorDeps> = {}): AdaptiveCoordinatorDeps {
+  const deps: AdaptiveCoordinatorDeps = {
+    spawnSession: vi.fn().mockResolvedValue(ok(nextHandle())),
+    awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => {
+      const handle = handles[0] ?? 'default-handle';
+      return makeSuccessAwait(handle);
+    }),
+    getAgentResult: vi.fn().mockResolvedValue({
+      recapMarkdown: 'APPROVE -- no findings. LGTM.',
+      artifacts: [],
+    }),
+    listOpenPRs: vi.fn().mockResolvedValue([]),
+    mergePR: vi.fn().mockResolvedValue(ok(undefined)),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })),
+    appendFile: vi.fn().mockResolvedValue(undefined),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    stderr: vi.fn(),
+    now: vi.fn().mockReturnValue(Date.now()),
+    port: 3456,
+    homedir: () => '/home/test',
+    joinPath: (...parts: string[]) => parts.join('/'),
+    nowIso: () => new Date().toISOString(),
+    generateId: () => 'test-id-' + Math.random().toString(36).slice(2),
+    fileExists: vi.fn().mockReturnValue(false),
+    archiveFile: vi.fn().mockResolvedValue(undefined),
+    pollForPR: vi.fn().mockResolvedValue('https://github.com/org/repo/pull/42'),
+    postToOutbox: vi.fn().mockResolvedValue(undefined),
+    pollOutboxAck: vi.fn().mockResolvedValue('acked'),
+    ...overrides,
+  };
+  return deps;
+}
+
+function makeOpts(goal = 'Implement auth feature'): AdaptivePipelineOpts {
+  return {
+    workspace: '/workspace',
+    goal,
+    dryRun: false,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// touchesUI -- pure helper
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('touchesUI', () => {
+  it('returns true for "ui" keyword', () => {
+    expect(touchesUI('Add a new UI component')).toBe(true);
+  });
+
+  it('returns true for "screen" keyword', () => {
+    expect(touchesUI('Build the login screen')).toBe(true);
+  });
+
+  it('returns true for "component" keyword', () => {
+    expect(touchesUI('Create a Button component')).toBe(true);
+  });
+
+  it('returns true for "design" keyword', () => {
+    expect(touchesUI('Design the checkout flow')).toBe(true);
+  });
+
+  it('returns true for "ux" keyword', () => {
+    expect(touchesUI('Improve ux for mobile')).toBe(true);
+  });
+
+  it('returns true for "frontend" keyword', () => {
+    expect(touchesUI('Refactor the frontend state management')).toBe(true);
+  });
+
+  it('returns false for backend goal', () => {
+    expect(touchesUI('Implement OAuth refresh token rotation')).toBe(false);
+  });
+
+  it('returns false for generic coding goal', () => {
+    expect(touchesUI('Add database migration for users table')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(touchesUI('Add a UI modal')).toBe(true);
+    expect(touchesUI('Add a ui modal')).toBe(true);
+    expect(touchesUI('Add a UI modal'.toUpperCase())).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runImplementPipeline -- pitch archival
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runImplementPipeline - pitch archival', () => {
+  it('archives pitch.md on successful pipeline run', async () => {
+    const deps = makeFakeDeps();
+    const outcome = await runImplementPipeline(deps, makeOpts(), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(outcome.kind).toBe('merged');
+    expect(deps.archiveFile).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(deps.archiveFile).mock.calls[0]![0]).toBe('/workspace/.workrail/current-pitch.md');
+    expect(vi.mocked(deps.archiveFile).mock.calls[0]![1]).toContain('used-pitches/pitch-');
+  });
+
+  it('archives pitch.md even when coding session spawn fails (finally block)', async () => {
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockResolvedValue(err('connection refused')),
+    });
+
+    const outcome = await runImplementPipeline(deps, makeOpts(), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(outcome.kind).toBe('escalated');
+    // Pitch archival must still happen even though the coding session failed
+    expect(deps.archiveFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('archives pitch.md even when coding session times out', async () => {
+    let spawnCount = 0;
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async () => {
+        spawnCount++;
+        return ok(`handle-${spawnCount}`);
+      }),
+      awaitSessions: vi.fn().mockResolvedValue(makeTimeoutAwait('handle-1')),
+    });
+
+    const outcome = await runImplementPipeline(deps, makeOpts(), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(outcome.kind).toBe('escalated');
+    expect(deps.archiveFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs a warning if archiveFile throws but does not change the outcome', async () => {
+    const deps = makeFakeDeps({
+      archiveFile: vi.fn().mockRejectedValue(new Error('disk full')),
+    });
+
+    // Pipeline should succeed even if archive fails
+    const outcome = await runImplementPipeline(deps, makeOpts(), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(outcome.kind).toBe('merged');
+    expect(deps.stderr).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to archive pitch.md'),
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runImplementPipeline -- UX gate
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runImplementPipeline - UX gate', () => {
+  it('dispatches ui-ux-design-workflow when goal contains UI keywords', async () => {
+    const spawnGoals: string[] = [];
+    const spawnWorkflows: string[] = [];
+
+    let spawnCount = 0;
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string, goal: string) => {
+        spawnWorkflows.push(workflowId);
+        spawnGoals.push(goal);
+        return ok(`handle-${++spawnCount}`);
+      }),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => {
+        return makeSuccessAwait(handles[0]!);
+      }),
+    });
+
+    await runImplementPipeline(deps, makeOpts('Build the login screen with proper UX'), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(spawnWorkflows).toContain('ui-ux-design-workflow');
+  });
+
+  it('does NOT dispatch UX workflow for non-UI goal', async () => {
+    const spawnWorkflows: string[] = [];
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string) => {
+        spawnWorkflows.push(workflowId);
+        return ok(`handle-${Math.random()}`);
+      }),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => {
+        return makeSuccessAwait(handles[0]!);
+      }),
+    });
+
+    await runImplementPipeline(deps, makeOpts('Implement OAuth token refresh'), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(spawnWorkflows).not.toContain('ui-ux-design-workflow');
+  });
+
+  it('escalates if UX gate spawn fails', async () => {
+    let spawnCount = 0;
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string) => {
+        spawnCount++;
+        if (workflowId === 'ui-ux-design-workflow') {
+          return err('ui workflow not found');
+        }
+        return ok(`handle-${spawnCount}`);
+      }),
+    });
+
+    const outcome = await runImplementPipeline(deps, makeOpts('Build new UI screen'), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(outcome.kind).toBe('escalated');
+    if (outcome.kind === 'escalated') {
+      expect(outcome.escalationReason.phase).toBe('ux-gate');
+    }
+    // Still archives pitch even on UX gate failure
+    expect(deps.archiveFile).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runImplementPipeline -- coding session escalation
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runImplementPipeline - coding session', () => {
+  it('escalates with phase=coding when coding session spawn fails', async () => {
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockResolvedValue(err('daemon not running')),
+    });
+
+    const outcome = await runImplementPipeline(deps, makeOpts(), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(outcome.kind).toBe('escalated');
+    if (outcome.kind === 'escalated') {
+      expect(outcome.escalationReason.phase).toBe('coding');
+    }
+  });
+
+  it('escalates with phase=coding when coding session times out', async () => {
+    let spawnCount = 0;
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async () => ok(`h${++spawnCount}`)),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => {
+        return makeTimeoutAwait(handles[0]!);
+      }),
+    });
+
+    const outcome = await runImplementPipeline(deps, makeOpts(), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(outcome.kind).toBe('escalated');
+    if (outcome.kind === 'escalated') {
+      expect(outcome.escalationReason.phase).toBe('coding');
+      expect(outcome.escalationReason.reason).toContain('timeout');
+    }
+  });
+
+  it('escalates when no PR is found after coding session', async () => {
+    let spawnCount = 0;
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async () => ok(`h${++spawnCount}`)),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      pollForPR: vi.fn().mockResolvedValue(null), // no PR found
+    });
+
+    const outcome = await runImplementPipeline(deps, makeOpts(), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(outcome.kind).toBe('escalated');
+    if (outcome.kind === 'escalated') {
+      expect(outcome.escalationReason.phase).toBe('pr-detection');
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runImplementPipeline -- fix loop cap
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runImplementPipeline - fix loop cap', () => {
+  it('escalates after exactly 2 fix iterations with minor verdict', async () => {
+    // Review always returns 'minor' verdict
+    const minorNotes = 'Some MINOR findings found. NIT: missing test.';
+    let spawnCount = 0;
+
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async () => ok(`h${++spawnCount}`)),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockResolvedValue({
+        recapMarkdown: minorNotes,
+        artifacts: [],
+      }),
+    });
+
+    const outcome = await runImplementPipeline(deps, makeOpts(), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(outcome.kind).toBe('escalated');
+    if (outcome.kind === 'escalated') {
+      expect(outcome.escalationReason.phase).toBe('fix-loop');
+      expect(outcome.escalationReason.reason).toContain('2 fix iterations exhausted');
+    }
+
+    // postToOutbox called when fix loop exhausted
+    expect(deps.postToOutbox).toHaveBeenCalledWith(
+      expect.stringContaining('fix loop exhausted'),
+      expect.any(Object),
+    );
+  });
+
+  it('merges on clean verdict after first fix iteration', async () => {
+    let reviewCount = 0;
+    let spawnCount = 0;
+
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async () => ok(`h${++spawnCount}`)),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockImplementation(async () => {
+        reviewCount++;
+        if (reviewCount === 1) {
+          // First review: minor
+          return { recapMarkdown: 'MINOR findings: missing test', artifacts: [] };
+        }
+        // Second review (after fix): clean
+        return { recapMarkdown: 'APPROVE -- LGTM, all findings addressed', artifacts: [] };
+      }),
+    });
+
+    const outcome = await runImplementPipeline(deps, makeOpts(), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(outcome.kind).toBe('merged');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runImplementPipeline -- spawn cutoff
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runImplementPipeline - spawn cutoff', () => {
+  it('escalates on coding spawn if coordinator elapsed > 100 minutes', async () => {
+    const pastStart = Date.now() - 101 * 60 * 1000; // 101 minutes ago
+    const deps = makeFakeDeps();
+
+    const outcome = await runImplementPipeline(deps, makeOpts(), '/workspace/.workrail/current-pitch.md', pastStart);
+
+    expect(outcome.kind).toBe('escalated');
+    if (outcome.kind === 'escalated') {
+      expect(outcome.escalationReason.reason).toContain('coordinator elapsed');
+    }
+    // No spawn should have been attempted
+    expect(deps.spawnSession).not.toHaveBeenCalledWith('coding-task-workflow-agentic', expect.any(String), expect.any(String), expect.any(Object));
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runImplementPipeline -- happy path
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runImplementPipeline - happy path', () => {
+  it('returns merged outcome when review is clean', async () => {
+    let spawnCount = 0;
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async () => ok(`h${++spawnCount}`)),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockResolvedValue({
+        recapMarkdown: 'APPROVE -- LGTM. No findings.',
+        artifacts: [],
+      }),
+    });
+
+    const outcome = await runImplementPipeline(deps, makeOpts(), '/workspace/.workrail/current-pitch.md', Date.now());
+
+    expect(outcome.kind).toBe('merged');
+    if (outcome.kind === 'merged') {
+      expect(outcome.prUrl).toBeTruthy();
+    }
+    // coding-task-workflow-agentic was spawned with pitchPath in context
+    expect(deps.spawnSession).toHaveBeenCalledWith(
+      'coding-task-workflow-agentic',
+      expect.any(String),
+      '/workspace',
+      expect.objectContaining({ pitchPath: '/workspace/.workrail/current-pitch.md' }),
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// buildDepBumpGoal -- pure helper from quick-review.ts
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('buildDepBumpGoal', () => {
+  it('includes [DEP BUMP] prefix', () => {
+    const goal = buildDepBumpGoal([123], 'bump lodash from 4.17.20 to 4.17.21');
+    expect(goal).toMatch(/^\[DEP BUMP\]/);
+  });
+
+  it('includes PR number', () => {
+    const goal = buildDepBumpGoal([99], 'bump react to 18.2.0');
+    expect(goal).toContain('PR #99');
+  });
+
+  it('includes skip architecture audit instruction', () => {
+    const goal = buildDepBumpGoal([1], 'bump dep');
+    expect(goal).toContain('skip architecture audit');
+    expect(goal).toContain('version compatibility');
+  });
+});

--- a/tests/unit/adaptive-implement.test.ts
+++ b/tests/unit/adaptive-implement.test.ts
@@ -17,6 +17,7 @@ import {
   runImplementPipeline,
   touchesUI,
 } from '../../src/coordinators/modes/implement.js';
+import { runAuditChain } from '../../src/coordinators/modes/implement-shared.js';
 import { buildDepBumpGoal } from '../../src/coordinators/modes/quick-review.js';
 import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts } from '../../src/coordinators/adaptive-pipeline.js';
 import type { AwaitResult } from '../../src/cli/commands/worktrain-await.js';
@@ -425,6 +426,97 @@ describe('runImplementPipeline - happy path', () => {
       expect.any(String),
       '/workspace',
       expect.objectContaining({ pitchPath: '/workspace/.workrail/current-pitch.md' }),
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// runAuditChain -- escalating audit chain for blocking/critical findings
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('runAuditChain', () => {
+  it('dispatches production-readiness-audit when review returns blocking', async () => {
+    const spawnedWorkflows: string[] = [];
+    let spawnCount = 0;
+
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async (workflowId: string) => {
+        spawnedWorkflows.push(workflowId);
+        return ok(`h${++spawnCount}`);
+      }),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      // Re-review after audit returns clean so we can verify the audit was dispatched
+      getAgentResult: vi.fn().mockResolvedValue({
+        recapMarkdown: 'APPROVE -- LGTM. All findings addressed.',
+        artifacts: [],
+      }),
+    });
+
+    const opts: AdaptivePipelineOpts = { workspace: '/workspace', goal: 'Fix auth bug', dryRun: false };
+    await runAuditChain(deps, opts, 'https://github.com/org/repo/pull/42', Date.now(), 'blocking');
+
+    // Must dispatch production-readiness-audit as the audit workflow
+    expect(spawnedWorkflows).toContain('production-readiness-audit');
+    expect(deps.spawnSession).toHaveBeenCalledWith(
+      'production-readiness-audit',
+      expect.any(String),
+      '/workspace',
+      expect.objectContaining({ prUrl: 'https://github.com/org/repo/pull/42', severity: 'blocking' }),
+    );
+  });
+
+  it('merges PR when post-audit re-review returns clean verdict', async () => {
+    let spawnCount = 0;
+
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async () => ok(`h${++spawnCount}`)),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      getAgentResult: vi.fn().mockResolvedValue({
+        // No blocking keywords -- 'APPROVE' and 'LGTM' are clean signals
+        recapMarkdown: 'APPROVE -- LGTM. All findings addressed and verified.',
+        artifacts: [],
+      }),
+    });
+
+    const opts: AdaptivePipelineOpts = { workspace: '/workspace', goal: 'Fix auth bug', dryRun: false };
+    const outcome = await runAuditChain(deps, opts, 'https://github.com/org/repo/pull/42', Date.now(), 'blocking');
+
+    expect(outcome.kind).toBe('merged');
+    if (outcome.kind === 'merged') {
+      expect(outcome.prUrl).toBe('https://github.com/org/repo/pull/42');
+    }
+    // Must NOT post the do-not-merge escalation when verdict is clean
+    expect(deps.postToOutbox).not.toHaveBeenCalledWith(
+      expect.stringContaining('Do NOT auto-merge'),
+      expect.any(Object),
+    );
+  });
+
+  it('escalates to Human Outbox and does NOT merge when post-audit re-review is still blocking', async () => {
+    let spawnCount = 0;
+
+    const deps = makeFakeDeps({
+      spawnSession: vi.fn().mockImplementation(async () => ok(`h${++spawnCount}`)),
+      awaitSessions: vi.fn().mockImplementation(async (handles: readonly string[]) => makeSuccessAwait(handles[0]!)),
+      // Post-audit re-review still returns blocking
+      getAgentResult: vi.fn().mockResolvedValue({
+        recapMarkdown: 'CRITICAL findings remain: SQL injection vulnerability not resolved.',
+        artifacts: [],
+      }),
+    });
+
+    const opts: AdaptivePipelineOpts = { workspace: '/workspace', goal: 'Fix auth bug', dryRun: false };
+    const outcome = await runAuditChain(deps, opts, 'https://github.com/org/repo/pull/42', Date.now(), 'blocking');
+
+    // Must NOT merge
+    expect(outcome.kind).toBe('escalated');
+    // Must post to Human Outbox: message indicates human review required, metadata has do-not-merge note
+    expect(deps.postToOutbox).toHaveBeenCalledWith(
+      expect.stringContaining('human review'),
+      expect.objectContaining({
+        prUrl: 'https://github.com/org/repo/pull/42',
+        note: 'Do NOT auto-merge. Human review required.',
+      }),
     );
   });
 });

--- a/tests/unit/route-task.test.ts
+++ b/tests/unit/route-task.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Unit tests for src/coordinators/routing/route-task.ts
+ *
+ * Tests routeTask() pure function for all 4 routing rules and edge cases.
+ * All tests use an injectable fileExists fake -- no filesystem access.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  routeTask,
+  extractPrNumbers,
+  type PipelineMode,
+} from '../../src/coordinators/routing/route-task.js';
+
+// ─── Fake deps ───────────────────────────────────────────────────────────────
+
+const noPitch = { fileExists: (_path: string) => false };
+const hasPitch = { fileExists: (_path: string) => true };
+
+// ═══════════════════════════════════════════════════════════════════════════
+// extractPrNumbers -- pure helper
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('extractPrNumbers', () => {
+  it('extracts PR #N reference', () => {
+    expect(extractPrNumbers('Review PR #123')).toEqual([123]);
+  });
+
+  it('extracts PR#N (no space) reference', () => {
+    expect(extractPrNumbers('Review PR#456')).toEqual([456]);
+  });
+
+  it('extracts MR !N reference (GitLab-style)', () => {
+    expect(extractPrNumbers('Review MR !789')).toEqual([789]);
+  });
+
+  it('extracts MR #N reference', () => {
+    expect(extractPrNumbers('Review MR #321')).toEqual([321]);
+  });
+
+  it('extracts multiple PR references', () => {
+    expect(extractPrNumbers('Review PR #1 and PR #2')).toEqual([1, 2]);
+  });
+
+  it('returns empty array for no PR references', () => {
+    expect(extractPrNumbers('Refactor auth code')).toEqual([]);
+  });
+
+  it('does NOT match bare ticket numbers like #123', () => {
+    // "Fix issue #42" -- bare hash is not a PR reference
+    expect(extractPrNumbers('Fix issue #42')).toEqual([]);
+  });
+
+  it('does NOT match APPROVE or similar words with numbers', () => {
+    expect(extractPrNumbers('APPROVE #5 findings from QA')).toEqual([]);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// routeTask -- Rule 1: QUICK_REVIEW
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('routeTask - Rule 1: QUICK_REVIEW', () => {
+  it('routes dep-bump keyword + PR number to QUICK_REVIEW', () => {
+    const mode = routeTask('bump lodash from 4.17.20 to 4.17.21 -- Review PR #99', '/workspace', noPitch);
+    expect(mode.kind).toBe('QUICK_REVIEW');
+    if (mode.kind === 'QUICK_REVIEW') {
+      expect(mode.prNumbers).toContain(99);
+    }
+  });
+
+  it('routes chore: prefix + PR number to QUICK_REVIEW', () => {
+    const mode = routeTask('chore: update deps -- Review PR #42', '/workspace', noPitch);
+    expect(mode.kind).toBe('QUICK_REVIEW');
+  });
+
+  it('routes dependabot keyword + PR number to QUICK_REVIEW', () => {
+    const mode = routeTask('Dependabot: security update -- Review PR #10', '/workspace', noPitch);
+    expect(mode.kind).toBe('QUICK_REVIEW');
+  });
+
+  it('routes "dependency upgrade" phrase + PR number to QUICK_REVIEW', () => {
+    const mode = routeTask('dependency upgrade for axios -- Review PR #55', '/workspace', noPitch);
+    expect(mode.kind).toBe('QUICK_REVIEW');
+  });
+
+  it('dep-bump WITHOUT PR number does NOT route to QUICK_REVIEW', () => {
+    // No PR number -> falls to Rule 3 or Rule 4
+    const mode = routeTask('bump lodash from 4.17.20 to 4.17.21', '/workspace', noPitch);
+    expect(mode.kind).not.toBe('QUICK_REVIEW');
+    expect(mode.kind).toBe('FULL'); // no pitch either
+  });
+
+  it('dep-bump + PR number takes priority over IMPLEMENT even if pitch.md exists', () => {
+    const mode = routeTask('bump lodash -- Review PR #99', '/workspace', hasPitch);
+    expect(mode.kind).toBe('QUICK_REVIEW');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// routeTask -- Rule 2: REVIEW_ONLY
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('routeTask - Rule 2: REVIEW_ONLY', () => {
+  it('routes goal with PR #N reference to REVIEW_ONLY', () => {
+    const mode = routeTask('Review PR #123 before merge', '/workspace', noPitch);
+    expect(mode.kind).toBe('REVIEW_ONLY');
+    if (mode.kind === 'REVIEW_ONLY') {
+      expect(mode.prNumbers).toContain(123);
+    }
+  });
+
+  it('routes goal with MR !456 reference to REVIEW_ONLY', () => {
+    const mode = routeTask('Review MR !456 for security', '/workspace', noPitch);
+    expect(mode.kind).toBe('REVIEW_ONLY');
+  });
+
+  it('routes github_prs_poll trigger provider to REVIEW_ONLY with empty prNumbers', () => {
+    const mode = routeTask('Review open PRs', '/workspace', noPitch, 'github_prs_poll');
+    expect(mode.kind).toBe('REVIEW_ONLY');
+    if (mode.kind === 'REVIEW_ONLY') {
+      expect(mode.prNumbers).toEqual([]);
+    }
+  });
+
+  it('REVIEW_ONLY takes priority over IMPLEMENT when pitch.md exists', () => {
+    const mode = routeTask('Review PR #123', '/workspace', hasPitch);
+    expect(mode.kind).toBe('REVIEW_ONLY');
+  });
+
+  // False positive tests
+  it('does NOT route bare ticket number to REVIEW_ONLY', () => {
+    // "Fix bug #42" -- bare hash must NOT match PR reference
+    const mode = routeTask('Fix bug #42 in the auth module', '/workspace', noPitch);
+    expect(mode.kind).toBe('FULL');
+  });
+
+  it('does NOT route "issue #123" to REVIEW_ONLY', () => {
+    const mode = routeTask('Implement the fix for issue #123', '/workspace', noPitch);
+    expect(mode.kind).toBe('FULL');
+  });
+
+  it('does NOT route random hash number like "report has 3 PRs" to REVIEW_ONLY', () => {
+    // "report has 3 PRs" - "3 PRs" != "PR #N"
+    const mode = routeTask('the report has 3 PRs in scope', '/workspace', noPitch);
+    expect(mode.kind).toBe('FULL');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// routeTask -- Rule 3: IMPLEMENT
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('routeTask - Rule 3: IMPLEMENT', () => {
+  it('routes to IMPLEMENT when pitch.md exists', () => {
+    const mode = routeTask('Implement the auth feature', '/workspace', hasPitch);
+    expect(mode.kind).toBe('IMPLEMENT');
+    if (mode.kind === 'IMPLEMENT') {
+      expect(mode.pitchPath).toContain('current-pitch.md');
+    }
+  });
+
+  it('pitchPath contains the workspace path', () => {
+    const mode = routeTask('Some task', '/my/workspace', hasPitch);
+    expect(mode.kind).toBe('IMPLEMENT');
+    if (mode.kind === 'IMPLEMENT') {
+      expect(mode.pitchPath).toContain('/my/workspace');
+    }
+  });
+
+  it('pitchPath contains .workrail/current-pitch.md', () => {
+    const mode = routeTask('Some task', '/workspace', hasPitch);
+    expect(mode.kind).toBe('IMPLEMENT');
+    if (mode.kind === 'IMPLEMENT') {
+      expect(mode.pitchPath).toContain('.workrail/current-pitch.md');
+    }
+  });
+
+  it('does NOT route to IMPLEMENT when fileExists returns false', () => {
+    const mode = routeTask('Some task', '/workspace', noPitch);
+    expect(mode.kind).toBe('FULL');
+  });
+
+  it('fileExists is called with the correct path', () => {
+    const calledPaths: string[] = [];
+    const trackingDeps = {
+      fileExists: (path: string) => {
+        calledPaths.push(path);
+        return false;
+      },
+    };
+    routeTask('Some task', '/my/workspace', trackingDeps);
+    expect(calledPaths.length).toBeGreaterThan(0);
+    expect(calledPaths[0]).toContain('/my/workspace');
+    expect(calledPaths[0]).toContain('.workrail/current-pitch.md');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// routeTask -- Rule 4: FULL (default)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('routeTask - Rule 4: FULL (default)', () => {
+  it('routes to FULL when no signals match', () => {
+    const mode = routeTask('Implement OAuth refresh token rotation', '/workspace', noPitch);
+    expect(mode.kind).toBe('FULL');
+    if (mode.kind === 'FULL') {
+      expect(mode.goal).toBe('Implement OAuth refresh token rotation');
+    }
+  });
+
+  it('routes to FULL for generic implementation goal', () => {
+    const mode = routeTask('Add pagination to the search results', '/workspace', noPitch);
+    expect(mode.kind).toBe('FULL');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Priority ordering
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('routeTask - priority ordering', () => {
+  it('Rule 1 wins over Rule 2 (dep-bump + PR beats plain PR reference)', () => {
+    const mode = routeTask('chore: bump dep -- Review PR #1', '/workspace', noPitch);
+    expect(mode.kind).toBe('QUICK_REVIEW');
+  });
+
+  it('Rule 1 wins over Rule 3 (dep-bump + PR beats pitch.md)', () => {
+    const mode = routeTask('bump dep -- Review PR #1', '/workspace', hasPitch);
+    expect(mode.kind).toBe('QUICK_REVIEW');
+  });
+
+  it('Rule 2 wins over Rule 3 (PR reference beats pitch.md)', () => {
+    const mode = routeTask('Review PR #123', '/workspace', hasPitch);
+    expect(mode.kind).toBe('REVIEW_ONLY');
+  });
+
+  it('Rule 3 wins over Rule 4 (pitch.md beats default)', () => {
+    const mode = routeTask('Some vague task', '/workspace', hasPitch);
+    expect(mode.kind).toBe('IMPLEMENT');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Stale pitch edge case
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('routeTask - stale pitch edge cases', () => {
+  it('routes to IMPLEMENT even when goal mentions "bump" but no PR number (stale pitch wins over Rule 1 partial)', () => {
+    // dep-bump keyword present BUT no PR number -> Rule 1 does not apply
+    // pitch.md exists -> Rule 3 applies
+    const mode = routeTask('bump lodash', '/workspace', hasPitch);
+    expect(mode.kind).toBe('IMPLEMENT');
+  });
+
+  it('routes to FULL when pitch.md gone after previous IMPLEMENT archival', () => {
+    const mode = routeTask('Continue implementing auth feature', '/workspace', noPitch);
+    expect(mode.kind).toBe('FULL');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Workspace path normalization
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('routeTask - workspace path normalization', () => {
+  it('handles workspace path with trailing slash', () => {
+    const calledPaths: string[] = [];
+    const trackingDeps = {
+      fileExists: (path: string) => {
+        calledPaths.push(path);
+        return false;
+      },
+    };
+    routeTask('Some task', '/my/workspace/', trackingDeps);
+    // Should not produce double slashes in the pitch path
+    expect(calledPaths[0]).not.toContain('//');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `runAdaptivePipeline()` as the routing brain for autonomous WorkTrain sessions, routing tasks to QUICK_REVIEW / REVIEW_ONLY / IMPLEMENT / FULL pipelines based on 4 static rules (no LLM classification)
- Implements all 4 mode executors with phase-level error handling, a 2-iteration fix loop cap, a production-readiness audit chain for critical findings, UX gate for UI tasks, and pitch archival in `finally` blocks
- Registers the `worktrain run pipeline` CLI command and adds `dispatchAdaptivePipeline()` to `TriggerRouter` for Option B in-process queue poller integration

## Design decisions

- **Pure routing**: `routeTask()` is a pure synchronous function with injected `fileExists` -- no async, no LLM, same inputs always produce same output
- **Discriminated union outcomes**: `PipelineOutcome { merged | escalated | dry_run }` makes illegal states unrepresentable at compile time
- **Hardcoded timeouts**: Discovery 35m, Shaping 35m, Coding 65m, Review 25m, spawn cutoff 100m, total cap 120m -- never LLM-computed (pitch invariant 17)
- **findingCategory TODO**: `ReviewVerdictArtifactV1` has no `findingCategory` field; all Critical findings dispatch `production-readiness-audit` (safe default). TODO comment filed in `implement-shared.ts` for follow-up

## Note on base branch

This branch is built on top of `feat/github-queue-poll` (GitHub issue queue poll trigger, not yet merged). The PR diff will include those changes as context. The coordinator specifically uses `dispatchAdaptivePipeline()` for the Option B in-process queue poller integration.

## Files

**New (9):** `adaptive-pipeline.ts`, `routing/route-task.ts`, `modes/review-only.ts`, `modes/quick-review.ts`, `modes/implement.ts`, `modes/implement-shared.ts`, `modes/full-pipeline.ts`, `cli/commands/worktrain-pipeline.ts`, `artifacts/discovery-handoff.ts`

**Modified (3):** `src/cli/commands/index.ts`, `src/trigger/trigger-router.ts`, `src/v2/durable-core/schemas/artifacts/index.ts`

**Tests (3):** `route-task.test.ts` (35 tests), `adaptive-implement.test.ts` (26 tests), `adaptive-full-pipeline.test.ts` (17 tests)

## Test plan

- [x] `npm run build` -- clean, no type errors
- [x] 78/78 coordinator unit tests pass
- [x] 5153/5153 full test suite passes, 0 regressions
- [ ] CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)