### PR TITLE
feat(cli): add worktrain trigger test dry-run command

### DIFF
--- a/design-candidates-trigger-test.md
+++ b/design-candidates-trigger-test.md
@@ -1,0 +1,81 @@
+# Design Candidates: worktrain trigger test dry-run command
+
+## Problem Understanding
+
+### Core Tensions
+1. **Exit code semantics vs CliResult semantics**: The spec requires exit 1 when no issues would dispatch. But `CliResult.failure` is semantically an 'error'. Using it for 'no dispatch' is a semantic mismatch -- acceptable because the spec explicitly says this is useful for scripting.
+2. **Real API calls in a 'dry-run' command**: The command makes real GitHub API calls and reads real session files. The dry-run label refers to 'no dispatch', not 'no I/O'. Invariant: the command never writes anything (no sessions, no labels, no logs).
+3. **Code duplication vs. coupling**: The queue picker logic already exists in `polling-scheduler.ts::doPollGitHubQueue`. Duplicating it in the test command is the right choice because the scheduler's implementation is tightly coupled to PollingScheduler internals (router, store, intervals). Extracting a shared utility would increase coupling.
+4. **countActiveSessions encapsulation**: Private function in polling-scheduler.ts. Inline equivalent (3 lines: count .json files in sessions dir) rather than expose as a module export.
+
+### Likely Seam
+`WorktrainTriggerTestDeps` interface is the real seam. Everything injectable, nothing hardcoded.
+
+### What Makes It Hard
+- The queue picker skip logic has several conditions (excludeLabels, in-progress label, sess_ pattern, idempotency, maturity) -- all must be mirrored accurately.
+- Exit code convention (failure = no dispatch) is counter-intuitive but explicitly specified.
+- `loadQueueConfig` uses the 'label' type; the spec needs the config to be shaped as `GitHubQueueConfig` with the trigger's `source.repo` and `source.token` merged in. The real `pollGitHubQueueIssues` takes a `GitHubQueuePollingSource` + `GitHubQueueConfig` separately -- these come from different config sources.
+
+## Philosophy Constraints
+- Immutability by default -- all deps interfaces readonly
+- Errors are data -- CliResult return, never throw
+- Validate at boundaries -- all input validation at start of execute function
+- Prefer fakes over mocks -- injectable deps enable tests without real I/O
+- YAGNI -- implement exactly what's specified
+- Compose with small pure functions -- slight tension: the execute function is moderately long (~100 lines) but this matches existing repo patterns (spawn command)
+
+## Impact Surface
+- `src/cli/commands/index.ts` -- new export added
+- `src/cli-worktrain.ts` -- new `trigger` command group added (no mutations to existing commands)
+- `tests/unit/worktrain-trigger-test.test.ts` -- new test file
+
+## Candidates
+
+### Candidate A: Minimal inline approach
+Single `executeWorktrainTriggerTestCommand` function, all logic inline, no extracted helpers. Mirrors the `executeWorktrainSpawnCommand` pattern.
+
+- **Summary**: One function, loop over issues, print results, return CliResult.
+- **Tensions resolved**: YAGNI, simplicity, minimal surface area
+- **Tensions accepted**: logic duplication with doPollGitHubQueue is explicit
+- **Boundary**: everything in one function
+- **Failure mode**: function is ~120 lines but matches existing repo pattern (spawn is ~120 lines)
+- **Repo pattern**: follows exactly
+- **Gains**: easy to read, no abstraction overhead
+- **Give up**: if skip logic changes, manual update required
+- **Scope**: best-fit
+- **Philosophy**: honors YAGNI, immutability, errors as data
+
+### Candidate B: Extract pick logic as separate exported function
+A `runQueuePick(issues, config, deps)` function returns `Array<{issue, decision, reason}>`. `executeWorktrainTriggerTestCommand` calls it and prints.
+
+- **Summary**: Separate pick function + print function orchestrated by execute.
+- **Tensions resolved**: testability of pick logic independently
+- **Tensions accepted**: extra type + function, slight over-engineering
+- **Boundary**: pick logic separated from I/O via intermediate result type
+- **Failure mode**: intermediate type that never gets reused elsewhere
+- **Repo pattern**: departs slightly (existing commands don't extract intermediate types)
+- **Gains**: pick logic independently testable
+- **Give up**: YAGNI violation -- spec test cases test execute function behavior, not pick logic
+- **Scope**: slightly broad
+- **Philosophy**: honors 'compose with small pure functions' more strongly; mild conflict with YAGNI
+
+## Comparison and Recommendation
+
+**Recommendation: Candidate A** -- single `executeWorktrainTriggerTestCommand` function following the exact deps interface specified.
+
+Rationale:
+- All 5 spec test cases test execute function behavior (print output, exit code), not internal structure
+- `executeWorktrainSpawnCommand` is ~120 lines with no extracted helpers and is perfectly readable
+- The skip conditions are well-named intermediate variables, making the logic clear
+- Philosophy: YAGNI wins over 'compose with small functions' here because no evidence of reuse
+
+## Self-Critique
+- **Strongest counter-argument**: The pick loop has ~5 conditions. A future extension (e.g., add a new skip reason) means touching the same inline block twice (execute function + test). With Candidate B's extract, only the pick function changes.
+- **Pivot condition**: If a second command needed queue pick logic (e.g., `worktrain trigger preview`), Candidate B would be immediately justified.
+- **Narrower option**: Could avoid the `trigger` command group entirely and name the command `worktrain trigger-test`. Lost because the spec explicitly shows the `trigger` subcommand group.
+- **Assumption that would invalidate**: If the spec's test cases actually verify intermediate state (they don't -- all tests check print output and exit codes).
+
+## Open Questions for Main Agent
+1. The spec's `loadTriggerConfig` dep returns `Result<TriggerIndex, string>` but `TriggerIndex` is not a named export -- it's `Map<string, TriggerDefinition>`. Use the concrete type directly.
+2. The `pollGitHubQueueIssues` function requires a `GitHubQueuePollingSource` (from trigger) AND a `GitHubQueueConfig` (from config.json). The dry-run must wire these from the correct sources. The trigger's `pollingSource` provides repo+token; `loadQueueConfig()` provides the queue filter type.
+3. The maturity description strings in the output ('has acceptance criteria') should match the actual `describeMaturityReason()` logic from polling-scheduler.ts.

--- a/design-review-findings-trigger-test.md
+++ b/design-review-findings-trigger-test.md
@@ -1,0 +1,63 @@
+# Design Review Findings: worktrain trigger test dry-run command
+
+## Tradeoff Review
+
+### T1: failure() for 'no dispatch' (exit 1)
+- Print all dry-run output via `deps.print()` before returning CliResult. CliResult carries only the exit code signal.
+- Acceptable: spec explicitly specifies exit 1 for no-dispatch.
+- Hidden assumption: resolve by printing a summary message before returning.
+
+### T2: Code duplication with doPollGitHubQueue
+- SCOPE LOCK on 3 heuristics documented in github-queue-poller.ts. Drift risk is low.
+- Acceptable: dry-run is advisory, any drift is a documentation bug.
+
+### T3: countActiveSessions inlined
+- 3 lines: readdir + count .json files. Matches the private function in polling-scheduler.ts exactly.
+- Acceptable: file-based sessions contract is stable.
+
+### T4: pollGitHubQueueIssues wiring
+- execute function builds GitHubQueuePollingSource from trigger.pollingSource (safe after provider validation).
+- Deps interface has `pollGitHubQueueIssues: (config: GitHubQueueConfig)` -- the pollingSource is constructed internally and passed to the real function, not injected.
+
+## Failure Mode Review
+
+All failure modes covered:
+- triggers.yml absent: err from loadTriggerConfig, clear error output
+- triggerId not found: undefined from index.get(), clear error
+- Non-queue trigger: provider check with specified error message
+- No queue config: null from loadQueueConfig, clear error (not silent)
+- GitHub API error: err from pollGitHubQueueIssues, clear error
+- Sessions dir absent: countActiveSessions returns 0 (ENOENT = 0 active)
+- Accidental dispatch: architecturally prevented -- no dispatch dep in interface
+
+Highest-risk: FM4 (no queue config). Must print explicit error, not just '0 dispatch' summary.
+
+## Runner-Up / Simpler Alternative Review
+
+Runner-up (extract pick function) contributes one element worth borrowing: local `IssueDecision` type for the classification pass. Adopted as a local type within the execute function -- no exported helpers.
+
+Simpler alternative (no deps interface) breaks testability. Not viable.
+
+## Philosophy Alignment
+
+Satisfied: immutability, errors as data, validate at boundaries, prefer fakes over mocks, determinism, document why.
+
+Under tension (acceptable): compose with small functions (single 120-line function matches repo pattern).
+
+## Findings
+
+### Yellow (Minor)
+- **Y1**: The `failure()` call for 'no dispatch' will produce a message via printResult(). The message field should be set to an empty string or skipped to avoid a confusing 'Error:' prefix in output. All output should go through `deps.print()` before the CliResult is returned.
+- **Y2**: The spec shows `upstreamSpecUrl: (none)` in the output. This requires the execute function to run the same `extractUpstreamSpecUrl()` logic as the scheduler. This function is private in polling-scheduler.ts -- either inline it or import it. Best: inline a 2-line version.
+
+No Red or Orange findings.
+
+## Recommended Revisions
+
+1. Before returning `failure()` for no-dispatch, print the summary via `deps.print()`. Return `failure('')` so printResult doesn't double-print.
+2. Inline `extractUpstreamSpecUrl(body)` (2 lines) in the command file to produce the `upstreamSpecUrl` line in output.
+3. Use `{ kind: 'success' }` (not failure) for the success path -- the spec says exit 0, which is the success CliResult.
+
+## Residual Concerns
+
+None material. The design is sound and matches established repo patterns.

--- a/implementation_plan_trigger_test.md
+++ b/implementation_plan_trigger_test.md
@@ -1,0 +1,154 @@
+# Implementation Plan: worktrain trigger test dry-run command
+
+## 1. Problem Statement
+
+When configuring a GitHub queue-poll trigger, operators have no way to validate that the trigger is correctly configured without running the full daemon. Adding `worktrain trigger test <triggerId>` provides a fast feedback loop: it shows exactly which issues would be dispatched and which would be skipped, using real API calls but never dispatching any sessions.
+
+## 2. Acceptance Criteria
+
+- [ ] `worktrain trigger test self-improvement` loads the trigger by ID from triggers.yml
+- [ ] If the trigger is not a github_queue_poll provider, prints error: "Trigger 'X' is not a queue poll trigger -- only github_queue_poll triggers can be tested with this command"
+- [ ] Prints header: trigger ID, provider, queue config summary, active sessions count
+- [ ] For each issue: prints whether it WOULD DISPATCH or WOULD SKIP with reason
+- [ ] For WOULD DISPATCH issues: prints maturity and upstreamSpecUrl (or "(none)")
+- [ ] For WOULD SKIP issues: prints the skip reason (active_session, maturity=idea, excluded_label, etc.)
+- [ ] Prints summary line: "N would dispatch, M would skip"
+- [ ] Exits 0 if at least 1 issue would dispatch
+- [ ] Exits 1 if no issues would dispatch
+- [ ] All 5 test cases in tests/unit/worktrain-trigger-test.test.ts pass
+- [ ] `npm run build` succeeds
+- [ ] `npx vitest run` succeeds with no regressions
+
+## 3. Non-Goals
+
+- No changes to `src/mcp/` (explicitly excluded per task spec)
+- No changes to actual trigger dispatch logic
+- No support for non-queue poll trigger types (clear error message only)
+- No `--json` output flag
+- No `--dry-run` flag (the entire command IS a dry-run)
+- No actual session dispatch under any circumstances
+- No write actions of any kind (no session files, no labels, no logs)
+
+## 4. Philosophy-Driven Constraints
+
+- All I/O injected via `WorktrainTriggerTestDeps` -- zero direct fs/fetch/os imports in the command file
+- All failures returned as `CliResult` -- never thrown
+- Tests use pure fake deps (no vi.mock())
+- No mutation of any state -- pure read-only query
+
+## 5. Invariants
+
+1. **DRY-RUN INVARIANT**: The command must never dispatch any real sessions. Enforced architecturally: no dispatch function in the deps interface.
+2. **Real API calls are permitted**: The command makes real GitHub API calls to show accurate results.
+3. **Exit code convention**: exit 0 iff >= 1 issue would dispatch; exit 1 if 0 would dispatch.
+4. **Provider gate**: only `github_queue_poll` triggers can be tested. All other providers produce a clear error.
+5. **Skip logic must mirror the scheduler**: The same skip conditions as `doPollGitHubQueue` in polling-scheduler.ts: excludeLabels -> worktrain:in-progress label -> sess_ pattern -> checkIdempotency -> inferMaturity.
+
+## 6. Selected Approach + Rationale
+
+**Approach**: Single `executeWorktrainTriggerTestCommand` function with injected deps, following the exact `WorktrainTriggerTestDeps` interface from the spec. All output via `deps.print()`. Returns `{ kind: 'success' }` (exit 0) or a sentinel failure value (exit 1). The CLI layer in `cli-worktrain.ts` handles exit code directly (not via `interpretCliResultWithoutDI`) to avoid the output-formatter prepending emoji/color to the already-printed dry-run output.
+
+**Rationale**: Matches the injectable-deps pattern of all existing worktrain commands. Single-function design matches `executeWorktrainSpawnCommand` (~120 lines, no extracted helpers). Test cases test behavioral output, not internal sub-functions.
+
+**Runner-up**: Extract `runQueuePick()` as a separate function. Lost because: test cases test execute() behavior, not pick logic; adds a type that never leaves the file; YAGNI.
+
+## 7. Vertical Slices
+
+### Slice 1: Core command file
+**File**: `src/cli/commands/worktrain-trigger-test.ts`
+
+Create `WorktrainTriggerTestDeps`, `WorktrainTriggerTestOpts`, and `executeWorktrainTriggerTestCommand`.
+
+Logic:
+1. `deps.loadTriggerConfig()` -> get trigger index
+2. Find trigger by ID -> error if not found
+3. Validate `trigger.provider === 'github_queue_poll'` -> error with specified message if not
+4. Narrow pollingSource to `GitHubQueuePollingSource`
+5. `deps.loadQueueConfig()` -> error if null or err
+6. `deps.countActiveSessions()` -> count
+7. Print header lines (trigger ID, provider, queue config summary, active sessions)
+8. `deps.pollGitHubQueueIssues(queueConfig)` -> fetch issues
+9. Loop over issues: classify each (excludeLabels, in-progress label, sess_ pattern, idempotency, maturity)
+10. Collect `IssueDecision[]` (local type: `{issue, wouldDispatch, reason, maturity}`)
+11. Print per-issue output
+12. Print summary
+13. Return `{ kind: 'success' }` if dispatches > 0, `{ kind: 'failure', ... }` if 0
+
+**Done when**: file exists, exports function and types, TypeScript compiles.
+
+### Slice 2: Export from index.ts
+**File**: `src/cli/commands/index.ts`
+
+Add export for `executeWorktrainTriggerTestCommand` and types.
+
+**Done when**: index.ts exports the new function.
+
+### Slice 3: Wire into CLI
+**File**: `src/cli-worktrain.ts`
+
+Add `const triggerCommand = program.command('trigger').description(...)` and `triggerCommand.command('test <triggerId>')...`. Wire real deps. Handle exit code directly:
+```typescript
+const result = await executeWorktrainTriggerTestCommand(deps, { triggerId, port: options.port });
+if (result.kind === 'failure') process.exit(1);
+```
+
+**Done when**: `worktrain trigger test --help` works (conceptually).
+
+### Slice 4: Tests
+**File**: `tests/unit/worktrain-trigger-test.test.ts`
+
+5 test cases:
+1. Non-queue trigger returns error
+2. Ready issue: prints WOULD DISPATCH, maturity: ready
+3. Active session: prints WOULD SKIP, reason: active_session
+4. Idea maturity: prints WOULD SKIP, reason: maturity=idea (no spec, no checklist)
+5. Concurrency cap: all-skip when activeSessions >= maxTotalConcurrentSessions
+
+**Done when**: all 5 pass.
+
+## 8. Test Design
+
+Pattern: `makeBaseDeps()` helper returns fake deps with valid defaults. Each test overrides the specific dep needed for that scenario.
+
+```typescript
+function makeBaseDeps(overrides = {}): { deps: WorktrainTriggerTestDeps; printLines: string[] }
+```
+
+Fake deps:
+- `loadTriggerConfig`: returns ok(Map with a github_queue_poll trigger)
+- `loadQueueConfig`: returns ok({ type: 'label', queueLabel: 'worktrain:ready', repo: 'owner/repo', token: 'tok', maxTotalConcurrentSessions: 1, pollIntervalSeconds: 300, excludeLabels: [] })
+- `pollGitHubQueueIssues`: returns ok([])
+- `countActiveSessions`: returns 0
+- `checkIdempotency`: returns 'clear'
+- `inferMaturity`: returns 'ready'
+- `print`: pushes to printLines[]
+- `stderr`: no-op
+
+Test cases use targeted overrides.
+
+## 9. Risk Register
+
+| Risk | Severity | Mitigation |
+|------|----------|-----------|
+| Skip logic drifts from doPollGitHubQueue | Low | Comment in code points to doPollGitHubQueue as reference; SCOPE LOCK documented |
+| output-formatter double-prints dry-run output | Mitigated | CLI layer handles exit code directly, bypasses interpretCliResultWithoutDI |
+| pollGitHubQueueIssues signature mismatch | Low | Execute function builds GitHubQueuePollingSource from trigger.pollingSource internally |
+| countActiveSessions miscounts | Low | Same 3-line logic as private function in polling-scheduler.ts |
+
+## 10. PR Packaging Strategy
+
+Single PR: `feat/trigger-test-command`
+Commit message: `feat(cli): add worktrain trigger test dry-run command`
+
+## 11. Philosophy Alignment
+
+| Principle | Status |
+|-----------|--------|
+| Immutability by default | Satisfied: all deps readonly, no state mutation |
+| Errors are data | Satisfied: CliResult return, no throws |
+| Validate at boundaries | Satisfied: provider check, config null check at entry |
+| Make illegal states unrepresentable | Satisfied: no dispatch dep in interface |
+| Prefer fakes over mocks | Satisfied: test uses pure fake deps |
+| YAGNI with discipline | Satisfied: no extracted helpers, no extra options |
+| Document why not what | Satisfied: WHY comments on failure() usage and dry-run invariant |
+| Compose with small functions | Mild tension: single 100-line function -- matches repo pattern |

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -36,6 +36,7 @@ import {
   executeWorktrainAwaitCommand,
   executeWorktrainDaemonCommand,
   executeWorktrainOverviewCommand,
+  executeWorktrainTriggerTestCommand,
   buildConsoleServiceFromDataDir,
   type Priority,
 } from './cli/commands/index.js';
@@ -1251,6 +1252,86 @@ runCommand
     });
 
     process.exit(result.hasErrors ? 1 : 0);
+  });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TRIGGER COMMAND GROUP
+// ═══════════════════════════════════════════════════════════════════════════
+
+const triggerCommand = program
+  .command('trigger')
+  .description('Trigger management commands');
+
+triggerCommand
+  .command('test <triggerId>')
+  .description('Dry-run the queue picker for a trigger -- shows what would dispatch without dispatching')
+  .option('-p, --port <n>', 'Console server port for active session count', parseInt)
+  .action(async (triggerId: string, options: { port?: number }) => {
+    const { loadTriggerConfigFromFile, buildTriggerIndex } = await import('./trigger/trigger-store.js');
+    const { loadQueueConfig } = await import('./trigger/github-queue-config.js');
+    const { pollGitHubQueueIssues, checkIdempotency, inferMaturity } = await import('./trigger/adapters/github-queue-poller.js');
+
+    const cwd = process.cwd();
+
+    const result = await executeWorktrainTriggerTestCommand(
+      {
+        loadTriggerConfig: async () => {
+          const configResult = await loadTriggerConfigFromFile(cwd, process.env);
+          if (configResult.kind === 'err') {
+            const e = configResult.error;
+            const msg = e.kind === 'file_not_found'
+              ? `triggers.yml not found at ${e.filePath}`
+              : e.kind === 'io_error'
+              ? `IO error reading triggers.yml: ${e.message}`
+              : `Failed to parse triggers.yml: ${JSON.stringify(e)}`;
+            return { kind: 'err', error: msg };
+          }
+          const indexResult = buildTriggerIndex(configResult.value);
+          if (indexResult.kind === 'err') {
+            const idxErr = indexResult.error;
+            const triggerId2 = 'triggerId' in idxErr ? idxErr.triggerId : '(unknown)';
+            return { kind: 'err', error: `Duplicate trigger ID: ${triggerId2}` };
+          }
+          return { kind: 'ok', value: indexResult.value };
+        },
+        loadQueueConfig: async () => {
+          return loadQueueConfig();
+        },
+        pollGitHubQueueIssues: async (source, config) => {
+          const result2 = await pollGitHubQueueIssues(source, config);
+          if (result2.kind === 'err') {
+            const e = result2.error;
+            return { kind: 'err', error: `${e.kind}: ${(e as { message: string }).message}` };
+          }
+          return result2;
+        },
+        countActiveSessions: async () => {
+          const sessionsDir = path.join(os.homedir(), '.workrail', 'daemon-sessions');
+          try {
+            const files = await fs.promises.readdir(sessionsDir);
+            return files.filter((f) => f.endsWith('.json')).length;
+          } catch {
+            return 0;
+          }
+        },
+        checkIdempotency: async (issueNumber: number) => {
+          const sessionsDir = path.join(os.homedir(), '.workrail', 'daemon-sessions');
+          return checkIdempotency(issueNumber, sessionsDir);
+        },
+        inferMaturity: (issue) => inferMaturity(issue.body),
+        print: (line: string) => process.stdout.write(line + '\n'),
+        stderr: (line: string) => process.stderr.write(line + '\n'),
+      },
+      { triggerId, port: options.port },
+    );
+
+    // WHY handle exit code directly (not via interpretCliResultWithoutDI):
+    // All dry-run output is already printed via deps.print(). The CliResult.failure
+    // carries an empty message to avoid the output-formatter printing a redundant
+    // '❌ ...' prefix after the [DryRun] summary. We only need the exit code.
+    if (result.kind === 'failure') {
+      process.exit(1);
+    }
   });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -71,3 +71,8 @@ export {
   type WorktrainPipelineCommandDeps,
   type WorktrainPipelineCommandOpts,
 } from './worktrain-pipeline.js';
+export {
+  executeWorktrainTriggerTestCommand,
+  type WorktrainTriggerTestDeps,
+  type WorktrainTriggerTestOpts,
+} from './worktrain-trigger-test.js';

--- a/src/cli/commands/worktrain-trigger-test.ts
+++ b/src/cli/commands/worktrain-trigger-test.ts
@@ -1,0 +1,310 @@
+/**
+ * WorkTrain Trigger Test Command
+ *
+ * `worktrain trigger test <triggerId>` -- dry-run the queue picker for a
+ * github_queue_poll trigger. Shows which issues would be dispatched and which
+ * would be skipped, using real API calls but NEVER dispatching any sessions.
+ *
+ * Design invariants:
+ * - DRY-RUN INVARIANT: this command NEVER dispatches sessions. Enforced by
+ *   the absence of any dispatch function in WorktrainTriggerTestDeps.
+ * - All I/O is injected via WorktrainTriggerTestDeps. Zero direct fs/fetch imports.
+ * - All failures are returned as CliResult -- never thrown.
+ * - Real API calls are permitted (to show accurate results).
+ * - Exit code: 0 if >= 1 issue would dispatch, 1 if none (useful for scripts).
+ *   The CliResult.failure return for 'no dispatch' is intentional -- it is a
+ *   scripting convention, not an error condition.
+ * - Skip logic mirrors doPollGitHubQueue in polling-scheduler.ts (SCOPE LOCK:
+ *   do not add skip conditions without updating the scheduler too).
+ */
+
+import type { CliResult } from '../types/cli-result.js';
+import { failure, success } from '../types/cli-result.js';
+import type { TriggerDefinition } from '../../trigger/types.js';
+import type { GitHubQueuePollingSource } from '../../trigger/types.js';
+import type { GitHubQueueConfig } from '../../trigger/github-queue-config.js';
+import type { GitHubQueueIssue } from '../../trigger/adapters/github-queue-poller.js';
+import type { Result } from '../../runtime/result.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Injected dependencies for the trigger test command.
+ * All real I/O is behind these interfaces for full testability.
+ *
+ * WHY no dispatch dep: the DRY-RUN INVARIANT is enforced at the type level.
+ * Adding a dispatch dep here would require a conscious code change, not an accident.
+ */
+export interface WorktrainTriggerTestDeps {
+  /**
+   * Load the trigger config from triggers.yml.
+   * Returns a Map<triggerId, TriggerDefinition> or an error string.
+   * WHY injectable: allows tests to inject any trigger config without real files.
+   */
+  readonly loadTriggerConfig: () => Promise<Result<Map<string, TriggerDefinition>, string>>;
+  /**
+   * Load the queue config from ~/.workrail/config.json.
+   * Returns null when no queue config is present.
+   * WHY injectable: allows tests to inject queue configs without real files.
+   */
+  readonly loadQueueConfig: () => Promise<Result<GitHubQueueConfig | null, string>>;
+  /**
+   * Fetch open GitHub issues matching the queue config filter.
+   * Takes the queue config (filter type, label/user, etc.) plus the polling source
+   * (repo, token) from the trigger.
+   * WHY injectable: allows tests to inject issue lists without real HTTP calls.
+   */
+  readonly pollGitHubQueueIssues: (
+    source: GitHubQueuePollingSource,
+    config: GitHubQueueConfig,
+  ) => Promise<Result<GitHubQueueIssue[], string>>;
+  /**
+   * Count active sessions by scanning ~/.workrail/daemon-sessions/ for JSON files.
+   * Returns 0 when the directory doesn't exist or is unreadable.
+   * WHY injectable: allows tests to simulate any active session count.
+   */
+  readonly countActiveSessions: () => Promise<number>;
+  /**
+   * Check if an issue already has an active session.
+   * Conservative default: returns 'active' on any read/parse error.
+   * WHY injectable: allows tests to control per-issue idempotency state.
+   */
+  readonly checkIdempotency: (issueNumber: number) => Promise<'active' | 'clear'>;
+  /**
+   * Infer the maturity of an issue from its body.
+   * Returns 'idea' | 'specced' | 'ready' using the 3 deterministic heuristics.
+   * WHY injectable: allows tests to control maturity per issue.
+   */
+  readonly inferMaturity: (issue: GitHubQueueIssue) => 'idea' | 'specced' | 'ready';
+  /**
+   * Write a line to stdout (dry-run output).
+   * WHY injectable: allows tests to capture all output for assertion.
+   */
+  readonly print: (line: string) => void;
+  /**
+   * Write a line to stderr (errors and warnings).
+   * WHY injectable: allows tests to capture error output separately.
+   */
+  readonly stderr: (line: string) => void;
+}
+
+export interface WorktrainTriggerTestOpts {
+  /** The trigger ID to test (e.g. 'self-improvement'). */
+  readonly triggerId: string;
+  /** Override the console HTTP server port for active session count. Not used by this command. */
+  readonly port?: number;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// COMMAND EXECUTION
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Execute the dry-run trigger test command.
+ *
+ * Returns success (exit 0) if at least one issue would be dispatched.
+ * Returns failure (exit 1) if no issues would be dispatched.
+ *
+ * WHY failure for 'no dispatch': the exit code convention is explicitly specified
+ * for scripting use cases (e.g. CI checks that verify a trigger has work to do).
+ * It is NOT a runtime error -- all dry-run output is printed via deps.print().
+ */
+export async function executeWorktrainTriggerTestCommand(
+  deps: WorktrainTriggerTestDeps,
+  opts: WorktrainTriggerTestOpts,
+): Promise<CliResult> {
+  const triggerId = opts.triggerId.trim();
+  if (!triggerId) {
+    deps.stderr('[DryRun] Error: triggerId must not be empty.');
+    return failure('triggerId must not be empty.');
+  }
+
+  // ---- Load trigger config ----
+  const triggerIndexResult = await deps.loadTriggerConfig();
+  if (triggerIndexResult.kind === 'err') {
+    deps.stderr(`[DryRun] Error: Failed to load triggers.yml: ${triggerIndexResult.error}`);
+    return failure(`Failed to load triggers.yml: ${triggerIndexResult.error}`);
+  }
+
+  const triggerIndex = triggerIndexResult.value;
+  const trigger = triggerIndex.get(triggerId);
+  if (!trigger) {
+    deps.stderr(`[DryRun] Error: Trigger '${triggerId}' not found in triggers.yml.`);
+    return failure(`Trigger '${triggerId}' not found in triggers.yml.`);
+  }
+
+  // ---- Validate provider ----
+  if (trigger.provider !== 'github_queue_poll') {
+    deps.stderr(
+      `[DryRun] Error: Trigger '${triggerId}' is not a queue poll trigger -- ` +
+      `only github_queue_poll triggers can be tested with this command`,
+    );
+    return failure(
+      `Trigger '${triggerId}' is not a queue poll trigger -- ` +
+      `only github_queue_poll triggers can be tested with this command`,
+    );
+  }
+
+  // Safe: provider === 'github_queue_poll' guarantees pollingSource is GitHubQueuePollingSource
+  const pollingSource = trigger.pollingSource as GitHubQueuePollingSource;
+
+  // ---- Load queue config ----
+  const queueConfigResult = await deps.loadQueueConfig();
+  if (queueConfigResult.kind === 'err') {
+    deps.stderr(`[DryRun] Error: Failed to load queue config: ${queueConfigResult.error}`);
+    return failure(`Failed to load queue config: ${queueConfigResult.error}`);
+  }
+
+  const queueConfig = queueConfigResult.value;
+  if (queueConfig === null) {
+    deps.stderr('[DryRun] Error: No queue config found in ~/.workrail/config.json (missing "queue" key).');
+    return failure('No queue config found in ~/.workrail/config.json (missing "queue" key).');
+  }
+
+  // ---- Active session count ----
+  const activeSessions = await deps.countActiveSessions();
+
+  // ---- Print header ----
+  deps.print(`[DryRun] Trigger: ${triggerId} (${trigger.provider})`);
+  deps.print(
+    `[DryRun] Queue config: type=${queueConfig.type}${queueConfig.queueLabel ? ` queueLabel=${queueConfig.queueLabel}` : ''}${queueConfig.user ? ` user=${queueConfig.user}` : ''} repo=${queueConfig.repo}`,
+  );
+  deps.print(
+    `[DryRun] Active sessions: ${activeSessions} / maxTotalConcurrentSessions: ${queueConfig.maxTotalConcurrentSessions}`,
+  );
+  deps.print('');
+
+  // ---- Concurrency cap check (mirrors doPollGitHubQueue invariant) ----
+  // WHY check before fetching: the real scheduler skips the entire cycle when
+  // the concurrency cap is reached. The dry-run reflects this same behavior.
+  if (activeSessions >= queueConfig.maxTotalConcurrentSessions) {
+    deps.print(
+      `[DryRun] Concurrency cap reached: active sessions (${activeSessions}) >= ` +
+      `maxTotalConcurrentSessions (${queueConfig.maxTotalConcurrentSessions})`,
+    );
+    deps.print('[DryRun] Summary: 0 would dispatch, 0 would skip (concurrency cap)');
+    // WHY failure: exit 1 signals 'no dispatch' for scripting use cases
+    return failure('');
+  }
+
+  // ---- Fetch issues ----
+  const issuesResult = await deps.pollGitHubQueueIssues(pollingSource, queueConfig);
+  if (issuesResult.kind === 'err') {
+    deps.stderr(`[DryRun] Error: Failed to fetch issues: ${issuesResult.error}`);
+    return failure(`Failed to fetch issues: ${issuesResult.error}`);
+  }
+
+  const issues = issuesResult.value;
+
+  // ---- Classify each issue (mirrors doPollGitHubQueue skip logic -- SCOPE LOCK) ----
+  type IssueDecision =
+    | { readonly kind: 'dispatch'; readonly issue: GitHubQueueIssue; readonly maturity: 'idea' | 'specced' | 'ready'; readonly upstreamSpecUrl: string | undefined }
+    | { readonly kind: 'skip'; readonly issue: GitHubQueueIssue; readonly reason: string };
+
+  const decisions: IssueDecision[] = [];
+
+  for (const issue of issues) {
+    const issueLabels = issue.labels.map((l) => l.name);
+
+    // H: excludeLabels filter
+    const excludedLabel = queueConfig.excludeLabels.find((el) => issueLabels.includes(el));
+    if (excludedLabel) {
+      decisions.push({ kind: 'skip', issue, reason: `excluded_label: ${excludedLabel}` });
+      continue;
+    }
+
+    // H3: worktrain:in-progress label (active/skip -- not a maturity level)
+    if (issueLabels.includes('worktrain:in-progress')) {
+      decisions.push({ kind: 'skip', issue, reason: 'active_session_or_in_progress' });
+      continue;
+    }
+
+    // H3: session ID pattern in body (active/skip)
+    if (/sess_[a-z0-9]+/.test(issue.body)) {
+      decisions.push({ kind: 'skip', issue, reason: 'active_session_or_in_progress' });
+      continue;
+    }
+
+    // Per-issue idempotency check (conservative: any parse error = active)
+    const idempotencyStatus = await deps.checkIdempotency(issue.number);
+    if (idempotencyStatus === 'active') {
+      decisions.push({ kind: 'skip', issue, reason: 'active_session' });
+      continue;
+    }
+
+    // Infer maturity (exactly 3 heuristics -- SCOPE LOCK per github-queue-poller.ts)
+    const maturity = deps.inferMaturity(issue);
+
+    // Only 'ready' and 'specced' would dispatch; 'idea' is skipped
+    if (maturity === 'idea') {
+      decisions.push({ kind: 'skip', issue, reason: 'maturity=idea (no spec, no checklist)' });
+      continue;
+    }
+
+    decisions.push({
+      kind: 'dispatch',
+      issue,
+      maturity,
+      upstreamSpecUrl: extractUpstreamSpecUrl(issue.body),
+    });
+  }
+
+  // ---- Print per-issue results ----
+  for (const decision of decisions) {
+    if (decision.kind === 'dispatch') {
+      deps.print(`[DryRun] Issue #${decision.issue.number} "${decision.issue.title}" -- WOULD DISPATCH`);
+      deps.print(`  maturity: ${decision.maturity} (${describeMaturity(decision.maturity)})`);
+      deps.print(`  upstreamSpecUrl: ${decision.upstreamSpecUrl ?? '(none)'}`);
+    } else {
+      deps.print(`[DryRun] Issue #${decision.issue.number} "${decision.issue.title}" -- WOULD SKIP`);
+      deps.print(`  reason: ${decision.reason}`);
+    }
+    deps.print('');
+  }
+
+  // ---- Summary ----
+  const dispatchCount = decisions.filter((d) => d.kind === 'dispatch').length;
+  const skipCount = decisions.filter((d) => d.kind === 'skip').length;
+  deps.print(`[DryRun] Summary: ${dispatchCount} would dispatch, ${skipCount} would skip`);
+
+  // WHY failure for 0 dispatch: exit 1 is explicitly specified for scripting use cases.
+  // This is NOT a runtime error -- all output was already printed via deps.print().
+  if (dispatchCount === 0) {
+    return failure('');
+  }
+
+  return success();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PRIVATE HELPERS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Extract the upstream spec URL from an issue body.
+ *
+ * WHY duplicated from polling-scheduler.ts: that function is private to the scheduler.
+ * This is a 2-line extraction matching the same heuristic. If the heuristic changes,
+ * update both (they are part of the SCOPE LOCK on 3 maturity heuristics).
+ */
+function extractUpstreamSpecUrl(body: string): string | undefined {
+  const specLineMatch = /upstream_spec:\s*(https?:\/\/\S+)/i.exec(body);
+  if (specLineMatch?.[1]) return specLineMatch[1];
+  const firstPara = body.split(/\n\s*\n/)[0] ?? '';
+  const urlMatch = /(https?:\/\/\S+)/.exec(firstPara);
+  return urlMatch?.[1];
+}
+
+/**
+ * Human-readable description of a maturity level.
+ * Matches the labels shown in the spec's example output.
+ */
+function describeMaturity(maturity: 'idea' | 'specced' | 'ready'): string {
+  switch (maturity) {
+    case 'ready':   return 'has acceptance criteria';
+    case 'specced': return 'has checklist or acceptance criteria heading';
+    case 'idea':    return 'no spec, no checklist';
+  }
+}

--- a/tests/unit/worktrain-trigger-test.test.ts
+++ b/tests/unit/worktrain-trigger-test.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for executeWorktrainTriggerTestCommand
+ *
+ * Uses fake deps (in-memory, no real I/O). No vi.mock() -- follows repo pattern
+ * of "prefer fakes over mocks".
+ *
+ * Test cases:
+ * 1. Non-queue trigger returns error
+ * 2. Clean run prints dispatch for ready issue
+ * 3. Skips issue with active session
+ * 4. Skips idea-maturity issue
+ * 5. Concurrency cap causes all-skip
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  executeWorktrainTriggerTestCommand,
+  type WorktrainTriggerTestDeps,
+} from '../../src/cli/commands/worktrain-trigger-test.js';
+import type { TriggerDefinition } from '../../src/trigger/types.js';
+import type { GitHubQueueConfig } from '../../src/trigger/github-queue-config.js';
+import type { GitHubQueueIssue } from '../../src/trigger/adapters/github-queue-poller.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TEST FIXTURES
+// ═══════════════════════════════════════════════════════════════════════════
+
+const QUEUE_POLL_TRIGGER: TriggerDefinition = {
+  id: 'self-improvement' as TriggerDefinition['id'],
+  provider: 'github_queue_poll',
+  workflowId: 'coding-task-workflow-agentic',
+  workspacePath: '/workspace',
+  goal: 'Autonomous task',
+  concurrencyMode: 'serial',
+  pollingSource: {
+    provider: 'github_queue_poll',
+    repo: 'EtienneBBeaulac/workrail',
+    token: 'ghp_fake',
+    pollIntervalSeconds: 300,
+  },
+};
+
+const GENERIC_TRIGGER: TriggerDefinition = {
+  id: 'webhook-trigger' as TriggerDefinition['id'],
+  provider: 'generic',
+  workflowId: 'coding-task-workflow-agentic',
+  workspacePath: '/workspace',
+  goal: 'Handle webhook',
+  concurrencyMode: 'serial',
+};
+
+const QUEUE_CONFIG: GitHubQueueConfig = {
+  type: 'label',
+  queueLabel: 'worktrain:ready',
+  repo: 'EtienneBBeaulac/workrail',
+  token: 'ghp_fake',
+  pollIntervalSeconds: 300,
+  maxTotalConcurrentSessions: 1,
+  excludeLabels: [],
+};
+
+function makeIssue(overrides: Partial<GitHubQueueIssue> = {}): GitHubQueueIssue {
+  return {
+    id: 127,
+    number: 127,
+    title: 'Add findingCategory to review-verdict schema',
+    body: 'upstream_spec: https://example.com/spec/review-verdict',
+    url: 'https://github.com/EtienneBBeaulac/workrail/issues/127',
+    labels: [],
+    createdAt: '2026-04-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HELPERS
+// ═══════════════════════════════════════════════════════════════════════════
+
+function makeBaseDeps(overrides: Partial<WorktrainTriggerTestDeps> = {}): {
+  deps: WorktrainTriggerTestDeps;
+  printLines: string[];
+  stderrLines: string[];
+} {
+  const printLines: string[] = [];
+  const stderrLines: string[] = [];
+
+  const triggerIndex = new Map<string, TriggerDefinition>([
+    ['self-improvement', QUEUE_POLL_TRIGGER],
+    ['webhook-trigger', GENERIC_TRIGGER],
+  ]);
+
+  const deps: WorktrainTriggerTestDeps = {
+    loadTriggerConfig: async () => ({ kind: 'ok', value: triggerIndex }),
+    loadQueueConfig: async () => ({ kind: 'ok', value: QUEUE_CONFIG }),
+    pollGitHubQueueIssues: async () => ({ kind: 'ok', value: [makeIssue()] }),
+    countActiveSessions: async () => 0,
+    checkIdempotency: async () => 'clear',
+    inferMaturity: () => 'ready',
+    print: (line) => printLines.push(line),
+    stderr: (line) => stderrLines.push(line),
+    ...overrides,
+  };
+
+  return { deps, printLines, stderrLines };
+}
+
+const VALID_OPTS = { triggerId: 'self-improvement' };
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('executeWorktrainTriggerTestCommand', () => {
+  it('1. Non-queue trigger returns error with specified message', async () => {
+    const { deps, stderrLines } = makeBaseDeps();
+
+    const result = await executeWorktrainTriggerTestCommand(deps, { triggerId: 'webhook-trigger' });
+
+    expect(result.kind).toBe('failure');
+    // The spec requires a specific error message
+    const errorMessage = stderrLines.join('\n');
+    expect(errorMessage).toContain('webhook-trigger');
+    expect(errorMessage).toContain('not a queue poll trigger');
+    expect(errorMessage).toContain('only github_queue_poll triggers can be tested with this command');
+  });
+
+  it('2. Clean run: prints WOULD DISPATCH for ready issue and exits 0', async () => {
+    const issue = makeIssue({
+      number: 127,
+      title: 'Add findingCategory to review-verdict schema',
+      body: 'upstream_spec: https://example.com/spec/review-verdict',
+    });
+
+    const { deps, printLines } = makeBaseDeps({
+      pollGitHubQueueIssues: async () => ({ kind: 'ok', value: [issue] }),
+      inferMaturity: () => 'ready',
+    });
+
+    const result = await executeWorktrainTriggerTestCommand(deps, VALID_OPTS);
+
+    expect(result.kind).toBe('success');
+    const output = printLines.join('\n');
+    expect(output).toContain('[DryRun] Trigger: self-improvement (github_queue_poll)');
+    expect(output).toContain('#127');
+    expect(output).toContain('WOULD DISPATCH');
+    expect(output).toContain('maturity: ready');
+    expect(output).toContain('1 would dispatch');
+  });
+
+  it('3. Skips issue with active session (reason: active_session)', async () => {
+    const issue = makeIssue({ number: 119, title: 'Stuck detection escalation' });
+
+    const { deps, printLines } = makeBaseDeps({
+      pollGitHubQueueIssues: async () => ({ kind: 'ok', value: [issue] }),
+      checkIdempotency: async () => 'active',
+    });
+
+    const result = await executeWorktrainTriggerTestCommand(deps, VALID_OPTS);
+
+    // WHY failure: exit 1 when no issues would dispatch (scripting convention)
+    expect(result.kind).toBe('failure');
+    const output = printLines.join('\n');
+    expect(output).toContain('#119');
+    expect(output).toContain('WOULD SKIP');
+    expect(output).toContain('active_session');
+    expect(output).toContain('0 would dispatch');
+  });
+
+  it('4. Skips idea-maturity issue (reason: maturity=idea)', async () => {
+    const issue = makeIssue({ number: 103, title: 'Jira polling trigger', body: 'No spec here.' });
+
+    const { deps, printLines } = makeBaseDeps({
+      pollGitHubQueueIssues: async () => ({ kind: 'ok', value: [issue] }),
+      inferMaturity: () => 'idea',
+    });
+
+    const result = await executeWorktrainTriggerTestCommand(deps, VALID_OPTS);
+
+    expect(result.kind).toBe('failure');
+    const output = printLines.join('\n');
+    expect(output).toContain('#103');
+    expect(output).toContain('WOULD SKIP');
+    expect(output).toContain('maturity=idea');
+    expect(output).toContain('0 would dispatch');
+  });
+
+  it('5. Concurrency cap: all-skip when activeSessions >= maxTotalConcurrentSessions', async () => {
+    const { deps, printLines } = makeBaseDeps({
+      // Active sessions already at the cap
+      countActiveSessions: async () => 1,
+      // QUEUE_CONFIG.maxTotalConcurrentSessions = 1, so 1 >= 1 = skip
+    });
+
+    const result = await executeWorktrainTriggerTestCommand(deps, VALID_OPTS);
+
+    expect(result.kind).toBe('failure');
+    const output = printLines.join('\n');
+    expect(output).toContain('Concurrency cap reached');
+    expect(output).toContain('0 would dispatch');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `worktrain trigger test <triggerId>` command that dry-runs the queue picker for a `github_queue_poll` trigger
- Shows which issues would be dispatched vs. skipped (with reasons), using real API calls but never dispatching sessions
- Exits 0 if at least 1 issue would dispatch, exits 1 if none (useful for CI/scripting)
- Validates trigger type: only `github_queue_poll` triggers are supported; other providers get a clear error message

## Test plan

- [ ] `npx vitest run tests/unit/worktrain-trigger-test.test.ts` -- all 5 tests pass
- [ ] `npm run build` -- clean
- [ ] `npx vitest run` -- no regressions introduced (pre-existing delivery-action failures on base branch are unrelated to this change)
- [ ] Manual: `worktrain trigger test <triggerId>` prints dry-run output without dispatching any sessions
- [ ] Manual: non-queue trigger produces clear error message
- [ ] Manual: exit code is 0 when issues would dispatch, 1 when none would

🤖 Generated with [Claude Code](https://claude.com/claude-code)