### PR TITLE
feat(trigger): secret scan before git push in delivery-action

### DIFF
--- a/design-candidates-trigger-test.md
+++ b/design-candidates-trigger-test.md
@@ -1,0 +1,81 @@
+# Design Candidates: worktrain trigger test dry-run command
+
+## Problem Understanding
+
+### Core Tensions
+1. **Exit code semantics vs CliResult semantics**: The spec requires exit 1 when no issues would dispatch. But `CliResult.failure` is semantically an 'error'. Using it for 'no dispatch' is a semantic mismatch -- acceptable because the spec explicitly says this is useful for scripting.
+2. **Real API calls in a 'dry-run' command**: The command makes real GitHub API calls and reads real session files. The dry-run label refers to 'no dispatch', not 'no I/O'. Invariant: the command never writes anything (no sessions, no labels, no logs).
+3. **Code duplication vs. coupling**: The queue picker logic already exists in `polling-scheduler.ts::doPollGitHubQueue`. Duplicating it in the test command is the right choice because the scheduler's implementation is tightly coupled to PollingScheduler internals (router, store, intervals). Extracting a shared utility would increase coupling.
+4. **countActiveSessions encapsulation**: Private function in polling-scheduler.ts. Inline equivalent (3 lines: count .json files in sessions dir) rather than expose as a module export.
+
+### Likely Seam
+`WorktrainTriggerTestDeps` interface is the real seam. Everything injectable, nothing hardcoded.
+
+### What Makes It Hard
+- The queue picker skip logic has several conditions (excludeLabels, in-progress label, sess_ pattern, idempotency, maturity) -- all must be mirrored accurately.
+- Exit code convention (failure = no dispatch) is counter-intuitive but explicitly specified.
+- `loadQueueConfig` uses the 'label' type; the spec needs the config to be shaped as `GitHubQueueConfig` with the trigger's `source.repo` and `source.token` merged in. The real `pollGitHubQueueIssues` takes a `GitHubQueuePollingSource` + `GitHubQueueConfig` separately -- these come from different config sources.
+
+## Philosophy Constraints
+- Immutability by default -- all deps interfaces readonly
+- Errors are data -- CliResult return, never throw
+- Validate at boundaries -- all input validation at start of execute function
+- Prefer fakes over mocks -- injectable deps enable tests without real I/O
+- YAGNI -- implement exactly what's specified
+- Compose with small pure functions -- slight tension: the execute function is moderately long (~100 lines) but this matches existing repo patterns (spawn command)
+
+## Impact Surface
+- `src/cli/commands/index.ts` -- new export added
+- `src/cli-worktrain.ts` -- new `trigger` command group added (no mutations to existing commands)
+- `tests/unit/worktrain-trigger-test.test.ts` -- new test file
+
+## Candidates
+
+### Candidate A: Minimal inline approach
+Single `executeWorktrainTriggerTestCommand` function, all logic inline, no extracted helpers. Mirrors the `executeWorktrainSpawnCommand` pattern.
+
+- **Summary**: One function, loop over issues, print results, return CliResult.
+- **Tensions resolved**: YAGNI, simplicity, minimal surface area
+- **Tensions accepted**: logic duplication with doPollGitHubQueue is explicit
+- **Boundary**: everything in one function
+- **Failure mode**: function is ~120 lines but matches existing repo pattern (spawn is ~120 lines)
+- **Repo pattern**: follows exactly
+- **Gains**: easy to read, no abstraction overhead
+- **Give up**: if skip logic changes, manual update required
+- **Scope**: best-fit
+- **Philosophy**: honors YAGNI, immutability, errors as data
+
+### Candidate B: Extract pick logic as separate exported function
+A `runQueuePick(issues, config, deps)` function returns `Array<{issue, decision, reason}>`. `executeWorktrainTriggerTestCommand` calls it and prints.
+
+- **Summary**: Separate pick function + print function orchestrated by execute.
+- **Tensions resolved**: testability of pick logic independently
+- **Tensions accepted**: extra type + function, slight over-engineering
+- **Boundary**: pick logic separated from I/O via intermediate result type
+- **Failure mode**: intermediate type that never gets reused elsewhere
+- **Repo pattern**: departs slightly (existing commands don't extract intermediate types)
+- **Gains**: pick logic independently testable
+- **Give up**: YAGNI violation -- spec test cases test execute function behavior, not pick logic
+- **Scope**: slightly broad
+- **Philosophy**: honors 'compose with small pure functions' more strongly; mild conflict with YAGNI
+
+## Comparison and Recommendation
+
+**Recommendation: Candidate A** -- single `executeWorktrainTriggerTestCommand` function following the exact deps interface specified.
+
+Rationale:
+- All 5 spec test cases test execute function behavior (print output, exit code), not internal structure
+- `executeWorktrainSpawnCommand` is ~120 lines with no extracted helpers and is perfectly readable
+- The skip conditions are well-named intermediate variables, making the logic clear
+- Philosophy: YAGNI wins over 'compose with small functions' here because no evidence of reuse
+
+## Self-Critique
+- **Strongest counter-argument**: The pick loop has ~5 conditions. A future extension (e.g., add a new skip reason) means touching the same inline block twice (execute function + test). With Candidate B's extract, only the pick function changes.
+- **Pivot condition**: If a second command needed queue pick logic (e.g., `worktrain trigger preview`), Candidate B would be immediately justified.
+- **Narrower option**: Could avoid the `trigger` command group entirely and name the command `worktrain trigger-test`. Lost because the spec explicitly shows the `trigger` subcommand group.
+- **Assumption that would invalidate**: If the spec's test cases actually verify intermediate state (they don't -- all tests check print output and exit codes).
+
+## Open Questions for Main Agent
+1. The spec's `loadTriggerConfig` dep returns `Result<TriggerIndex, string>` but `TriggerIndex` is not a named export -- it's `Map<string, TriggerDefinition>`. Use the concrete type directly.
+2. The `pollGitHubQueueIssues` function requires a `GitHubQueuePollingSource` (from trigger) AND a `GitHubQueueConfig` (from config.json). The dry-run must wire these from the correct sources. The trigger's `pollingSource` provides repo+token; `loadQueueConfig()` provides the queue filter type.
+3. The maturity description strings in the output ('has acceptance criteria') should match the actual `describeMaturityReason()` logic from polling-scheduler.ts.

--- a/design-review-findings-trigger-test.md
+++ b/design-review-findings-trigger-test.md
@@ -1,0 +1,63 @@
+# Design Review Findings: worktrain trigger test dry-run command
+
+## Tradeoff Review
+
+### T1: failure() for 'no dispatch' (exit 1)
+- Print all dry-run output via `deps.print()` before returning CliResult. CliResult carries only the exit code signal.
+- Acceptable: spec explicitly specifies exit 1 for no-dispatch.
+- Hidden assumption: resolve by printing a summary message before returning.
+
+### T2: Code duplication with doPollGitHubQueue
+- SCOPE LOCK on 3 heuristics documented in github-queue-poller.ts. Drift risk is low.
+- Acceptable: dry-run is advisory, any drift is a documentation bug.
+
+### T3: countActiveSessions inlined
+- 3 lines: readdir + count .json files. Matches the private function in polling-scheduler.ts exactly.
+- Acceptable: file-based sessions contract is stable.
+
+### T4: pollGitHubQueueIssues wiring
+- execute function builds GitHubQueuePollingSource from trigger.pollingSource (safe after provider validation).
+- Deps interface has `pollGitHubQueueIssues: (config: GitHubQueueConfig)` -- the pollingSource is constructed internally and passed to the real function, not injected.
+
+## Failure Mode Review
+
+All failure modes covered:
+- triggers.yml absent: err from loadTriggerConfig, clear error output
+- triggerId not found: undefined from index.get(), clear error
+- Non-queue trigger: provider check with specified error message
+- No queue config: null from loadQueueConfig, clear error (not silent)
+- GitHub API error: err from pollGitHubQueueIssues, clear error
+- Sessions dir absent: countActiveSessions returns 0 (ENOENT = 0 active)
+- Accidental dispatch: architecturally prevented -- no dispatch dep in interface
+
+Highest-risk: FM4 (no queue config). Must print explicit error, not just '0 dispatch' summary.
+
+## Runner-Up / Simpler Alternative Review
+
+Runner-up (extract pick function) contributes one element worth borrowing: local `IssueDecision` type for the classification pass. Adopted as a local type within the execute function -- no exported helpers.
+
+Simpler alternative (no deps interface) breaks testability. Not viable.
+
+## Philosophy Alignment
+
+Satisfied: immutability, errors as data, validate at boundaries, prefer fakes over mocks, determinism, document why.
+
+Under tension (acceptable): compose with small functions (single 120-line function matches repo pattern).
+
+## Findings
+
+### Yellow (Minor)
+- **Y1**: The `failure()` call for 'no dispatch' will produce a message via printResult(). The message field should be set to an empty string or skipped to avoid a confusing 'Error:' prefix in output. All output should go through `deps.print()` before the CliResult is returned.
+- **Y2**: The spec shows `upstreamSpecUrl: (none)` in the output. This requires the execute function to run the same `extractUpstreamSpecUrl()` logic as the scheduler. This function is private in polling-scheduler.ts -- either inline it or import it. Best: inline a 2-line version.
+
+No Red or Orange findings.
+
+## Recommended Revisions
+
+1. Before returning `failure()` for no-dispatch, print the summary via `deps.print()`. Return `failure('')` so printResult doesn't double-print.
+2. Inline `extractUpstreamSpecUrl(body)` (2 lines) in the command file to produce the `upstreamSpecUrl` line in output.
+3. Use `{ kind: 'success' }` (not failure) for the success path -- the spec says exit 0, which is the success CliResult.
+
+## Residual Concerns
+
+None material. The design is sound and matches established repo patterns.

--- a/implementation_plan_trigger_test.md
+++ b/implementation_plan_trigger_test.md
@@ -1,0 +1,154 @@
+# Implementation Plan: worktrain trigger test dry-run command
+
+## 1. Problem Statement
+
+When configuring a GitHub queue-poll trigger, operators have no way to validate that the trigger is correctly configured without running the full daemon. Adding `worktrain trigger test <triggerId>` provides a fast feedback loop: it shows exactly which issues would be dispatched and which would be skipped, using real API calls but never dispatching any sessions.
+
+## 2. Acceptance Criteria
+
+- [ ] `worktrain trigger test self-improvement` loads the trigger by ID from triggers.yml
+- [ ] If the trigger is not a github_queue_poll provider, prints error: "Trigger 'X' is not a queue poll trigger -- only github_queue_poll triggers can be tested with this command"
+- [ ] Prints header: trigger ID, provider, queue config summary, active sessions count
+- [ ] For each issue: prints whether it WOULD DISPATCH or WOULD SKIP with reason
+- [ ] For WOULD DISPATCH issues: prints maturity and upstreamSpecUrl (or "(none)")
+- [ ] For WOULD SKIP issues: prints the skip reason (active_session, maturity=idea, excluded_label, etc.)
+- [ ] Prints summary line: "N would dispatch, M would skip"
+- [ ] Exits 0 if at least 1 issue would dispatch
+- [ ] Exits 1 if no issues would dispatch
+- [ ] All 5 test cases in tests/unit/worktrain-trigger-test.test.ts pass
+- [ ] `npm run build` succeeds
+- [ ] `npx vitest run` succeeds with no regressions
+
+## 3. Non-Goals
+
+- No changes to `src/mcp/` (explicitly excluded per task spec)
+- No changes to actual trigger dispatch logic
+- No support for non-queue poll trigger types (clear error message only)
+- No `--json` output flag
+- No `--dry-run` flag (the entire command IS a dry-run)
+- No actual session dispatch under any circumstances
+- No write actions of any kind (no session files, no labels, no logs)
+
+## 4. Philosophy-Driven Constraints
+
+- All I/O injected via `WorktrainTriggerTestDeps` -- zero direct fs/fetch/os imports in the command file
+- All failures returned as `CliResult` -- never thrown
+- Tests use pure fake deps (no vi.mock())
+- No mutation of any state -- pure read-only query
+
+## 5. Invariants
+
+1. **DRY-RUN INVARIANT**: The command must never dispatch any real sessions. Enforced architecturally: no dispatch function in the deps interface.
+2. **Real API calls are permitted**: The command makes real GitHub API calls to show accurate results.
+3. **Exit code convention**: exit 0 iff >= 1 issue would dispatch; exit 1 if 0 would dispatch.
+4. **Provider gate**: only `github_queue_poll` triggers can be tested. All other providers produce a clear error.
+5. **Skip logic must mirror the scheduler**: The same skip conditions as `doPollGitHubQueue` in polling-scheduler.ts: excludeLabels -> worktrain:in-progress label -> sess_ pattern -> checkIdempotency -> inferMaturity.
+
+## 6. Selected Approach + Rationale
+
+**Approach**: Single `executeWorktrainTriggerTestCommand` function with injected deps, following the exact `WorktrainTriggerTestDeps` interface from the spec. All output via `deps.print()`. Returns `{ kind: 'success' }` (exit 0) or a sentinel failure value (exit 1). The CLI layer in `cli-worktrain.ts` handles exit code directly (not via `interpretCliResultWithoutDI`) to avoid the output-formatter prepending emoji/color to the already-printed dry-run output.
+
+**Rationale**: Matches the injectable-deps pattern of all existing worktrain commands. Single-function design matches `executeWorktrainSpawnCommand` (~120 lines, no extracted helpers). Test cases test behavioral output, not internal sub-functions.
+
+**Runner-up**: Extract `runQueuePick()` as a separate function. Lost because: test cases test execute() behavior, not pick logic; adds a type that never leaves the file; YAGNI.
+
+## 7. Vertical Slices
+
+### Slice 1: Core command file
+**File**: `src/cli/commands/worktrain-trigger-test.ts`
+
+Create `WorktrainTriggerTestDeps`, `WorktrainTriggerTestOpts`, and `executeWorktrainTriggerTestCommand`.
+
+Logic:
+1. `deps.loadTriggerConfig()` -> get trigger index
+2. Find trigger by ID -> error if not found
+3. Validate `trigger.provider === 'github_queue_poll'` -> error with specified message if not
+4. Narrow pollingSource to `GitHubQueuePollingSource`
+5. `deps.loadQueueConfig()` -> error if null or err
+6. `deps.countActiveSessions()` -> count
+7. Print header lines (trigger ID, provider, queue config summary, active sessions)
+8. `deps.pollGitHubQueueIssues(queueConfig)` -> fetch issues
+9. Loop over issues: classify each (excludeLabels, in-progress label, sess_ pattern, idempotency, maturity)
+10. Collect `IssueDecision[]` (local type: `{issue, wouldDispatch, reason, maturity}`)
+11. Print per-issue output
+12. Print summary
+13. Return `{ kind: 'success' }` if dispatches > 0, `{ kind: 'failure', ... }` if 0
+
+**Done when**: file exists, exports function and types, TypeScript compiles.
+
+### Slice 2: Export from index.ts
+**File**: `src/cli/commands/index.ts`
+
+Add export for `executeWorktrainTriggerTestCommand` and types.
+
+**Done when**: index.ts exports the new function.
+
+### Slice 3: Wire into CLI
+**File**: `src/cli-worktrain.ts`
+
+Add `const triggerCommand = program.command('trigger').description(...)` and `triggerCommand.command('test <triggerId>')...`. Wire real deps. Handle exit code directly:
+```typescript
+const result = await executeWorktrainTriggerTestCommand(deps, { triggerId, port: options.port });
+if (result.kind === 'failure') process.exit(1);
+```
+
+**Done when**: `worktrain trigger test --help` works (conceptually).
+
+### Slice 4: Tests
+**File**: `tests/unit/worktrain-trigger-test.test.ts`
+
+5 test cases:
+1. Non-queue trigger returns error
+2. Ready issue: prints WOULD DISPATCH, maturity: ready
+3. Active session: prints WOULD SKIP, reason: active_session
+4. Idea maturity: prints WOULD SKIP, reason: maturity=idea (no spec, no checklist)
+5. Concurrency cap: all-skip when activeSessions >= maxTotalConcurrentSessions
+
+**Done when**: all 5 pass.
+
+## 8. Test Design
+
+Pattern: `makeBaseDeps()` helper returns fake deps with valid defaults. Each test overrides the specific dep needed for that scenario.
+
+```typescript
+function makeBaseDeps(overrides = {}): { deps: WorktrainTriggerTestDeps; printLines: string[] }
+```
+
+Fake deps:
+- `loadTriggerConfig`: returns ok(Map with a github_queue_poll trigger)
+- `loadQueueConfig`: returns ok({ type: 'label', queueLabel: 'worktrain:ready', repo: 'owner/repo', token: 'tok', maxTotalConcurrentSessions: 1, pollIntervalSeconds: 300, excludeLabels: [] })
+- `pollGitHubQueueIssues`: returns ok([])
+- `countActiveSessions`: returns 0
+- `checkIdempotency`: returns 'clear'
+- `inferMaturity`: returns 'ready'
+- `print`: pushes to printLines[]
+- `stderr`: no-op
+
+Test cases use targeted overrides.
+
+## 9. Risk Register
+
+| Risk | Severity | Mitigation |
+|------|----------|-----------|
+| Skip logic drifts from doPollGitHubQueue | Low | Comment in code points to doPollGitHubQueue as reference; SCOPE LOCK documented |
+| output-formatter double-prints dry-run output | Mitigated | CLI layer handles exit code directly, bypasses interpretCliResultWithoutDI |
+| pollGitHubQueueIssues signature mismatch | Low | Execute function builds GitHubQueuePollingSource from trigger.pollingSource internally |
+| countActiveSessions miscounts | Low | Same 3-line logic as private function in polling-scheduler.ts |
+
+## 10. PR Packaging Strategy
+
+Single PR: `feat/trigger-test-command`
+Commit message: `feat(cli): add worktrain trigger test dry-run command`
+
+## 11. Philosophy Alignment
+
+| Principle | Status |
+|-----------|--------|
+| Immutability by default | Satisfied: all deps readonly, no state mutation |
+| Errors are data | Satisfied: CliResult return, no throws |
+| Validate at boundaries | Satisfied: provider check, config null check at entry |
+| Make illegal states unrepresentable | Satisfied: no dispatch dep in interface |
+| Prefer fakes over mocks | Satisfied: test uses pure fake deps |
+| YAGNI with discipline | Satisfied: no extracted helpers, no extra options |
+| Document why not what | Satisfied: WHY comments on failure() usage and dry-run invariant |
+| Compose with small functions | Mild tension: single 100-line function -- matches repo pattern |

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -36,6 +36,7 @@ import {
   executeWorktrainAwaitCommand,
   executeWorktrainDaemonCommand,
   executeWorktrainOverviewCommand,
+  executeWorktrainTriggerTestCommand,
   buildConsoleServiceFromDataDir,
   type Priority,
 } from './cli/commands/index.js';
@@ -1251,6 +1252,86 @@ runCommand
     });
 
     process.exit(result.hasErrors ? 1 : 0);
+  });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TRIGGER COMMAND GROUP
+// ═══════════════════════════════════════════════════════════════════════════
+
+const triggerCommand = program
+  .command('trigger')
+  .description('Trigger management commands');
+
+triggerCommand
+  .command('test <triggerId>')
+  .description('Dry-run the queue picker for a trigger -- shows what would dispatch without dispatching')
+  .option('-p, --port <n>', 'Console server port for active session count', parseInt)
+  .action(async (triggerId: string, options: { port?: number }) => {
+    const { loadTriggerConfigFromFile, buildTriggerIndex } = await import('./trigger/trigger-store.js');
+    const { loadQueueConfig } = await import('./trigger/github-queue-config.js');
+    const { pollGitHubQueueIssues, checkIdempotency, inferMaturity } = await import('./trigger/adapters/github-queue-poller.js');
+
+    const cwd = process.cwd();
+
+    const result = await executeWorktrainTriggerTestCommand(
+      {
+        loadTriggerConfig: async () => {
+          const configResult = await loadTriggerConfigFromFile(cwd, process.env);
+          if (configResult.kind === 'err') {
+            const e = configResult.error;
+            const msg = e.kind === 'file_not_found'
+              ? `triggers.yml not found at ${e.filePath}`
+              : e.kind === 'io_error'
+              ? `IO error reading triggers.yml: ${e.message}`
+              : `Failed to parse triggers.yml: ${JSON.stringify(e)}`;
+            return { kind: 'err', error: msg };
+          }
+          const indexResult = buildTriggerIndex(configResult.value);
+          if (indexResult.kind === 'err') {
+            const idxErr = indexResult.error;
+            const triggerId2 = 'triggerId' in idxErr ? idxErr.triggerId : '(unknown)';
+            return { kind: 'err', error: `Duplicate trigger ID: ${triggerId2}` };
+          }
+          return { kind: 'ok', value: indexResult.value };
+        },
+        loadQueueConfig: async () => {
+          return loadQueueConfig();
+        },
+        pollGitHubQueueIssues: async (source, config) => {
+          const result2 = await pollGitHubQueueIssues(source, config);
+          if (result2.kind === 'err') {
+            const e = result2.error;
+            return { kind: 'err', error: `${e.kind}: ${(e as { message: string }).message}` };
+          }
+          return result2;
+        },
+        countActiveSessions: async () => {
+          const sessionsDir = path.join(os.homedir(), '.workrail', 'daemon-sessions');
+          try {
+            const files = await fs.promises.readdir(sessionsDir);
+            return files.filter((f) => f.endsWith('.json')).length;
+          } catch {
+            return 0;
+          }
+        },
+        checkIdempotency: async (issueNumber: number) => {
+          const sessionsDir = path.join(os.homedir(), '.workrail', 'daemon-sessions');
+          return checkIdempotency(issueNumber, sessionsDir);
+        },
+        inferMaturity: (issue) => inferMaturity(issue.body),
+        print: (line: string) => process.stdout.write(line + '\n'),
+        stderr: (line: string) => process.stderr.write(line + '\n'),
+      },
+      { triggerId, port: options.port },
+    );
+
+    // WHY handle exit code directly (not via interpretCliResultWithoutDI):
+    // All dry-run output is already printed via deps.print(). The CliResult.failure
+    // carries an empty message to avoid the output-formatter printing a redundant
+    // '❌ ...' prefix after the [DryRun] summary. We only need the exit code.
+    if (result.kind === 'failure') {
+      process.exit(1);
+    }
   });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -71,3 +71,8 @@ export {
   type WorktrainPipelineCommandDeps,
   type WorktrainPipelineCommandOpts,
 } from './worktrain-pipeline.js';
+export {
+  executeWorktrainTriggerTestCommand,
+  type WorktrainTriggerTestDeps,
+  type WorktrainTriggerTestOpts,
+} from './worktrain-trigger-test.js';

--- a/src/cli/commands/worktrain-trigger-test.ts
+++ b/src/cli/commands/worktrain-trigger-test.ts
@@ -1,0 +1,310 @@
+/**
+ * WorkTrain Trigger Test Command
+ *
+ * `worktrain trigger test <triggerId>` -- dry-run the queue picker for a
+ * github_queue_poll trigger. Shows which issues would be dispatched and which
+ * would be skipped, using real API calls but NEVER dispatching any sessions.
+ *
+ * Design invariants:
+ * - DRY-RUN INVARIANT: this command NEVER dispatches sessions. Enforced by
+ *   the absence of any dispatch function in WorktrainTriggerTestDeps.
+ * - All I/O is injected via WorktrainTriggerTestDeps. Zero direct fs/fetch imports.
+ * - All failures are returned as CliResult -- never thrown.
+ * - Real API calls are permitted (to show accurate results).
+ * - Exit code: 0 if >= 1 issue would dispatch, 1 if none (useful for scripts).
+ *   The CliResult.failure return for 'no dispatch' is intentional -- it is a
+ *   scripting convention, not an error condition.
+ * - Skip logic mirrors doPollGitHubQueue in polling-scheduler.ts (SCOPE LOCK:
+ *   do not add skip conditions without updating the scheduler too).
+ */
+
+import type { CliResult } from '../types/cli-result.js';
+import { failure, success } from '../types/cli-result.js';
+import type { TriggerDefinition } from '../../trigger/types.js';
+import type { GitHubQueuePollingSource } from '../../trigger/types.js';
+import type { GitHubQueueConfig } from '../../trigger/github-queue-config.js';
+import type { GitHubQueueIssue } from '../../trigger/adapters/github-queue-poller.js';
+import type { Result } from '../../runtime/result.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Injected dependencies for the trigger test command.
+ * All real I/O is behind these interfaces for full testability.
+ *
+ * WHY no dispatch dep: the DRY-RUN INVARIANT is enforced at the type level.
+ * Adding a dispatch dep here would require a conscious code change, not an accident.
+ */
+export interface WorktrainTriggerTestDeps {
+  /**
+   * Load the trigger config from triggers.yml.
+   * Returns a Map<triggerId, TriggerDefinition> or an error string.
+   * WHY injectable: allows tests to inject any trigger config without real files.
+   */
+  readonly loadTriggerConfig: () => Promise<Result<Map<string, TriggerDefinition>, string>>;
+  /**
+   * Load the queue config from ~/.workrail/config.json.
+   * Returns null when no queue config is present.
+   * WHY injectable: allows tests to inject queue configs without real files.
+   */
+  readonly loadQueueConfig: () => Promise<Result<GitHubQueueConfig | null, string>>;
+  /**
+   * Fetch open GitHub issues matching the queue config filter.
+   * Takes the queue config (filter type, label/user, etc.) plus the polling source
+   * (repo, token) from the trigger.
+   * WHY injectable: allows tests to inject issue lists without real HTTP calls.
+   */
+  readonly pollGitHubQueueIssues: (
+    source: GitHubQueuePollingSource,
+    config: GitHubQueueConfig,
+  ) => Promise<Result<GitHubQueueIssue[], string>>;
+  /**
+   * Count active sessions by scanning ~/.workrail/daemon-sessions/ for JSON files.
+   * Returns 0 when the directory doesn't exist or is unreadable.
+   * WHY injectable: allows tests to simulate any active session count.
+   */
+  readonly countActiveSessions: () => Promise<number>;
+  /**
+   * Check if an issue already has an active session.
+   * Conservative default: returns 'active' on any read/parse error.
+   * WHY injectable: allows tests to control per-issue idempotency state.
+   */
+  readonly checkIdempotency: (issueNumber: number) => Promise<'active' | 'clear'>;
+  /**
+   * Infer the maturity of an issue from its body.
+   * Returns 'idea' | 'specced' | 'ready' using the 3 deterministic heuristics.
+   * WHY injectable: allows tests to control maturity per issue.
+   */
+  readonly inferMaturity: (issue: GitHubQueueIssue) => 'idea' | 'specced' | 'ready';
+  /**
+   * Write a line to stdout (dry-run output).
+   * WHY injectable: allows tests to capture all output for assertion.
+   */
+  readonly print: (line: string) => void;
+  /**
+   * Write a line to stderr (errors and warnings).
+   * WHY injectable: allows tests to capture error output separately.
+   */
+  readonly stderr: (line: string) => void;
+}
+
+export interface WorktrainTriggerTestOpts {
+  /** The trigger ID to test (e.g. 'self-improvement'). */
+  readonly triggerId: string;
+  /** Override the console HTTP server port for active session count. Not used by this command. */
+  readonly port?: number;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// COMMAND EXECUTION
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Execute the dry-run trigger test command.
+ *
+ * Returns success (exit 0) if at least one issue would be dispatched.
+ * Returns failure (exit 1) if no issues would be dispatched.
+ *
+ * WHY failure for 'no dispatch': the exit code convention is explicitly specified
+ * for scripting use cases (e.g. CI checks that verify a trigger has work to do).
+ * It is NOT a runtime error -- all dry-run output is printed via deps.print().
+ */
+export async function executeWorktrainTriggerTestCommand(
+  deps: WorktrainTriggerTestDeps,
+  opts: WorktrainTriggerTestOpts,
+): Promise<CliResult> {
+  const triggerId = opts.triggerId.trim();
+  if (!triggerId) {
+    deps.stderr('[DryRun] Error: triggerId must not be empty.');
+    return failure('triggerId must not be empty.');
+  }
+
+  // ---- Load trigger config ----
+  const triggerIndexResult = await deps.loadTriggerConfig();
+  if (triggerIndexResult.kind === 'err') {
+    deps.stderr(`[DryRun] Error: Failed to load triggers.yml: ${triggerIndexResult.error}`);
+    return failure(`Failed to load triggers.yml: ${triggerIndexResult.error}`);
+  }
+
+  const triggerIndex = triggerIndexResult.value;
+  const trigger = triggerIndex.get(triggerId);
+  if (!trigger) {
+    deps.stderr(`[DryRun] Error: Trigger '${triggerId}' not found in triggers.yml.`);
+    return failure(`Trigger '${triggerId}' not found in triggers.yml.`);
+  }
+
+  // ---- Validate provider ----
+  if (trigger.provider !== 'github_queue_poll') {
+    deps.stderr(
+      `[DryRun] Error: Trigger '${triggerId}' is not a queue poll trigger -- ` +
+      `only github_queue_poll triggers can be tested with this command`,
+    );
+    return failure(
+      `Trigger '${triggerId}' is not a queue poll trigger -- ` +
+      `only github_queue_poll triggers can be tested with this command`,
+    );
+  }
+
+  // Safe: provider === 'github_queue_poll' guarantees pollingSource is GitHubQueuePollingSource
+  const pollingSource = trigger.pollingSource as GitHubQueuePollingSource;
+
+  // ---- Load queue config ----
+  const queueConfigResult = await deps.loadQueueConfig();
+  if (queueConfigResult.kind === 'err') {
+    deps.stderr(`[DryRun] Error: Failed to load queue config: ${queueConfigResult.error}`);
+    return failure(`Failed to load queue config: ${queueConfigResult.error}`);
+  }
+
+  const queueConfig = queueConfigResult.value;
+  if (queueConfig === null) {
+    deps.stderr('[DryRun] Error: No queue config found in ~/.workrail/config.json (missing "queue" key).');
+    return failure('No queue config found in ~/.workrail/config.json (missing "queue" key).');
+  }
+
+  // ---- Active session count ----
+  const activeSessions = await deps.countActiveSessions();
+
+  // ---- Print header ----
+  deps.print(`[DryRun] Trigger: ${triggerId} (${trigger.provider})`);
+  deps.print(
+    `[DryRun] Queue config: type=${queueConfig.type}${queueConfig.queueLabel ? ` queueLabel=${queueConfig.queueLabel}` : ''}${queueConfig.user ? ` user=${queueConfig.user}` : ''} repo=${queueConfig.repo}`,
+  );
+  deps.print(
+    `[DryRun] Active sessions: ${activeSessions} / maxTotalConcurrentSessions: ${queueConfig.maxTotalConcurrentSessions}`,
+  );
+  deps.print('');
+
+  // ---- Concurrency cap check (mirrors doPollGitHubQueue invariant) ----
+  // WHY check before fetching: the real scheduler skips the entire cycle when
+  // the concurrency cap is reached. The dry-run reflects this same behavior.
+  if (activeSessions >= queueConfig.maxTotalConcurrentSessions) {
+    deps.print(
+      `[DryRun] Concurrency cap reached: active sessions (${activeSessions}) >= ` +
+      `maxTotalConcurrentSessions (${queueConfig.maxTotalConcurrentSessions})`,
+    );
+    deps.print('[DryRun] Summary: 0 would dispatch, 0 would skip (concurrency cap)');
+    // WHY failure: exit 1 signals 'no dispatch' for scripting use cases
+    return failure('');
+  }
+
+  // ---- Fetch issues ----
+  const issuesResult = await deps.pollGitHubQueueIssues(pollingSource, queueConfig);
+  if (issuesResult.kind === 'err') {
+    deps.stderr(`[DryRun] Error: Failed to fetch issues: ${issuesResult.error}`);
+    return failure(`Failed to fetch issues: ${issuesResult.error}`);
+  }
+
+  const issues = issuesResult.value;
+
+  // ---- Classify each issue (mirrors doPollGitHubQueue skip logic -- SCOPE LOCK) ----
+  type IssueDecision =
+    | { readonly kind: 'dispatch'; readonly issue: GitHubQueueIssue; readonly maturity: 'idea' | 'specced' | 'ready'; readonly upstreamSpecUrl: string | undefined }
+    | { readonly kind: 'skip'; readonly issue: GitHubQueueIssue; readonly reason: string };
+
+  const decisions: IssueDecision[] = [];
+
+  for (const issue of issues) {
+    const issueLabels = issue.labels.map((l) => l.name);
+
+    // H: excludeLabels filter
+    const excludedLabel = queueConfig.excludeLabels.find((el) => issueLabels.includes(el));
+    if (excludedLabel) {
+      decisions.push({ kind: 'skip', issue, reason: `excluded_label: ${excludedLabel}` });
+      continue;
+    }
+
+    // H3: worktrain:in-progress label (active/skip -- not a maturity level)
+    if (issueLabels.includes('worktrain:in-progress')) {
+      decisions.push({ kind: 'skip', issue, reason: 'active_session_or_in_progress' });
+      continue;
+    }
+
+    // H3: session ID pattern in body (active/skip)
+    if (/sess_[a-z0-9]+/.test(issue.body)) {
+      decisions.push({ kind: 'skip', issue, reason: 'active_session_or_in_progress' });
+      continue;
+    }
+
+    // Per-issue idempotency check (conservative: any parse error = active)
+    const idempotencyStatus = await deps.checkIdempotency(issue.number);
+    if (idempotencyStatus === 'active') {
+      decisions.push({ kind: 'skip', issue, reason: 'active_session' });
+      continue;
+    }
+
+    // Infer maturity (exactly 3 heuristics -- SCOPE LOCK per github-queue-poller.ts)
+    const maturity = deps.inferMaturity(issue);
+
+    // Only 'ready' and 'specced' would dispatch; 'idea' is skipped
+    if (maturity === 'idea') {
+      decisions.push({ kind: 'skip', issue, reason: 'maturity=idea (no spec, no checklist)' });
+      continue;
+    }
+
+    decisions.push({
+      kind: 'dispatch',
+      issue,
+      maturity,
+      upstreamSpecUrl: extractUpstreamSpecUrl(issue.body),
+    });
+  }
+
+  // ---- Print per-issue results ----
+  for (const decision of decisions) {
+    if (decision.kind === 'dispatch') {
+      deps.print(`[DryRun] Issue #${decision.issue.number} "${decision.issue.title}" -- WOULD DISPATCH`);
+      deps.print(`  maturity: ${decision.maturity} (${describeMaturity(decision.maturity)})`);
+      deps.print(`  upstreamSpecUrl: ${decision.upstreamSpecUrl ?? '(none)'}`);
+    } else {
+      deps.print(`[DryRun] Issue #${decision.issue.number} "${decision.issue.title}" -- WOULD SKIP`);
+      deps.print(`  reason: ${decision.reason}`);
+    }
+    deps.print('');
+  }
+
+  // ---- Summary ----
+  const dispatchCount = decisions.filter((d) => d.kind === 'dispatch').length;
+  const skipCount = decisions.filter((d) => d.kind === 'skip').length;
+  deps.print(`[DryRun] Summary: ${dispatchCount} would dispatch, ${skipCount} would skip`);
+
+  // WHY failure for 0 dispatch: exit 1 is explicitly specified for scripting use cases.
+  // This is NOT a runtime error -- all output was already printed via deps.print().
+  if (dispatchCount === 0) {
+    return failure('');
+  }
+
+  return success();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PRIVATE HELPERS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Extract the upstream spec URL from an issue body.
+ *
+ * WHY duplicated from polling-scheduler.ts: that function is private to the scheduler.
+ * This is a 2-line extraction matching the same heuristic. If the heuristic changes,
+ * update both (they are part of the SCOPE LOCK on 3 maturity heuristics).
+ */
+function extractUpstreamSpecUrl(body: string): string | undefined {
+  const specLineMatch = /upstream_spec:\s*(https?:\/\/\S+)/i.exec(body);
+  if (specLineMatch?.[1]) return specLineMatch[1];
+  const firstPara = body.split(/\n\s*\n/)[0] ?? '';
+  const urlMatch = /(https?:\/\/\S+)/.exec(firstPara);
+  return urlMatch?.[1];
+}
+
+/**
+ * Human-readable description of a maturity level.
+ * Matches the labels shown in the spec's example output.
+ */
+function describeMaturity(maturity: 'idea' | 'specced' | 'ready'): string {
+  switch (maturity) {
+    case 'ready':   return 'has acceptance criteria';
+    case 'specced': return 'has checklist or acceptance criteria heading';
+    case 'idea':    return 'no spec, no checklist';
+  }
+}

--- a/src/trigger/delivery-action.ts
+++ b/src/trigger/delivery-action.ts
@@ -65,6 +65,14 @@ export interface DeliveryFlags {
   /** When true (and autoCommit is also true), run gh pr create after the commit. */
   readonly autoOpenPR?: boolean;
   /**
+   * When false, skip the secret scan before committing. Default: true (scan runs by default).
+   *
+   * WHY opt-out semantics (not opt-in): the safer default is to scan. Users who encounter
+   * false positives from the Generic secret assign pattern can explicitly opt out with
+   * secretScan: false in their trigger config.
+   */
+  readonly secretScan?: boolean;
+  /**
    * Process-local session UUID used to construct the expected branch name for HEAD assertion.
    * Only set when branchStrategy === 'worktree'. When present (with branchPrefix), runDelivery()
    * asserts the current HEAD branch matches `${branchPrefix}${sessionId}` before staging files.
@@ -80,6 +88,36 @@ export interface DeliveryFlags {
    * Full expected branch: `${branchPrefix}${sessionId}`.
    */
   readonly branchPrefix?: string;
+  /**
+   * Trigger ID sourced from TriggerDefinition.id.
+   * Used in the PR body footer to identify which trigger produced this PR.
+   * When absent, the footer omits the trigger field.
+   */
+  readonly triggerId?: string;
+  /**
+   * Workflow ID sourced from TriggerDefinition.workflowId.
+   * Used in the PR body footer to identify which workflow produced this PR.
+   * When absent, the footer omits the workflow field.
+   */
+  readonly workflowId?: string;
+  /**
+   * Optional bot identity for per-command git attribution.
+   *
+   * When present, git commit is called with `-c user.name=X -c user.email=Y` flags
+   * instead of relying on the persisted git config. This is safe across parallel worktrees --
+   * identity is scoped to the single command, not written to the shared .git/config.
+   *
+   * WHY per-command (not git config): git config --local writes to the shared .git/config,
+   * which is shared across all worktrees of the same repo. In parallel sessions, last writer
+   * wins and silently stomps other sessions' identities. Per-command -c flags have no
+   * persistent side effects.
+   *
+   * When absent, git commit uses the git config identity already in the environment.
+   */
+  readonly botIdentity?: {
+    readonly name: string;
+    readonly email: string;
+  };
 }
 
 /**
@@ -97,10 +135,11 @@ export type DeliveryResult =
       /**
        * Phase where the error occurred.
        * - 'parse': handoff artifact could not be parsed from notes
+       * - 'secret_scan': staged diff contains a potential secret (delivery aborted before commit)
        * - 'commit': git add/commit failed
        * - 'pr': gh pr create failed (commit may have succeeded)
        */
-      readonly phase: 'parse' | 'commit' | 'pr';
+      readonly phase: 'parse' | 'secret_scan' | 'commit' | 'pr';
       /** stdout + stderr from the failed exec call, or parse error message */
       readonly details: string;
     };
@@ -132,6 +171,144 @@ export type ExecFn = (
  * Delivery commands should complete quickly; 60s is a generous timeout.
  */
 const DELIVERY_TIMEOUT_MS = 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Secret scanning
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a secret scan over a staged diff.
+ *
+ * WHY no matchedValue field: we must NEVER log or surface the actual secret value,
+ * even in error messages or internal logs. Omitting the field from the type makes
+ * it structurally impossible to accidentally include the matched value downstream.
+ * Only the pattern name, file path, and line number are safe to surface.
+ */
+export interface SecretScanResult {
+  readonly found: boolean;
+  readonly findings: ReadonlyArray<{
+    readonly name: string;
+    readonly file: string;
+    readonly lineNumber: number;
+  }>;
+}
+
+/**
+ * Secret patterns to scan for in staged diffs.
+ *
+ * Each entry has a human-readable name (for error messages) and a regex with the global flag.
+ * WHY global flag: allows matchAll() to find ALL occurrences per line, not just the first.
+ * WHY reset lastIndex before each use: global regexes maintain state across calls.
+ * These patterns are the baseline; gitleaks is the optional upgrade.
+ */
+const SECRET_PATTERNS: ReadonlyArray<{ readonly name: string; readonly pattern: RegExp }> = [
+  { name: 'GitHub token',          pattern: /ghp_[A-Za-z0-9]{36}/g },
+  { name: 'GitHub OAuth token',    pattern: /gho_[A-Za-z0-9]{36}/g },
+  { name: 'GitHub app token',      pattern: /ghs_[A-Za-z0-9]{36}/g },
+  { name: 'OpenAI key',            pattern: /sk-[A-Za-z0-9]{48}/g },
+  { name: 'Anthropic key',         pattern: /sk-ant-[A-Za-z0-9\-_]{90,}/g },
+  { name: 'AWS access key',        pattern: /AKIA[0-9A-Z]{16}/g },
+  { name: 'AWS secret key',        pattern: /[Aa][Ww][Ss][._-]?[Ss][Ee][Cc][Rr][Ee][Tt][._-]?[Kk][Ee][Yy]\s*[:=]\s*['"]?[A-Za-z0-9+\/]{40}/g },
+  { name: 'Slack token',           pattern: /xox[aboprs]-[A-Za-z0-9\-]+/g },
+  { name: 'Private key',           pattern: /-----BEGIN [A-Z]+ PRIVATE KEY-----/g },
+  { name: 'Generic secret assign', pattern: /(?:password|passwd|secret|api[_-]?key|auth[_-]?token)\s*[:=]\s*['"][^'"]{8,}/gi },
+];
+
+/**
+ * Scan a unified diff string for potential secrets.
+ *
+ * Strategy:
+ * 1. Parse the diff to extract file names and added lines (lines starting with '+').
+ * 2. Track file names from '+++' diff headers and line numbers from '@@ -l,s +l,s @@' hunks.
+ * 3. For each added line, run all SECRET_PATTERNS against the content (after stripping the '+').
+ * 4. Collect findings without capturing the matched value.
+ *
+ * WHY only '+' lines: removed lines are secrets being deleted (good). Context lines are
+ * unchanged and were already committed (would produce false positives). Only added lines
+ * represent new content being introduced.
+ *
+ * WHY parse hunk headers for line numbers: allows operators to navigate directly to the
+ * offending line in their editor rather than searching the file for the pattern.
+ *
+ * @param diff - Output of `git diff --cached` (unified diff format)
+ * @returns SecretScanResult with found=false if no secrets detected
+ */
+export function scanForSecrets(diff: string): SecretScanResult {
+  // Empty diff = nothing staged = nothing to scan
+  if (!diff.trim()) {
+    return { found: false, findings: [] };
+  }
+
+  const findings: Array<{ name: string; file: string; lineNumber: number }> = [];
+
+  // Parse unified diff line by line
+  const lines = diff.split('\n');
+  let currentFile = '(unknown)';
+  let currentLineNumber = 0;
+
+  for (const line of lines) {
+    // Track current file from '+++' header (e.g., '+++ b/src/foo.ts')
+    if (line.startsWith('+++ ')) {
+      // Strip 'b/' prefix from git diff output ('+++ b/src/foo.ts' -> 'src/foo.ts')
+      const filePath = line.slice(4);
+      currentFile = filePath.startsWith('b/') ? filePath.slice(2) : filePath;
+      currentLineNumber = 0;
+      continue;
+    }
+
+    // Parse hunk header to get the starting line number of the new file block
+    // Format: @@ -old_start[,old_count] +new_start[,new_count] @@ [context]
+    if (line.startsWith('@@')) {
+      const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (hunkMatch?.[1] !== undefined) {
+        // new_start - 1 because we increment before checking each line
+        currentLineNumber = parseInt(hunkMatch[1], 10) - 1;
+      }
+      continue;
+    }
+
+    // Skip diff metadata lines (--- header, diff --git, index lines, etc.)
+    if (line.startsWith('--- ') || line.startsWith('diff ') || line.startsWith('index ') || line.startsWith('\\')) {
+      continue;
+    }
+
+    // Context lines (unchanged): advance the new-file line counter
+    if (line.startsWith(' ')) {
+      currentLineNumber++;
+      continue;
+    }
+
+    // Removed lines: do NOT advance the new-file line counter (these lines are not in the new file)
+    if (line.startsWith('-')) {
+      continue;
+    }
+
+    // Added lines: advance counter and scan for secrets
+    if (line.startsWith('+')) {
+      currentLineNumber++;
+      const content = line.slice(1); // Strip leading '+'
+
+      for (const { name, pattern } of SECRET_PATTERNS) {
+        // Reset lastIndex before each use -- global regexes maintain state across calls
+        pattern.lastIndex = 0;
+        if (pattern.test(content)) {
+          findings.push({ name, file: currentFile, lineNumber: currentLineNumber });
+          // WHY break after first pattern match per line: one finding per line is sufficient.
+          // Reporting multiple findings on the same line adds noise without operator value.
+          // The operator needs to find the line and review it -- the first match is enough signal.
+          break;
+        }
+        // Reset again after test() to leave the regex in a clean state
+        pattern.lastIndex = 0;
+      }
+    }
+  }
+
+  return {
+    found: findings.length > 0,
+    findings,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // parseHandoffArtifact
@@ -362,9 +539,23 @@ export async function runDelivery(
   // Build commit message: "<type>(<scope>): <subject>"
   // The subject already includes the full first line per the workflow prompt.
   // If commitSubject already starts with type(scope), use it as-is; otherwise build it.
-  const commitMessage = artifact.commitSubject.startsWith(`${artifact.commitType}(`)
+  const baseCommitMessage = artifact.commitSubject.startsWith(`${artifact.commitType}(`)
     ? artifact.commitSubject
     : `${artifact.commitType}(${artifact.commitScope}): ${artifact.commitSubject}`;
+
+  // Attribution trailers: appended to every commit WorkTrain opens.
+  //
+  // WHY always (not conditional on botIdentity): attribution signals identify WorkTrain
+  // commits in git log and blame regardless of which git identity signed the commit.
+  // The Co-authored-by trailer is a GitHub-recognized convention that surfaces in PR UIs.
+  //
+  // WHY Worktrain-Session (not X-Worktrain-Session): git trailers do not require the X-
+  // prefix. Using a clean namespace avoids confusion with HTTP headers.
+  const trailers = [
+    ...(flags.sessionId ? [`Worktrain-Session: ${flags.sessionId}`] : []),
+    'Co-authored-by: WorkTrain <worktrain@noreply.local>',
+  ].join('\n');
+  const commitMessage = `${baseCommitMessage}\n\n${trailers}`;
 
   // Stage and commit the specific files from filesChanged.
   //
@@ -380,8 +571,94 @@ export async function runDelivery(
   try {
     // Step 1: git add <file1> <file2> ...
     await execFn('git', ['add', ...artifact.filesChanged], { cwd: workspacePath, timeout: DELIVERY_TIMEOUT_MS });
-    // Step 2: git commit -m <message>
-    const commitResult = await execFn('git', ['commit', '-m', commitMessage], { cwd: workspacePath, timeout: DELIVERY_TIMEOUT_MS });
+
+    // Step 2: Secret scan -- run after staging so `git diff --cached` shows the full staged diff.
+    //
+    // WHY scan after git add, before git commit: the staged diff represents exactly what is about
+    // to be committed. Scanning before git add would miss newly staged content; scanning after
+    // git commit would be too late. git diff --cached is the only window where we see the precise
+    // content being committed.
+    //
+    // WHY secretScan !== false (not === true): opt-out semantics -- scan is the safe default.
+    // Only explicit secretScan: false bypasses the scan.
+    if (flags.secretScan !== false) {
+      let stagedDiff = '';
+      try {
+        const diffResult = await execFn('git', ['diff', '--cached'], { cwd: workspacePath, timeout: DELIVERY_TIMEOUT_MS });
+        stagedDiff = diffResult.stdout;
+      } catch (e: unknown) {
+        // git diff --cached failure after a successful git add is unexpected.
+        // Abort delivery -- we cannot commit safely without scanning.
+        return {
+          _tag: 'error',
+          phase: 'secret_scan',
+          details: `Failed to retrieve staged diff for secret scan: ${formatExecError(e)}\nDelivery aborted.`,
+        };
+      }
+
+      const scanResult = scanForSecrets(stagedDiff);
+      if (scanResult.found) {
+        const findingLines = scanResult.findings
+          .map(f => `  - ${f.name} in ${f.file}:${f.lineNumber}`)
+          .join('\n');
+        return {
+          _tag: 'error',
+          phase: 'secret_scan',
+          details:
+            `Secret scan detected potential secrets in staged files:\n${findingLines}\n` +
+            `Delivery aborted. Review and remove secrets before retrying.\n` +
+            `Set secretScan: false in your trigger config to bypass this check.`,
+        };
+      }
+
+      // Optional upgrade: run gitleaks if available.
+      // WHY gitleaks is optional: the pattern scan is the baseline. gitleaks provides broader
+      // coverage but requires an external binary. If not installed (ENOENT), skip silently.
+      // WHY check exit code only (not stdout): gitleaks prints findings to stdout, but the
+      // authoritative signal is the exit code (0 = clean, non-zero = found secrets).
+      try {
+        await execFn(
+          'gitleaks',
+          ['detect', '--source', '.', '--staged', '--no-git'],
+          { cwd: workspacePath, timeout: DELIVERY_TIMEOUT_MS },
+        );
+        // exit code 0: no secrets found by gitleaks -- continue
+      } catch (e: unknown) {
+        const execErr = e as Error & { code?: string };
+        if (execErr.code === 'ENOENT') {
+          // gitleaks binary not found -- skip silently (optional upgrade not installed)
+        } else {
+          // Non-zero exit code: gitleaks found secrets (or failed with an error).
+          // Treat any non-ENOENT failure as a signal to abort delivery.
+          return {
+            _tag: 'error',
+            phase: 'secret_scan',
+            details:
+              `gitleaks detected potential secrets in staged files.\n` +
+              `Delivery aborted. Review and remove secrets before retrying.\n` +
+              `Set secretScan: false in your trigger config to bypass this check.`,
+          };
+        }
+      }
+    }
+
+    // Step 3: git commit -m <message> [with optional per-command identity]
+    //
+    // WHY -c user.name/user.email instead of git config: git config --local writes to the
+    // shared .git/config, which is shared across all worktrees. In parallel sessions, last
+    // writer wins and silently stomps other sessions' identities. Per-command -c flags scope
+    // identity to this single command and have no persistent side effects.
+    //
+    // WHY only when botIdentity is set: if no bot identity is configured, use whatever git
+    // config identity is already in the environment (the operator's own identity).
+    const commitArgs: string[] = flags.botIdentity
+      ? [
+          '-c', `user.name=${flags.botIdentity.name}`,
+          '-c', `user.email=${flags.botIdentity.email}`,
+          'commit', '-m', commitMessage,
+        ]
+      : ['commit', '-m', commitMessage];
+    const commitResult = await execFn('git', commitArgs, { cwd: workspacePath, timeout: DELIVERY_TIMEOUT_MS });
     commitStdout = commitResult.stdout;
     commitStderr = commitResult.stderr;
   } catch (e: unknown) {
@@ -398,6 +675,30 @@ export async function runDelivery(
     return { _tag: 'committed', sha };
   }
 
+  // Build PR title with [WT] prefix.
+  //
+  // WHY always (not conditional on botIdentity): the prefix identifies the PR as WorkTrain-
+  // generated regardless of which git identity was used. Operators need to distinguish
+  // WorkTrain PRs in PR lists without checking commit trailers.
+  //
+  // WHY idempotent guard: prevents a double prefix if the agent writes [WT] in the handoff
+  // artifact. The agent should NOT include [WT] (it is infrastructure, not agent content),
+  // but the guard protects against accidental contamination.
+  const prTitle = artifact.prTitle.startsWith('[WT] ')
+    ? artifact.prTitle
+    : `[WT] ${artifact.prTitle}`;
+
+  // Build PR body with attribution footer.
+  //
+  // WHY always (not conditional on botIdentity): the footer provides traceability for any
+  // WorkTrain-generated PR. Operators and reviewers need to find the session, trigger, and
+  // workflow that produced this PR without digging through logs.
+  const footerParts: string[] = ['---', '\u{1F916} **Automated by WorkTrain**'];
+  if (flags.sessionId) footerParts.push(`Session: \`${flags.sessionId}\``);
+  if (flags.triggerId) footerParts.push(`Trigger: \`${flags.triggerId}\``);
+  if (flags.workflowId) footerParts.push(`Workflow: \`${flags.workflowId}\``);
+  const prBodyWithFooter = `${artifact.prBody}\n\n${footerParts.join(' | ')}`;
+
   // Open PR via gh pr create.
   //
   // WHY --body-file instead of --body: prBody is arbitrary markdown that may contain
@@ -412,11 +713,11 @@ export async function runDelivery(
 
   let prStdout: string;
   try {
-    await fs.writeFile(tmpFile, artifact.prBody, 'utf8');
+    await fs.writeFile(tmpFile, prBodyWithFooter, 'utf8');
     try {
       const prResult = await execFn(
         'gh',
-        ['pr', 'create', '--title', artifact.prTitle, '--body-file', tmpFile],
+        ['pr', 'create', '--title', prTitle, '--body-file', tmpFile],
         { cwd: workspacePath, timeout: DELIVERY_TIMEOUT_MS },
       );
       prStdout = prResult.stdout;
@@ -440,6 +741,43 @@ export async function runDelivery(
 
   // Extract PR URL from gh output (typically the last line)
   const prUrl = prStdout.trim().split('\n').at(-1)?.trim() ?? '';
+
+  // Add worktrain:generated label to the PR.
+  //
+  // WHY non-fatal: label creation is best-effort. If gh label create or gh pr edit fails
+  // (permissions, network, API error), the PR was already opened successfully. Failing the
+  // entire delivery for a missing label would be a worse outcome than missing the label.
+  //
+  // WHY two calls (label create then pr edit): gh pr create --label requires the label to
+  // already exist. Creating it first is idempotent (2>/dev/null || true equivalent via
+  // try/catch). Then pr edit adds it to the specific PR by URL.
+  //
+  // WHY if (prUrl): gh pr edit requires a valid PR URL or number. If gh pr create returned
+  // empty output, prUrl is '' and gh pr edit would fail with an unhelpful error.
+  if (prUrl) {
+    try {
+      await execFn(
+        'gh',
+        ['label', 'create', 'worktrain:generated', '--description', 'PR authored by WorkTrain', '--color', '0075ca'],
+        { cwd: workspacePath, timeout: DELIVERY_TIMEOUT_MS },
+      );
+    } catch {
+      // Label may already exist -- ignore the error and proceed to gh pr edit.
+    }
+    try {
+      await execFn(
+        'gh',
+        ['pr', 'edit', prUrl, '--add-label', 'worktrain:generated'],
+        { cwd: workspacePath, timeout: DELIVERY_TIMEOUT_MS },
+      );
+    } catch (e: unknown) {
+      // Non-fatal: log the failure so operators can investigate, but do not change the result.
+      console.warn(
+        `[runDelivery] WARNING: Failed to add worktrain:generated label to PR ${prUrl}: ` +
+        `${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
 
   return { _tag: 'pr_opened', url: prUrl };
 }

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -316,6 +316,18 @@ async function maybeRunDelivery(
     {
       autoCommit: trigger.autoCommit,
       autoOpenPR: trigger.autoOpenPR,
+      // secretScan: pass trigger value (undefined = use default true in runDelivery).
+      // WHY ?? true not needed here: runDelivery checks flags.secretScan !== false,
+      // so undefined is equivalent to true. Passing trigger.secretScan preserves the
+      // explicit false from triggers.yml without needing a default here.
+      secretScan: trigger.secretScan ?? true,
+      // Attribution: triggerId and workflowId are used in the PR body footer so operators
+      // can trace the PR back to the trigger and workflow that produced it.
+      triggerId,
+      workflowId: trigger.workflowId,
+      // Per-command git identity: threaded from WorkflowRunSuccess.botIdentity (which was
+      // set from trigger.botIdentity in runWorkflow). Avoids writing to the shared .git/config.
+      ...(result.botIdentity !== undefined ? { botIdentity: result.botIdentity } : {}),
       // Branch assertion: verify HEAD matches expected branch before git push.
       // Only meaningful for worktree sessions -- 'none' sessions use trigger.workspacePath.
       // WHY result.sessionId (not split from path): sessionId is threaded directly through

--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -105,6 +105,7 @@ interface ParsedTriggerRaw {
   onComplete?: { runOn?: string; workflowId?: string; goal?: string };
   autoCommit?: string;   // 'true' | 'false' scalar
   autoOpenPR?: string;   // 'true' | 'false' scalar
+  secretScan?: string;   // 'true' | 'false' scalar; default true (opt-out semantics)
   // Workspace namespacing (Phase 1).
   workspaceName?: string;  // raw string; validated + branded in validateAndResolveTrigger
   soulFile?: string;       // raw path; cascade-resolved in validateAndResolveTrigger
@@ -480,6 +481,7 @@ function setTriggerField(trigger: ParsedTriggerRaw, key: string, value: string):
     case 'callbackUrl':      trigger.callbackUrl = value; break;
     case 'autoCommit':       trigger.autoCommit = value; break;
     case 'autoOpenPR':       trigger.autoOpenPR = value; break;
+    case 'secretScan':       trigger.secretScan = value; break;
     case 'workspaceName':    trigger.workspaceName = value; break;
     case 'soulFile':         trigger.soulFile = value; break;
     case 'branchStrategy':   trigger.branchStrategy = value; break;
@@ -835,6 +837,17 @@ function validateAndResolveTrigger(
   const autoCommit = raw.autoCommit?.trim().toLowerCase() === 'true';
   const autoOpenPR = raw.autoOpenPR?.trim().toLowerCase() === 'true';
 
+  // Parse secretScan boolean flag.
+  // Default: true (opt-out semantics -- scan runs unless explicitly disabled).
+  // WHY opt-out: a scan that defaults to off provides no security value. Users who encounter
+  // false positives can disable with secretScan: false. Users who forget to enable it are safe.
+  // When absent: undefined (treated as true in runDelivery via flags.secretScan !== false).
+  // When 'false': false (scan is explicitly disabled for this trigger).
+  // When 'true': true (redundant but explicit; parsed for consistency).
+  const secretScan: boolean | undefined = raw.secretScan?.trim()
+    ? raw.secretScan.trim().toLowerCase() === 'true'
+    : undefined;
+
   // Warn if autoOpenPR is set without autoCommit -- a PR requires a commit.
   // WHY soft warning (not hard error): allows users to add autoOpenPR first and
   // configure autoCommit later without breaking the config load. Delivery is
@@ -1141,6 +1154,8 @@ function validateAndResolveTrigger(
     ...(onComplete !== undefined ? { onComplete } : {}),
     ...(autoCommit ? { autoCommit } : {}),
     ...(autoOpenPR ? { autoOpenPR } : {}),
+    // secretScan: only spread when explicitly set in YAML (undefined = use default true in runDelivery)
+    ...(secretScan !== undefined ? { secretScan } : {}),
     ...(pollingSource !== undefined ? { pollingSource } : {}),
     // Workspace namespacing (Phase 1).
     ...(resolvedWorkspaceName !== undefined ? { workspaceName: resolvedWorkspaceName } : {}),

--- a/src/trigger/types.ts
+++ b/src/trigger/types.ts
@@ -481,6 +481,18 @@ export interface TriggerDefinition {
   readonly autoCommit?: boolean;
 
   /**
+   * When false, skip the secret scan before committing. Default: true (scan runs).
+   *
+   * WHY opt-out (not opt-in): the safer default is to scan. Operators who encounter
+   * false positives from the Generic secret assign pattern can explicitly disable
+   * the scan with secretScan: false in triggers.yml.
+   *
+   * Only meaningful when autoCommit: true. Has no effect when autoCommit is false.
+   * In YAML:   secretScan: false
+   */
+  readonly secretScan?: boolean;
+
+  /**
    * When true (and autoCommit is also true), the daemon runs `gh pr create` after
    * a successful commit. Reads prTitle and prBody from the handoff artifact.
    *

--- a/tests/unit/delivery-secret-scan.test.ts
+++ b/tests/unit/delivery-secret-scan.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for the secret scan feature in src/trigger/delivery-action.ts
+ *
+ * Covers:
+ * - scanForSecrets(): pure function, all critical patterns
+ * - runDelivery() integration: scan gate, opt-out via secretScan: false
+ *
+ * Key invariant tested explicitly: the matched secret VALUE is never present in
+ * the error message. Only pattern name, file path, and line number are surfaced.
+ *
+ * All tests use an injected fake execFn -- no child_process mock.
+ * Call sequence when secretScan is enabled:
+ *   Call 0: git add <files>
+ *   Call 1: git diff --cached  (returns staged diff)
+ *   Call 2: git commit -m <message>
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { scanForSecrets, runDelivery } from '../../src/trigger/delivery-action.js';
+import type { HandoffArtifact, DeliveryFlags, ExecFn } from '../../src/trigger/delivery-action.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeArtifact(overrides: Partial<HandoffArtifact> = {}): HandoffArtifact {
+  return {
+    commitType: 'feat',
+    commitScope: 'trigger',
+    commitSubject: 'feat(trigger): add secret scan',
+    prTitle: 'feat(trigger): add secret scan',
+    prBody: '## Summary\n- Added secret scan\n\n## Test plan\n- [ ] Tests pass',
+    filesChanged: ['src/trigger/delivery-action.ts'],
+    followUpTickets: [],
+    ...overrides,
+  };
+}
+
+function makeFlags(overrides: Partial<DeliveryFlags> = {}): DeliveryFlags {
+  return { autoCommit: true, autoOpenPR: false, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// scanForSecrets() -- pure function tests (no execFn needed)
+// ---------------------------------------------------------------------------
+
+describe('scanForSecrets', () => {
+  it('returns found=false for a clean diff with no secrets', () => {
+    const diff = `diff --git a/src/foo.ts b/src/foo.ts
+index abc1234..def5678 100644
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -1,3 +1,4 @@
+ const x = 1;
++const y = 2;
+ export { x };
+`;
+    const result = scanForSecrets(diff);
+    expect(result.found).toBe(false);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('detects a GitHub token (ghp_ pattern) in an added line', () => {
+    const fakeToken = 'ghp_' + 'A'.repeat(36);
+    const diff = `diff --git a/src/config.ts b/src/config.ts
+index abc1234..def5678 100644
+--- a/src/config.ts
++++ b/src/config.ts
+@@ -1,3 +1,4 @@
+ const x = 1;
++const token = '${fakeToken}';
+ export { x };
+`;
+    const result = scanForSecrets(diff);
+    expect(result.found).toBe(true);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]?.name).toBe('GitHub token');
+    expect(result.findings[0]?.file).toBe('src/config.ts');
+    // Hunk starts at new line 1. Context line "const x = 1" = line 1. Added line = line 2.
+    expect(result.findings[0]?.lineNumber).toBe(2);
+  });
+
+  it('detects an Anthropic key (sk-ant- pattern)', () => {
+    const fakeKey = 'sk-ant-' + 'A'.repeat(90);
+    const diff = `diff --git a/src/llm.ts b/src/llm.ts
+index abc1234..def5678 100644
+--- a/src/llm.ts
++++ b/src/llm.ts
+@@ -1,2 +1,3 @@
+ const x = 1;
++const apiKey = '${fakeKey}';
+ export {};
+`;
+    const result = scanForSecrets(diff);
+    expect(result.found).toBe(true);
+    expect(result.findings.length).toBeGreaterThan(0);
+    const anthropicFinding = result.findings.find(f => f.name === 'Anthropic key');
+    expect(anthropicFinding).toBeDefined();
+    expect(anthropicFinding?.file).toBe('src/llm.ts');
+  });
+
+  it('does NOT include the matched value in findings -- only name, file, lineNumber', () => {
+    const fakeToken = 'ghp_' + 'B'.repeat(36);
+    const diff = `diff --git a/src/secret.ts b/src/secret.ts
+index abc1234..def5678 100644
+--- a/src/secret.ts
++++ b/src/secret.ts
+@@ -1,1 +1,2 @@
++const tok = '${fakeToken}';
+ export {};
+`;
+    const result = scanForSecrets(diff);
+    expect(result.found).toBe(true);
+    expect(result.findings).toHaveLength(1);
+
+    // Critical invariant: the actual secret value must NOT appear anywhere in the findings
+    const finding = result.findings[0];
+    expect(finding).toBeDefined();
+    if (finding) {
+      // The finding object only has name, file, lineNumber -- no value field
+      expect(Object.keys(finding)).toEqual(['name', 'file', 'lineNumber']);
+      // Extra safety: the token itself is not stringified anywhere in the finding
+      expect(JSON.stringify(finding)).not.toContain(fakeToken);
+    }
+  });
+
+  it('detects a PEM private key header', () => {
+    const diff = `diff --git a/keys/private.pem b/keys/private.pem
+index abc1234..def5678 100644
+--- a/keys/private.pem
++++ b/keys/private.pem
+@@ -0,0 +1,3 @@
++-----BEGIN RSA PRIVATE KEY-----
++MIIEowIBAAKCAQEA...
++-----END RSA PRIVATE KEY-----
+`;
+    const result = scanForSecrets(diff);
+    expect(result.found).toBe(true);
+    const keyFinding = result.findings.find(f => f.name === 'Private key');
+    expect(keyFinding).toBeDefined();
+    expect(keyFinding?.file).toBe('keys/private.pem');
+  });
+
+  it('returns found=false for an empty diff', () => {
+    const result = scanForSecrets('');
+    expect(result.found).toBe(false);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it('does NOT flag secrets on removed lines (- prefix)', () => {
+    // A secret being removed is a GOOD thing -- do not flag it
+    const fakeToken = 'ghp_' + 'C'.repeat(36);
+    const diff = `diff --git a/src/old.ts b/src/old.ts
+index abc1234..def5678 100644
+--- a/src/old.ts
++++ b/src/old.ts
+@@ -1,3 +1,2 @@
+ const x = 1;
+-const oldToken = '${fakeToken}';
+ export {};
+`;
+    const result = scanForSecrets(diff);
+    expect(result.found).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runDelivery() integration tests -- secret scan gate
+// ---------------------------------------------------------------------------
+
+describe('runDelivery -- secret scan gate', () => {
+  /**
+   * Build a fake execFn for the commit-only flow with secret scan enabled.
+   * Call order: 0=git add, 1=git diff --cached, 2=gitleaks (ENOENT), 3=git commit
+   *
+   * WHY gitleaks call: runDelivery() attempts gitleaks after the pattern scan.
+   * In tests gitleaks is not installed, so it throws ENOENT. The fake simulates this.
+   */
+  function makeExecWithCleanDiff(commitOutput = '[main abc1234] feat(trigger): add secret scan'): ExecFn {
+    const gitleaksNotFound = Object.assign(new Error('gitleaks: command not found'), { code: 'ENOENT' });
+    return vi.fn()
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })                 // git add
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })                 // git diff --cached (empty = clean)
+      .mockRejectedValueOnce(gitleaksNotFound)                           // gitleaks (ENOENT = not installed)
+      .mockResolvedValueOnce({ stdout: commitOutput, stderr: '' }) as ExecFn;  // git commit
+  }
+
+  it('passes through cleanly when staged diff contains no secrets', async () => {
+    const exec = makeExecWithCleanDiff();
+    const result = await runDelivery(makeArtifact(), '/workspace', makeFlags(), exec);
+    expect(result._tag).toBe('committed');
+    // Verify git diff --cached was called
+    const calls = (exec as ReturnType<typeof vi.fn>).mock.calls;
+    const diffCall = calls.find((c: unknown[]) => Array.isArray(c) && c[0] === 'git' && Array.isArray(c[1]) && (c[1] as string[]).includes('diff'));
+    expect(diffCall).toBeDefined();
+  });
+
+  it('returns phase: secret_scan error when diff contains a GitHub token', async () => {
+    const fakeToken = 'ghp_' + 'D'.repeat(36);
+    const dirtyDiff = `diff --git a/src/config.ts b/src/config.ts
+index abc1234..def5678 100644
+--- a/src/config.ts
++++ b/src/config.ts
+@@ -1,1 +1,2 @@
++const tok = '${fakeToken}';
+ export {};
+`;
+    const exec = vi.fn()
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })                         // git add
+      .mockResolvedValueOnce({ stdout: dirtyDiff, stderr: '' }) as ExecFn;      // git diff --cached
+
+    const result = await runDelivery(makeArtifact(), '/workspace', makeFlags(), exec);
+    expect(result._tag).toBe('error');
+    if (result._tag === 'error') {
+      expect(result.phase).toBe('secret_scan');
+      // Details must mention the pattern name, file, and line number
+      expect(result.details).toContain('GitHub token');
+      expect(result.details).toContain('src/config.ts');
+      // Details must NOT contain the actual secret value
+      expect(result.details).not.toContain(fakeToken);
+      // Details should include the opt-out hint
+      expect(result.details).toContain('secretScan: false');
+    }
+    // git commit must NOT have been called -- delivery aborted before commit
+    const calls = (exec as ReturnType<typeof vi.fn>).mock.calls as Array<[string, string[]]>;
+    const commitCall = calls.find(([file, args]) => file === 'git' && args[0] === 'commit');
+    expect(commitCall).toBeUndefined();
+  });
+
+  it('returns phase: secret_scan error for Anthropic key (sk-ant- pattern)', async () => {
+    const fakeKey = 'sk-ant-' + 'E'.repeat(90);
+    const dirtyDiff = `diff --git a/src/llm.ts b/src/llm.ts
+index abc1234..def5678 100644
+--- a/src/llm.ts
++++ b/src/llm.ts
+@@ -1,1 +1,2 @@
++const k = '${fakeKey}';
+ export {};
+`;
+    const exec = vi.fn()
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: dirtyDiff, stderr: '' }) as ExecFn;
+
+    const result = await runDelivery(makeArtifact(), '/workspace', makeFlags(), exec);
+    expect(result._tag).toBe('error');
+    if (result._tag === 'error') {
+      expect(result.phase).toBe('secret_scan');
+      expect(result.details).toContain('Anthropic key');
+      // The actual key value must NOT appear in the error message
+      expect(result.details).not.toContain(fakeKey);
+    }
+  });
+
+  it('skips the scan entirely when secretScan: false is set in flags', async () => {
+    // With secretScan: false, call sequence is: git add (0), git commit (1) -- no diff call
+    const exec = vi.fn()
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })                              // git add
+      .mockResolvedValueOnce({ stdout: '[main abc1234] feat', stderr: '' }) as ExecFn; // git commit
+
+    const flags = makeFlags({ secretScan: false });
+    const result = await runDelivery(makeArtifact(), '/workspace', flags, exec);
+    expect(result._tag).toBe('committed');
+
+    // Only 2 calls: git add + git commit. No git diff --cached call.
+    expect((exec as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    const calls = (exec as ReturnType<typeof vi.fn>).mock.calls as Array<[string, string[]]>;
+    const diffCall = calls.find(([file, args]) => file === 'git' && args.includes('diff'));
+    expect(diffCall).toBeUndefined();
+  });
+
+  it('does NOT include the matched value in the error message (invariant)', async () => {
+    const secretValue = 'ghp_' + 'F'.repeat(36);
+    const dirtyDiff = `diff --git a/src/cfg.ts b/src/cfg.ts
+index abc..def 100644
+--- a/src/cfg.ts
++++ b/src/cfg.ts
+@@ -1,1 +1,2 @@
++const t = '${secretValue}';
+ export {};
+`;
+    const exec = vi.fn()
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: dirtyDiff, stderr: '' }) as ExecFn;
+
+    const result = await runDelivery(makeArtifact(), '/workspace', makeFlags(), exec);
+    expect(result._tag).toBe('error');
+    if (result._tag === 'error') {
+      // The actual secret value must NEVER appear in any part of the error output
+      expect(result.details).not.toContain(secretValue);
+      expect(result.phase).toBe('secret_scan');
+    }
+  });
+
+  it('detects -----BEGIN RSA PRIVATE KEY----- in staged diff', async () => {
+    const dirtyDiff = `diff --git a/keys/id_rsa b/keys/id_rsa
+index abc..def 100644
+--- a/keys/id_rsa
++++ b/keys/id_rsa
+@@ -0,0 +1,3 @@
++-----BEGIN RSA PRIVATE KEY-----
++MIIEowIBAAKCAQEA...
++-----END RSA PRIVATE KEY-----
+`;
+    const exec = vi.fn()
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: dirtyDiff, stderr: '' }) as ExecFn;
+
+    const result = await runDelivery(makeArtifact(), '/workspace', makeFlags(), exec);
+    expect(result._tag).toBe('error');
+    if (result._tag === 'error') {
+      expect(result.phase).toBe('secret_scan');
+      expect(result.details).toContain('Private key');
+    }
+  });
+});

--- a/tests/unit/worktrain-trigger-test.test.ts
+++ b/tests/unit/worktrain-trigger-test.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for executeWorktrainTriggerTestCommand
+ *
+ * Uses fake deps (in-memory, no real I/O). No vi.mock() -- follows repo pattern
+ * of "prefer fakes over mocks".
+ *
+ * Test cases:
+ * 1. Non-queue trigger returns error
+ * 2. Clean run prints dispatch for ready issue
+ * 3. Skips issue with active session
+ * 4. Skips idea-maturity issue
+ * 5. Concurrency cap causes all-skip
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  executeWorktrainTriggerTestCommand,
+  type WorktrainTriggerTestDeps,
+} from '../../src/cli/commands/worktrain-trigger-test.js';
+import type { TriggerDefinition } from '../../src/trigger/types.js';
+import type { GitHubQueueConfig } from '../../src/trigger/github-queue-config.js';
+import type { GitHubQueueIssue } from '../../src/trigger/adapters/github-queue-poller.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TEST FIXTURES
+// ═══════════════════════════════════════════════════════════════════════════
+
+const QUEUE_POLL_TRIGGER: TriggerDefinition = {
+  id: 'self-improvement' as TriggerDefinition['id'],
+  provider: 'github_queue_poll',
+  workflowId: 'coding-task-workflow-agentic',
+  workspacePath: '/workspace',
+  goal: 'Autonomous task',
+  concurrencyMode: 'serial',
+  pollingSource: {
+    provider: 'github_queue_poll',
+    repo: 'EtienneBBeaulac/workrail',
+    token: 'ghp_fake',
+    pollIntervalSeconds: 300,
+  },
+};
+
+const GENERIC_TRIGGER: TriggerDefinition = {
+  id: 'webhook-trigger' as TriggerDefinition['id'],
+  provider: 'generic',
+  workflowId: 'coding-task-workflow-agentic',
+  workspacePath: '/workspace',
+  goal: 'Handle webhook',
+  concurrencyMode: 'serial',
+};
+
+const QUEUE_CONFIG: GitHubQueueConfig = {
+  type: 'label',
+  queueLabel: 'worktrain:ready',
+  repo: 'EtienneBBeaulac/workrail',
+  token: 'ghp_fake',
+  pollIntervalSeconds: 300,
+  maxTotalConcurrentSessions: 1,
+  excludeLabels: [],
+};
+
+function makeIssue(overrides: Partial<GitHubQueueIssue> = {}): GitHubQueueIssue {
+  return {
+    id: 127,
+    number: 127,
+    title: 'Add findingCategory to review-verdict schema',
+    body: 'upstream_spec: https://example.com/spec/review-verdict',
+    url: 'https://github.com/EtienneBBeaulac/workrail/issues/127',
+    labels: [],
+    createdAt: '2026-04-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HELPERS
+// ═══════════════════════════════════════════════════════════════════════════
+
+function makeBaseDeps(overrides: Partial<WorktrainTriggerTestDeps> = {}): {
+  deps: WorktrainTriggerTestDeps;
+  printLines: string[];
+  stderrLines: string[];
+} {
+  const printLines: string[] = [];
+  const stderrLines: string[] = [];
+
+  const triggerIndex = new Map<string, TriggerDefinition>([
+    ['self-improvement', QUEUE_POLL_TRIGGER],
+    ['webhook-trigger', GENERIC_TRIGGER],
+  ]);
+
+  const deps: WorktrainTriggerTestDeps = {
+    loadTriggerConfig: async () => ({ kind: 'ok', value: triggerIndex }),
+    loadQueueConfig: async () => ({ kind: 'ok', value: QUEUE_CONFIG }),
+    pollGitHubQueueIssues: async () => ({ kind: 'ok', value: [makeIssue()] }),
+    countActiveSessions: async () => 0,
+    checkIdempotency: async () => 'clear',
+    inferMaturity: () => 'ready',
+    print: (line) => printLines.push(line),
+    stderr: (line) => stderrLines.push(line),
+    ...overrides,
+  };
+
+  return { deps, printLines, stderrLines };
+}
+
+const VALID_OPTS = { triggerId: 'self-improvement' };
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TESTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('executeWorktrainTriggerTestCommand', () => {
+  it('1. Non-queue trigger returns error with specified message', async () => {
+    const { deps, stderrLines } = makeBaseDeps();
+
+    const result = await executeWorktrainTriggerTestCommand(deps, { triggerId: 'webhook-trigger' });
+
+    expect(result.kind).toBe('failure');
+    // The spec requires a specific error message
+    const errorMessage = stderrLines.join('\n');
+    expect(errorMessage).toContain('webhook-trigger');
+    expect(errorMessage).toContain('not a queue poll trigger');
+    expect(errorMessage).toContain('only github_queue_poll triggers can be tested with this command');
+  });
+
+  it('2. Clean run: prints WOULD DISPATCH for ready issue and exits 0', async () => {
+    const issue = makeIssue({
+      number: 127,
+      title: 'Add findingCategory to review-verdict schema',
+      body: 'upstream_spec: https://example.com/spec/review-verdict',
+    });
+
+    const { deps, printLines } = makeBaseDeps({
+      pollGitHubQueueIssues: async () => ({ kind: 'ok', value: [issue] }),
+      inferMaturity: () => 'ready',
+    });
+
+    const result = await executeWorktrainTriggerTestCommand(deps, VALID_OPTS);
+
+    expect(result.kind).toBe('success');
+    const output = printLines.join('\n');
+    expect(output).toContain('[DryRun] Trigger: self-improvement (github_queue_poll)');
+    expect(output).toContain('#127');
+    expect(output).toContain('WOULD DISPATCH');
+    expect(output).toContain('maturity: ready');
+    expect(output).toContain('1 would dispatch');
+  });
+
+  it('3. Skips issue with active session (reason: active_session)', async () => {
+    const issue = makeIssue({ number: 119, title: 'Stuck detection escalation' });
+
+    const { deps, printLines } = makeBaseDeps({
+      pollGitHubQueueIssues: async () => ({ kind: 'ok', value: [issue] }),
+      checkIdempotency: async () => 'active',
+    });
+
+    const result = await executeWorktrainTriggerTestCommand(deps, VALID_OPTS);
+
+    // WHY failure: exit 1 when no issues would dispatch (scripting convention)
+    expect(result.kind).toBe('failure');
+    const output = printLines.join('\n');
+    expect(output).toContain('#119');
+    expect(output).toContain('WOULD SKIP');
+    expect(output).toContain('active_session');
+    expect(output).toContain('0 would dispatch');
+  });
+
+  it('4. Skips idea-maturity issue (reason: maturity=idea)', async () => {
+    const issue = makeIssue({ number: 103, title: 'Jira polling trigger', body: 'No spec here.' });
+
+    const { deps, printLines } = makeBaseDeps({
+      pollGitHubQueueIssues: async () => ({ kind: 'ok', value: [issue] }),
+      inferMaturity: () => 'idea',
+    });
+
+    const result = await executeWorktrainTriggerTestCommand(deps, VALID_OPTS);
+
+    expect(result.kind).toBe('failure');
+    const output = printLines.join('\n');
+    expect(output).toContain('#103');
+    expect(output).toContain('WOULD SKIP');
+    expect(output).toContain('maturity=idea');
+    expect(output).toContain('0 would dispatch');
+  });
+
+  it('5. Concurrency cap: all-skip when activeSessions >= maxTotalConcurrentSessions', async () => {
+    const { deps, printLines } = makeBaseDeps({
+      // Active sessions already at the cap
+      countActiveSessions: async () => 1,
+      // QUEUE_CONFIG.maxTotalConcurrentSessions = 1, so 1 >= 1 = skip
+    });
+
+    const result = await executeWorktrainTriggerTestCommand(deps, VALID_OPTS);
+
+    expect(result.kind).toBe('failure');
+    const output = printLines.join('\n');
+    expect(output).toContain('Concurrency cap reached');
+    expect(output).toContain('0 would dispatch');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `scanForSecrets(diff: string): SecretScanResult` pure function in `delivery-action.ts` that scans staged diffs for 9 common secret patterns (GitHub tokens, OpenAI/Anthropic keys, AWS credentials, Slack tokens, PEM private keys, generic secret assignments)
- Wire the scan into `runDelivery()` between `git add` and `git commit` using `git diff --cached`, aborting delivery with a `phase: 'secret_scan'` error if secrets are detected
- Add optional gitleaks upgrade: if `gitleaks` binary is installed, run it after the pattern scan; ENOENT = skip silently
- Add `secretScan?: boolean` to `DeliveryFlags`, `TriggerDefinition`, parsed in `trigger-store.ts`, threaded through `trigger-router.ts` (default: `true`, opt-out with `secretScan: false`)

## Key invariants

- **Never logs matched secret values** - only pattern name, file path, and line number are surfaced; the `SecretScanResult` type omits the matched value by design (type-level enforcement)
- Only scans `+` prefix lines (added lines) - not context or removed lines
- `secretScan` defaults to `true` (opt-out semantics - safer default)
- Error message includes `secretScan: false` opt-out hint for operators encountering false positives

## Test plan

- [x] `scanForSecrets()` pure function tests: clean diff, GitHub token, Anthropic key, private key, empty diff, removed lines not flagged
- [x] Matched value NOT present in findings or error message (explicit invariant test)
- [x] `runDelivery()` integration: clean diff passes through, dirty diff aborts before commit, `secretScan: false` skips entire scan
- [x] `npm run build` clean
- [x] `npx vitest run tests/unit/delivery-secret-scan.test.ts` - 13/13 pass
- [x] `npx vitest run tests/unit/delivery-action.test.ts tests/unit/trigger-store.test.ts tests/unit/trigger-router.test.ts` - all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)