### PR TITLE
feat(trigger): default branchStrategy to worktree for commit/PR triggers

### DIFF
--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -101,7 +101,7 @@ interface ParsedTriggerRaw {
   // Note: maxSessionMinutes and maxTurns are stored as raw strings here because
   // the YAML parser returns all scalars as strings. Numeric conversion and
   // validation happen in validateAndResolveTrigger at the boundary.
-  agentConfig?: { model?: string; maxSessionMinutes?: string; maxTurns?: string };
+  agentConfig?: { model?: string; maxSessionMinutes?: string; maxTurns?: string; stuckAbortPolicy?: string };
   onComplete?: { runOn?: string; workflowId?: string; goal?: string };
   autoCommit?: string;   // 'true' | 'false' scalar
   autoOpenPR?: string;   // 'true' | 'false' scalar
@@ -323,7 +323,7 @@ function parseTriggersYaml(
         // agentConfig is a sub-object block with scalar string values.
         // Baseline indent: lineIndent (indent of the "agentConfig:" key line).
         lineIndex++;
-        const agentConfig: { model?: string; maxSessionMinutes?: string; maxTurns?: string } = {};
+        const agentConfig: { model?: string; maxSessionMinutes?: string; maxTurns?: string; stuckAbortPolicy?: string } = {};
         while (lineIndex < lines.length) {
           const acLine = lines[lineIndex];
           if (acLine === undefined) break;
@@ -351,6 +351,7 @@ function parseTriggersYaml(
             if (acKey === 'model') agentConfig.model = acValueResult.value;
             else if (acKey === 'maxSessionMinutes') agentConfig.maxSessionMinutes = acValueResult.value;
             else if (acKey === 'maxTurns') agentConfig.maxTurns = acValueResult.value;
+            else if (acKey === 'stuckAbortPolicy') agentConfig.stuckAbortPolicy = acValueResult.value;
           }
           lineIndex++;
         }
@@ -853,11 +854,29 @@ function validateAndResolveTrigger(
       maxTurns = asNumber;
     }
 
-    if (model !== undefined || maxSessionMinutes !== undefined || maxTurns !== undefined) {
+    // stuckAbortPolicy: validate against the closed 'abort' | 'notify_only' enum.
+    // WHY fail-fast: an invalid value silently falls through to undefined (no abort),
+    // which defeats the operator's intent. Validation at parse time matches the pattern
+    // used for concurrencyMode and branchStrategy.
+    let stuckAbortPolicy: 'abort' | 'notify_only' | undefined;
+    if (raw.agentConfig.stuckAbortPolicy !== undefined) {
+      const rawSap = raw.agentConfig.stuckAbortPolicy.trim();
+      if (rawSap !== 'abort' && rawSap !== 'notify_only') {
+        return err({
+          kind: 'invalid_field_value',
+          field: `agentConfig.stuckAbortPolicy (must be "abort" or "notify_only", got: "${rawSap}")`,
+          triggerId: rawId,
+        });
+      }
+      stuckAbortPolicy = rawSap;
+    }
+
+    if (model !== undefined || maxSessionMinutes !== undefined || maxTurns !== undefined || stuckAbortPolicy !== undefined) {
       agentConfig = {
         ...(model !== undefined ? { model } : {}),
         ...(maxSessionMinutes !== undefined ? { maxSessionMinutes } : {}),
         ...(maxTurns !== undefined ? { maxTurns } : {}),
+        ...(stuckAbortPolicy !== undefined ? { stuckAbortPolicy } : {}),
       };
     }
   }
@@ -928,13 +947,18 @@ function validateAndResolveTrigger(
   // ---------------------------------------------------------------------------
   // Worktree isolation fields (Issue #627)
   //
-  // branchStrategy: 'worktree' | 'none' -- default 'none' (opt-in to worktree isolation).
+  // branchStrategy: 'worktree' | 'none'
+  //   - Default 'none' for read-only triggers (no autoCommit, no autoOpenPR):
+  //     worktree creation requires git auth (git fetch) and disk access; read-only
+  //     triggers (MR review, polling) should not incur this overhead.
+  //   - Smart default 'worktree' when autoCommit or autoOpenPR is true and
+  //     branchStrategy is absent: concurrent coding sessions corrupt the main
+  //     checkout without isolation. Making this the default prevents accidental
+  //     clobber for the common coding-trigger case.
+  //   - Explicit 'branchStrategy: none' is the opt-out (always wins).
+  //
   // baseBranch: the base branch to branch from; default 'main'.
   // branchPrefix: prefix for the session branch name; default 'worktrain/'.
-  //
-  // WHY 'none' as default: worktree creation requires git auth (git fetch) and disk
-  // access. Read-only triggers (MR review, polling) should not incur this overhead.
-  // Only coding triggers that write to the repo should use 'worktree'.
   //
   // WHY validate at parse time: an invalid branchStrategy would silently fall through
   // to 'none' if not caught here. Fail-fast at load time is consistent with other
@@ -948,8 +972,20 @@ function validateAndResolveTrigger(
       triggerId: rawId,
     });
   }
-  const branchStrategy: 'worktree' | 'none' | undefined =
-    rawBranchStrategy === 'worktree' ? 'worktree' : rawBranchStrategy === 'none' ? 'none' : undefined;
+  // Smart default: if autoCommit or autoOpenPR is set but branchStrategy is absent,
+  // default to 'worktree'. Isolated worktrees prevent concurrent session clobber.
+  // Explicit 'branchStrategy: none' is the opt-out.
+  let branchStrategy: 'worktree' | 'none' | undefined;
+  if (!rawBranchStrategy && (autoCommit || autoOpenPR)) {
+    branchStrategy = 'worktree';
+    console.log(
+      `[TriggerStore] Trigger "${rawId}" has autoCommit/autoOpenPR but no branchStrategy -- ` +
+      `defaulting to branchStrategy: "worktree" for session isolation. ` +
+      `Use branchStrategy: none to opt out.`,
+    );
+  } else {
+    branchStrategy = rawBranchStrategy === 'worktree' ? 'worktree' : rawBranchStrategy === 'none' ? 'none' : undefined;
+  }
 
   const baseBranch = raw.baseBranch?.trim() || undefined;
   const branchPrefix = raw.branchPrefix?.trim() || undefined;

--- a/src/trigger/types.ts
+++ b/src/trigger/types.ts
@@ -601,7 +601,8 @@ export interface TriggerDefinition {
    * agent writes go to the isolated checkout. trigger.workspacePath continues to
    * be used for git operations (-C flag) that target the repo, not the worktree.
    *
-   * Default: 'none' (opt-in). Use 'worktree' for coding triggers (autoCommit: true).
+   * Default: 'worktree' when autoCommit or autoOpenPR is true; 'none' otherwise.
+   * Explicit 'branchStrategy: none' is the opt-out when autoCommit/autoOpenPR is set.
    * In YAML: branchStrategy: worktree
    */
   readonly branchStrategy?: 'worktree' | 'none';

--- a/tests/unit/trigger-store.test.ts
+++ b/tests/unit/trigger-store.test.ts
@@ -1340,3 +1340,154 @@ triggers:
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// branchStrategy smart default
+// ---------------------------------------------------------------------------
+
+describe('branchStrategy smart default', () => {
+  it('defaults branchStrategy to worktree when autoCommit is true and branchStrategy is absent', () => {
+    const yaml = `
+triggers:
+  - id: auto-commit-no-strategy
+    provider: generic
+    workflowId: my-workflow
+    workspacePath: /workspace
+    goal: Run workflow
+    autoCommit: "true"
+`;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const result = loadTriggerConfig(yaml, {});
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.triggers[0]?.branchStrategy).toBe('worktree');
+    }
+    // Should log an informational message about the smart default
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('defaulting to branchStrategy: "worktree"'));
+    logSpy.mockRestore();
+  });
+
+  it('defaults branchStrategy to worktree when autoOpenPR is true and branchStrategy is absent', () => {
+    const yaml = `
+triggers:
+  - id: auto-pr-no-strategy
+    provider: generic
+    workflowId: my-workflow
+    workspacePath: /workspace
+    goal: Run workflow
+    autoCommit: "true"
+    autoOpenPR: "true"
+`;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const result = loadTriggerConfig(yaml, {});
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.triggers[0]?.branchStrategy).toBe('worktree');
+    }
+    logSpy.mockRestore();
+  });
+
+  it('keeps branchStrategy none when explicit branchStrategy: none and autoCommit: true (explicit opt-out wins)', () => {
+    const yaml = `
+triggers:
+  - id: explicit-none
+    provider: generic
+    workflowId: my-workflow
+    workspacePath: /workspace
+    goal: Run workflow
+    branchStrategy: none
+    autoCommit: "true"
+`;
+    const result = loadTriggerConfig(yaml, {});
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.triggers[0]?.branchStrategy).toBe('none');
+    }
+  });
+
+  it('keeps branchStrategy undefined when neither autoCommit nor autoOpenPR is set and branchStrategy is absent', () => {
+    const yaml = `
+triggers:
+  - id: read-only-trigger
+    provider: generic
+    workflowId: my-workflow
+    workspacePath: /workspace
+    goal: Run workflow
+`;
+    const result = loadTriggerConfig(yaml, {});
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      // No branchStrategy in YAML and no autoCommit/autoOpenPR -- stays undefined (no git overhead)
+      expect(result.value.triggers[0]?.branchStrategy).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stuckAbortPolicy parsing
+// ---------------------------------------------------------------------------
+
+describe('stuckAbortPolicy parsing', () => {
+  it('parses agentConfig.stuckAbortPolicy: "abort" correctly', () => {
+    const yaml = `
+triggers:
+  - id: stuck-abort-trigger
+    provider: generic
+    workflowId: my-workflow
+    workspacePath: /workspace
+    goal: Run workflow
+    agentConfig:
+      maxSessionMinutes: 60
+      stuckAbortPolicy: abort
+`;
+    const result = loadTriggerConfig(yaml, {});
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.triggers[0]?.agentConfig?.stuckAbortPolicy).toBe('abort');
+    }
+  });
+
+  it('parses agentConfig.stuckAbortPolicy: "notify_only" correctly', () => {
+    const yaml = `
+triggers:
+  - id: stuck-notify-trigger
+    provider: generic
+    workflowId: my-workflow
+    workspacePath: /workspace
+    goal: Run workflow
+    agentConfig:
+      stuckAbortPolicy: notify_only
+`;
+    const result = loadTriggerConfig(yaml, {});
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.triggers[0]?.agentConfig?.stuckAbortPolicy).toBe('notify_only');
+    }
+  });
+
+  it('skips trigger when stuckAbortPolicy has an invalid value', () => {
+    const yaml = `
+triggers:
+  - id: bad-stuck-trigger
+    provider: generic
+    workflowId: my-workflow
+    workspacePath: /workspace
+    goal: Run workflow
+    agentConfig:
+      stuckAbortPolicy: kill
+`;
+    const result = loadTriggerConfig(yaml, {});
+
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      // Trigger is skipped due to invalid stuckAbortPolicy value
+      expect(result.value.triggers).toHaveLength(0);
+    }
+  });
+});

--- a/triggers.yml
+++ b/triggers.yml
@@ -38,6 +38,7 @@ triggers:
     workflowId: coding-task-workflow-agentic
     workspacePath: /Users/etienneb/git/personal/workrail
     queueType: assignee
+    goalTemplate: "{{$.issue.title}}"
     branchStrategy: worktree
     baseBranch: main
     branchPrefix: "worktrain/"
@@ -46,6 +47,8 @@ triggers:
     source:
       repo: EtienneBBeaulac/workrail
       token: $WORKTRAIN_BOT_TOKEN
+      pollIntervalSeconds: 3600
     agentConfig:
-      maxSessionMinutes: 90
+      maxSessionMinutes: 120
       maxTurns: 60
+      stuckAbortPolicy: abort


### PR DESCRIPTION
## Summary

- **Smart default for `branchStrategy`**: when a trigger has `autoCommit: true` or `autoOpenPR: true` and no explicit `branchStrategy`, defaults to `'worktree'` instead of `undefined`. Concurrent coding sessions without isolation corrupt the shared workspace checkout. Explicit `branchStrategy: none` opts out.
- **`stuckAbortPolicy` parser support**: adds parsing and validation of `agentConfig.stuckAbortPolicy` (`abort` | `notify_only`) in `trigger-store.ts`, enabling the field to take effect at runtime.
- **`self-improvement` trigger updates**: adds `goalTemplate: "{{$.issue.title}}"` (suppresses startup warning), increases `maxSessionMinutes` to 120, adds `stuckAbortPolicy: abort` and `pollIntervalSeconds: 3600`.

## Test plan

- [ ] `npm run build` passes clean
- [ ] `npx vitest run tests/unit/trigger-store.test.ts` -- 75 tests pass
- [ ] New test: `autoCommit: true` + no `branchStrategy` → `branchStrategy === 'worktree'`
- [ ] New test: `autoOpenPR: true` + no `branchStrategy` → `branchStrategy === 'worktree'`
- [ ] New test: `branchStrategy: none` + `autoCommit: true` → stays `'none'` (explicit opt-out)
- [ ] New test: neither `autoCommit` nor `autoOpenPR` + no `branchStrategy` → stays `undefined`
- [ ] New test: `stuckAbortPolicy: abort` parses correctly
- [ ] New test: `stuckAbortPolicy: notify_only` parses correctly
- [ ] New test: invalid `stuckAbortPolicy` value causes trigger to be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)