### PR TITLE
fix(coordinator): replace HTTP awaitSessions/getAgentResult in-process

### DIFF
--- a/docs/design/coordinator-in-process-await-candidates.md
+++ b/docs/design/coordinator-in-process-await-candidates.md
@@ -1,0 +1,128 @@
+# Design Candidates: In-Process awaitSessions and getAgentResult
+
+**Date:** 2026-04-19
+**Task:** Replace HTTP-to-self `awaitSessions` and `getAgentResult` in `src/trigger/trigger-listener.ts` with in-process `ConsoleService` calls.
+
+---
+
+## Problem Understanding
+
+### Tensions
+
+1. **Construction order vs. dependency injection**: `coordinatorDeps` must be constructed before `TriggerRouter` (it is a constructor argument), but `ConsoleService` needs to be available inside the closure. The `routerRef` forward-reference pattern already solves a similar ordering problem -- `consoleService` can be constructed before the closure and captured by the closure.
+
+2. **Graceful degradation vs. correctness**: If `ctx.v2.dataDir` or `ctx.v2.directoryListing` is null (the daemon-console.ts path guards against this), should `awaitSessions` degrade to returning all-failed or crash? The design doc says construct before `coordinatorDeps` -- the guard should produce a logged warning and graceful fallback since the coordinator handles `allSucceeded: false`.
+
+3. **Session visibility race**: Sessions created in-process by `spawnSession()` may not be immediately readable via `getSessionDetail()`. This is why `SESSION_LOAD_FAILED` must be treated as "not ready yet" (retry), not as failure.
+
+4. **Interface cleanliness vs. minimal scope**: `CoordinatorDeps.port` is a required field (`readonly port: number`) that is never read by coordinator logic (`grep deps.port` returns nothing). Removing `port: DAEMON_CONSOLE_PORT` from the trigger-listener deps object requires either (a) making `port` optional in the interface, or (b) using a `0` sentinel.
+
+### Likely Seam
+
+The composition root `startTriggerListener()` in `src/trigger/trigger-listener.ts` is the correct and only seam. This is where all other deps are wired, `ctx.v2.*` ports are available, and `ConsoleService` can be constructed.
+
+### What Makes This Hard
+
+- `CoordinatorDeps.port` is required but unused by coordinator logic. The design doc says to remove it, but the interface requires it. TypeScript will reject omitting a required field.
+- The `error` terminal status mentioned in the task description does not exist in `ConsoleRunStatus` (`'in_progress' | 'complete' | 'complete_with_gaps' | 'blocked'`). The design doc is authoritative.
+- The dynamic import pattern is required to avoid circular dependency (same as `daemon-console.ts:113`).
+
+---
+
+## Philosophy Constraints
+
+From `/Users/etienneb/CLAUDE.md`:
+- **Architectural fixes over patches** -- this fix IS the architectural fix (in-process instead of HTTP)
+- **Immutability by default** -- `pending Set` mutation is minimal and contained in the polling loop
+- **Errors are data** -- use `.isOk()` / `.isErr()` on `ResultAsync`, not try/catch
+- **Validate at boundaries, trust inside** -- guard `ctx.v2.dataDir` at construction time
+- **Document "why", not "what"** -- add WHY comments on new implementations
+
+No philosophy conflicts with repo patterns -- `daemon-console.ts` already uses the exact same construction approach.
+
+---
+
+## Impact Surface
+
+- **`AdaptiveCoordinatorDeps` interface**: No change (extends `CoordinatorDeps`, no new fields needed)
+- **`CoordinatorDeps` interface** (`src/coordinators/pr-review.ts:210`): `port` is `required number` -- must be made optional if removing from trigger-listener deps
+- **CLI path** (`src/cli-worktrain.ts:1549`): sets `port` in deps object for out-of-process coordinator -- remains correct either way
+- **Pipeline coordinators** (`full-pipeline.ts`, `implement.ts`, `pr-review.ts`): call `awaitSessions`/`getAgentResult` by interface -- behavior change is transparent
+- **`src/mcp/`**: Not touched (explicit out-of-scope)
+
+---
+
+## Candidates
+
+### Candidate A: Design doc implementation with `port` made optional
+
+**Summary**: Implement exactly per design doc. Construct `ConsoleService` locally in `startTriggerListener()`. Replace `awaitSessions` and `getAgentResult` with in-process calls. Make `readonly port: number` optional (`readonly port?: number`) in `CoordinatorDeps` to allow removing it from the trigger-listener deps object.
+
+**Tensions resolved**: All four tensions resolved cleanly. `SESSION_LOAD_FAILED` = retry. Guard for `ctx.v2` nulls. `port` field made honest (optional, unused by logic).
+
+**Tension accepted**: Requires touching `src/coordinators/pr-review.ts` for one-char interface change.
+
+**Boundary**: `startTriggerListener()` composition root -- correct seam.
+
+**Why best fit**: Fully executes design doc intent. `deps.port` confirmed unused by all coordinator logic.
+
+**Failure mode**: None identified. `grep deps.port` confirmed zero usages in coordinator logic.
+
+**Repo pattern**: Follows `daemon-console.ts` construction pattern exactly. Follows `spawnSession` in-process migration pattern.
+
+**Gains**: Clean interface, no dead required field, full design doc compliance, no `0` sentinel.
+
+**Losses**: Touches `src/coordinators/pr-review.ts` (one-char change).
+
+**Scope judgment**: Best-fit. The scope restriction says "do not touch `src/mcp/`" not "do not touch `src/coordinators/`".
+
+**Philosophy fit**: Honors "architectural fixes over patches", "make illegal states unrepresentable" (no sentinel), "errors are data".
+
+---
+
+### Candidate B: Design doc implementation, keep `port: 0` sentinel
+
+**Summary**: Same `ConsoleService` construction and awaitSessions/getAgentResult replacement, but set `port: 0` in the trigger-listener deps object instead of making the interface field optional.
+
+**Tensions resolved**: Removes HTTP-to-self bugs. Zero interface changes.
+
+**Tension accepted**: Leaves dead required field with a misleading `0` value.
+
+**Failure mode**: Future code reads `deps.port` and uses `0` as a real port, producing silent bugs.
+
+**Repo pattern**: Departs from design doc intent ("remove the constant and port from coordinatorDeps").
+
+**Gains**: No interface touch; purely local change.
+
+**Losses**: Interface stays polluted with unused required field; violates design doc intent; `0` sentinel is an illegal state that can be constructed.
+
+**Scope judgment**: Too narrow (doesn't fully execute design doc intent).
+
+**Philosophy fit**: Conflicts with "make illegal states unrepresentable" and "architectural fixes over patches".
+
+---
+
+## Comparison and Recommendation
+
+**Recommendation: Candidate A.**
+
+`deps.port` is confirmed unused by any coordinator logic (exhaustive grep). Making it optional is a one-character change that eliminates a dead field and fully executes the design doc intent. The scope restriction is explicitly "do not touch `src/mcp/`" -- `src/coordinators/pr-review.ts` is in scope. Candidate A is the correct architectural fix.
+
+The `0` sentinel in Candidate B is precisely the kind of "patch over architectural fix" that CLAUDE.md's philosophy warns against.
+
+---
+
+## Self-Critique
+
+**Strongest argument against Candidate A**: A conservative interpretation of "only touch trigger-listener.ts" would favor the sentinel. If the reviewer intended zero interface changes, Candidate B is the safe choice.
+
+**Pivot condition**: If touching `pr-review.ts` causes unexpected test failures (e.g., tests construct `CoordinatorDeps` with `port` required and would need to add `port: undefined`), fall back to `port: 0` sentinel or make it optional with a default. But since `port` is already unused, this risk is low.
+
+**Assumption that would invalidate**: If some test or code path actually reads `deps.port` and would break if `0` is used or the field is absent. The grep confirms this does not exist.
+
+---
+
+## Open Questions for Main Agent
+
+1. Should the guard for `ctx.v2.dataDir === undefined` cause a process.stderr warning only, or should it cause `startTriggerListener` to return an `err`? (Daemon-console.ts returns `err` -- but trigger-listener has already started by this point. Recommendation: warn + let `awaitSessions`/`getAgentResult` return degraded results.)
+2. Should the `consoleService` local variable be constructed inside a try/catch or guarded more defensively? (No -- the constructor is synchronous and cannot throw given valid inputs.)

--- a/docs/design/coordinator-in-process-await-design-review.md
+++ b/docs/design/coordinator-in-process-await-design-review.md
@@ -1,0 +1,93 @@
+# Design Review: In-Process awaitSessions and getAgentResult
+
+**Date:** 2026-04-19
+**Candidate reviewed:** Candidate A from `coordinator-in-process-await-candidates.md`
+
+---
+
+## Tradeoff Review
+
+**Tradeoff: `port` field made optional in `CoordinatorDeps`**
+- Verified: `deps.port` is unused by all coordinator logic (grep returns zero results)
+- Condition that invalidates: TypeScript errors showing `port` required elsewhere
+- Mitigation: Run `npm run build` immediately; pivot to `port: 0` sentinel if errors appear
+- **Verdict: Acceptable**
+
+**Tradeoff: `null consoleService` fallback for missing `ctx.v2` ports**
+- Verified: `createToolContext()` always provides non-null values in production
+- Condition that invalidates: Not applicable in production path
+- Mitigation: Warn on stderr + degrade gracefully to same all-failed behavior as current HTTP failure
+- **Verdict: Acceptable**
+
+**Tradeoff: Pending-Set polling over check-all-handles-every-poll**
+- Verified: Terminal state transitions are monotonic (event log is append-only)
+- Condition that invalidates: Not possible given ConsoleRunStatus projection semantics
+- **Verdict: Correct and more efficient**
+
+---
+
+## Failure Mode Review
+
+| Failure Mode | Handled? | Risk |
+|---|---|---|
+| `ctx.v2.dataDir`/`directoryListing` null | Yes -- null guard + graceful fallback | Low |
+| Session not yet visible after spawnSession | Yes -- SESSION_LOAD_FAILED treated as retry | Low |
+| TypeScript error from port optional | Partially -- pivot to sentinel if needed | Low |
+| ConsoleService circular dependency | Yes -- dynamic import pattern | Low |
+| getSessionDetail/getNodeDetail unexpected throw | Yes -- ResultAsync + outer try/catch | Low |
+
+**Highest-risk**: TypeScript port optional change causing build failure. Pivot defined and trivial.
+
+---
+
+## Runner-Up / Simpler Alternative Review
+
+**Candidate B** (port: 0 sentinel): Nothing worth borrowing. The only advantage was zero interface changes, but it introduces a dead required field with a misleading sentinel value.
+
+**Simpler variant** (keep `port: DAEMON_CONSOLE_PORT`): Insufficient -- leaves dead code after removing the HTTP deps that needed it. Design doc explicitly lists port removal as required.
+
+**No hybrid needed.**
+
+---
+
+## Philosophy Alignment
+
+| Principle | Status |
+|---|---|
+| Architectural fixes over patches | SATISFIED -- root-cause fix, not workaround |
+| Make illegal states unrepresentable | SATISFIED -- no sentinel, optional instead |
+| Dependency injection for boundaries | SATISFIED -- ConsoleService gets ports injected |
+| Immutability by default | SATISFIED -- minimal mutable state (pending Set only) |
+| Errors are data | SATISFIED -- ResultAsync.isOk()/isErr() throughout |
+| YAGNI with discipline | SATISFIED -- no speculative abstractions |
+| Document "why", not "what" | REQUIRED -- add WHY comments in implementation |
+
+One acceptable tension: null consoleService uses nullable variable rather than Result type. Acceptable at initialization boundary (not domain logic).
+
+---
+
+## Findings
+
+**No Red (blocking) findings.**
+
+**Orange (should address before shipping):**
+- None identified.
+
+**Yellow (advisory):**
+- Y1: The `ctx.v2` null guard creates a nullable `consoleService` variable. If `ctx.v2` is ever null in production, the stderr warning may be missed. Recommend making the warning prominent: `[CRITICAL trigger-listener:reason=consoleService_unavailable]` prefix.
+
+---
+
+## Recommended Revisions
+
+1. Add `[CRITICAL]` prefix to the `ctx.v2` null guard warning to make it visible in logs.
+2. Add WHY comment on new `awaitSessions` explaining the in-process approach (mirrors the spawnSession WHY comment pattern).
+3. Add WHY comment on `ConsoleService` construction explaining it avoids the HTTP race condition.
+
+---
+
+## Residual Concerns
+
+- **None blocking.** The design is sound, the tradeoffs are acceptable, and the failure modes are covered.
+- Build verification (`npm run build`) will immediately catch any TypeScript issues from the `port` optional change.
+- The implementation is a near-direct transcription of the design doc pseudocode, reducing creative risk.

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -206,8 +206,8 @@ export interface CoordinatorDeps {
   /** Return the current wall-clock time in milliseconds. */
   readonly now: () => number;
 
-  /** Resolved console HTTP server port (after lock file discovery). */
-  readonly port: number;
+  /** Resolved console HTTP server port (after lock file discovery). Optional in in-process contexts. */
+  readonly port?: number;
 
   /**
    * Read file contents as UTF-8 string.

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -391,16 +391,41 @@ export async function startTriggerListener(
   // fs/exec/HTTP implementations. This pattern mirrors the pr-review command in
   // cli-worktrain.ts (lines 958-1244), which uses the same deps interface.
   //
-  // WHY port=3456 (DAEMON_CONSOLE_PORT): still used by awaitSessions and getAgentResult
-  // which poll the console HTTP API. This constant is kept for those paths.
-  //
   // WHY let routerRef (forward reference): coordinatorDeps must be constructed before
   // TriggerRouter (it is a constructor argument). spawnSession needs the router to
   // call router.dispatch() in-process. The forward-ref is assigned exactly once,
   // immediately after new TriggerRouter(), and never mutated again.
   // ---------------------------------------------------------------------------
-  const DAEMON_CONSOLE_PORT = 3456;
   const execFileAsync = promisify(execFile);
+
+  // WHY in-process ConsoleService (not HTTP): awaitSessions and getAgentResult previously
+  // made HTTP calls to http://127.0.0.1:3456 (the daemon's own console API) from inside
+  // the daemon process. This caused silent all-failed returns on ECONNREFUSED and a
+  // race condition where sessions created in-process by spawnSession() were not yet
+  // visible via HTTP when the first poll fired. ConsoleService provides the same data
+  // via direct store access, eliminating both failure modes.
+  //
+  // Construction mirrors daemon-console.ts lines 123-129. A second ConsoleService
+  // instance has no correctness issue -- the summary cache is instance-scoped and
+  // mtime-invalidated. The instance is cheap to construct.
+  //
+  // WHY lazy import: avoids circular dependency at module load time (same pattern as
+  // daemon-console.ts which also uses await import for ConsoleService).
+  const { ConsoleService } = await import('../v2/usecases/console-service.js');
+  let consoleService: InstanceType<typeof ConsoleService> | null = null;
+  if (!ctx.v2?.dataDir || !ctx.v2?.directoryListing) {
+    process.stderr.write(
+      '[CRITICAL trigger-listener:reason=consoleService_unavailable] ctx.v2.dataDir or ctx.v2.directoryListing not available -- awaitSessions and getAgentResult will degrade to all-failed / empty results\n',
+    );
+  } else {
+    consoleService = new ConsoleService({
+      directoryListing: ctx.v2.directoryListing,
+      dataDir: ctx.v2.dataDir,
+      sessionStore: ctx.v2.sessionStore,
+      snapshotStore: ctx.v2.snapshotStore,
+      pinnedWorkflowStore: ctx.v2.pinnedStore,
+    });
+  }
 
   // Forward reference for in-process dispatch. Assigned after router construction.
   // WHY let (not const): construction order requires coordinatorDeps before router.
@@ -496,108 +521,117 @@ export async function startTriggerListener(
       nowIso: () => new Date().toISOString(),
     }),
 
+    // WHY in-process polling (not HTTP): see ConsoleService construction comment above.
+    // SESSION_LOAD_FAILED on getSessionDetail() is treated as "not ready yet" (retry),
+    // not as failure. This handles the race where spawnSession() creates a session
+    // in-process but the event log is not yet complete enough to project.
     awaitSessions: async (handles: readonly string[], timeoutMs: number) => {
-      const { executeWorktrainAwaitCommand } = await import('../cli/commands/worktrain-await.js');
-      let resolvedResult: import('../cli/commands/worktrain-await.js').AwaitResult | null = null;
+      const POLL_INTERVAL_MS = 3_000;
 
-      await executeWorktrainAwaitCommand(
-        {
-          fetch: (url: string) => globalThis.fetch(url),
-          readFile: (p: string) => fs.promises.readFile(p, 'utf-8'),
-          stdout: (line: string) => {
-            try {
-              resolvedResult = JSON.parse(line) as import('../cli/commands/worktrain-await.js').AwaitResult;
-            } catch { /* ignore */ }
-          },
-          stderr: (line: string) => process.stderr.write(line + '\n'),
-          homedir: os.homedir,
-          joinPath: path.join,
-          sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
-          now: () => Date.now(),
-        },
-        {
-          sessions: [...handles].join(','),
-          mode: 'all',
-          timeout: `${Math.round(timeoutMs / 1000)}s`,
-          port: DAEMON_CONSOLE_PORT,
-        },
-      );
-
-      if (resolvedResult === null) {
+      if (consoleService === null) {
         process.stderr.write(
-          `[WARN coord:reason=await_failed] awaitSessions: could not get session results -- daemon may be unreachable or timed out. Returning all ${handles.length} session(s) as failed.\n`,
+          `[WARN coord:reason=await_degraded] awaitSessions: ConsoleService unavailable -- returning all ${handles.length} session(s) as failed.\n`,
         );
+        return {
+          results: [...handles].map((h) => ({
+            handle: h,
+            outcome: 'failed' as const,
+            status: null,
+            durationMs: 0,
+          })),
+          allSucceeded: false,
+        };
       }
-      return resolvedResult ?? {
-        results: [...handles].map((h) => ({
-          handle: h,
-          outcome: 'failed' as const,
-          status: null,
-          durationMs: 0,
-        })),
-        allSucceeded: false,
+
+      const startMs = Date.now();
+      const pending = new Set(handles);
+      const results = new Map<string, { handle: string; outcome: 'success' | 'failed' | 'timeout'; status: string | null; durationMs: number }>();
+
+      while (pending.size > 0) {
+        const elapsed = Date.now() - startMs;
+        if (elapsed >= timeoutMs) {
+          break;
+        }
+
+        for (const handle of [...pending]) {
+          try {
+            const detail = await consoleService.getSessionDetail(handle);
+            if (detail.isErr()) {
+              // SESSION_LOAD_FAILED or NODE_NOT_FOUND: session not yet visible or corrupt.
+              // Retry on next poll cycle -- do not mark as failed.
+              continue;
+            }
+            const run = detail.value.runs[0];
+            if (!run) continue; // session started but no run yet
+
+            const status = run.status;
+            if (status === 'complete' || status === 'complete_with_gaps') {
+              results.set(handle, { handle, outcome: 'success', status, durationMs: Date.now() - startMs });
+              pending.delete(handle);
+            } else if (status === 'blocked') {
+              results.set(handle, { handle, outcome: 'failed', status, durationMs: Date.now() - startMs });
+              pending.delete(handle);
+            }
+            // in_progress: still running -- stay in pending
+          } catch {
+            // Unexpected throw (should not happen with ResultAsync, but defensive)
+            results.set(handle, { handle, outcome: 'failed', status: null, durationMs: Date.now() - startMs });
+            pending.delete(handle);
+          }
+        }
+
+        if (pending.size > 0) {
+          await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+        }
+      }
+
+      // Any remaining pending handles hit the timeout
+      for (const handle of pending) {
+        results.set(handle, { handle, outcome: 'timeout', status: null, durationMs: timeoutMs });
+      }
+
+      const resultsArray = [...results.values()];
+      return {
+        results: resultsArray,
+        allSucceeded: resultsArray.every((r) => r.outcome === 'success'),
       };
     },
 
     getAgentResult: async (sessionHandle: string): Promise<{ recapMarkdown: string | null; artifacts: readonly unknown[] }> => {
       const emptyResult = { recapMarkdown: null, artifacts: [] as readonly unknown[] };
-      try {
-        const sessionUrl = `http://127.0.0.1:${DAEMON_CONSOLE_PORT}/api/v2/sessions/${encodeURIComponent(sessionHandle)}`;
-        const sessionRes = await globalThis.fetch(sessionUrl, { signal: AbortSignal.timeout(30_000) });
-        if (!sessionRes.ok) {
-          process.stderr.write(`[WARN coord:reason=http_error status=${sessionRes.status} handle=${sessionHandle.slice(0, 16)}] getAgentResult: session fetch returned HTTP ${sessionRes.status}\n`);
-          return emptyResult;
-        }
-        const sessionBody = await sessionRes.json() as Record<string, unknown>;
-        if (sessionBody['success'] !== true) {
-          return emptyResult;
-        }
-        const data = sessionBody['data'] as Record<string, unknown> | undefined;
-        if (!data) return emptyResult;
-        const runs = data['runs'] as Array<Record<string, unknown>> | undefined;
-        if (!Array.isArray(runs) || runs.length === 0) return emptyResult;
 
-        const firstRun = runs[0] as Record<string, unknown>;
-        const tipNodeId = typeof firstRun['preferredTipNodeId'] === 'string'
-          ? firstRun['preferredTipNodeId']
-          : null;
+      if (consoleService === null) {
+        return emptyResult;
+      }
+
+      try {
+        const detailResult = await consoleService.getSessionDetail(sessionHandle);
+        if (detailResult.isErr()) return emptyResult;
+
+        const run = detailResult.value.runs[0];
+        if (!run) return emptyResult;
+
+        const tipNodeId = run.preferredTipNodeId;
         if (!tipNodeId) return emptyResult;
 
-        const allNodes = Array.isArray(firstRun['nodes'])
-          ? (firstRun['nodes'] as Array<Record<string, unknown>>)
-          : [];
-        const allNodeIds = allNodes
-          .map((n) => (typeof n['nodeId'] === 'string' ? n['nodeId'] : null))
-          .filter((id): id is string => id !== null);
+        const allNodeIds = run.nodes.map((n) => n.nodeId).filter((id): id is string => typeof id === 'string' && id !== '');
         const nodeIdsToFetch = allNodeIds.length > 0 ? allNodeIds : [tipNodeId];
 
-        const baseNodeUrl = `http://127.0.0.1:${DAEMON_CONSOLE_PORT}/api/v2/sessions/${encodeURIComponent(sessionHandle)}/nodes/`;
         let recap: string | null = null;
         const collectedArtifacts: unknown[] = [];
 
         for (const nodeId of nodeIdsToFetch) {
           try {
-            const nodeRes = await globalThis.fetch(
-              baseNodeUrl + encodeURIComponent(nodeId),
-              { signal: AbortSignal.timeout(30_000) },
-            );
-            if (!nodeRes.ok) continue;
-            const nodeBody = await nodeRes.json() as Record<string, unknown>;
-            if (nodeBody['success'] !== true) continue;
-            const nodeData = nodeBody['data'] as Record<string, unknown> | undefined;
-            if (!nodeData) continue;
+            const nodeResult = await consoleService.getNodeDetail(sessionHandle, nodeId);
+            if (nodeResult.isErr()) continue;
 
             if (nodeId === tipNodeId) {
-              recap = typeof nodeData['recapMarkdown'] === 'string' ? nodeData['recapMarkdown'] : null;
+              recap = nodeResult.value.recapMarkdown;
             }
-            const nodeArtifacts = nodeData['artifacts'];
-            if (Array.isArray(nodeArtifacts) && nodeArtifacts.length > 0) {
-              collectedArtifacts.push(...nodeArtifacts);
+            if (nodeResult.value.artifacts.length > 0) {
+              collectedArtifacts.push(...nodeResult.value.artifacts);
             }
-          } catch (nodeErr) {
-            const msg = nodeErr instanceof Error ? nodeErr.message : String(nodeErr);
-            process.stderr.write(`[WARN coord:reason=node_exception handle=${sessionHandle.slice(0, 16)} node=${nodeId.slice(0, 16)}] getAgentResult: ${msg}\n`);
-          }
+          } catch { continue; }
         }
 
         return { recapMarkdown: recap, artifacts: collectedArtifacts };
@@ -653,7 +687,6 @@ export async function startTriggerListener(
 
     stderr: (line: string) => process.stderr.write(line + '\n'),
     now: () => Date.now(),
-    port: DAEMON_CONSOLE_PORT,
 
     // AdaptiveCoordinatorDeps extensions (beyond CoordinatorDeps)
 


### PR DESCRIPTION
## Summary

- Replace `awaitSessions` (which called `executeWorktrainAwaitCommand` -> HTTP to port 3456) with an in-process pending-Set polling loop using `ConsoleService.getSessionDetail()`
- Replace `getAgentResult` (which used `globalThis.fetch` to port 3456) with in-process `ConsoleService.getSessionDetail()` + `getNodeDetail()` calls
- Remove `DAEMON_CONSOLE_PORT = 3456` constant and `port: DAEMON_CONSOLE_PORT` from coordinator deps
- Make `CoordinatorDeps.port` optional (was required but never read by coordinator logic)
- Add `ConsoleService` construction in `startTriggerListener()` using `ctx.v2` ports, mirroring `daemon-console.ts` pattern

Fixes silent all-failed returns on `ECONNREFUSED` and a race condition where sessions created in-process by `spawnSession()` were not yet visible via HTTP on the first poll. See `docs/design/coordinator-access-audit.md` for full analysis.

## Test plan

- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] `npx vitest run tests/unit/trigger-router.test.ts` - all 60 tests pass
- [ ] `npx vitest run tests/unit/coordinator-pr-review.test.ts` - all 81 tests pass
- [ ] No regressions in full test suite (pre-existing failures in `workflow-runner-load-session-notes.test.ts` are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)