### PR TITLE
fix(daemon): raise DEFAULT_MAX_TURNS from 50 to 200

### DIFF
--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -89,10 +89,12 @@ const DEFAULT_SESSION_TIMEOUT_MINUTES = 30;
  * Per-trigger overrides are set via triggers.yml agentConfig.maxTurns.
  * WHY: prevents infinite retry loops when the LLM keeps calling continue_workflow
  * with a broken token -- without a cap, each isError tool_result is visible to the
- * LLM and it will simply retry, looping forever. 50 turns is generous enough for
- * long coding tasks while still being a hard safety net.
+ * LLM and it will simply retry, looping forever. 200 turns provides a generous
+ * safety net for complex autonomous workflows (e.g. wr.discovery deep codebase
+ * exploration) without being the bottleneck -- wall-clock maxSessionMinutes is
+ * the primary cap for runaway sessions.
  */
-const DEFAULT_MAX_TURNS = 50;
+const DEFAULT_MAX_TURNS = 200;
 
 /**
  * Conditionally spreads workrailSessionId into a daemon event object.


### PR DESCRIPTION
## Summary

- `DEFAULT_MAX_TURNS` was 50, which is too low for complex autonomous workflows like `wr.discovery` that legitimately need 50+ turns for deep codebase exploration.
- Raised to 200 to give sufficient headroom while keeping it as a safety net against infinite retry loops.
- Wall-clock `maxSessionMinutes` remains the primary cap for runaway sessions; turn count should not be the bottleneck.

## Test plan

- [x] `npm run build` -- clean
- [x] `npx vitest run` -- no regressions introduced (pre-existing failures in `workflow-runner-load-session-notes.test.ts` are unrelated and present on main)
- [ ] Rebuild dist and reinstall daemon after merge: `npm run build && node dist/cli-worktrain.js daemon --install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)