### PR TITLE
fix(storage): return null for empty workflowId instead of throwing

### DIFF
--- a/src/infrastructure/storage/file-workflow-storage.ts
+++ b/src/infrastructure/storage/file-workflow-storage.ts
@@ -252,6 +252,9 @@ export class FileWorkflowStorage implements IWorkflowStorage {
   }
 
   public async getWorkflowById(id: string): Promise<Workflow | null> {
+    if (!id || id.trim() === '') {
+      return null; // Empty ID is not a valid workflow reference
+    }
     const safeId = sanitizeId(id);
 
     // Try cache first

--- a/tests/unit/file-workflow-storage-recursive.test.ts
+++ b/tests/unit/file-workflow-storage-recursive.test.ts
@@ -175,5 +175,27 @@ describe('FileWorkflowStorage (Recursive & Flags)', () => {
     const workflow = await storage.getWorkflowById('same');
     expect(workflow?.definition.name).toBe('Workflow same standard');
   });
+
+  it('should return null for empty string id without throwing', async () => {
+    const storage = new FileWorkflowStorage(
+      tempDir,
+      createCustomDirectorySource(tempDir, 'Test'),
+      createMockFlags(false),
+      {}
+    );
+    const result = await storage.getWorkflowById('');
+    expect(result).toBeNull();
+  });
+
+  it('should return null for whitespace-only id without throwing', async () => {
+    const storage = new FileWorkflowStorage(
+      tempDir,
+      createCustomDirectorySource(tempDir, 'Test'),
+      createMockFlags(false),
+      {}
+    );
+    const result = await storage.getWorkflowById('  ');
+    expect(result).toBeNull();
+  });
 });
 


### PR DESCRIPTION
## Summary

- `getWorkflowById('')` (empty string) previously called `sanitizeId('')`, which threw `InvalidWorkflowError` because empty string fails the `/^[a-zA-Z0-9_.-]+$/` regex -- producing misleading `source-N` error logs
- Added a 3-line early-return guard at the top of `getWorkflowById` that returns `null` immediately for empty or whitespace-only IDs, before `sanitizeId` is ever called
- This is purely additive: no existing behavior changes for any valid non-empty ID

## Test plan

- [ ] `getWorkflowById('')` returns null (no throw, no error log)
- [ ] `getWorkflowById('  ')` returns null (no throw, no error log)
- [ ] All 8 existing `FileWorkflowStorage` tests continue to pass
- [ ] `npm run build` exits clean
- [ ] `npx vitest run tests/unit/file-workflow-storage-recursive.test.ts` shows 8/8 passed

Fixes the hardening case identified after root bug #729 was resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)