### PR TITLE
fix(cli): load ~/.workrail/.env before trigger validate

### DIFF
--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -1618,6 +1618,10 @@ triggerCommand
   .description('Static analysis of triggers.yml -- reports issues without running anything. Exits 1 if any errors found.')
   .option('--config <path>', 'Path to triggers.yml (default: ~/.workrail/triggers.yml)')
   .action(async (options: { config?: string }) => {
+    // Load ~/.workrail/.env so $ENV_VAR secret references in triggers.yml resolve correctly.
+    await loadDaemonEnv();
+    process.stdout.write('[Note: loaded ~/.workrail/.env for secret resolution]\n');
+
     const { loadTriggerConfigFromFile } = await import('./trigger/trigger-store.js');
 
     const defaultConfigFilePath = path.join(os.homedir(), '.workrail', 'triggers.yml');


### PR DESCRIPTION
## Summary

- `worktrain trigger validate` was failing to resolve `$ENV_VAR` secret references in `triggers.yml` because `loadDaemonEnv()` was not called before validation
- The daemon auto-loads `~/.workrail/.env` at startup but the validate command ran in a shell context where those secrets weren't exported
- Fixes: triggers with `hmacSecret: $WORKTRAIN_BOT_TOKEN` now validate correctly from the CLI, matching daemon runtime behavior

## Changes

- Added `await loadDaemonEnv()` to the `trigger validate` action handler in `src/cli-worktrain.ts`, before `executeWorktrainTriggerValidateCommand` is called
- Added `[Note: loaded ~/.workrail/.env for secret resolution]` to the output so users know why secrets resolve from the CLI
- `loadDaemonEnv` was already imported; zero new dependencies

## Test plan

- [x] `npm run build` - clean TypeScript compile
- [x] `npx vitest run` - 357 test files passed, 5326 tests passed, 0 failures
- [ ] Manual: run `worktrain trigger validate` with a trigger that has a `$SECRET` reference and verify it resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)