### PR TITLE
fix(trigger): remove maxTurns -- wall-clock timeout governs child sessions

### DIFF
--- a/triggers.yml
+++ b/triggers.yml
@@ -46,5 +46,4 @@ triggers:
       pollIntervalSeconds: 3600
     agentConfig:
       maxSessionMinutes: 120
-      maxTurns: 60
       stuckAbortPolicy: abort


### PR DESCRIPTION
## Summary

- Removes `maxTurns: 60` from the `self-improvement` trigger's `agentConfig`
- `test-task` and `mr-review` already had no `maxTurns` -- no change needed
- The wall-clock `maxSessionMinutes` and `stuckAbortPolicy: abort` are the correct safety nets; `maxTurns` was causing child sessions (`wr.discovery`, `coding-task-workflow-agentic`) to be prematurely terminated

## Why

The FULL pipeline coordinator spawns child sessions. Those child sessions inherit the trigger's `maxTurns` cap. `wr.discovery` hit exactly 50 turns and timed out; `coding-task-workflow-agentic` hit 60 turns and timed out. Removing the explicit cap lets the workflow's internal step structure and the wall-clock timeout govern instead.

Note: `workflow-runner.ts` has a `DEFAULT_MAX_TURNS = 50` fallback applied when `maxTurns` is absent from the config. If sessions still time out at 50 turns post-merge, a follow-up `src/` change will be needed.

## Test plan

- [x] `npm run build` clean (config change only)
- [x] `grep maxTurns triggers.yml` returns 0 matches
- [ ] After merge: `npm run build && node dist/cli-worktrain.js daemon --install`
- [ ] Confirm `worktrain trigger validate` shows only info-level `missing-max-turns` warnings (non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)