### PR TITLE
chore(trigger): remove stale workflowId from self-improvement trigger

### DIFF
--- a/triggers.yml
+++ b/triggers.yml
@@ -28,20 +28,13 @@ triggers:
     agentConfig:
       maxSessionMinutes: 30
 
-  # Self-improvement queue: apply "worktrain:ready" label to any issue to queue it.
-  # WorkTrain acts as EtienneBBeaulac. PRs are identifiable by [WT] prefix and
-  # worktrain/ branch name. Token resolved from $WORKTRAIN_BOT_TOKEN env var.
   # Self-improvement queue: assign issues to worktrain-etienneb to queue them.
   # WorkTrain acts as EtienneBBeaulac. PRs get [WT] prefix and worktrain/ branch.
   - id: self-improvement
     provider: github_queue_poll
-    workflowId: coding-task-workflow-agentic
     workspacePath: /Users/etienneb/git/personal/workrail
-    queueType: assignee
-    # goalTemplate is unused for github_queue_poll triggers -- the poller sets goal
-    # directly from the issue title at dispatch time. This explicit value suppresses
-    # the startup warning: "no static goal or goalTemplate -- defaulting to {{$.goal}}".
     goalTemplate: "{{$.issue.title}}"
+    queueType: assignee
     branchStrategy: worktree
     baseBranch: main
     branchPrefix: "worktrain/"


### PR DESCRIPTION
## Summary

- Removes `workflowId: coding-task-workflow-agentic` from the `self-improvement` trigger in `triggers.yml`. For `github_queue_poll` triggers, `workflowId` is ignored by the daemon (the adaptive coordinator decides the pipeline) -- keeping it causes a confusing warning at daemon startup.
- Removes the duplicate comment block at the top of the trigger (two overlapping lines from a previous merge).
- Removes the now-unnecessary inline comment on `goalTemplate` that explained the startup warning suppression.

No runtime behavior changes. The `trigger-store.ts` code already handled absent `workflowId` for this provider (assigns `''` sentinel, never forwarded to the adaptive dispatcher).

## Test plan

- [x] `npm run validate:workflows` -- all 24 workflows valid
- [x] `npm run build` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)