### PR TITLE
fix(trigger): extend 30s dedup window to route() and dispatch() paths

### DIFF
--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -488,6 +488,12 @@ export class TriggerRouter {
    * number of unique goal+workspace pairs dispatched in the last 30s -- always
    * a small number in practice.
    *
+   * IMPORTANT: This map is shared across route(), dispatch(), and
+   * dispatchAdaptivePipeline(). Any new dispatch path added to this class
+   * MUST include the dedup check (cleanup-on-entry + check + set) before
+   * calling queue.enqueue(). Omitting it from a new path silently re-opens
+   * the duplicate-pipeline bug on that path.
+   *
    * @see dispatchAdaptivePipeline
    * @see ADAPTIVE_DEDUPE_TTL_MS
    */
@@ -677,6 +683,30 @@ export class TriggerRouter {
       ...(trigger.branchPrefix !== undefined ? { branchPrefix: trigger.branchPrefix } : {}),
     };
 
+    // Deduplicate: if the same goal+workspace was dispatched within 30s, skip.
+    // WHY here (after workflowTrigger construction, before emitter.emit):
+    // - The goal must be fully resolved (goalTemplate interpolation happens above).
+    // - No trigger_fired event is emitted for deduped dispatches -- consistent with
+    //   the dispatchCondition guard which also returns before the emitter call.
+    // WHY shared map (_recentAdaptiveDispatches): cross-path dedup is intentional --
+    // a dispatch via any path (route, dispatch, dispatchAdaptivePipeline) sets the key.
+    {
+      const dedupeKey = `${workflowTrigger.goal}::${workflowTrigger.workspacePath}`;
+      const now = Date.now();
+      // Cleanup-on-entry: purge stale entries before checking/inserting.
+      for (const [key, ts] of this._recentAdaptiveDispatches) {
+        if (now - ts >= TriggerRouter.ADAPTIVE_DEDUPE_TTL_MS) {
+          this._recentAdaptiveDispatches.delete(key);
+        }
+      }
+      const lastDispatch = this._recentAdaptiveDispatches.get(dedupeKey);
+      if (lastDispatch !== undefined && now - lastDispatch < TriggerRouter.ADAPTIVE_DEDUPE_TTL_MS) {
+        console.log(`[TriggerRouter] Skipping duplicate route dispatch: goal="${workflowTrigger.goal.slice(0, 60)}" (already dispatched within 30s)`);
+        return { _tag: 'enqueued', triggerId: trigger.id };
+      }
+      this._recentAdaptiveDispatches.set(dedupeKey, now);
+    }
+
     // Emit trigger_fired: the webhook was accepted and validated.
     this.emitter?.emit({ kind: 'trigger_fired', triggerId: trigger.id, workflowId: trigger.workflowId });
 
@@ -815,6 +845,26 @@ export class TriggerRouter {
    * @returns The workflowId that was dispatched.
    */
   dispatch(workflowTrigger: WorkflowTrigger): string {
+    // Deduplicate: if the same goal+workspace was dispatched within 30s, skip.
+    // WHY same map and pattern as route() and dispatchAdaptivePipeline():
+    // cross-path dedup is intentional -- a dispatch via any path sets the key.
+    {
+      const dedupeKey = `${workflowTrigger.goal}::${workflowTrigger.workspacePath}`;
+      const now = Date.now();
+      // Cleanup-on-entry: purge stale entries before checking/inserting.
+      for (const [key, ts] of this._recentAdaptiveDispatches) {
+        if (now - ts >= TriggerRouter.ADAPTIVE_DEDUPE_TTL_MS) {
+          this._recentAdaptiveDispatches.delete(key);
+        }
+      }
+      const lastDispatch = this._recentAdaptiveDispatches.get(dedupeKey);
+      if (lastDispatch !== undefined && now - lastDispatch < TriggerRouter.ADAPTIVE_DEDUPE_TTL_MS) {
+        console.log(`[TriggerRouter] Skipping duplicate dispatch: goal="${workflowTrigger.goal.slice(0, 60)}" (already dispatched within 30s)`);
+        return workflowTrigger.workflowId;
+      }
+      this._recentAdaptiveDispatches.set(dedupeKey, now);
+    }
+
     void this.queue.enqueue(workflowTrigger.workflowId, async () => {
       // Same semaphore pattern as route(): acquire inside the callback so dispatch()
       // returns immediately, then wait for a slot before calling runWorkflowFn().

--- a/tests/unit/trigger-router.test.ts
+++ b/tests/unit/trigger-router.test.ts
@@ -330,17 +330,36 @@ describe('TriggerRouter.route', () => {
       };
     }
 
+    /**
+     * Make events with unique goals so the 30s dedup window does not suppress them.
+     * Concurrency tests verify queue serialization/parallelism for distinct tasks --
+     * they are not testing dedup behavior.
+     */
+    function makeUniqueEvents(count: number): ReturnType<typeof makeEvent>[] {
+      return Array.from({ length: count }, (_, i) => {
+        const payload = { pull_request: { html_url: `https://example.com/mr/${i}`, title: `MR ${i}` } };
+        return makeEvent({ payload, rawBody: Buffer.from(JSON.stringify(payload)) });
+      });
+    }
+
     it('serial trigger: second call does not start until first completes (same queue key)', async () => {
       // Proves the serial ternary: queueKey = trigger.id (not trigger.id:UUID).
       // If the ternary were inverted to 'parallel', BOTH calls would be in-flight
       // after the first flush and this test would fail.
-      const trigger = makeTrigger({ concurrencyMode: 'serial' });
+      //
+      // WHY unique goals: the 30s dedup window suppresses duplicate goal+workspace dispatches.
+      // Concurrency tests verify queue serialization for distinct tasks, not dedup behavior.
+      const trigger = makeTrigger({
+        concurrencyMode: 'serial',
+        goalTemplate: '{{$.pull_request.title}}',
+      });
       const { fn, inFlight, releaseAll } = makeLatchedRunWorkflow();
       const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn);
 
-      // Fire two events without awaiting -- the queue processes them serially.
-      router.route(makeEvent());
-      router.route(makeEvent());
+      // Fire two events with unique goals -- the queue processes them serially.
+      const [event1, event2] = makeUniqueEvents(2);
+      router.route(event1!);
+      router.route(event2!);
 
       // Drain the microtask queue so KeyedAsyncQueue has had a chance to start
       // the first call (and NOT start the second, since they share the same key).
@@ -364,14 +383,21 @@ describe('TriggerRouter.route', () => {
       // Proves the parallel ternary: queueKey = trigger.id:UUID (unique per fire).
       // If the ternary were inverted to 'serial', only one call would be in-flight
       // after the flush and this test would fail.
-      const trigger = makeTrigger({ concurrencyMode: 'parallel' });
+      //
+      // WHY unique goals: the 30s dedup window suppresses duplicate goal+workspace dispatches.
+      // Concurrency tests verify queue parallelism for distinct tasks, not dedup behavior.
+      const trigger = makeTrigger({
+        concurrencyMode: 'parallel',
+        goalTemplate: '{{$.pull_request.title}}',
+      });
       const { fn, inFlight, releaseAll } = makeLatchedRunWorkflow();
       const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn);
 
-      // Fire two events without awaiting -- each gets its own queue key, so both
+      // Fire two events with unique goals -- each gets its own queue key, so both
       // start concurrently without waiting for the other.
-      router.route(makeEvent());
-      router.route(makeEvent());
+      const [event1, event2] = makeUniqueEvents(2);
+      router.route(event1!);
+      router.route(event2!);
 
       // Drain the microtask queue -- both calls should now be in-flight.
       await new Promise<void>((r) => setImmediate(r));
@@ -1092,16 +1118,34 @@ describe('TriggerRouter maxConcurrentSessions semaphore', () => {
     };
   }
 
+  /**
+   * Make N events with unique goals for semaphore/concurrency tests.
+   * Each event carries a unique pull_request.title which is used as the goal
+   * via goalTemplate='{{$.pull_request.title}}', so the 30s dedup window treats
+   * them as distinct tasks and does not suppress any of them.
+   */
+  function makeUniqueEvents(count: number): ReturnType<typeof makeEvent>[] {
+    return Array.from({ length: count }, (_, i) => {
+      const payload = { pull_request: { html_url: `https://example.com/mr/${i}`, title: `Semaphore task ${i}` } };
+      return makeEvent({ payload, rawBody: Buffer.from(JSON.stringify(payload)) });
+    });
+  }
+
   it('limits concurrent runWorkflow() calls to maxConcurrentSessions', async () => {
     // Proves the semaphore caps at the configured limit.
     // With cap=2 and 3 fires: first two should start, third should be queued.
-    const trigger = makeTrigger({ concurrencyMode: 'parallel' });
+    //
+    // WHY unique goals (goalTemplate): the 30s dedup window suppresses duplicate
+    // goal+workspace dispatches. Semaphore tests use distinct tasks -- each event
+    // gets a unique title-based goal so the dedup does not interfere.
+    const trigger = makeTrigger({ concurrencyMode: 'parallel', goalTemplate: '{{$.pull_request.title}}' });
     const { fn, inFlight, releaseAll } = makeLatchedRunWorkflow();
     const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn, undefined, 2);
 
-    router.route(makeEvent());
-    router.route(makeEvent());
-    router.route(makeEvent());
+    const [e1, e2, e3] = makeUniqueEvents(3);
+    router.route(e1!);
+    router.route(e2!);
+    router.route(e3!);
 
     // Drain: give semaphore time to start the first two (third is blocked, waiting for slot).
     await new Promise<void>((r) => setImmediate(r));
@@ -1122,13 +1166,17 @@ describe('TriggerRouter maxConcurrentSessions semaphore', () => {
 
   it('queue-and-wait: third dispatch proceeds after one of the first two completes', async () => {
     // Proves that queued dispatches are not dropped -- they execute once a slot opens.
-    const trigger = makeTrigger({ concurrencyMode: 'parallel' });
+    //
+    // WHY unique goals (goalTemplate): dedup window would suppress identical goal+workspace
+    // calls. These tests verify semaphore behavior for distinct tasks.
+    const trigger = makeTrigger({ concurrencyMode: 'parallel', goalTemplate: '{{$.pull_request.title}}' });
     const { fn, inFlight, releaseNext, releaseAll } = makeLatchedRunWorkflow();
     const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn, undefined, 2);
 
-    router.route(makeEvent());
-    router.route(makeEvent());
-    router.route(makeEvent());
+    const [e1, e2, e3] = makeUniqueEvents(3);
+    router.route(e1!);
+    router.route(e2!);
+    router.route(e3!);
 
     await new Promise<void>((r) => setImmediate(r));
     await new Promise<void>((r) => setImmediate(r));
@@ -1154,7 +1202,9 @@ describe('TriggerRouter maxConcurrentSessions semaphore', () => {
     // ORANGE-1: proves the finally block releases the slot even when runWorkflowFn
     // returns an error result (workflow failed but slot must still be freed).
     // Without the finally block, a failing workflow would permanently consume a slot.
-    const trigger = makeTrigger({ concurrencyMode: 'parallel' });
+    //
+    // WHY unique goals (goalTemplate): dedup window would suppress the second call.
+    const trigger = makeTrigger({ concurrencyMode: 'parallel', goalTemplate: '{{$.pull_request.title}}' });
     let firstCallUnblock!: () => void;
     let secondCallResolved = false;
 
@@ -1172,11 +1222,12 @@ describe('TriggerRouter maxConcurrentSessions semaphore', () => {
     // cap=1 so second dispatch can only run after first releases the semaphore slot
     const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn, undefined, 1);
 
-    router.route(makeEvent());
+    const [e1, e2] = makeUniqueEvents(2);
+    router.route(e1!);
     await new Promise<void>((r) => setImmediate(r));
 
     // First call is running -- second is queued (cap=1)
-    router.route(makeEvent());
+    router.route(e2!);
     expect(secondCallResolved).toBe(false);
 
     // Unblock the first call (returns error) -- finally MUST release the slot
@@ -1189,18 +1240,22 @@ describe('TriggerRouter maxConcurrentSessions semaphore', () => {
 
   it('defaults to 3 concurrent sessions when maxConcurrentSessions is not specified', async () => {
     // Proves the default is 3, not unlimited.
-    const trigger = makeTrigger({ concurrencyMode: 'parallel' });
+    //
+    // WHY unique goals (goalTemplate): dedup window would suppress calls 2-4 with the
+    // same goal+workspace. Use unique events to test the semaphore cap independently.
+    const trigger = makeTrigger({ concurrencyMode: 'parallel', goalTemplate: '{{$.pull_request.title}}' });
     const { fn, inFlight, releaseAll } = makeLatchedRunWorkflow();
     // No maxConcurrentSessions argument -- should default to 3
     const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn);
 
     expect(router.maxConcurrentSessions).toBe(3);
 
-    // Fire 4 dispatches -- only 3 should be in-flight simultaneously
-    router.route(makeEvent());
-    router.route(makeEvent());
-    router.route(makeEvent());
-    router.route(makeEvent());
+    // Fire 4 dispatches with unique goals -- only 3 should be in-flight simultaneously
+    const [e1, e2, e3, e4] = makeUniqueEvents(4);
+    router.route(e1!);
+    router.route(e2!);
+    router.route(e3!);
+    router.route(e4!);
 
     await new Promise<void>((r) => setImmediate(r));
     await new Promise<void>((r) => setImmediate(r));
@@ -1491,6 +1546,138 @@ describe('late-bound goals integration', () => {
     // interpolateGoalTemplate should have warned about the missing token
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("goalTemplate variable '$.goal' not found"));
     warnSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TriggerRouter.route and dispatch: deduplication within 30s window
+//
+// Verifies that rapid-fire webhook events and direct dispatches for the same
+// goal+workspace are deduplicated within the 30-second TTL window, preventing
+// duplicate pipeline sessions from webhook retries.
+// ---------------------------------------------------------------------------
+
+describe('TriggerRouter.route and dispatch deduplication', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('route(): second dispatch for the same goal+workspace within 30s is blocked', async () => {
+    // WHY: proves that rapid-fire webhook retries for the same trigger do not
+    // spawn duplicate pipeline sessions within the TTL window.
+    vi.useFakeTimers();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const trigger = makeTrigger();
+    const { fn, calls } = makeFakeRunWorkflow();
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn);
+
+    // First route() call -- should proceed
+    router.route(makeEvent());
+
+    // Advance time by 10s (within 30s window)
+    vi.advanceTimersByTime(10_000);
+
+    // Second route() call -- same goal+workspace, within TTL, should be blocked
+    const secondResult = router.route(makeEvent());
+
+    // Flush the async queue
+    await Promise.resolve();
+
+    // Only the first dispatch should have reached runWorkflowFn
+    expect(calls.length).toBeLessThanOrEqual(1);
+
+    // route() still returns 'enqueued' (silent skip -- 202 was already sent)
+    expect(secondResult._tag).toBe('enqueued');
+
+    // Skip log was emitted for the blocked dispatch
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping duplicate route dispatch'),
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('already dispatched within 30s'),
+    );
+
+    logSpy.mockRestore();
+  });
+
+  it('dispatch(): second dispatch for the same goal+workspace within 30s is blocked', async () => {
+    // WHY: proves the console AUTO dispatch path also deduplicates within the TTL window.
+    vi.useFakeTimers();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const trigger = makeTrigger();
+    const { fn, calls } = makeFakeRunWorkflow();
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn);
+
+    const workflowTrigger = {
+      workflowId: trigger.workflowId,
+      goal: trigger.goal,
+      workspacePath: trigger.workspacePath,
+      context: {},
+    };
+
+    // First dispatch -- should proceed
+    router.dispatch(workflowTrigger);
+
+    // Advance time by 10s (within 30s window)
+    vi.advanceTimersByTime(10_000);
+
+    // Second dispatch -- same goal+workspace, within TTL, should be blocked
+    router.dispatch(workflowTrigger);
+
+    // Flush
+    await Promise.resolve();
+
+    // Only the first dispatch should have reached runWorkflowFn
+    expect(calls.length).toBeLessThanOrEqual(1);
+
+    // Skip log was emitted
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping duplicate dispatch'),
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('already dispatched within 30s'),
+    );
+
+    logSpy.mockRestore();
+  });
+
+  it('different goals on the same workspace within 30s are both dispatched', async () => {
+    // WHY: proves the deduplication key is goal+workspace (not workspace-only).
+    // Different tasks arriving for the same repo within 30s must all dispatch.
+    vi.useFakeTimers();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const trigger1 = makeTrigger({ id: asTriggerId('trigger-a'), goal: 'review PR #42' });
+    const trigger2 = makeTrigger({ id: asTriggerId('trigger-b'), goal: 'review PR #43' });
+    const { fn: fn1, calls: calls1 } = makeFakeRunWorkflow();
+    const { fn: fn2, calls: calls2 } = makeFakeRunWorkflow();
+    const router1 = new TriggerRouter(makeIndex(trigger1), FAKE_CTX, FAKE_API_KEY, fn1);
+    const router2 = new TriggerRouter(makeIndex(trigger2), FAKE_CTX, FAKE_API_KEY, fn2);
+
+    const event1 = makeEvent({ triggerId: asTriggerId('trigger-a') });
+    const event2 = makeEvent({ triggerId: asTriggerId('trigger-b') });
+
+    router1.route(event1);
+    vi.advanceTimersByTime(5_000);
+    router2.route(event2);
+
+    // Flush: advance fake timers to allow setTimeout(r, 20) inside the queue to resolve
+    vi.advanceTimersByTime(100);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Both dispatches should have reached runWorkflowFn (different goals = different keys)
+    expect(calls1).toHaveLength(1);
+    expect(calls2).toHaveLength(1);
+
+    // No skip log emitted for either dispatch
+    expect(logSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Skipping duplicate'),
+    );
+
+    logSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

- The 30s adaptive dispatch dedup window (PR #706) only covered `dispatchAdaptivePipeline()`. Firing the same webhook twice in quick succession still spawned two full pipelines because `route()` goes directly to `runWorkflowFn()` without the dedup check.
- Added the same cleanup-on-entry + 30s TTL dedup guard to both `route()` and `dispatch()`, reusing the existing `_recentAdaptiveDispatches` map and `ADAPTIVE_DEDUPE_TTL_MS` constant.
- The shared map is intentional: a dispatch via any path (route, dispatch, dispatchAdaptivePipeline) sets the key, preventing cross-path duplicates.
- Updated 6 existing concurrency/semaphore tests to use unique goals per event (via `goalTemplate`) so they test distinct-task concurrency rather than relying on the absence of a dedup guard.

## Test plan

- [ ] `npm run build` -- clean
- [ ] `npx vitest run tests/unit/trigger-router.test.ts` -- 60/60 pass (3 new dedup tests)
- [ ] `npx vitest run` -- 360 files, 5386 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)