### PR TITLE
fix(coordinator): wrap external I/O calls in try/catch to prevent crashes

### DIFF
--- a/docs/design/coordinator-io-error-handling-candidates.md
+++ b/docs/design/coordinator-io-error-handling-candidates.md
@@ -1,0 +1,199 @@
+# Coordinator I/O Error Handling -- Design Candidates
+
+Generated: 2026-04-19
+
+## Problem Understanding
+
+### Core Tensions
+
+1. **Crash-safety vs. DI purity**: The coordinator declares "all phase failures produce
+   `PipelineOutcome { kind: 'escalated' }` -- never thrown" as a design invariant, but three
+   injected dep functions (`getAgentResult`, `postToOutbox`, `pollForPR`) are called without
+   try/catch in the mode files. Any throw from these functions crashes the coordinator silently
+   instead of returning a structured `PipelineOutcome`. The fix must enforce the invariant at
+   the right boundary.
+
+2. **Verbosity vs. DRY**: `postToOutbox` is called at 8+ critical escalation points across
+   `implement-shared.ts` and `full-pipeline.ts`. Each call site needs individual protection.
+   Inline try/catch at 8 sites is repetitive; a helper would reduce duplication but adds
+   abstraction not in the existing codebase pattern.
+
+3. **`process.stderr.write()` vs. `deps.stderr()`**: The prescribed pattern uses
+   `process.stderr.write()` in catch blocks, but the rest of the coordinator uses the injected
+   `deps.stderr()`. The tension is minor -- catch blocks represent unexpected I/O failures,
+   so using `process.stderr.write()` signals this is an emergency log path, not a normal
+   operational log.
+
+### Likely Seam
+
+The mode files are the correct seam. `implement-shared.ts`, `full-pipeline.ts`, and
+`implement.ts` are the callers of the three unsafe deps. The coordinator owns the
+escalation-first invariant -- not the injectors (`trigger-listener.ts`, `cli-worktrain.ts`).
+
+### What Makes This Hard
+
+- `postToOutbox` calls are immediately followed by `return { kind: 'escalated', ... }`. The
+  try/catch must wrap ONLY the `postToOutbox` call, not the return statement. Careful
+  placement required.
+- `pollForPR` is called in BOTH `implement.ts` (explicitly mentioned in task) AND
+  `full-pipeline.ts` line 454 (not mentioned but equally unsafe). Both must be wrapped.
+- UX gate zombie detection: `implement.ts` line 144 assigns `uxHandle` from `uxSpawnResult.value`
+  without a null/empty-string guard before passing to `awaitSessions`. This is the only session
+  handle in the coordinator without the guard -- a separate gap alongside the I/O error handling.
+
+---
+
+## Philosophy Constraints
+
+**From `CLAUDE.md`:**
+- "Errors are data -- represent failure as values (Result/Either), not exceptions as control flow"
+- "Type safety as the first line of defense"
+
+**From `adaptive-pipeline.ts` header (design invariant):**
+- "All phase failures produce PipelineOutcome { kind: 'escalated' } -- never thrown."
+- "All I/O is injected via AdaptiveCoordinatorDeps. Zero direct fs/fetch/exec imports."
+
+**Repo precedent:**
+- `archiveFile` (in `implement.ts` and `full-pipeline.ts`): try/catch inline in finally block, log-and-continue. This is the exact model for `postToOutbox`.
+- `writeFile` routing log (in `adaptive-pipeline.ts`): try/catch inline, log-and-continue.
+
+**Conflicts:** None material. The stated philosophy (errors as data) and the repo pattern (inline try/catch for non-Result deps) are consistent.
+
+---
+
+## Impact Surface
+
+- `runReviewAndVerdictCycle` is called from both `implement.ts` and `full-pipeline.ts`. Fixing
+  `getAgentResult` in `implement-shared.ts` protects both callers automatically.
+- `runAuditChain` (also in `implement-shared.ts`) calls both `getAgentResult` and `postToOutbox`
+  at multiple points.
+- `adaptive-pipeline.ts` line 362 calls `postToOutbox` in the `ESCALATE` routing case -- this is
+  OUT OF SCOPE for this task (task restricts changes to the 3 mode files).
+- No callers outside these files change signature or return type.
+
+---
+
+## Candidates
+
+### Candidate 1: Inline try/catch at each call site (prescribed pattern)
+
+**Summary:** Wrap each `getAgentResult`, `postToOutbox`, and `pollForPR` call individually in
+a try/catch block in the 3 mode files.
+
+**Tensions resolved:** Crash-safety fully addressed. Accepts: slight verbosity from 8+
+`postToOutbox` sites.
+
+**Boundary:** At the mode file call sites -- the correct boundary. The coordinator owns the
+escalation-first invariant; the mode files are where the invariant must be enforced.
+
+**Failure mode:** Missing the `pollForPR` call in `full-pipeline.ts` (not explicitly called out
+in task description but confirmed unsafe by code analysis). Must be systematic.
+
+**Repo-pattern relationship:** Follows `archiveFile` try/catch pattern exactly. Adapts
+`writeFile` routing-log pattern from `adaptive-pipeline.ts`.
+
+**Gains:** Zero risk to happy path. Locally visible -- reviewer can see exactly what is
+protected at each call site. No new abstractions.
+
+**Losses:** Mildly repetitive for `postToOutbox` sites. Functions grow slightly.
+
+**Scope:** Best-fit. The 3 files are exactly the seam.
+
+**Philosophy fit:** Honors "errors are data", "escalation-first invariant", "DI for boundaries".
+Minor: uses `process.stderr.write()` in catch blocks rather than `deps.stderr()`, consistent
+with prescribed pattern and emergency-log semantics.
+
+---
+
+### Candidate 2: Wrap at injection site (safe wrapper functions)
+
+**Summary:** Wrap `getAgentResult`, `postToOutbox`, `pollForPR` in safe adapter functions at
+the injection sites (`trigger-listener.ts`, `cli-worktrain.ts`) so the deps never throw from
+the coordinator's perspective.
+
+**Tensions resolved:** DI purity -- the mode files stay clean. Accepts: changes to 2 files
+outside the permitted scope.
+
+**Boundary:** At the injection layer. Wrong boundary for this task -- the coordinator owns the
+escalation invariant, not the injectors. Injectors wire up the real implementation; they are
+not responsible for the coordinator's recovery behavior.
+
+**Failure mode:** Wrapping at injection site catches throws but cannot return `PipelineOutcome`
+-- would need to return null or a sentinel, which the mode files then check. Adds complexity
+at both ends, solving neither fully.
+
+**Repo-pattern relationship:** Departs -- existing injected deps use Result types for
+error-returning deps; plain-promise deps are not wrapped at injection sites.
+
+**Scope:** Too broad -- reaches outside the permitted 3 files.
+
+**Verdict: Rejected.** Out of scope and wrong seam.
+
+---
+
+### Candidate 3: Private helper `safePostToOutbox(deps, msg, meta)`
+
+**Summary:** Extract a private helper that wraps `deps.postToOutbox` in try/catch, reducing
+repetition at the 8+ `postToOutbox` call sites.
+
+**Tensions resolved:** DRY for `postToOutbox`. Accepts: new abstraction not prescribed by task.
+
+**Boundary:** Same 3 mode files, plus a local helper function in `implement-shared.ts`.
+
+**Failure mode:** Helper abstraction obscures the try/catch from reviewers; may hide future
+misuse (e.g., someone using the helper for a call that SHOULD escalate on failure).
+
+**Repo-pattern relationship:** No precedent for dep-wrapper helpers in the mode files. `archiveFile`
+try/catch is inline without a helper.
+
+**Scope:** Best-fit only if `postToOutbox` had 15+ sites. At 8, YAGNI says no.
+
+**Verdict: Skipped.** Task spec gives explicit inline pattern. YAGNI applies.
+
+---
+
+## Comparison and Recommendation
+
+**Candidate 1 is the clear choice.**
+
+All three candidates converge on the same underlying mechanism (try/catch). The only real
+alternatives differ in location (injection site -- wrong boundary) or DRY abstraction (helper --
+not warranted at 8 sites). Convergence is honest here.
+
+Candidate 1:
+- Follows the prescribed pattern from the task description exactly
+- Follows the repo precedent (`archiveFile`, `writeFile` try/catch)
+- Is locally visible and reviewable
+- Carries zero happy-path risk
+- Can be applied systematically to all confirmed call sites
+
+---
+
+## Self-Critique
+
+**Strongest argument against:** The 8+ `postToOutbox` call sites produce repetitive code. If
+the count grew to 20+, a helper would be clearly warranted. At 8, the verbosity is manageable.
+
+**Narrower option that might work:** Only fix `getAgentResult` and `pollForPR` (HIGH severity),
+skip `postToOutbox` wrapping (MEDIUM severity). Would reduce scope. Loses: `postToOutbox` crash
+at escalation decision points is still a real failure mode that kills the pipeline silently.
+
+**Broader option:** Candidate 2 (wrap at injection). Would be justified only if there were a
+precedent of wrapping injected deps at the injection layer. No such precedent exists.
+
+**Invalidating assumption:** If `postToOutbox` is guaranteed never to throw in production (e.g.,
+the real impl is in-memory rather than disk-based). The audit doc confirms it uses
+`fs.promises.appendFile` -- can fail on disk full or permission error. Assumption holds.
+
+---
+
+## Open Questions for Main Agent
+
+None. The problem, solution, and scope are fully specified. Implementation is mechanical.
+
+- Confirm `pollForPR` in `full-pipeline.ts` line 454 also needs wrapping (not explicitly in
+  task description but confirmed unsafe -- include it).
+- For `postToOutbox`: the task says "log a warning and continue". Use `process.stderr.write()`
+  as prescribed, not `deps.stderr()`.
+- UX gate zombie detection in `implement.ts`: add `if (!uxHandle || uxHandle.trim() === '')` guard
+  after line 144, consistent with all 9 other session handle checks in the coordinator.

--- a/docs/design/coordinator-io-error-handling-design-review.md
+++ b/docs/design/coordinator-io-error-handling-design-review.md
@@ -1,0 +1,120 @@
+# Coordinator I/O Error Handling -- Design Review Findings
+
+Generated: 2026-04-19
+
+## Tradeoff Review
+
+### Verbosity (8+ `postToOutbox` inline try/catch sites)
+
+- **Verdict:** Acceptable. At 8 sites, YAGNI wins. The `archiveFile` precedent in the same files
+  shows inline try/catch is the established pattern.
+- **Break condition:** If `postToOutbox` call sites grow to 15+, extract a private helper.
+- **Hidden assumption:** `postToOutbox` call count stays roughly constant in the near term.
+
+### `deps.stderr()` vs. `process.stderr.write()` in catch blocks
+
+- **Verdict:** Use `deps.stderr()` to match the existing `archiveFile` pattern in `implement.ts`
+  and `full-pipeline.ts`. The task spec example uses `process.stderr.write()` but the actual repo
+  uses `deps.stderr()` for the identical use case. `deps.stderr()` is more consistent and testable.
+- **Break condition:** None. `deps.stderr()` is strictly better here.
+
+### `pollForPR` in `full-pipeline.ts` not in task description but included
+
+- **Verdict:** Include it. It's the same unsafe call pattern, same dep, same risk. Excluding it
+  would leave the fix incomplete.
+- **Hidden assumption:** Both `pollForPR` call sites use the same real implementation -- confirmed.
+
+---
+
+## Failure Mode Review
+
+| Mode | Handled? | Risk | Notes |
+|------|----------|------|-------|
+| Missing a call site | Mitigated | Medium | Grep check after implementation |
+| `postToOutbox` throw during escalation sequence | Yes | Low | `return` is on next line after try/catch |
+| `getAgentResult` throw with non-Error | Yes | Low | `e instanceof Error ? e.message : String(e)` |
+| `pollForPR` throw leaving `prUrl` uninitialized | Yes (with care) | Medium | Must use `let prUrl; try {...} catch -> return escalated` |
+| UX gate empty `uxHandle` zombie | Yes (after fix) | Low | Same 4-line guard as 9 other handles |
+
+**Highest-risk failure mode:** `pollForPR` catch block structure. If written incorrectly (catch
+logs but falls through), `prUrl` would be undefined and the subsequent `if (!prUrl)` check would
+catch it -- but the `prUrl` variable would need to be declared with `let` outside the try block.
+The fix requires care in the variable declaration pattern.
+
+---
+
+## Runner-Up / Simpler Alternative Review
+
+**Runner-up:** Private `safePostToOutbox` helper.
+- **Strength worth borrowing:** Standardized log message format across all `postToOutbox` sites.
+- **Adopted:** Standardize the log message format inline (consistent `[WARN coordinator] postToOutbox failed: ...` prefix across all sites).
+- **Rejected:** Full helper extraction. YAGNI at 8 sites. No precedent in repo.
+
+**Simpler alternative:** Skip `postToOutbox` wrapping (only fix `getAgentResult` and `pollForPR`).
+- **Rejected:** `postToOutbox` crashes at critical escalation points. Medium severity is still a
+  production crash path that must be fixed.
+
+---
+
+## Philosophy Alignment
+
+| Principle | Status |
+|-----------|--------|
+| Errors are data | Fully satisfied -- throws become `PipelineOutcome` values |
+| Escalation-first invariant | Enforced -- no throw-exit paths remain after fix |
+| Make illegal states unrepresentable | Satisfied -- coordinator now always returns a value |
+| DI for boundaries | Satisfied -- no new imports, changes are in mode files only |
+| Compose with small functions | Under acceptable tension -- functions grow slightly |
+| Document why not what | Needs 1-line comment per postToOutbox catch explaining non-fatal rationale |
+| YAGNI with discipline | Satisfied -- no speculative helper |
+
+---
+
+## Findings
+
+### Yellow: `pollForPR` variable declaration pattern
+
+The `let prUrl` declaration must be placed BEFORE the try/catch block (not inside it) so that
+the catch block can `return` an escalated outcome and the variable remains in scope after. If
+the variable is declared inside `try`, TypeScript will not compile. This is a known TypeScript
+pattern but worth flagging explicitly.
+
+**Fix:** Use the explicit two-step pattern from the task spec:
+```typescript
+let prUrl: string | null;
+try {
+  prUrl = await deps.pollForPR(branchPattern, PR_POLL_TIMEOUT_MS);
+} catch (e) {
+  const msg = e instanceof Error ? e.message : String(e);
+  deps.stderr(`[WARN coordinator] pollForPR threw: ${msg}`);
+  return { kind: 'escalated', escalationReason: { phase: 'pr-detection', reason: `pollForPR threw: ${msg}` } };
+}
+if (!prUrl) { ... }
+```
+
+### Yellow: `deps.stderr()` vs. `process.stderr.write()`
+
+Use `deps.stderr()` in catch blocks. The task spec example uses `process.stderr.write()` but the
+repo's `archiveFile` catch blocks use `deps.stderr()`. Consistency with repo pattern wins.
+
+---
+
+## Recommended Revisions
+
+1. Use `deps.stderr()` (not `process.stderr.write()`) in all catch blocks.
+2. Use `let prUrl: string | null` declared before the try block for `pollForPR` calls.
+3. Add a one-line comment in each `postToOutbox` catch explaining non-fatal policy:
+   `// postToOutbox write failure is non-fatal -- escalation still returns below`
+4. Include `pollForPR` in `full-pipeline.ts` even though task description only names `implement.ts`.
+5. Include UX gate zombie detection fix in `implement.ts` line 144.
+
+---
+
+## Residual Concerns
+
+- **No tests for throw injection:** This PR fixes the runtime behavior but adds no tests for
+  the throw paths. Tests are a planned follow-up (per the audit doc). The absence of tests means
+  a regression in this fix would not be caught by CI. Low concern for this PR -- the fix is
+  mechanical and the pattern is simple.
+- **`adaptive-pipeline.ts` line 362 `postToOutbox` is unguarded** but is explicitly out of scope
+  for this task. Should be addressed in a follow-up.

--- a/src/coordinators/modes/full-pipeline.ts
+++ b/src/coordinators/modes/full-pipeline.ts
@@ -244,7 +244,17 @@ async function runFullPipelineCore(
   // Read discovery handoff artifact and build shaping context.
   // (Pitch invariant 12: try artifact first; fallback to lastStepNotes if length > 50)
 
-  const discoveryAgentResult = await deps.getAgentResult(discoveryHandle);
+  let discoveryAgentResult: Awaited<ReturnType<typeof deps.getAgentResult>>;
+  try {
+    discoveryAgentResult = await deps.getAgentResult(discoveryHandle);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    deps.stderr(`[coordinator] getAgentResult failed: ${msg}`);
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'review', reason: `getAgentResult threw: ${msg}` },
+    };
+  }
   const handoffArtifact = readDiscoveryHandoffArtifact(
     discoveryAgentResult.artifacts,
     discoveryHandle,
@@ -369,24 +379,34 @@ async function runFullPipelineCore(
     // FULL mode (Large complexity) + touchesUI: require human outbox ack
     // before coding starts. Poll for 24 hours; timeout -> escalate.
     const ackRequestId = deps.generateId();
-    await deps.postToOutbox(
-      `UX design complete for "${opts.goal}" -- please review and acknowledge before coding starts`,
-      {
-        requestId: ackRequestId,
-        goal: opts.goal,
-        workspace: opts.workspace,
-        phase: 'ux-gate',
-        uxSessionHandle: uxHandle,
-        note: 'Acknowledge this message to allow coding to begin. No response in 24h = escalation.',
-      },
-    );
+    try {
+      await deps.postToOutbox(
+        `UX design complete for "${opts.goal}" -- please review and acknowledge before coding starts`,
+        {
+          requestId: ackRequestId,
+          goal: opts.goal,
+          workspace: opts.workspace,
+          phase: 'ux-gate',
+          uxSessionHandle: uxHandle,
+          note: 'Acknowledge this message to allow coding to begin. No response in 24h = escalation.',
+        },
+      );
+    } catch (e) {
+      // postToOutbox write failure is non-fatal -- UX gate ack poll still proceeds
+      deps.stderr(`[WARN coordinator] postToOutbox failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
 
     const ackResult = await deps.pollOutboxAck(ackRequestId, UX_GATE_ACK_TIMEOUT_MS);
     if (ackResult === 'timeout') {
-      await deps.postToOutbox(
-        `UX gate timed out: no acknowledgment received within 24 hours for "${opts.goal}"`,
-        { requestId: ackRequestId, goal: opts.goal, phase: 'ux-gate-timeout' },
-      );
+      try {
+        await deps.postToOutbox(
+          `UX gate timed out: no acknowledgment received within 24 hours for "${opts.goal}"`,
+          { requestId: ackRequestId, goal: opts.goal, phase: 'ux-gate-timeout' },
+        );
+      } catch (e) {
+        // postToOutbox write failure is non-fatal -- escalation still returns below
+        deps.stderr(`[WARN coordinator] postToOutbox failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
       return {
         kind: 'escalated',
         escalationReason: {
@@ -451,7 +471,17 @@ async function runFullPipelineCore(
   const branchPattern = `worktrain/${codingHandle.slice(0, 16)}`;
   deps.stderr(`[full-pipeline] Polling for PR on branch pattern: ${branchPattern}`);
 
-  const prUrl = await deps.pollForPR(branchPattern, PR_POLL_TIMEOUT_MS);
+  let prUrl: string | null;
+  try {
+    prUrl = await deps.pollForPR(branchPattern, PR_POLL_TIMEOUT_MS);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    deps.stderr(`[coordinator] pollForPR threw: ${msg}`);
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'pr-detection', reason: `pollForPR threw: ${msg}` },
+    };
+  }
   if (!prUrl) {
     return {
       kind: 'escalated',

--- a/src/coordinators/modes/implement-shared.ts
+++ b/src/coordinators/modes/implement-shared.ts
@@ -84,7 +84,17 @@ export async function runReviewAndVerdictCycle(
     };
   }
 
-  const agentResult = await deps.getAgentResult(reviewHandle);
+  let agentResult: Awaited<ReturnType<typeof deps.getAgentResult>>;
+  try {
+    agentResult = await deps.getAgentResult(reviewHandle);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    deps.stderr(`[coordinator] getAgentResult failed: ${msg}`);
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'review', reason: `getAgentResult threw: ${msg}` },
+    };
+  }
   const verdictFromArtifact = readVerdictArtifact(agentResult.artifacts, reviewHandle);
   const findingsResult = verdictFromArtifact !== null
     ? { kind: 'ok' as const, value: verdictFromArtifact }
@@ -115,10 +125,15 @@ export async function runReviewAndVerdictCycle(
     case 'minor': {
       if (iteration >= MAX_FIX_ITERATIONS) {
         deps.stderr(`[review-cycle] ${MAX_FIX_ITERATIONS} fix iterations exhausted -- escalating`);
-        await deps.postToOutbox(
-          `Adaptive pipeline escalated: fix loop exhausted after ${MAX_FIX_ITERATIONS} iterations`,
-          { prUrl, phase: 'fix-loop', reason: 'max iterations reached', findingSummaries: findings.findingSummaries },
-        );
+        try {
+          await deps.postToOutbox(
+            `Adaptive pipeline escalated: fix loop exhausted after ${MAX_FIX_ITERATIONS} iterations`,
+            { prUrl, phase: 'fix-loop', reason: 'max iterations reached', findingSummaries: findings.findingSummaries },
+          );
+        } catch (e) {
+          // postToOutbox write failure is non-fatal -- escalation still returns below
+          deps.stderr(`[WARN coordinator] postToOutbox failed: ${e instanceof Error ? e.message : String(e)}`);
+        }
         return {
           kind: 'escalated',
           escalationReason: { phase: 'fix-loop', reason: `${MAX_FIX_ITERATIONS} fix iterations exhausted` },
@@ -220,10 +235,15 @@ export async function runAuditChain(
   );
 
   if (auditSpawnResult.kind === 'err') {
-    await deps.postToOutbox(
-      `Adaptive pipeline escalated: audit workflow failed to spawn`,
-      { prUrl, phase: 'audit', reason: auditSpawnResult.error, severity },
-    );
+    try {
+      await deps.postToOutbox(
+        `Adaptive pipeline escalated: audit workflow failed to spawn`,
+        { prUrl, phase: 'audit', reason: auditSpawnResult.error, severity },
+      );
+    } catch (e) {
+      // postToOutbox write failure is non-fatal -- escalation still returns below
+      deps.stderr(`[WARN coordinator] postToOutbox failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
     return {
       kind: 'escalated',
       escalationReason: { phase: 'audit', reason: `audit spawn failed: ${auditSpawnResult.error}` },
@@ -232,10 +252,15 @@ export async function runAuditChain(
 
   const auditHandle = auditSpawnResult.value;
   if (!auditHandle) {
-    await deps.postToOutbox(
-      `Adaptive pipeline escalated: audit returned empty handle`,
-      { prUrl, phase: 'audit', severity },
-    );
+    try {
+      await deps.postToOutbox(
+        `Adaptive pipeline escalated: audit returned empty handle`,
+        { prUrl, phase: 'audit', severity },
+      );
+    } catch (e) {
+      // postToOutbox write failure is non-fatal -- escalation still returns below
+      deps.stderr(`[WARN coordinator] postToOutbox failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
     return {
       kind: 'escalated',
       escalationReason: { phase: 'audit', reason: 'audit returned empty handle' },
@@ -247,10 +272,15 @@ export async function runAuditChain(
 
   if (!auditResult || auditResult.outcome !== 'success') {
     const outcome = auditResult?.outcome ?? 'not_found';
-    await deps.postToOutbox(
-      `Adaptive pipeline escalated: audit session ${outcome}`,
-      { prUrl, phase: 'audit', auditOutcome: outcome, severity },
-    );
+    try {
+      await deps.postToOutbox(
+        `Adaptive pipeline escalated: audit session ${outcome}`,
+        { prUrl, phase: 'audit', auditOutcome: outcome, severity },
+      );
+    } catch (e) {
+      // postToOutbox write failure is non-fatal -- escalation still returns below
+      deps.stderr(`[WARN coordinator] postToOutbox failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
     return {
       kind: 'escalated',
       escalationReason: { phase: 'audit', reason: `audit session ${outcome}` },
@@ -271,10 +301,15 @@ export async function runAuditChain(
   );
 
   if (reReviewSpawnResult.kind === 'err') {
-    await deps.postToOutbox(
-      `Adaptive pipeline escalated: re-review after audit failed to spawn`,
-      { prUrl, phase: 're-review-after-audit', reason: reReviewSpawnResult.error },
-    );
+    try {
+      await deps.postToOutbox(
+        `Adaptive pipeline escalated: re-review after audit failed to spawn`,
+        { prUrl, phase: 're-review-after-audit', reason: reReviewSpawnResult.error },
+      );
+    } catch (e) {
+      // postToOutbox write failure is non-fatal -- escalation still returns below
+      deps.stderr(`[WARN coordinator] postToOutbox failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
     return {
       kind: 'escalated',
       escalationReason: {
@@ -286,10 +321,15 @@ export async function runAuditChain(
 
   const reReviewHandle = reReviewSpawnResult.value;
   if (!reReviewHandle) {
-    await deps.postToOutbox(
-      `Adaptive pipeline escalated: re-review after audit returned empty handle`,
-      { prUrl, phase: 're-review-after-audit' },
-    );
+    try {
+      await deps.postToOutbox(
+        `Adaptive pipeline escalated: re-review after audit returned empty handle`,
+        { prUrl, phase: 're-review-after-audit' },
+      );
+    } catch (e) {
+      // postToOutbox write failure is non-fatal -- escalation still returns below
+      deps.stderr(`[WARN coordinator] postToOutbox failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
     return {
       kind: 'escalated',
       escalationReason: { phase: 're-review-after-audit', reason: 're-review returned empty handle' },
@@ -301,27 +341,47 @@ export async function runAuditChain(
 
   if (!reReviewResult || reReviewResult.outcome !== 'success') {
     const outcome = reReviewResult?.outcome ?? 'not_found';
-    await deps.postToOutbox(
-      `Adaptive pipeline escalated: re-review after audit session ${outcome}`,
-      { prUrl, phase: 're-review-after-audit', reReviewOutcome: outcome },
-    );
+    try {
+      await deps.postToOutbox(
+        `Adaptive pipeline escalated: re-review after audit session ${outcome}`,
+        { prUrl, phase: 're-review-after-audit', reReviewOutcome: outcome },
+      );
+    } catch (e) {
+      // postToOutbox write failure is non-fatal -- escalation still returns below
+      deps.stderr(`[WARN coordinator] postToOutbox failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
     return {
       kind: 'escalated',
       escalationReason: { phase: 're-review-after-audit', reason: `re-review session ${outcome}` },
     };
   }
 
-  const reAgentResult = await deps.getAgentResult(reReviewHandle);
+  let reAgentResult: Awaited<ReturnType<typeof deps.getAgentResult>>;
+  try {
+    reAgentResult = await deps.getAgentResult(reReviewHandle);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    deps.stderr(`[coordinator] getAgentResult failed: ${msg}`);
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'review', reason: `getAgentResult threw: ${msg}` },
+    };
+  }
   const reVerdictFromArtifact = readVerdictArtifact(reAgentResult.artifacts, reReviewHandle);
   const reFindingsResult = reVerdictFromArtifact !== null
     ? { kind: 'ok' as const, value: reVerdictFromArtifact }
     : parseFindingsFromNotes(reAgentResult.recapMarkdown);
 
   if (reFindingsResult.kind === 'err') {
-    await deps.postToOutbox(
-      `Adaptive pipeline escalated: re-review verdict unparseable after audit`,
-      { prUrl, phase: 're-review-after-audit' },
-    );
+    try {
+      await deps.postToOutbox(
+        `Adaptive pipeline escalated: re-review verdict unparseable after audit`,
+        { prUrl, phase: 're-review-after-audit' },
+      );
+    } catch (e) {
+      // postToOutbox write failure is non-fatal -- escalation still returns below
+      deps.stderr(`[WARN coordinator] postToOutbox failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
     return {
       kind: 'escalated',
       escalationReason: { phase: 're-review-after-audit', reason: `re-review verdict parse failed` },
@@ -338,16 +398,21 @@ export async function runAuditChain(
 
   // Still blocking/critical after audit: post to Human Outbox, do NOT auto-merge
   deps.stderr(`[audit-chain] Post-audit verdict still ${reFindings.severity} -- escalating to Human Outbox`);
-  await deps.postToOutbox(
-    `PR requires human review: still ${reFindings.severity} after production-readiness audit`,
-    {
-      prUrl,
-      phase: 'audit-chain-complete',
-      severity: reFindings.severity,
-      findingSummaries: reFindings.findingSummaries,
-      note: 'Do NOT auto-merge. Human review required.',
-    },
-  );
+  try {
+    await deps.postToOutbox(
+      `PR requires human review: still ${reFindings.severity} after production-readiness audit`,
+      {
+        prUrl,
+        phase: 'audit-chain-complete',
+        severity: reFindings.severity,
+        findingSummaries: reFindings.findingSummaries,
+        note: 'Do NOT auto-merge. Human review required.',
+      },
+    );
+  } catch (e) {
+    // postToOutbox write failure is non-fatal -- escalation still returns below
+    deps.stderr(`[WARN coordinator] postToOutbox failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
 
   return {
     kind: 'escalated',

--- a/src/coordinators/modes/implement.ts
+++ b/src/coordinators/modes/implement.ts
@@ -142,6 +142,12 @@ async function runImplementCore(
     }
 
     const uxHandle = uxSpawnResult.value;
+    if (!uxHandle || uxHandle.trim() === '') {
+      return {
+        kind: 'escalated',
+        escalationReason: { phase: 'ux-gate', reason: 'UX design session returned empty handle' },
+      };
+    }
     const uxAwait = await deps.awaitSessions([uxHandle], REVIEW_TIMEOUT_MS);
     const uxResult = uxAwait.results[0];
 
@@ -211,7 +217,17 @@ async function runImplementCore(
   const branchPattern = `worktrain/${codingHandle.slice(0, 16)}`;
   deps.stderr(`[implement] Polling for PR on branch pattern: ${branchPattern}`);
 
-  const prUrl = await deps.pollForPR(branchPattern, PR_POLL_TIMEOUT_MS);
+  let prUrl: string | null;
+  try {
+    prUrl = await deps.pollForPR(branchPattern, PR_POLL_TIMEOUT_MS);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    deps.stderr(`[coordinator] pollForPR threw: ${msg}`);
+    return {
+      kind: 'escalated',
+      escalationReason: { phase: 'pr-detection', reason: `pollForPR threw: ${msg}` },
+    };
+  }
   if (!prUrl) {
     return {
       kind: 'escalated',


### PR DESCRIPTION
## Summary

- Wraps all `getAgentResult` calls in `implement-shared.ts` and `full-pipeline.ts` in try/catch; throws escalate with `phase: 'review'`
- Wraps all `postToOutbox` calls in try/catch; throws log a `[WARN coordinator]` message and continue (best-effort notification, non-fatal)
- Wraps all `pollForPR` calls in `implement.ts` and `full-pipeline.ts` in try/catch; throws escalate with `phase: 'pr-detection'`
- Adds UX gate zombie-detection null-guard in `implement.ts` (same `!handle || handle.trim() === ''` pattern as all other session handles)

Fixes the gap identified in `docs/design/coordinator-testability-audit.md`: any I/O failure in these three dep types previously threw unhandled, crashing the coordinator silently instead of returning `PipelineOutcome { kind: 'escalated' }`.

Scope: `implement-shared.ts`, `full-pipeline.ts`, `implement.ts` only. No changes to `src/mcp/`.

## Test plan

- [x] `npm run build` passes with zero TypeScript errors
- [x] `npx vitest run tests/unit/adaptive-implement.test.ts tests/unit/adaptive-full-pipeline.test.ts tests/unit/route-task.test.ts` -- 86/86 passed
- [x] Pre-existing test failures (`workflow-runner-load-session-notes.test.ts`) confirmed present on `main` before this branch
- [ ] CI green on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)