### PR TITLE
fix(daemon): emit session_aborted events on SIGTERM for in-flight sessions

### DIFF
--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -485,6 +485,21 @@ program
               // Clear heartbeat before stopping -- prevents timer from firing after
               // the process is in teardown state.
               clearInterval(heartbeatInterval);
+              // WHY emit session_aborted before handle.stop(): in-flight sessions have
+              // their agent loops killed by handle.stop() but never emit session_completed.
+              // Without these events the JSONL log shows them as RUNNING forever, making
+              // `worktrain health` and `worktrain status` untrustworthy after restart.
+              // steerRegistry keys are workrailSessionIds of sessions currently in the
+              // agent loop. Emit before handle.stop() while I/O is still active.
+              for (const workrailSessionId of handle.steerRegistry.keys()) {
+                emitter.emit({
+                  kind: 'session_aborted',
+                  sessionId: workrailSessionId,
+                  workrailSessionId,
+                  reason: 'daemon_shutdown',
+                  ts: Date.now(),
+                });
+              }
               emitter.emit({ kind: 'daemon_stopped', reason: 'graceful', ts: Date.now() });
               if (consoleHandle) {
                 await consoleHandle.stop();
@@ -567,6 +582,8 @@ function formatDaemonEventLine(raw: string): string | null {
       }
       return `${prefix}  workflow=${obj['workflowId'] ?? '?'} outcome=${outcome ?? '?'}${detail}`;
     }
+    case 'session_aborted':
+      return `${prefix}  reason=${obj['reason'] ?? '?'}`;
     case 'step_advanced':
       return `${prefix}  -> step advanced`;
     case 'issue_reported': {
@@ -1125,6 +1142,13 @@ function runHealthSummary(sessionId: string, raw: string): void {
         break;
       case 'session_completed':
         sessionOutcome = typeof obj['outcome'] === 'string' ? obj['outcome'] : null;
+        isLive = false;
+        break;
+      case 'session_aborted':
+        // WHY treat session_aborted as a terminal state: the daemon was stopped before
+        // the session completed. This is not a failure, but the session is definitively
+        // no longer running. Show ABORTED in the status line rather than RUNNING.
+        sessionOutcome = 'aborted';
         isLive = false;
         break;
     }

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -251,6 +251,31 @@ export interface DaemonStoppedEvent {
   readonly ts: number;
 }
 
+/**
+ * A workflow session was aborted because the daemon was stopped before the session completed.
+ *
+ * WHY: When the daemon receives SIGTERM/SIGINT, in-flight sessions are killed without
+ * completing. Without this event, the JSONL event log shows them as RUNNING forever,
+ * making `worktrain health` and `worktrain status` untrustworthy after a restart.
+ * Emitting this event at shutdown gives consumers a definitive terminal state.
+ *
+ * WHY reason is a closed union: make illegal states unrepresentable. 'daemon_shutdown'
+ * is graceful termination (SIGTERM/SIGINT); 'daemon_killed' is reserved for forceful
+ * termination (SIGKILL or OOM). Only 'daemon_shutdown' is emitted today.
+ *
+ * WHY sessionId = workrailSessionId: at shutdown time, the only available in-process
+ * session identifier is the workrailSessionId from the steerRegistry. The process-local
+ * UUID is not accessible at this boundary. Log consumers filter by either field, so this
+ * does not affect filtering correctness.
+ */
+export interface DaemonSessionAbortedEvent {
+  readonly kind: 'session_aborted';
+  readonly sessionId: string;
+  readonly workrailSessionId?: string;
+  readonly reason: 'daemon_shutdown' | 'daemon_killed';
+  readonly ts: number;
+}
+
 /** Periodic heartbeat confirming the daemon is still alive. */
 export interface DaemonHeartbeatEvent {
   readonly kind: 'daemon_heartbeat';
@@ -340,6 +365,7 @@ export type DaemonEvent =
   | ToolErrorEvent
   | StepAdvancedEvent
   | SessionCompletedEvent
+  | DaemonSessionAbortedEvent
   | DeliveryAttemptedEvent
   | IssueReportedEvent
   | LlmTurnStartedEvent

--- a/tests/unit/cli-worktrain-logs.test.ts
+++ b/tests/unit/cli-worktrain-logs.test.ts
@@ -62,6 +62,8 @@ function formatDaemonEventLine(raw: string): string | null {
       }
       return `${prefix}  workflow=${obj['workflowId'] ?? '?'} outcome=${outcome ?? '?'}${detail}`;
     }
+    case 'session_aborted':
+      return `${prefix}  reason=${obj['reason'] ?? '?'}`;
     case 'step_advanced':
       return `${prefix}  -> step advanced`;
     case 'issue_reported': {
@@ -306,6 +308,33 @@ describe('formatDaemonEventLine', () => {
     expect(result).not.toBeNull();
     expect(result).toContain('session TIMEOUT');
     expect(result).toContain('(max_turns)');
+  });
+
+  it('formats session_aborted with reason=daemon_shutdown', () => {
+    const line = makeEvent({
+      kind: 'session_aborted',
+      sessionId: 'sess_abc123xyz',
+      workrailSessionId: 'sess_abc123xyz',
+      reason: 'daemon_shutdown',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('session_aborted');
+    expect(result).toContain('reason=daemon_shutdown');
+    // sessionId prefix is sliced to 8 chars: 'sess_abc'
+    expect(result).toContain('[sess_abc]');
+  });
+
+  it('formats session_aborted with reason=daemon_killed', () => {
+    const line = makeEvent({
+      kind: 'session_aborted',
+      sessionId: 'sess_def456xyz',
+      reason: 'daemon_killed',
+    });
+    const result = formatDaemonEventLine(line);
+    expect(result).not.toBeNull();
+    expect(result).toContain('session_aborted');
+    expect(result).toContain('reason=daemon_killed');
   });
 
   it('formats step_advanced with arrow label', () => {

--- a/tests/unit/cli-worktrain-status.test.ts
+++ b/tests/unit/cli-worktrain-status.test.ts
@@ -96,3 +96,142 @@ describe('worktrain status -- sessionId length validation', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Replicated runHealthSummary logic (mirrors cli-worktrain.ts)
+//
+// WHY replicate: runHealthSummary() is inline in cli-worktrain.ts and not exported.
+// Replicating the relevant state-machine logic here documents the contract and
+// keeps tests in sync without requiring a subprocess or module extraction.
+// ---------------------------------------------------------------------------
+
+interface HealthState {
+  sessionOutcome: string | null;
+  isLive: boolean;
+}
+
+/**
+ * Process a sequence of JSONL event lines for a session and return the final
+ * health state. Mirrors the core logic of runHealthSummary() in cli-worktrain.ts.
+ */
+function computeHealthState(sessionId: string, raw: string): HealthState {
+  let sessionOutcome: string | null = null;
+  let isLive = true;
+
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const sid = typeof obj['sessionId'] === 'string' ? obj['sessionId'] : '';
+    const wrid = typeof obj['workrailSessionId'] === 'string' ? obj['workrailSessionId'] : '';
+    const matches = sid.startsWith(sessionId) || sid === sessionId ||
+      wrid.startsWith(sessionId) || wrid === sessionId;
+    if (!matches) continue;
+
+    const kind = typeof obj['kind'] === 'string' ? obj['kind'] : '';
+    switch (kind) {
+      case 'session_completed':
+        sessionOutcome = typeof obj['outcome'] === 'string' ? obj['outcome'] : null;
+        isLive = false;
+        break;
+      case 'session_aborted':
+        // WHY: session_aborted is a terminal state -- the daemon was stopped.
+        // Mirrors the case added to runHealthSummary() in cli-worktrain.ts.
+        sessionOutcome = 'aborted';
+        isLive = false;
+        break;
+    }
+  }
+
+  return { sessionOutcome, isLive };
+}
+
+/**
+ * Return the display status string (mirrors sessionStatus computation in runHealthSummary).
+ */
+function sessionStatusDisplay(state: HealthState): string {
+  return state.sessionOutcome !== null
+    ? state.sessionOutcome.toUpperCase()
+    : (state.isLive ? 'RUNNING' : 'UNKNOWN');
+}
+
+// ---------------------------------------------------------------------------
+// Tests: runHealthSummary session_aborted handling
+// ---------------------------------------------------------------------------
+
+describe('runHealthSummary -- session_aborted handling', () => {
+  const SESSION_ID = 'sess_abc123xyz456';
+
+  function makeJsonlLine(obj: Record<string, unknown>): string {
+    return JSON.stringify({ ts: Date.now(), ...obj });
+  }
+
+  it('session_aborted sets isLive = false', () => {
+    const raw = makeJsonlLine({
+      kind: 'session_aborted',
+      sessionId: SESSION_ID,
+      workrailSessionId: SESSION_ID,
+      reason: 'daemon_shutdown',
+    });
+    const state = computeHealthState(SESSION_ID, raw);
+    expect(state.isLive).toBe(false);
+  });
+
+  it('session_aborted sets sessionOutcome to aborted', () => {
+    const raw = makeJsonlLine({
+      kind: 'session_aborted',
+      sessionId: SESSION_ID,
+      workrailSessionId: SESSION_ID,
+      reason: 'daemon_shutdown',
+    });
+    const state = computeHealthState(SESSION_ID, raw);
+    expect(state.sessionOutcome).toBe('aborted');
+  });
+
+  it('session_aborted results in ABORTED display status', () => {
+    const raw = [
+      makeJsonlLine({ kind: 'session_started', sessionId: SESSION_ID, workflowId: 'wf-1', workspacePath: '/ws' }),
+      makeJsonlLine({ kind: 'session_aborted', sessionId: SESSION_ID, workrailSessionId: SESSION_ID, reason: 'daemon_shutdown' }),
+    ].join('\n');
+    const state = computeHealthState(SESSION_ID, raw);
+    expect(sessionStatusDisplay(state)).toBe('ABORTED');
+  });
+
+  it('session with no terminal event shows RUNNING', () => {
+    const raw = makeJsonlLine({
+      kind: 'session_started',
+      sessionId: SESSION_ID,
+      workflowId: 'wf-1',
+      workspacePath: '/ws',
+    });
+    const state = computeHealthState(SESSION_ID, raw);
+    expect(state.isLive).toBe(true);
+    expect(sessionStatusDisplay(state)).toBe('RUNNING');
+  });
+
+  it('session_completed with success shows SUCCESS', () => {
+    const raw = [
+      makeJsonlLine({ kind: 'session_started', sessionId: SESSION_ID, workflowId: 'wf-1', workspacePath: '/ws' }),
+      makeJsonlLine({ kind: 'session_completed', sessionId: SESSION_ID, workflowId: 'wf-1', outcome: 'success' }),
+    ].join('\n');
+    const state = computeHealthState(SESSION_ID, raw);
+    expect(state.isLive).toBe(false);
+    expect(sessionStatusDisplay(state)).toBe('SUCCESS');
+  });
+
+  it('session_aborted filters correctly by workrailSessionId', () => {
+    const OTHER_ID = 'sess_xyz999different';
+    const raw = [
+      makeJsonlLine({ kind: 'session_aborted', sessionId: SESSION_ID, workrailSessionId: SESSION_ID, reason: 'daemon_shutdown' }),
+      makeJsonlLine({ kind: 'session_aborted', sessionId: OTHER_ID, workrailSessionId: OTHER_ID, reason: 'daemon_shutdown' }),
+    ].join('\n');
+    const state = computeHealthState(SESSION_ID, raw);
+    expect(state.sessionOutcome).toBe('aborted');
+    expect(state.isLive).toBe(false);
+  });
+});

--- a/tests/unit/daemon-events.test.ts
+++ b/tests/unit/daemon-events.test.ts
@@ -191,6 +191,8 @@ describe('DaemonEventEmitter', () => {
       { kind: 'tool_call_failed', sessionId: 's1', toolName: 'Bash', durationMs: 12, errorMessage: 'Command failed' },
       // Stuck detection event.
       { kind: 'agent_stuck', sessionId: 's1', reason: 'repeated_tool_call', detail: 'Same tool+args 3 times', toolName: 'Bash', argsSummary: '{"command":"npm test"}' },
+      // Session aborted by daemon shutdown.
+      { kind: 'session_aborted', sessionId: 'sess_abc123', workrailSessionId: 'sess_abc123', reason: 'daemon_shutdown', ts: Date.now() },
     ];
 
     for (const event of events) {


### PR DESCRIPTION
## Summary

- In-flight daemon sessions were never getting a terminal event written to the JSONL log when the daemon received SIGTERM/SIGINT. The log showed them as RUNNING forever, making `worktrain health` and `worktrain status` untrustworthy after a daemon restart.
- Added `DaemonSessionAbortedEvent` interface to `daemon-events.ts` (closed `reason` union: `'daemon_shutdown' | 'daemon_killed'`) and added it to the `DaemonEvent` discriminated union.
- In the shutdown handler in `cli-worktrain.ts`, iterate `handle.steerRegistry.keys()` (workrailSessionIds of in-flight sessions) and emit `session_aborted` for each before calling `handle.stop()`.
- Updated `formatDaemonEventLine()` and `runHealthSummary()` to handle `session_aborted` as a terminal state (ABORTED display status, `isLive = false`).

## Test plan

- [ ] `npm run build` passes cleanly
- [ ] `npx vitest run tests/unit/daemon-events.test.ts tests/unit/cli-worktrain-logs.test.ts tests/unit/cli-worktrain-status.test.ts` -- 78 tests pass
- [ ] `npx vitest run` full suite -- no new failures (pre-existing unrelated failures excluded)
- [ ] `session_aborted` event formatted as `[HH:MM:SS] [sid] session_aborted  reason=daemon_shutdown`
- [ ] `worktrain health <sessionId>` shows `[ABORTED]` for sessions killed at daemon shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)