### PR TITLE
chore(docs): add phase-scoped context files to backlog

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -6935,3 +6935,52 @@ The MR management agent (if there is one) becomes thin: it's the interface for c
 ### Dependency
 
 Requires the event-driven coordination architecture (coordinator as event bus) -- so the coordinator knows when new comments arrive rather than the agent polling for them.
+
+---
+
+## Phase-scoped context files: rules targeted at specific pipeline phases (Apr 20, 2026)
+
+**The idea:** Instead of injecting all rules into every session, let teams define context files scoped to specific pipeline phases. A rule about "how we write commit messages" only matters at delivery time. A rule about "what makes a blocking finding" only matters during MR review. Injecting everything into every session wastes tokens and dilutes relevance.
+
+### Proposed convention
+
+**Phase-scoped files under `.worktrain/rules/`:**
+
+```
+.worktrain/rules/
+  discovery.md       -- injected into wr.discovery sessions only
+  shaping.md         -- injected into wr.shaping sessions only
+  implementation.md  -- injected into coding-task-workflow-agentic sessions
+  review.md          -- injected into mr-review-workflow-agentic sessions
+  delivery.md        -- injected at commit/push/PR-creation time (delivery-action.ts)
+  pr-management.md   -- injected into sessions that manage the MR lifecycle:
+                        answering review comments, applying requested changes,
+                        resolving conversations, updating PR description
+  all.md             -- injected into every session (same as today's AGENTS.md)
+```
+
+**Examples of what goes in each:**
+
+- `delivery.md`: "Commit messages must reference the Jira ticket. PR title must start with ticket number. Always request review from @team-lead."
+- `review.md`: "A blocking finding requires reproducible evidence. Performance findings are major only if the regression exceeds 10%. Security findings are always blocking."
+- `implementation.md`: "Never use `any`. Always write tests before implementation. Follow the Result/Either pattern, no thrown exceptions."
+- `pr-management.md`: "When a reviewer requests changes: acknowledge in a comment, create a fixup commit per finding, re-request review when done. Never resolve review threads yourself."
+
+### Relationship to existing AGENTS.md / CLAUDE.md
+
+Phase-scoped files are additive, not a replacement. The existing `AGENTS.md` / `CLAUDE.md` continue to apply to all sessions. Phase-scoped files are additional context loaded on top.
+
+**Load order (most specific wins if conflict):**
+1. `AGENTS.md` / `CLAUDE.md` (base, all sessions)
+2. `.worktrain/rules/all.md` (WorkTrain-specific base)
+3. Phase-specific file (e.g. `.worktrain/rules/review.md` for review sessions)
+
+### Implementation notes
+
+- The workflow runner already has `WORKSPACE_CONTEXT_CANDIDATE_PATHS`. Phase-scoped files add a second lookup: at session spawn time, the coordinator or trigger knows which workflow is being run and can pass an additional `phaseContextPath` to inject.
+- `delivery.md` is special -- it's injected into `delivery-action.ts`'s git commit message construction, not into a session prompt. The delivery action would read it and pass it as additional context to the `HandoffArtifact` construction.
+- The `pr-management.md` concept implies a new pipeline phase that doesn't exist yet: an autonomous PR management agent that monitors review comments and responds. This is a substantial new feature -- the rules file is ahead of the implementation.
+
+### Priority
+
+Medium. Phase-scoped rules make WorkTrain's autonomous actions more consistent with team conventions without requiring custom workflows per team. Design alongside multi-workspace support and trigger templates (they share the "per-workspace configuration" concern).

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -174,16 +174,84 @@ const WORKSPACE_CONTEXT_MAX_BYTES = 32 * 1024;
 const MAX_ASSEMBLED_CONTEXT_BYTES = 8192;
 
 /**
- * Candidate workspace context files in priority order.
- * WHY: Higher-priority files (repo-specific Claude config) are included first.
- * If the combined size exceeds WORKSPACE_CONTEXT_MAX_BYTES, lower-priority files
- * are truncated or dropped so the most relevant context always fits.
+ * A literal path entry: a single file at a known relative path.
+ * WHY: Claude Code and AGENTS.md paths are stable single-file conventions.
  */
-const WORKSPACE_CONTEXT_CANDIDATE_PATHS = [
-  '.claude/CLAUDE.md',
-  'CLAUDE.md',
-  'AGENTS.md',
-  '.github/AGENTS.md',
+type LiteralCandidatePath = {
+  readonly kind: 'literal';
+  readonly relativePath: string;
+};
+
+/**
+ * A glob pattern entry: zero or more files matching a pattern in a directory.
+ * WHY: Cursor, Windsurf, and Firebender all use directory-based conventions
+ * where teams add multiple rule files. A glob pattern discovers them all.
+ */
+type GlobCandidatePath = {
+  readonly kind: 'glob';
+  /** Relative to workspacePath, e.g. '.cursor/rules/*.mdc' */
+  readonly pattern: string;
+  /**
+   * WHY: .mdc (Cursor/Firebender) and .windsurf/rules/*.md files have YAML
+   * frontmatter with metadata (alwaysApply, description, etc.) not meant for
+   * LLM consumption. Must be stripped before injection.
+   */
+  readonly stripFrontmatter: boolean;
+  /**
+   * WHY: tinyglobby order is filesystem-dependent. Alpha sort ensures the same
+   * workspace produces the same context on every WorkTrain session.
+   */
+  readonly sort: 'alpha';
+};
+
+type WorkspaceContextCandidate = LiteralCandidatePath | GlobCandidatePath;
+
+/**
+ * Maximum files to read per glob pattern.
+ * WHY: Prevents I/O cost and context budget waste in repos where .cursor/rules/
+ * or similar directories contain many files (generated artifacts, etc.).
+ */
+const MAX_GLOB_FILES_PER_PATTERN = 20;
+
+/**
+ * Candidate workspace context files in priority order.
+ * WHY: More specific (tool-specific, project-specific) before more general.
+ * User-written Claude Code config takes top priority. Glob formats (newer) come
+ * before legacy single-file formats (older) for each tool to reduce duplicate
+ * injection when both coexist.
+ *
+ * Sources:
+ *   Claude Code: https://code.claude.com/docs/en/memory (April 2026)
+ *   Cursor .cursorrules: empirical (zillow-android-2/.cursorrules)
+ *   Cursor .cursor/rules/*.mdc: empirical (zillow-android-2/.cursor/rules/)
+ *   Windsurf .windsurf/rules/*.md: https://docs.windsurf.com/windsurf/cascade/memories (April 2026)
+ *   Firebender .firebender/rules/*.mdc: empirical (zillow-android-2/.firebender/rules/)
+ *   Firebender AGENTS.md: docs/integrations/firebender.md + empirical
+ *   GitHub Copilot: https://docs.github.com/en/copilot/customizing-copilot (April 2026)
+ *   Continue.dev: https://docs.continue.dev/customize/deep-dives/rules (April 2026)
+ *
+ * NOTE: .windsurfrules does NOT exist -- Windsurf uses .windsurf/rules/ directory.
+ * NOTE: alwaysApply: false rules in .mdc files are injected unconditionally in
+ *   Phase 1. Phase 2 will add filtering based on the alwaysApply frontmatter field.
+ */
+const WORKSPACE_CONTEXT_CANDIDATE_PATHS: readonly WorkspaceContextCandidate[] = [
+  { kind: 'literal', relativePath: '.claude/CLAUDE.md' },
+  { kind: 'literal', relativePath: 'CLAUDE.md' },
+  { kind: 'literal', relativePath: 'CLAUDE.local.md' },
+  { kind: 'literal', relativePath: 'AGENTS.md' },
+  { kind: 'literal', relativePath: '.github/AGENTS.md' },
+  // Cursor: newer directory format before legacy single-file format
+  { kind: 'glob', pattern: '.cursor/rules/*.mdc', stripFrontmatter: true, sort: 'alpha' },
+  { kind: 'literal', relativePath: '.cursorrules' },
+  // Windsurf: directory format only (.windsurfrules does NOT exist per official docs)
+  { kind: 'glob', pattern: '.windsurf/rules/*.md', stripFrontmatter: true, sort: 'alpha' },
+  // Firebender: both rules directory and AGENTS.md convention
+  { kind: 'glob', pattern: '.firebender/rules/*.mdc', stripFrontmatter: true, sort: 'alpha' },
+  { kind: 'literal', relativePath: '.firebender/AGENTS.md' },
+  // GitHub Copilot
+  { kind: 'literal', relativePath: '.github/copilot-instructions.md' },
+  // Continue.dev
+  { kind: 'glob', pattern: '.continue/rules/*.md', stripFrontmatter: false, sort: 'alpha' },
 ] as const;
 
 // WHY: Soul content is defined in soul-template.ts (zero imports) so the CLI
@@ -941,7 +1009,26 @@ async function loadDaemonSoul(resolvedPath?: string): Promise<string> {
 }
 
 /**
- * Scan the workspace for CLAUDE.md / AGENTS.md context files and combine them
+ * Strip YAML frontmatter from file content before injection into the system prompt.
+ *
+ * WHY: .mdc files (Cursor, Firebender) and .windsurf/rules/*.md files include
+ * YAML metadata (alwaysApply, description, trigger) that is tool-specific and
+ * not meaningful in a WorkTrain system prompt context.
+ *
+ * Safety: Only strips if the file starts with '---\n' or '---\r\n' (YAML frontmatter
+ * is always at the start of the file). Returns original content unchanged if:
+ * - File does not start with '---' (no frontmatter present -- safe no-op)
+ * - No closing '---' delimiter found (malformed frontmatter -- preserve as-is)
+ */
+export function stripFrontmatter(content: string): string {
+  if (!content.startsWith('---\n') && !content.startsWith('---\r\n')) return content;
+  const endIdx = content.indexOf('\n---', 4);
+  if (endIdx === -1) return content;
+  return content.slice(endIdx + 4).trimStart();
+}
+
+/**
+ * Scan the workspace for convention files across 7 AI tools and combine them
  * into a single string for injection into the system prompt.
  *
  * Files are read in priority order (WORKSPACE_CONTEXT_CANDIDATE_PATHS). Combined
@@ -954,39 +1041,78 @@ async function loadDaemonSoul(resolvedPath?: string): Promise<string> {
  * skipped (or logged at warn level for non-ENOENT errors). The agent can still run
  * without workspace context.
  */
-async function loadWorkspaceContext(workspacePath: string): Promise<string | null> {
+export async function loadWorkspaceContext(workspacePath: string): Promise<string | null> {
   const parts: string[] = [];
+  const injectedPaths: string[] = [];
   let combinedBytes = 0;
   let truncated = false;
 
-  for (const relativePath of WORKSPACE_CONTEXT_CANDIDATE_PATHS) {
-    if (truncated) break;
-
-    const fullPath = path.join(workspacePath, relativePath);
-    let content: string;
-    try {
-      content = await fs.readFile(fullPath, 'utf8');
-    } catch (err: unknown) {
-      const isEnoent = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
-      if (!isEnoent) {
-        // Unexpected error (permissions, etc.) -- log and skip.
-        console.warn(
-          `[WorkflowRunner] Skipping ${fullPath}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-      continue;
-    }
-
+  /**
+   * Accumulates a single file's content into parts[], respecting the byte budget.
+   * WHY extracted as inner helper: the same accumulation logic is needed for both
+   * literal and glob candidates.
+   */
+  function accumulateFile(relativePath: string, content: string): void {
     const contentBytes = Buffer.byteLength(content, 'utf8');
     if (combinedBytes + contentBytes > WORKSPACE_CONTEXT_MAX_BYTES) {
       // Fit as much of this file as will fill the remaining budget.
       const remaining = WORKSPACE_CONTEXT_MAX_BYTES - combinedBytes;
       const truncatedContent = content.slice(0, remaining);
       parts.push(`### ${relativePath}\n${truncatedContent}`);
+      injectedPaths.push(relativePath);
       truncated = true;
     } else {
       parts.push(`### ${relativePath}\n${content}`);
+      injectedPaths.push(relativePath);
       combinedBytes += contentBytes;
+    }
+  }
+
+  for (const entry of WORKSPACE_CONTEXT_CANDIDATE_PATHS) {
+    if (truncated) break;
+
+    if (entry.kind === 'literal') {
+      const fullPath = path.join(workspacePath, entry.relativePath);
+      let content: string;
+      try {
+        content = await fs.readFile(fullPath, 'utf8');
+      } catch (err: unknown) {
+        const isEnoent = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+        if (!isEnoent) {
+          // Unexpected error (permissions, etc.) -- log and skip.
+          console.warn(
+            `[WorkflowRunner] Skipping ${fullPath}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        continue;
+      }
+      accumulateFile(entry.relativePath, content);
+    } else {
+      // kind === 'glob': expand pattern, sort, cap, read each file.
+      const matches = await tinyGlob(entry.pattern, { cwd: workspacePath, absolute: false });
+      const sorted = [...matches].sort(); // alpha sort for determinism
+      if (sorted.length > MAX_GLOB_FILES_PER_PATTERN) {
+        console.warn(
+          `[WorkflowRunner] ${entry.pattern}: ${sorted.length} files found, capped at ${MAX_GLOB_FILES_PER_PATTERN}`,
+        );
+      }
+      for (const relativePath of sorted.slice(0, MAX_GLOB_FILES_PER_PATTERN)) {
+        if (truncated) break;
+        const fullPath = path.join(workspacePath, relativePath);
+        let content: string;
+        try {
+          content = await fs.readFile(fullPath, 'utf8');
+        } catch (err: unknown) {
+          const isEnoent = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+          if (!isEnoent) {
+            console.warn(
+              `[WorkflowRunner] Skipping ${fullPath}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+          continue;
+        }
+        accumulateFile(relativePath, entry.stripFrontmatter ? stripFrontmatter(content) : content);
+      }
     }
   }
 
@@ -998,9 +1124,7 @@ async function loadWorkspaceContext(workspacePath: string): Promise<string | nul
   }
 
   console.log(
-    `[WorkflowRunner] Injecting workspace context from: ${WORKSPACE_CONTEXT_CANDIDATE_PATHS.filter(
-      (p) => parts.some((part) => part.startsWith(`### ${p}`)),
-    ).join(', ')}`,
+    `[WorkflowRunner] Injecting workspace context from: ${injectedPaths.join(', ')}`,
   );
 
   return combined;

--- a/tests/unit/workflow-runner-workspace-context.test.ts
+++ b/tests/unit/workflow-runner-workspace-context.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Unit tests for loadWorkspaceContext() and stripFrontmatter() in workflow-runner.ts.
+ *
+ * Strategy: call exported functions directly with real filesystem state created
+ * in a temp directory. No mocking -- follows "prefer fakes over mocks" from CLAUDE.md.
+ *
+ * All temp files are created under os.tmpdir() and cleaned up in afterEach.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadWorkspaceContext, stripFrontmatter } from '../../src/daemon/workflow-runner.js';
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = path.join(os.tmpdir(), `wr-workspace-context-test-${randomUUID()}`);
+  await fs.mkdir(testDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(testDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// stripFrontmatter()
+// ---------------------------------------------------------------------------
+
+describe('stripFrontmatter()', () => {
+  it('strips YAML frontmatter delimited by ---', () => {
+    const content = '---\nalwaysApply: true\ndescription: My rule\n---\n# Rules\n- Use TypeScript';
+    expect(stripFrontmatter(content)).toBe('# Rules\n- Use TypeScript');
+  });
+
+  it('returns original content when file does not start with ---', () => {
+    const content = '# Rules\n- Use TypeScript';
+    expect(stripFrontmatter(content)).toBe(content);
+  });
+
+  it('returns original content when closing --- is not found (malformed frontmatter)', () => {
+    const content = '---\nalwaysApply: true\n# Rules\n- Use TypeScript';
+    expect(stripFrontmatter(content)).toBe(content);
+  });
+
+  it('handles CRLF line endings in frontmatter delimiter', () => {
+    const content = '---\r\nalwaysApply: true\r\n---\r\n# Rules';
+    const result = stripFrontmatter(content);
+    expect(result).toContain('# Rules');
+    expect(result).not.toContain('alwaysApply');
+  });
+
+  it('trims leading whitespace after the closing ---', () => {
+    const content = '---\nkey: val\n---\n\n\n# Rules';
+    expect(stripFrontmatter(content)).toBe('# Rules');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadWorkspaceContext() -- literal paths
+// ---------------------------------------------------------------------------
+
+describe('loadWorkspaceContext() -- literal paths', () => {
+  it('returns null when no context files exist', async () => {
+    const result = await loadWorkspaceContext(testDir);
+    expect(result).toBeNull();
+  });
+
+  it('injects CLAUDE.md when present', async () => {
+    await fs.writeFile(path.join(testDir, 'CLAUDE.md'), '# Project Rules\n- Use TypeScript', 'utf8');
+
+    const result = await loadWorkspaceContext(testDir);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('### CLAUDE.md');
+    expect(result).toContain('# Project Rules');
+  });
+
+  it('injects .claude/CLAUDE.md when present', async () => {
+    await fs.mkdir(path.join(testDir, '.claude'), { recursive: true });
+    await fs.writeFile(path.join(testDir, '.claude', 'CLAUDE.md'), 'claude-dir-content', 'utf8');
+
+    const result = await loadWorkspaceContext(testDir);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('### .claude/CLAUDE.md');
+    expect(result).toContain('claude-dir-content');
+  });
+
+  it('injects AGENTS.md when present', async () => {
+    await fs.writeFile(path.join(testDir, 'AGENTS.md'), 'agents-content', 'utf8');
+
+    const result = await loadWorkspaceContext(testDir);
+
+    expect(result).toContain('### AGENTS.md');
+    expect(result).toContain('agents-content');
+  });
+
+  it('silently skips missing literal files without error', async () => {
+    // Only one file exists; others silently skipped
+    await fs.writeFile(path.join(testDir, 'AGENTS.md'), 'agents-only', 'utf8');
+
+    const result = await loadWorkspaceContext(testDir);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('agents-only');
+    // Other literal paths not present
+    expect(result).not.toContain('.claude/CLAUDE.md');
+  });
+
+  it('joins multiple literal files with double newline separator', async () => {
+    await fs.writeFile(path.join(testDir, 'CLAUDE.md'), 'claude-content', 'utf8');
+    await fs.writeFile(path.join(testDir, 'AGENTS.md'), 'agents-content', 'utf8');
+
+    const result = await loadWorkspaceContext(testDir);
+
+    expect(result).toContain('claude-content\n\n### AGENTS.md\nagents-content');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadWorkspaceContext() -- glob paths
+// ---------------------------------------------------------------------------
+
+describe('loadWorkspaceContext() -- glob paths', () => {
+  it('expands .cursor/rules/*.mdc and returns all files alpha-sorted', async () => {
+    await fs.mkdir(path.join(testDir, '.cursor', 'rules'), { recursive: true });
+    await fs.writeFile(path.join(testDir, '.cursor', 'rules', 'b-rule.mdc'), '# Rule B', 'utf8');
+    await fs.writeFile(path.join(testDir, '.cursor', 'rules', 'a-rule.mdc'), '# Rule A', 'utf8');
+
+    const result = await loadWorkspaceContext(testDir);
+
+    expect(result).not.toBeNull();
+    // Both files present
+    expect(result).toContain('# Rule A');
+    expect(result).toContain('# Rule B');
+    // Alpha order: a-rule before b-rule
+    const idxA = result!.indexOf('a-rule.mdc');
+    const idxB = result!.indexOf('b-rule.mdc');
+    expect(idxA).toBeLessThan(idxB);
+  });
+
+  it('strips YAML frontmatter from .mdc files (stripFrontmatter: true)', async () => {
+    await fs.mkdir(path.join(testDir, '.cursor', 'rules'), { recursive: true });
+    await fs.writeFile(
+      path.join(testDir, '.cursor', 'rules', 'style.mdc'),
+      '---\nalwaysApply: true\ndescription: Style rules\n---\n# Style Rules\n- Use TypeScript',
+      'utf8',
+    );
+
+    const result = await loadWorkspaceContext(testDir);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('# Style Rules');
+    expect(result).not.toContain('alwaysApply');
+    expect(result).not.toContain('description: Style rules');
+  });
+
+  it('does NOT strip frontmatter from .continue/rules/*.md files (stripFrontmatter: false)', async () => {
+    await fs.mkdir(path.join(testDir, '.continue', 'rules'), { recursive: true });
+    await fs.writeFile(
+      path.join(testDir, '.continue', 'rules', 'style.md'),
+      '---\nname: style\n---\n# Style Rules',
+      'utf8',
+    );
+
+    const result = await loadWorkspaceContext(testDir);
+
+    expect(result).not.toBeNull();
+    // Frontmatter NOT stripped for .continue/rules
+    expect(result).toContain('name: style');
+    expect(result).toContain('# Style Rules');
+  });
+
+  it('returns no content for glob with no matching files (not an error)', async () => {
+    // .cursor/rules/ directory does not exist -- no error, just no content
+    const result = await loadWorkspaceContext(testDir);
+    expect(result).toBeNull();
+  });
+
+  it('caps glob results at 20 files (alphabetically first 20)', async () => {
+    await fs.mkdir(path.join(testDir, '.cursor', 'rules'), { recursive: true });
+
+    // Create 25 files with zero-padded names for deterministic alpha sort
+    for (let i = 0; i < 25; i++) {
+      const name = `rule-${String(i).padStart(2, '0')}.mdc`;
+      await fs.writeFile(
+        path.join(testDir, '.cursor', 'rules', name),
+        `# Rule ${i}`,
+        'utf8',
+      );
+    }
+
+    const result = await loadWorkspaceContext(testDir);
+
+    expect(result).not.toBeNull();
+    // Files 00-19 (alphabetically first 20) should be present
+    expect(result).toContain('rule-00.mdc');
+    expect(result).toContain('rule-19.mdc');
+    // Files 20-24 should NOT be present
+    expect(result).not.toContain('rule-20.mdc');
+    expect(result).not.toContain('rule-24.mdc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadWorkspaceContext() -- 32KB budget
+// ---------------------------------------------------------------------------
+
+describe('loadWorkspaceContext() -- byte budget', () => {
+  it('respects the 32KB combined cap and appends a truncation notice', async () => {
+    // Create a file larger than 32KB to trigger truncation
+    const bigContent = 'x'.repeat(33 * 1024);
+    await fs.writeFile(path.join(testDir, 'CLAUDE.md'), bigContent, 'utf8');
+    await fs.writeFile(path.join(testDir, 'AGENTS.md'), 'agents-content', 'utf8');
+
+    const result = await loadWorkspaceContext(testDir);
+
+    expect(result).not.toBeNull();
+    // Truncation notice appended
+    expect(result).toContain('[Workspace context truncated:');
+    // AGENTS.md dropped because budget was exhausted
+    expect(result).not.toContain('agents-content');
+  });
+
+  it('respects the 32KB cap across glob files in the inner loop', async () => {
+    await fs.mkdir(path.join(testDir, '.cursor', 'rules'), { recursive: true });
+
+    // Each file is ~8KB; after 4 files we exceed 32KB
+    const fileContent = 'y'.repeat(8 * 1024);
+    for (let i = 0; i < 10; i++) {
+      const name = `rule-${String(i).padStart(2, '0')}.mdc`;
+      await fs.writeFile(path.join(testDir, '.cursor', 'rules', name), fileContent, 'utf8');
+    }
+
+    const result = await loadWorkspaceContext(testDir);
+
+    expect(result).not.toBeNull();
+    // Should truncate and append notice (only 4 files fit in 32KB)
+    expect(result).toContain('[Workspace context truncated:');
+    // Files 05-09 should not appear (budget exhausted before them)
+    expect(result).not.toContain('rule-05.mdc');
+  });
+});


### PR DESCRIPTION
Rules targeted at specific pipeline phases: review.md, implementation.md, delivery.md, pr-management.md. Additive on top of existing AGENTS.md/CLAUDE.md.