### PR TITLE
feat(daemon): add daemon_stopped and heartbeat events, show in worktrain status

### DIFF
--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -804,6 +804,7 @@ program
         joinPath: path.join,
         print: (line: string) => process.stdout.write(line + '\n'),
         getDataDirEnv: () => process.env['WORKRAIL_DATA_DIR'],
+        readEventLog: (p: string) => fs.promises.readFile(p, 'utf-8').catch(() => ''),
       },
       {
         json: options.json,

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -26,6 +26,7 @@ import { promisify } from 'util';
 import { randomUUID } from 'crypto';
 
 import { interpretCliResultWithoutDI } from './cli/interpret-result.js';
+import { loadDaemonEnv } from './daemon/daemon-env.js';
 import { createContextAssembler } from './context-assembly/index.js';
 import { createListRecentSessions } from './context-assembly/infra.js';
 import {
@@ -311,6 +312,10 @@ program
   .option('--uninstall', 'Stop the daemon service and remove the launchd plist')
   .option('--status', 'Show the current status of the daemon service')
   .action(async (options: { install?: boolean; uninstall?: boolean; status?: boolean }) => {
+    // Load ~/.workrail/.env before anything else so secrets are available both
+    // for daemon startup (startDaemon path) and for plist construction (--install path).
+    await loadDaemonEnv();
+
     const { execFile: execFileRaw } = await import('child_process');
     const execFilePromise = promisify(execFileRaw);
 
@@ -353,6 +358,10 @@ program
         print: (line: string) => console.log(line),
         sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
         startDaemon: async () => {
+          // Load .env again as defense-in-depth: this callback may be invoked
+          // from paths other than the daemon action handler in the future.
+          await loadDaemonEnv();
+
           // This is the launchd entry point: `worktrain daemon` with no flags.
           // Run the same startup logic as `workrail daemon`.
           const { startTriggerListener } = await import('./trigger/trigger-listener.js');
@@ -438,8 +447,42 @@ program
 
           // Keep alive until SIGINT/SIGTERM.
           await new Promise<void>((resolve) => {
+            // Start periodic heartbeat. Emits daemon_heartbeat every 30s so
+            // `worktrain status` can determine whether the daemon is alive.
+            // WHY 30s: frequent enough to detect a crash within 90s (3x interval),
+            // cheap enough to not impact I/O (fire-and-forget JSONL append).
+            const heartbeatInterval = setInterval(() => {
+              const sessionsDir = path.join(os.homedir(), '.workrail', 'daemon-sessions');
+              // Count active sessions from the daemon-sessions dir. Best-effort:
+              // if the dir is unavailable, activeSessions defaults to 0.
+              fs.promises.readdir(sessionsDir)
+                .then((files) => files.filter((f) => f.endsWith('.json')).length)
+                .catch(() => 0)
+                .then((activeSessions) => {
+                  emitter.emit({ kind: 'daemon_heartbeat', activeSessions, ts: Date.now() });
+                });
+            }, 30_000);
+
+            // Best-effort crash event. Emitted when an uncaught exception reaches
+            // the process boundary. fire-and-forget -- the async write may not
+            // complete before process.exit(1), but this is explicitly acceptable:
+            // observability must never delay crash recovery.
+            // WHY process.on (not process.once): want to catch any uncaught exception,
+            // not only the first one. process.exit(1) after the emit prevents loops.
+            // WHY not re-throw: re-throwing after this handler fires will crash without
+            // the emit having a chance to initiate. Direct exit is more predictable.
+            process.on('uncaughtException', (err) => {
+              console.error('[WorkTrain] Uncaught exception -- daemon shutting down:', err);
+              emitter.emit({ kind: 'daemon_stopped', reason: 'crash', ts: Date.now() });
+              process.exit(1);
+            });
+
             const shutdown = async () => {
               console.log('\nShutting down daemon...');
+              // Clear heartbeat before stopping -- prevents timer from firing after
+              // the process is in teardown state.
+              clearInterval(heartbeatInterval);
+              emitter.emit({ kind: 'daemon_stopped', reason: 'graceful', ts: Date.now() });
               if (consoleHandle) {
                 await consoleHandle.stop();
               }

--- a/src/cli/commands/worktrain-overview.ts
+++ b/src/cli/commands/worktrain-overview.ts
@@ -86,6 +86,15 @@ export interface WorktrainOverviewCommandDeps {
    * Injected for testability.
    */
   readonly getDataDirEnv: () => string | undefined;
+  /**
+   * Read the contents of a file as a UTF-8 string. Returns '' on any error
+   * (file not found, permission denied, etc.) so the caller can degrade
+   * gracefully without branching on error kinds.
+   *
+   * WHY injected: keeps executeWorktrainOverviewCommand a pure function with
+   * all I/O at the boundary. Enables unit tests without vi.mock.
+   */
+  readonly readEventLog: (filePath: string) => Promise<string>;
 }
 
 export interface WorktrainOverviewCommandOpts {
@@ -168,6 +177,88 @@ function buildSessionTitle(s: ConsoleSessionSummary): string {
  */
 function extractStepLabel(_s: ConsoleSessionSummary): string | null {
   return null;
+}
+
+/**
+ * Parse today's daemon JSONL event log and return a human-readable "Daemon: ..." status line.
+ *
+ * Logic:
+ * - Find the most recent `daemon_heartbeat` or `daemon_stopped` event.
+ * - If `daemon_stopped` is most recent: "stopped gracefully (HH:MM:SS)" or "crashed (HH:MM:SS)"
+ * - If `daemon_heartbeat` is most recent and < 90s ago: "running (last heartbeat Xs ago, N active sessions)"
+ * - If `daemon_heartbeat` is most recent but >= 90s ago: "may have crashed (last heartbeat Xh ago)"
+ * - If neither found: "no events today"
+ *
+ * WHY 90s staleness threshold: 3x the 30s heartbeat interval. One missed heartbeat is noise;
+ * three consecutive misses indicates the daemon is likely no longer running.
+ */
+function parseDaemonStatusLine(nowMs: number, eventLogContent: string): string {
+  let latestHeartbeat: { ts: number; activeSessions: number } | null = null;
+  let latestStopped: { ts: number; reason: string } | null = null;
+
+  for (const raw of eventLogContent.split('\n')) {
+    if (!raw.trim()) continue;
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      continue; // Skip malformed lines silently.
+    }
+
+    const kind = typeof obj['kind'] === 'string' ? obj['kind'] : '';
+    const ts = typeof obj['ts'] === 'number' ? obj['ts'] : null;
+    if (ts === null) continue;
+
+    if (kind === 'daemon_heartbeat') {
+      if (latestHeartbeat === null || ts > latestHeartbeat.ts) {
+        const activeSessions = typeof obj['activeSessions'] === 'number' ? obj['activeSessions'] : 0;
+        latestHeartbeat = { ts, activeSessions };
+      }
+    } else if (kind === 'daemon_stopped') {
+      if (latestStopped === null || ts > latestStopped.ts) {
+        const reason = typeof obj['reason'] === 'string' ? obj['reason'] : 'unknown';
+        latestStopped = { ts, reason };
+      }
+    }
+  }
+
+  // Neither event found today.
+  if (latestHeartbeat === null && latestStopped === null) {
+    return 'Daemon: no events today';
+  }
+
+  // Determine which event is most recent.
+  const heartbeatTs = latestHeartbeat?.ts ?? -Infinity;
+  const stoppedTs = latestStopped?.ts ?? -Infinity;
+
+  if (stoppedTs >= heartbeatTs && latestStopped !== null) {
+    // Stopped event is most recent.
+    const stoppedTime = new Date(latestStopped.ts).toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+    if (latestStopped.reason === 'graceful') {
+      return `Daemon: stopped gracefully (${stoppedTime})`;
+    }
+    return `Daemon: crashed (${stoppedTime})`;
+  }
+
+  // Heartbeat event is most recent.
+  if (latestHeartbeat !== null) {
+    const agoMs = nowMs - latestHeartbeat.ts;
+    if (agoMs < 90_000) {
+      const agoSec = Math.round(agoMs / 1000);
+      const sessions = latestHeartbeat.activeSessions;
+      const sessionStr = sessions === 1 ? '1 active session' : `${sessions} active sessions`;
+      return `Daemon: running (last heartbeat ${agoSec}s ago, ${sessionStr})`;
+    }
+    // Stale heartbeat -- daemon may have crashed.
+    return `Daemon: may have crashed (last heartbeat ${formatRelativeTime(agoMs)})`;
+  }
+
+  return 'Daemon: no events today';
 }
 
 /**
@@ -267,6 +358,14 @@ export async function executeWorktrainOverviewCommand(
     return;
   }
 
+  // Read today's daemon event log for the Daemon: status line.
+  // WHY async read before output: keeps all I/O at the top; the status line is
+  // printed as part of the header section below.
+  const todayDate = new Date(nowMs).toISOString().slice(0, 10); // YYYY-MM-DD
+  const eventLogPath = deps.joinPath(deps.homedir(), '.workrail', 'events', 'daemon', `${todayDate}.jsonl`);
+  const eventLogContent = await deps.readEventLog(eventLogPath);
+  const daemonStatusLine = parseDaemonStatusLine(nowMs, eventLogContent);
+
   // Human-readable output.
   const date = new Date(nowMs);
   const dateStr = date.toLocaleDateString('en-US', {
@@ -282,6 +381,7 @@ export async function executeWorktrainOverviewCommand(
   });
 
   deps.print(`WorkTrain  [${dateStr}  ${timeStr}]`);
+  deps.print(daemonStatusLine);
   deps.print('Note: live session detection requires daemon (showing last-known state).');
   deps.print('');
 

--- a/src/daemon/daemon-env.ts
+++ b/src/daemon/daemon-env.ts
@@ -1,0 +1,51 @@
+/**
+ * loadDaemonEnv -- load ~/.workrail/.env into process.env at daemon startup.
+ *
+ * WHY: secrets like WORKTRAIN_BOT_TOKEN live in .env so users don't have to
+ * re-export them on every shell session or remember to pass them to --install.
+ * Shell env always wins (we only set if not already set).
+ *
+ * WHY separate module: loadDaemonEnv is called from src/cli-worktrain.ts (the
+ * composition root), but cli-worktrain.ts calls program.parse() at module level,
+ * making it untestable via import. Extracting here lets tests import and exercise
+ * the function directly without side effects.
+ *
+ * WHY optional deps: injectable I/O allows tests to control readFile and homedir
+ * without ESM module mocking (vi.spyOn cannot redefine ESM namespace exports).
+ * The composition root calls with no arguments (real defaults).
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+export interface LoadDaemonEnvDeps {
+  readonly readFile: (path: string) => Promise<string>;
+  readonly homedir: () => string;
+}
+
+const defaultDeps: LoadDaemonEnvDeps = {
+  readFile: (p) => fs.promises.readFile(p, 'utf-8'),
+  homedir: os.homedir,
+};
+
+export async function loadDaemonEnv(deps: LoadDaemonEnvDeps = defaultDeps): Promise<void> {
+  const envPath = path.join(deps.homedir(), '.workrail', '.env');
+  let content: string;
+  try {
+    content = await deps.readFile(envPath);
+  } catch {
+    return; // .env is optional -- missing is not an error
+  }
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const value = trimmed.slice(eqIdx + 1).trim();
+    if (key && !(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+}

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -244,6 +244,20 @@ export interface ToolCallFailedEvent {
   readonly workrailSessionId?: string;
 }
 
+/** Daemon process stopped cleanly (SIGTERM/SIGINT) or crashed (uncaught exception). */
+export interface DaemonStoppedEvent {
+  readonly kind: 'daemon_stopped';
+  readonly reason: 'graceful' | 'crash';
+  readonly ts: number;
+}
+
+/** Periodic heartbeat confirming the daemon is still alive. */
+export interface DaemonHeartbeatEvent {
+  readonly kind: 'daemon_heartbeat';
+  readonly activeSessions: number;
+  readonly ts: number;
+}
+
 /**
  * Emitted when the agent calls signal_coordinator to record a coordinator signal.
  *
@@ -317,6 +331,8 @@ export interface AgentStuckEvent {
  */
 export type DaemonEvent =
   | DaemonStartedEvent
+  | DaemonStoppedEvent
+  | DaemonHeartbeatEvent
   | TriggerFiredEvent
   | SessionQueuedEvent
   | SessionStartedEvent

--- a/tests/unit/cli-worktrain-overview.test.ts
+++ b/tests/unit/cli-worktrain-overview.test.ts
@@ -111,6 +111,9 @@ function makeDeps(
     joinPath: path.join,
     print: (line: string) => lines.push(line),
     getDataDirEnv: () => undefined,
+    // Default: no events today. Tests that need specific daemon status pass their
+    // own readEventLog via overrides.
+    readEventLog: () => Promise.resolve(''),
     ...overrides,
   };
   return { deps, lines };
@@ -555,5 +558,82 @@ describe('executeWorktrainOverviewCommand -- custom thresholds', () => {
     // Custom window (6h): 12h-old session should NOT show.
     await executeWorktrainOverviewCommand(deps2, { recentWindowMs: 6 * ONE_HOUR_MS });
     expect(linesCustom.some((l) => l.includes('Completed 12h ago'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: daemon status line
+// ---------------------------------------------------------------------------
+
+describe('executeWorktrainOverviewCommand -- daemon status line', () => {
+  /**
+   * Build a JSONL string with a single daemon event.
+   * ts is relative to NOW_MS so tests are deterministic.
+   */
+  function makeEventLog(...events: Array<Record<string, unknown>>): string {
+    return events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  }
+
+  it('shows "running" when recent daemon_heartbeat exists (< 90s ago)', async () => {
+    // Heartbeat 30 seconds ago.
+    const heartbeatTs = NOW_MS - 30_000;
+    const eventLog = makeEventLog({ kind: 'daemon_heartbeat', activeSessions: 2, ts: heartbeatTs });
+
+    const { deps, lines } = makeDeps(makeFakeConsoleService([]), {
+      readEventLog: () => Promise.resolve(eventLog),
+    });
+    await executeWorktrainOverviewCommand(deps);
+
+    const daemonLine = lines.find((l) => l.startsWith('Daemon:'));
+    expect(daemonLine).toBeDefined();
+    expect(daemonLine).toContain('running');
+    expect(daemonLine).toContain('30s ago');
+    expect(daemonLine).toContain('2 active sessions');
+  });
+
+  it('shows "may have crashed" when heartbeat is stale (>= 90s ago)', async () => {
+    // Heartbeat 4 hours ago (stale).
+    const heartbeatTs = NOW_MS - 4 * ONE_HOUR_MS;
+    const eventLog = makeEventLog({ kind: 'daemon_heartbeat', activeSessions: 0, ts: heartbeatTs });
+
+    const { deps, lines } = makeDeps(makeFakeConsoleService([]), {
+      readEventLog: () => Promise.resolve(eventLog),
+    });
+    await executeWorktrainOverviewCommand(deps);
+
+    const daemonLine = lines.find((l) => l.startsWith('Daemon:'));
+    expect(daemonLine).toBeDefined();
+    expect(daemonLine).toContain('may have crashed');
+    expect(daemonLine).toContain('4h ago');
+  });
+
+  it('shows "stopped gracefully" when daemon_stopped (graceful) is the most recent event', async () => {
+    // Stopped event is more recent than the last heartbeat.
+    const heartbeatTs = NOW_MS - 120_000; // 2 minutes ago
+    const stoppedTs = NOW_MS - 60_000;   // 1 minute ago (more recent)
+    const eventLog = makeEventLog(
+      { kind: 'daemon_heartbeat', activeSessions: 1, ts: heartbeatTs },
+      { kind: 'daemon_stopped', reason: 'graceful', ts: stoppedTs },
+    );
+
+    const { deps, lines } = makeDeps(makeFakeConsoleService([]), {
+      readEventLog: () => Promise.resolve(eventLog),
+    });
+    await executeWorktrainOverviewCommand(deps);
+
+    const daemonLine = lines.find((l) => l.startsWith('Daemon:'));
+    expect(daemonLine).toBeDefined();
+    expect(daemonLine).toContain('stopped gracefully');
+  });
+
+  it('shows "no events today" when event log is empty', async () => {
+    const { deps, lines } = makeDeps(makeFakeConsoleService([]), {
+      readEventLog: () => Promise.resolve(''),
+    });
+    await executeWorktrainOverviewCommand(deps);
+
+    const daemonLine = lines.find((l) => l.startsWith('Daemon:'));
+    expect(daemonLine).toBeDefined();
+    expect(daemonLine).toContain('no events today');
   });
 });

--- a/tests/unit/daemon-events.test.ts
+++ b/tests/unit/daemon-events.test.ts
@@ -171,6 +171,9 @@ describe('DaemonEventEmitter', () => {
 
     const events: DaemonEvent[] = [
       { kind: 'daemon_started', port: 3200, workspacePath: '/ws' },
+      // Daemon lifecycle events.
+      { kind: 'daemon_stopped', reason: 'graceful', ts: Date.now() },
+      { kind: 'daemon_heartbeat', activeSessions: 2, ts: Date.now() },
       { kind: 'trigger_fired', triggerId: 't1', workflowId: 'w1' },
       { kind: 'session_queued', triggerId: 't1', workflowId: 'w1' },
       { kind: 'session_started', sessionId: 's1', workflowId: 'w1', workspacePath: '/ws' },

--- a/tests/unit/worktrain-daemon.test.ts
+++ b/tests/unit/worktrain-daemon.test.ts
@@ -5,11 +5,12 @@
  * launchctl. This makes the tests fast, deterministic, and macOS-agnostic.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   executeWorktrainDaemonCommand,
   type WorktrainDaemonCommandDeps,
 } from '../../src/cli/commands/worktrain-daemon.js';
+import { loadDaemonEnv, type LoadDaemonEnvDeps } from '../../src/daemon/daemon-env.js';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // FAKE BUILDER
@@ -455,5 +456,92 @@ describe('worktrain daemon -- flag validation', () => {
     if (result.kind === 'failure') {
       expect(result.output.message).toContain('mutually exclusive');
     }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// loadDaemonEnv
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Tests for loadDaemonEnv().
+ *
+ * loadDaemonEnv reads ~/.workrail/.env and sets env vars in process.env.
+ * Shell env always wins: existing keys are never overwritten.
+ * Missing .env file is silently ignored.
+ *
+ * WHY injected deps: ESM module namespace exports cannot be spied on in Vitest
+ * (vi.spyOn on os.homedir fails with "cannot redefine property"). Using injected
+ * deps avoids module mocking entirely and follows the repo's DI philosophy.
+ */
+describe('loadDaemonEnv', () => {
+  // Track keys set by each test so we can clean up after.
+  const keysToClean: string[] = [];
+
+  beforeEach(() => {
+    keysToClean.length = 0;
+  });
+
+  afterEach(() => {
+    // Restore process.env: delete any keys added by the test.
+    for (const key of keysToClean) {
+      delete process.env[key];
+    }
+  });
+
+  /** Build fake deps with the given .env file content (or null for missing). */
+  function fakeDeps(content: string | null): LoadDaemonEnvDeps {
+    return {
+      homedir: () => '/fake/home',
+      readFile: async (p) => {
+        if (content === null) {
+          throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' });
+        }
+        return content;
+      },
+    };
+  }
+
+  it('loads .env file and sets missing env vars', async () => {
+    keysToClean.push('WORKTRAIN_BOT_TOKEN', 'ANOTHER_KEY');
+    delete process.env['WORKTRAIN_BOT_TOKEN'];
+    delete process.env['ANOTHER_KEY'];
+
+    await loadDaemonEnv(fakeDeps('WORKTRAIN_BOT_TOKEN=secret-token\nANOTHER_KEY=another-value'));
+
+    expect(process.env['WORKTRAIN_BOT_TOKEN']).toBe('secret-token');
+    expect(process.env['ANOTHER_KEY']).toBe('another-value');
+  });
+
+  it('does NOT override existing env vars (shell wins)', async () => {
+    process.env['EXISTING_KEY'] = 'original-shell-value';
+    keysToClean.push('EXISTING_KEY');
+
+    await loadDaemonEnv(fakeDeps('EXISTING_KEY=from-dot-env'));
+
+    expect(process.env['EXISTING_KEY']).toBe('original-shell-value');
+  });
+
+  it('silently ignores a missing .env file', async () => {
+    // Should not throw
+    await expect(loadDaemonEnv(fakeDeps(null))).resolves.toBeUndefined();
+  });
+
+  it('skips comment lines and empty lines', async () => {
+    keysToClean.push('ACTUAL_KEY');
+    delete process.env['ACTUAL_KEY'];
+
+    await loadDaemonEnv(fakeDeps('# this is a comment\n\nACTUAL_KEY=actual-value\n   # indented comment'));
+
+    expect(process.env['ACTUAL_KEY']).toBe('actual-value');
+  });
+
+  it('handles values containing = (splits on first = only)', async () => {
+    keysToClean.push('COMPLEX_VALUE');
+    delete process.env['COMPLEX_VALUE'];
+
+    await loadDaemonEnv(fakeDeps('COMPLEX_VALUE=value=with=equals=signs'));
+
+    expect(process.env['COMPLEX_VALUE']).toBe('value=with=equals=signs');
   });
 });


### PR DESCRIPTION
## Summary

- Adds `DaemonStoppedEvent` (kind: 'daemon_stopped', reason: 'graceful'|'crash') and `DaemonHeartbeatEvent` (kind: 'daemon_heartbeat', activeSessions) to the `DaemonEvent` discriminated union in `daemon-events.ts`
- Emits `daemon_stopped` on SIGTERM/SIGINT shutdown and on `uncaughtException` (best-effort crash detection) in `cli-worktrain.ts`
- Starts a 30-second heartbeat interval when the daemon starts; clears it on shutdown to prevent timer leaks
- Adds a "Daemon:" status line to `worktrain status` output by reading today's JSONL event log via an injected `readEventLog` dep

## Test plan

- [ ] `daemon-events.test.ts` exhaustiveness test: both new event kinds emitted and written to JSONL
- [ ] `cli-worktrain-overview.test.ts`: 4 new daemon status tests (running, may have crashed, stopped gracefully, no events today)
- [ ] All 355 test files pass (`npx vitest run`)
- [ ] `npm run build` -- clean

## Notes

- `daemon_stopped` with reason 'crash' is best-effort: fire-and-forget emit may not complete before `process.exit(1)`. SIGKILL produces no event. Both are expected and documented.
- Heartbeat interval is cleared via `clearInterval` in the shutdown closure before `handle.stop()` to prevent leaked timers.
- Includes `feat(daemon): auto-load ~/.workrail/.env at daemon startup` as a prerequisite commit on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)