### PR TITLE
fix(cli): validate lock file PID before trusting port discovery

### DIFF
--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -1624,6 +1624,15 @@ triggerCommand
       {
         fetch: (url, opts) => globalThis.fetch(url, opts),
         readFile: (p: string) => fs.promises.readFile(p, 'utf-8'),
+        deleteFile: (p: string) => fs.promises.unlink(p),
+        isPidAlive: (pid: number) => {
+          try {
+            process.kill(pid, 0); // signal 0 = existence check, no actual signal sent
+            return true;
+          } catch {
+            return false; // ESRCH = no such process
+          }
+        },
         print: (line: string) => process.stdout.write(line + '\n'),
         stderr: (line: string) => process.stderr.write(line + '\n'),
         homedir: os.homedir,

--- a/src/cli/commands/worktrain-trigger-poll.ts
+++ b/src/cli/commands/worktrain-trigger-poll.ts
@@ -34,6 +34,19 @@ export interface WorktrainTriggerPollDeps {
   ) => Promise<{ readonly ok: boolean; readonly status: number; readonly json: () => Promise<unknown> }>;
   /** Read a file as UTF-8 string. Used for daemon-console.lock port discovery. */
   readonly readFile: (path: string) => Promise<string>;
+  /**
+   * Delete a file. Used to remove stale lock files when a dead PID is detected.
+   * Errors are swallowed by the caller -- this is best-effort cleanup.
+   * WHY injectable: allows tests to verify cleanup without real filesystem side-effects.
+   */
+  readonly deleteFile: (path: string) => Promise<void>;
+  /**
+   * Check whether a process ID is alive.
+   * WHY injectable: allows tests to simulate dead-PID scenarios without spawning/killing real processes.
+   * Real implementation: process.kill(pid, 0) -- signal 0 = existence check, no actual signal sent.
+   * Returns false for any PID that is not alive (ESRCH) or for which we lack permission.
+   */
+  readonly isPidAlive: (pid: number) => boolean;
   /** Write a line to stdout (progress and results). */
   readonly print: (line: string) => void;
   /** Write a line to stderr (errors and warnings). */
@@ -79,28 +92,61 @@ const LOCK_FILE_NAMES = ['daemon-console.lock', 'dashboard.lock'] as const;
  *
  * Priority:
  * 1. Explicit --port flag (caller-provided override)
- * 2. Port from ~/.workrail/daemon-console.lock (daemon console)
- * 3. Port from ~/.workrail/dashboard.lock (MCP server, legacy)
+ * 2. Port from ~/.workrail/daemon-console.lock (daemon console), if PID is alive
+ * 3. Port from ~/.workrail/dashboard.lock (MCP server, legacy), if PID is alive
  * 4. Default: 3200 (spec requirement for trigger commands)
+ *
+ * Stale lock handling: if a lock file contains a `pid` field whose process is no
+ * longer alive, that lock file is skipped and the stale file is deleted as
+ * best-effort cleanup (errors from deletion are swallowed).
  */
 async function discoverConsolePort(
-  deps: Pick<WorktrainTriggerPollDeps, 'readFile' | 'homedir' | 'joinPath'>,
+  deps: Pick<WorktrainTriggerPollDeps, 'readFile' | 'deleteFile' | 'isPidAlive' | 'homedir' | 'joinPath' | 'stderr'>,
   portOverride?: number,
 ): Promise<number> {
   if (portOverride !== undefined && portOverride > 0) {
     return portOverride;
   }
 
+  let staleLockPath: string | undefined;
+
   for (const lockFileName of LOCK_FILE_NAMES) {
     const lockPath = deps.joinPath(deps.homedir(), '.workrail', lockFileName);
     try {
       const raw = await deps.readFile(lockPath);
-      const parsed = JSON.parse(raw) as { port?: unknown };
+      const parsed = JSON.parse(raw) as { port?: unknown; pid?: unknown };
+
+      // Validate the PID in the lock file before trusting the port.
+      // WHY: a stale lock file pointing to a dead PID causes the command to
+      // target a dead port, producing 404 or ECONNREFUSED. Signal 0 checks
+      // process existence without sending an actual signal.
+      // WHY guard pid > 0: process.kill(0, 0) kills the current process group;
+      // process.kill(negative, 0) targets a process group by PGID. Both are wrong here.
+      if (typeof parsed.pid === 'number' && parsed.pid > 0) {
+        if (!deps.isPidAlive(parsed.pid)) {
+          deps.stderr(
+            `[Poll] ${lockFileName} points to dead PID ${parsed.pid} -- skipping stale lock, falling back to port ${DEFAULT_POLL_PORT}`,
+          );
+          staleLockPath = lockPath;
+          continue; // skip this lock file
+        }
+      }
+
       if (typeof parsed.port === 'number' && parsed.port > 0) {
         return parsed.port;
       }
     } catch {
       // ENOENT or parse error -- try next lock file
+    }
+  }
+
+  // Best-effort cleanup: delete the stale lock file so future invocations
+  // don't have to work around it. Errors are swallowed -- cleanup is advisory.
+  if (staleLockPath !== undefined) {
+    try {
+      await deps.deleteFile(staleLockPath);
+    } catch {
+      // Swallow -- stale lock cleanup is best-effort
     }
   }
 

--- a/tests/unit/worktrain-trigger-poll.test.ts
+++ b/tests/unit/worktrain-trigger-poll.test.ts
@@ -40,6 +40,10 @@ function makeBaseDeps(overrides: Partial<WorktrainTriggerPollDeps> = {}): {
       }),
     }),
     readFile: async () => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); },
+    // Default: all PIDs are alive (no stale lock behavior unless overridden)
+    isPidAlive: () => true,
+    // Default: no-op cleanup (tests that verify deletion must override and capture calls)
+    deleteFile: async () => {},
     print: (line) => printLines.push(line),
     stderr: (line) => stderrLines.push(line),
     homedir: () => '/home/test',
@@ -145,7 +149,7 @@ describe('executeWorktrainTriggerPollCommand', () => {
     expect(stderrLines.some((l) => l.includes('Could not connect to WorkTrain daemon'))).toBe(true);
   });
 
-  it('uses daemon-console.lock port when lock file is present', async () => {
+  it('uses daemon-console.lock port when lock file is present and PID is alive', async () => {
     let capturedUrl = '';
     const { deps } = makeBaseDeps({
       readFile: async (p) => {
@@ -154,6 +158,8 @@ describe('executeWorktrainTriggerPollCommand', () => {
         }
         throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       },
+      // Explicitly mark PID 1234 as alive
+      isPidAlive: () => true,
       fetch: async (url) => {
         capturedUrl = url;
         return {
@@ -170,6 +176,58 @@ describe('executeWorktrainTriggerPollCommand', () => {
     await executeWorktrainTriggerPollCommand(deps, { triggerId: 'self-improvement' });
 
     expect(capturedUrl).toContain('3456');
+  });
+
+  it('falls back to port 3200 when daemon-console.lock PID is dead', async () => {
+    let capturedUrl = '';
+    const { deps, stderrLines } = makeBaseDeps({
+      readFile: async (p) => {
+        if (p.includes('daemon-console.lock')) {
+          // PID 99999 is dead -- will not be alive
+          return JSON.stringify({ pid: 99999, port: 3456 });
+        }
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      },
+      isPidAlive: () => false,
+      fetch: async (url) => {
+        capturedUrl = url;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: true,
+            data: { triggerId: 'self-improvement', cycleRan: true, message: 'Done.' },
+          }),
+        };
+      },
+    });
+
+    await executeWorktrainTriggerPollCommand(deps, { triggerId: 'self-improvement' });
+
+    // Should fall back to 3200, not use the stale 3456
+    expect(capturedUrl).toContain('3200');
+    expect(capturedUrl).not.toContain('3456');
+    // Should warn about the dead PID
+    expect(stderrLines.some((l) => l.includes('dead PID 99999'))).toBe(true);
+  });
+
+  it('deletes stale lock file when PID is dead', async () => {
+    const deletedPaths: string[] = [];
+    const { deps } = makeBaseDeps({
+      readFile: async (p) => {
+        if (p.includes('daemon-console.lock')) {
+          return JSON.stringify({ pid: 99999, port: 3456 });
+        }
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      },
+      isPidAlive: () => false,
+      deleteFile: async (path) => { deletedPaths.push(path); },
+    });
+
+    await executeWorktrainTriggerPollCommand(deps, { triggerId: 'self-improvement' });
+
+    // The stale daemon-console.lock should have been deleted
+    expect(deletedPaths.some((p) => p.includes('daemon-console.lock'))).toBe(true);
   });
 
   it('defaults to port 3200 when no lock file and no --port', async () => {


### PR DESCRIPTION
## Summary

- Stale `daemon-console.lock` files pointing to dead PIDs caused `worktrain trigger poll` to target a dead port and receive 404 or connection refused errors
- Added `isPidAlive` dep (wraps `process.kill(pid, 0)` -- signal 0 checks existence without sending a real signal) and `deleteFile` dep to `WorktrainTriggerPollDeps`
- `discoverConsolePort()` now validates the PID from each lock file before trusting its port; on a dead PID it warns, skips the lock file, and falls back to port 3200
- Stale lock file is deleted as best-effort cleanup so future invocations don't encounter the same problem

## Test plan

- [x] `npm run build` -- clean, no TypeScript errors
- [x] `npx vitest run tests/unit/worktrain-trigger-poll.test.ts` -- 10 tests pass (8 original + 2 new)
  - New: "falls back to port 3200 when daemon-console.lock PID is dead"
  - New: "deletes stale lock file when PID is dead"
- [x] Full `npx vitest run` -- 5353 pass, 1 pre-existing perf flake unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)