### PR TITLE
fix(trigger): add dispatch Set to prevent duplicate queue dispatches

### DIFF
--- a/src/trigger/polling-scheduler.ts
+++ b/src/trigger/polling-scheduler.ts
@@ -82,6 +82,22 @@ export class PollingScheduler {
    * Prevents concurrent polls for the same trigger.
    */
   private readonly polling = new Map<string, boolean>();
+  /**
+   * In-memory set of issue numbers currently being dispatched via dispatchAdaptivePipeline().
+   *
+   * WHY this exists instead of using DaemonRegistry:
+   * DaemonRegistry tracks ephemeral session liveness (start/stop signals) and does not
+   * carry issue-domain knowledge. Adding issueNumber to DaemonEntry would violate its
+   * single responsibility (liveness tracking) and require 4+ file changes. This Set
+   * follows the existing this.polling Map pattern in the same class -- a private readonly
+   * mutable guard behind the class boundary -- and is sufficient for same-process duplicate
+   * prevention. Cross-restart idempotency is handled by checkIdempotency() (sidecar scan).
+   *
+   * Lifecycle: issue added BEFORE dispatchAdaptivePipeline() call (I1). Removed in both
+   * .then() and .catch() handlers unconditionally (I2). Never awaited in the poll cycle
+   * body to preserve fire-and-forget semantics.
+   */
+  private readonly dispatchingIssues = new Set<number>();
 
   constructor(
     private readonly triggers: readonly TriggerDefinition[],
@@ -431,6 +447,14 @@ export class PollingScheduler {
       // H3: session ID pattern in body (active/skip)
       if (/sess_[a-z0-9]+/.test(issue.body)) { skipped.push({ issue, reason: 'active_session_or_in_progress' }); continue; }
 
+      // Fast in-memory idempotency check (I3: runs before sidecar scan).
+      // Guards against duplicate dispatch within a single process lifetime for issues
+      // whose dispatchAdaptivePipeline() Promise is still in flight.
+      if (this.dispatchingIssues.has(issue.number)) {
+        skipped.push({ issue, reason: 'active_session_in_process' });
+        continue;
+      }
+
       // Per-issue idempotency (conservative: any parse error = active)
       const idempotencyStatus = await checkIdempotency(issue.number, sessionsDir);
       if (idempotencyStatus === 'active') { skipped.push({ issue, reason: 'active_session' }); continue; }
@@ -510,7 +534,15 @@ export class PollingScheduler {
         'Inject coordinatorDeps and modeExecutors in the TriggerRouter constructor.',
       );
     }
-    void (this.router as {
+
+    // I1: Add to dispatchingIssues BEFORE calling dispatchAdaptivePipeline().
+    // Prevents duplicate dispatch if the next poll cycle fires before this Promise settles.
+    this.dispatchingIssues.add(top.issue.number);
+    console.log(`[QueuePoll] in-flight-add #${top.issue.number}`);
+
+    // Capture the Promise without awaiting it (fire-and-forget semantics preserved).
+    // I2: Cleanup in BOTH .then() and .catch() -- unconditional regardless of outcome.
+    const dispatchP = (this.router as {
       dispatchAdaptivePipeline: (
         goal: string,
         workspace: string,
@@ -521,6 +553,15 @@ export class PollingScheduler {
       workflowTrigger.workspacePath,
       workflowTrigger.context,
     );
+    void dispatchP
+      .then(() => {
+        this.dispatchingIssues.delete(top.issue.number);
+        console.log(`[QueuePoll] in-flight-clear #${top.issue.number} reason=completed`);
+      })
+      .catch(() => {
+        this.dispatchingIssues.delete(top.issue.number);
+        console.log(`[QueuePoll] in-flight-clear #${top.issue.number} reason=error`);
+      });
     console.log(`[QueuePoll] dispatched via adaptivePipeline goal="${workflowTrigger.goal.slice(0, 80)}"`);
 
     for (let i = 1; i < candidates.length; i++) {

--- a/tests/unit/polling-scheduler.test.ts
+++ b/tests/unit/polling-scheduler.test.ts
@@ -573,4 +573,84 @@ describe('doPollGitHubQueue adaptive routing', () => {
       (scheduler as unknown as { doPoll(t: TriggerDefinition): Promise<void> }).doPoll(trigger),
     ).rejects.toThrow('dispatchAdaptivePipeline not available on router');
   });
+
+  it('blocks same issue from being dispatched twice while first Promise is in flight', async () => {
+    // Proves I1+I3: dispatchingIssues.has() check prevents duplicate dispatch
+    // within the same process when the first dispatchAdaptivePipeline() Promise has not settled.
+    const tmpDir = await makeTmpDir();
+    const store = new PolledEventStore({ WORKRAIL_HOME: tmpDir });
+
+    // Deferred Promise: won't resolve until we call resolve() manually.
+    // This simulates a long-running session still in flight.
+    let resolveDispatch!: () => void;
+    const deferredDispatch = new Promise<void>((resolve) => { resolveDispatch = resolve; });
+
+    const adaptiveDispatched: Array<{ goal: string }> = [];
+    const router = {
+      dispatch: () => { throw new Error('dispatch() should not be called'); },
+      dispatchAdaptivePipeline: async (goal: string) => {
+        adaptiveDispatched.push({ goal });
+        return deferredDispatch;
+      },
+    } as unknown as TriggerRouter;
+
+    const trigger = makeQueuePollTrigger();
+    const scheduler = new PollingScheduler([trigger], router, store, makeQueueFetch());
+
+    // First poll: issue #42 dispatched, Promise in flight
+    await (scheduler as unknown as { doPoll(t: TriggerDefinition): Promise<void> }).doPoll(trigger);
+    expect(adaptiveDispatched).toHaveLength(1);
+
+    // Second poll before Promise settles: issue #42 is in dispatchingIssues -> blocked
+    await (scheduler as unknown as { doPoll(t: TriggerDefinition): Promise<void> }).doPoll(trigger);
+    expect(adaptiveDispatched).toHaveLength(1); // still 1, not 2
+
+    // Unblock the deferred Promise to avoid hanging
+    resolveDispatch();
+    await deferredDispatch;
+  });
+
+  it('allows re-dispatch of issue after dispatchAdaptivePipeline Promise settles', async () => {
+    // Proves I2: cleanup in .then() removes issue from dispatchingIssues,
+    // making it eligible for dispatch on the next poll cycle.
+    const tmpDir = await makeTmpDir();
+    const store = new PolledEventStore({ WORKRAIL_HOME: tmpDir });
+
+    // Deferred Promise pattern -- controlled resolution
+    let resolveDispatch!: () => void;
+    let deferredDispatch = new Promise<void>((resolve) => { resolveDispatch = resolve; });
+
+    const adaptiveDispatched: Array<{ goal: string }> = [];
+    const router = {
+      dispatch: () => { throw new Error('dispatch() should not be called'); },
+      dispatchAdaptivePipeline: async (goal: string) => {
+        adaptiveDispatched.push({ goal });
+        return deferredDispatch;
+      },
+    } as unknown as TriggerRouter;
+
+    const trigger = makeQueuePollTrigger();
+    const scheduler = new PollingScheduler([trigger], router, store, makeQueueFetch());
+
+    // First poll: issue #42 dispatched
+    await (scheduler as unknown as { doPoll(t: TriggerDefinition): Promise<void> }).doPoll(trigger);
+    expect(adaptiveDispatched).toHaveLength(1);
+
+    // Resolve the deferred Promise -- .then() handler fires (microtask), clears dispatchingIssues
+    resolveDispatch();
+    await deferredDispatch;
+    // Drain microtasks so .then() cleanup runs before the next doPoll call
+    await Promise.resolve();
+
+    // Re-arm the deferred Promise for the second dispatch
+    deferredDispatch = new Promise<void>((resolve) => { resolveDispatch = resolve; });
+
+    // Second poll after Promise settled: issue #42 no longer in dispatchingIssues -> dispatched again
+    await (scheduler as unknown as { doPoll(t: TriggerDefinition): Promise<void> }).doPoll(trigger);
+    expect(adaptiveDispatched).toHaveLength(2);
+
+    // Cleanup
+    resolveDispatch();
+    await deferredDispatch;
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `dispatchingIssues: Set<number>` to `PollingScheduler` as a fast in-memory idempotency check
- Prevents the same issue from being dispatched multiple times when sessions run without a `worktreePath` in their sidecar (`branchStrategy: none`)
- Covers the new behavior with 2 unit tests in `polling-scheduler.test.ts`

## Test plan

- [ ] `npm test` passes locally (unit tests cover the new Set guard)
- [ ] CI passes on this PR
- [ ] Verify no duplicate dispatches when polling fires rapidly for the same issue

Generated with [Claude Code](https://claude.com/claude-code)