### PR TITLE
fix(coordinator): increase discovery timeout and add explicit goalTemplate

### DIFF
--- a/src/coordinators/adaptive-pipeline.ts
+++ b/src/coordinators/adaptive-pipeline.ts
@@ -13,16 +13,16 @@
  * - COORDINATOR_SPAWN_CUTOFF_MS is checked before every spawn point.
  *
  * Timeout constants (hardcoded, never LLM-computed -- pitch invariant 17):
- * - Discovery: 35 minutes
+ * - Discovery: 55 minutes
  * - Shaping: 35 minutes
  * - Coding: 65 minutes
  * - Review (child): 25 minutes
- * - Refuse new spawns after: 100 minutes
- * - Total wall-clock cap: 120 minutes
+ * - Refuse new spawns after: 150 minutes
+ * - Total wall-clock cap: 180 minutes
  *
  * WHY separate timeout constants for spawn cutoff vs. total cap:
- * At 35+35+65 = 135 minutes, a maximally slow FULL pipeline can exceed the 120m cap.
- * The COORDINATOR_SPAWN_CUTOFF_MS (100m) guard prevents new spawns after 100 minutes
+ * At 55+35+65 = 155 minutes, a maximally slow FULL pipeline can exceed the 150m cutoff.
+ * The COORDINATOR_SPAWN_CUTOFF_MS (150m) guard prevents new spawns after 150 minutes
  * of elapsed time. Phases already started run to their per-phase timeout.
  * This resolves the budget conflict without reducing per-phase budgets (rabbit hole #2).
  */
@@ -35,8 +35,8 @@ import type { PipelineMode } from './routing/route-task.js';
 // TIMEOUT CONSTANTS (hardcoded, never LLM-computed)
 // ═══════════════════════════════════════════════════════════════════════════
 
-/** Discovery session timeout: 35 minutes. */
-export const DISCOVERY_TIMEOUT_MS = 35 * 60 * 1000;
+/** Discovery session timeout: 55 minutes -- workrail codebase needs more time on complex questions. */
+export const DISCOVERY_TIMEOUT_MS = 55 * 60 * 1000;
 
 /** Shaping session timeout: 35 minutes. */
 export const SHAPING_TIMEOUT_MS = 35 * 60 * 1000;
@@ -48,21 +48,21 @@ export const CODING_TIMEOUT_MS = 65 * 60 * 1000;
 export const REVIEW_TIMEOUT_MS = 25 * 60 * 1000;
 
 /**
- * Coordinator spawn cutoff: refuse new spawns after 100 minutes of elapsed time.
+ * Coordinator spawn cutoff: refuse new spawns after 150 minutes of elapsed time.
  *
- * WHY 100 minutes (not 120):
- * Provides a 20-minute buffer before the total cap to allow any in-flight
+ * WHY 150 minutes (not 180):
+ * Provides a 30-minute buffer before the total cap to allow any in-flight
  * session to complete within the COORDINATOR_MAX_MS wall-clock limit.
- * A phase started at exactly 100m has up to 20m to finish before the coordinator
- * exits at 120m.
+ * A phase started at exactly 150m has up to 30m to finish before the coordinator
+ * exits at 180m. The 30m buffer exceeds the longest single phase (REVIEW_TIMEOUT_MS=25m).
  */
-export const COORDINATOR_SPAWN_CUTOFF_MS = 100 * 60 * 1000;
+export const COORDINATOR_SPAWN_CUTOFF_MS = 150 * 60 * 1000;
 
 /**
- * Total coordinator wall-clock cap: 120 minutes.
+ * Total coordinator wall-clock cap: 180 minutes.
  * The coordinator must exit (escalate) by this time regardless of phase status.
  */
-export const COORDINATOR_MAX_MS = 120 * 60 * 1000;
+export const COORDINATOR_MAX_MS = 180 * 60 * 1000;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // DOMAIN TYPES

--- a/tests/unit/adaptive-full-pipeline.test.ts
+++ b/tests/unit/adaptive-full-pipeline.test.ts
@@ -10,7 +10,7 @@
  * - Fallback skipped when notes length <= 50 (no assembledContextSummary injected)
  * - Fallback skipped when recapMarkdown is null
  * - Escalation on discovery session failure (shaping never called)
- * - Spawn cutoff check prevents spawn after 100 minutes
+ * - Spawn cutoff check prevents spawn after 150 minutes
  * - renderHandoff() generates expected markdown structure
  */
 
@@ -346,8 +346,8 @@ describe('runFullPipeline - discovery session failure', () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('runFullPipeline - spawn cutoff', () => {
-  it('escalates immediately if coordinator started > 100 minutes ago', async () => {
-    const pastStart = Date.now() - 101 * 60 * 1000;
+  it('escalates immediately if coordinator started > 150 minutes ago', async () => {
+    const pastStart = Date.now() - 151 * 60 * 1000;
     const deps = makeFakeDeps();
 
     const outcome = await runFullPipeline(deps, makeOpts(), pastStart);

--- a/tests/unit/adaptive-implement.test.ts
+++ b/tests/unit/adaptive-implement.test.ts
@@ -383,8 +383,8 @@ describe('runImplementPipeline - fix loop cap', () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('runImplementPipeline - spawn cutoff', () => {
-  it('escalates on coding spawn if coordinator elapsed > 100 minutes', async () => {
-    const pastStart = Date.now() - 101 * 60 * 1000; // 101 minutes ago
+  it('escalates on coding spawn if coordinator elapsed > 150 minutes', async () => {
+    const pastStart = Date.now() - 151 * 60 * 1000; // 151 minutes ago
     const deps = makeFakeDeps();
 
     const outcome = await runImplementPipeline(deps, makeOpts(), '/workspace/.workrail/current-pitch.md', pastStart);

--- a/triggers.yml
+++ b/triggers.yml
@@ -38,6 +38,9 @@ triggers:
     workflowId: coding-task-workflow-agentic
     workspacePath: /Users/etienneb/git/personal/workrail
     queueType: assignee
+    # goalTemplate is unused for github_queue_poll triggers -- the poller sets goal
+    # directly from the issue title at dispatch time. This explicit value suppresses
+    # the startup warning: "no static goal or goalTemplate -- defaulting to {{$.goal}}".
     goalTemplate: "{{$.issue.title}}"
     branchStrategy: worktree
     baseBranch: main


### PR DESCRIPTION
## Summary

- Increases `DISCOVERY_TIMEOUT_MS` from 35min to 55min -- the workrail codebase is large and `wr.discovery` legitimately needs more time on complex questions
- Adjusts `COORDINATOR_SPAWN_CUTOFF_MS` from 100min to 150min and `COORDINATOR_MAX_MS` from 120min to 180min to maintain the safety buffer invariant (30min buffer > longest single phase)
- Adds explicit `goalTemplate` to the self-improvement trigger in `triggers.yml` to suppress the startup warning: "no static goal or goalTemplate -- defaulting to {{$.goal}}" (goal is set by the poller directly at dispatch time)
- Updates two spawn-cutoff tests to use the new 150min threshold

## Test plan

- [x] `npm run build` -- clean
- [x] `npx vitest run` -- 356 test files passed, 5280 tests passed, 0 failures
- [x] Two previously failing spawn-cutoff tests updated to use 151min threshold and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)