### PR TITLE
feat(trigger): activate self-improvement queue trigger

### DIFF
--- a/triggers.yml
+++ b/triggers.yml
@@ -27,10 +27,23 @@ triggers:
     agentConfig:
       maxSessionMinutes: 30
 
-  # Self-improvement queue: NOT YET CONFIGURED.
-  # Queue opt-in mechanism is unresolved -- see backlog "Queue opt-in design" section.
-  # Do not activate until the queue shape and identity model are settled.
-  # Placeholder only -- daemon will skip this trigger until provider config is complete.
-  # - id: self-improvement
-  #   provider: github_queue_poll
-  #   ...TBD...
+  # Self-improvement queue: apply "worktrain:ready" label to any issue to queue it.
+  # WorkTrain acts as EtienneBBeaulac. PRs are identifiable by [WT] prefix and
+  # worktrain/ branch name. Token resolved from $WORKTRAIN_BOT_TOKEN env var.
+  - id: self-improvement
+    provider: github_queue_poll
+    workflowId: coding-task-workflow-agentic
+    workspacePath: /Users/etienneb/git/personal/workrail
+    queueType: label
+    queueLabel: "worktrain:ready"
+    branchStrategy: worktree
+    baseBranch: main
+    branchPrefix: "worktrain/"
+    autoCommit: true
+    autoOpenPR: true
+    source:
+      repo: EtienneBBeaulac/workrail
+      token: $WORKTRAIN_BOT_TOKEN
+    agentConfig:
+      maxSessionMinutes: 90
+      maxTurns: 60


### PR DESCRIPTION
Enables the github_queue_poll trigger. Apply worktrain:ready label to any issue to queue it. WorkTrain acts as EtienneBBeaulac, commits with [WT] prefix.