### PR TITLE
fix(engine): skip workflowId lookup for github_queue_poll triggers

### DIFF
--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -314,6 +314,12 @@ export async function startTriggerListener(
     // WHY two passes: do not mutate the Map while iterating it.
     const unknownTriggerIds: string[] = [];
     for (const [triggerId, trigger] of triggerIndex) {
+      // github_queue_poll triggers have no workflowId -- the adaptive coordinator
+      // decides the pipeline based on task content. Skip workflowId validation for
+      // these triggers; the sentinel '' would always fail the resolver lookup.
+      if (trigger.provider === 'github_queue_poll') {
+        continue;
+      }
       let found: boolean;
       try {
         found = await getWorkflowByIdFn(trigger.workflowId);


### PR DESCRIPTION
## Summary

- `TriggerListener` was calling `getWorkflowById('')` for `github_queue_poll` triggers because their `workflowId` is stored as the sentinel `''` (by design -- the adaptive coordinator decides the pipeline, not a fixed workflowId)
- `getWorkflowById('')` always returns `null`, causing the `self-improvement` trigger to be skipped at every daemon start with "workflowId '' was not found"
- Fix: skip the `getWorkflowByIdFn` resolver check for `github_queue_poll` triggers in `TriggerListener`

Note: `trigger-store.ts` already has the complementary fix (the `isQueuePollProvider` guard that skips parse-time workflowId validation) -- that was already on main. This PR adds the missing runtime guard in `trigger-listener.ts`.

## Test plan

- [x] `npm run build` -- clean
- [x] `npx vitest run tests/unit/trigger-store.test.ts` -- 77/77 passed
- [x] `npx vitest run` -- no new regressions (pre-existing: perf timing flake + daemon lock race + untracked test file)
- [ ] After merge: `npm run build && node dist/cli-worktrain.js daemon --install` -- daemon starts with all 3 triggers loaded (test-task, mr-review, self-improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)