### PR TITLE
fix(trigger): bypass dispatch dedup for pre-allocated sessions

### DIFF
--- a/docs/design/dispatch-dedup-prealloc-bypass-candidates.md
+++ b/docs/design/dispatch-dedup-prealloc-bypass-candidates.md
@@ -1,0 +1,187 @@
+# Design Candidates: Bypass Dispatch Dedup for Pre-Allocated Sessions
+
+**Date:** 2026-04-19
+**Status:** Decided -- Option A (guard before dedup block)
+**Scope:** `src/trigger/trigger-router.ts`, `dispatch()` method only
+
+---
+
+## Problem Understanding
+
+### Core Tensions
+
+1. **Dedup protection vs session liveness** -- The 30s dedup window in `dispatch()` exists to prevent
+   duplicate pipeline sessions from webhook retries. But the same mechanism incorrectly kills child
+   sessions spawned by `spawnSession()`, which already pre-created the session in the store via
+   `executeStartWorkflow()`. The invariant 'same key = duplicate' is false for pre-allocated sessions.
+
+2. **Shared state vs path-specific logic** -- `_recentAdaptiveDispatches` is intentionally shared
+   across `route()`, `dispatch()`, and `dispatchAdaptivePipeline()`. This cross-path coupling causes
+   the key collision: `dispatchAdaptivePipeline()` writes `goal::workspace` at t=0, then `dispatch()`
+   reads it at t~=0 and returns early. The fix must carve out an exception for one specific case
+   without breaking the shared-state intent.
+
+3. **Code reuse vs early-exit clarity** -- The dedup block is a scoped `{...}` block at the top of
+   `dispatch()`. Adding the guard before it avoids duplicating the enqueue block, but requires
+   careful restructuring to keep one enqueue call reached by both paths.
+
+### Likely Seam
+
+The real seam is `dispatch()` lines 851-866 (the dedup block). The symptom (zombie session) is
+downstream, but the root cause (early return that bypasses `queue.enqueue()`) is exactly here.
+
+### What Makes It Hard
+
+A junior developer might:
+- Add `_preAllocatedStartResponse` as a new parameter instead of checking the existing field.
+- Delete the dedup block from `dispatch()` entirely (Option B) -- too broad.
+- Add the guard inside the dedup block as a `return` that skips `_recentAdaptiveDispatches.set()`,
+  which is technically acceptable (the map entry from `dispatchAdaptivePipeline()` is still valid
+  for blocking duplicate top-level calls) but less clear.
+- Accidentally duplicate the `queue.enqueue()` callback body, creating divergent result-handling.
+
+---
+
+## Philosophy Constraints
+
+**Source: `/Users/etienneb/CLAUDE.md`**
+
+- **Architectural fixes over patches** -- the guard models the invariant, not a special case
+- **Make illegal states unrepresentable** -- `_preAllocatedStartResponse !== undefined` is a
+  compile-time discriminator; the guard makes 'dedup fires for pre-allocated session' impossible
+- **YAGNI with discipline** -- Option A is the minimal fix; no speculative abstractions
+- **Document why, not what** -- the guard comment must explain the invariant, not describe the code
+
+No conflicts between stated philosophy and repo patterns detected.
+
+---
+
+## Impact Surface
+
+- `spawnSession()` in `src/trigger/trigger-listener.ts` is the only caller that sets
+  `_preAllocatedStartResponse`. The fix must not change its call signature.
+- `queue.enqueue()` callback body in `dispatch()` handles the full `WorkflowRunResult` union
+  (success, error, timeout, stuck, delivery_failed). Both the guard path and the normal path must
+  reach the same callback body -- no duplication.
+- `_recentAdaptiveDispatches` -- for non-prealloc calls, cleanup-on-entry and set must still run.
+- `route()` and `dispatchAdaptivePipeline()` -- no changes to either.
+
+---
+
+## Candidates
+
+### Candidate A: Early-return guard before the dedup block (Option A from design doc)
+
+**Summary:** Add `if (workflowTrigger._preAllocatedStartResponse !== undefined) { void this.queue.enqueue(...); return workflowTrigger.workflowId; }` before the scoped dedup block. The dedup block is only reached when the field is absent.
+
+**Tensions resolved:** Dedup protection vs session liveness (fully resolved for pre-alloc path).
+**Tensions accepted:** Shared state coupling remains -- the map is still shared.
+
+**Boundary solved at:** `dispatch()` entry, before the dedup block. This is the real seam.
+
+**Why this boundary:** The bug fires at the dedup block. The guard is placed exactly where the
+divergence must happen. No other location would be more direct.
+
+**Failure mode:** If the guard path and the normal path have separate `queue.enqueue()` callback
+bodies, any future change to one body must be mirrored to the other. Mitigated by restructuring
+so both paths reach the same enqueue call.
+
+**Repo pattern:** Follows the `dispatchCondition` early-exit pattern in `route()` (lines 641-653).
+Departs in that `dispatch()` previously had no such guard.
+
+**Gains:** Minimal blast radius. Self-documenting -- the guard directly encodes the invariant.
+**Loses:** Slightly more complex method structure if naively implemented with two enqueue blocks.
+
+**Scope:** Best-fit. Single method, single guard.
+
+**Philosophy:** Honors 'Architectural fixes', 'Make illegal states unrepresentable', 'YAGNI'.
+No conflicts.
+
+---
+
+### Candidate B: Wrap dedup block in `if (!_preAllocatedStartResponse)` (same intent, cleaner structure)
+
+**Summary:** Wrap the entire scoped dedup block in `if (workflowTrigger._preAllocatedStartResponse === undefined)`. Both paths then fall through to the same `void this.queue.enqueue(...)` call at the bottom of the method.
+
+**Tensions resolved:** Same as A, plus eliminates code duplication risk.
+**Tensions accepted:** Same as A.
+
+**Boundary:** Same as A.
+
+**Failure mode:** `_recentAdaptiveDispatches.set()` must still run for non-prealloc paths that
+pass dedup. This is naturally handled by the wrap -- the set is inside the block.
+
+**Repo pattern:** More consistent with the existing scoped-block style in `dispatch()`.
+
+**Gains:** Single enqueue block -- no duplication risk.
+**Loses:** The `_preAllocatedStartResponse` check is farther from the enqueue call than in A,
+making the intent slightly less immediate.
+
+**Scope:** Best-fit. Same scope as A.
+
+**Philosophy:** Same as A.
+
+---
+
+### Candidate C: Remove dedup from `dispatch()` entirely (Option B from design doc)
+
+**Summary:** Delete the entire dedup block from `dispatch()`. The dedup that protects against
+webhook retries lives in `dispatchAdaptivePipeline()` and `route()`, both of which are the
+actual entry points for external events.
+
+**Tensions resolved:** Eliminates the shared-state coupling entirely.
+
+**Boundary:** Too broad -- removes protection from the HTTP console route at `console-routes.ts:868`
+which calls `dispatch()` directly.
+
+**Failure mode:** Rapid-fire console dispatches could spawn duplicates if the HTTP layer does not
+deduplicate. No evidence exists that this protection is currently needed, but removing it is a
+behavioral change beyond the scope of this fix.
+
+**Repo pattern:** Departs from the established shared-dedup-map pattern.
+
+**Scope:** Too broad. The task explicitly specifies Option A.
+
+**Philosophy:** Conflicts with 'YAGNI with discipline' -- speculative fix for an unproven gap.
+
+---
+
+## Comparison and Recommendation
+
+All three candidates converge on the same fundamental fix. C is ruled out (too broad). A and B
+are structurally equivalent -- the choice is whether to use an early-return guard (A) or a
+wrapping if-block (B).
+
+**Recommendation: Implement B's structure with A's intent.**
+
+Use `if (workflowTrigger._preAllocatedStartResponse === undefined)` to wrap the dedup block,
+with the `void this.queue.enqueue(...)` call appearing once after the if-block. This gives:
+- No code duplication (single enqueue call)
+- Clear separation: 'if non-prealloc, check dedup; then enqueue regardless'
+- Consistent with the scoped-block style already in `dispatch()`
+
+**Rationale:** The task pseudocode suggests A's early-return pattern, but B is equivalent and
+avoids the duplication risk. Any reviewer familiar with the design doc will understand either shape.
+
+---
+
+## Self-Critique
+
+**Strongest counter-argument:** The task pseudocode explicitly shows an early-return guard (A).
+A reviewer seeing the design doc side-by-side with the implementation may expect exactly that
+pattern. Diverging to a wrap (B) adds a tiny friction.
+
+**Pivot conditions:**
+- If the enqueue callback body diverges between paths in A, switch to B immediately.
+- If `dispatch()` gains a third call path that also needs dedup bypass, consider Option C or
+  a separate dedup map (Option C from design doc) at that point.
+
+**Assumption that would invalidate this design:** If `_preAllocatedStartResponse` could ever be
+set on a call where dedup should still fire. The JSDoc is explicit: the field is only set by
+`spawnSession`/`spawn_agent` which already hold a pre-created session. This assumption is safe.
+
+---
+
+## Open Questions for the Main Agent
+
+None. The problem, solution, boundary, and tests are fully specified.

--- a/docs/design/dispatch-dedup-prealloc-bypass-design-review.md
+++ b/docs/design/dispatch-dedup-prealloc-bypass-design-review.md
@@ -1,0 +1,100 @@
+# Design Review: Bypass Dispatch Dedup for Pre-Allocated Sessions
+
+**Date:** 2026-04-19
+**Reviewer:** Claude (automated design review pass)
+**Selected approach:** Wrap dedup block in `if (workflowTrigger._preAllocatedStartResponse === undefined)`
+
+---
+
+## Tradeoff Review
+
+### Shared dedup map stays shared
+
+The `_recentAdaptiveDispatches` map remains shared across all dispatch paths. Pre-alloc calls
+bypass the check but do not update the map.
+
+**Assessment:** Sound. The map entry from `dispatchAdaptivePipeline()` correctly blocks duplicate
+top-level pipelines for 30s. Pre-alloc calls are child sessions -- they should not add new map
+entries. All cross-path scenarios analyzed; no violations found.
+
+**Condition for unacceptability:** If a legitimate retry of the same goal+workspace (without
+pre-alloc) must fire within 30s of the original dispatch. Unlikely in practice; TTL is 30s.
+
+### Comment is the only regression protection
+
+The guard `if (_preAllocatedStartResponse === undefined)` wrapping the dedup block has no
+compile-time enforcement beyond the unit test.
+
+**Assessment:** Acceptable. The unit test `dispatch() with _preAllocatedStartResponse bypasses
+dedup and calls runWorkflowFn` catches any regression. The JSDoc on the field and the guard
+comment provide documentation-level protection.
+
+---
+
+## Failure Mode Review
+
+| Mode | Handled? | Mitigation |
+|---|---|---|
+| Guard removed in refactor | Yes | Unit test catches it |
+| Falsy check instead of `!== undefined` | Non-issue | Type is always an object when present |
+| Semaphore deadlock | Not new risk | Pre-existing FIFO semaphore handles this |
+| Session completes before enqueue | Not real | executeStartWorkflow doesn't run agent loop |
+
+**Highest-risk:** Guard removed in refactor. Mitigated by unit test.
+
+---
+
+## Runner-Up / Simpler Alternative Review
+
+- **Runner-up (early-return guard A):** Structurally equivalent. Loses because B keeps a single
+  enqueue block, reducing duplication risk. No elements worth borrowing beyond the guard comment.
+- **Simpler alternative (extract `_enqueueDispatch`):** Would be cleaner but is out of scope for
+  this targeted fix. No correctness benefit.
+
+---
+
+## Philosophy Alignment
+
+All relevant CLAUDE.md principles are satisfied:
+- **Architectural fixes over patches** -- the guard models the root invariant
+- **Make illegal states unrepresentable** -- compile-time discriminator
+- **YAGNI with discipline** -- minimal change, no speculation
+- **Document why, not what** -- guard comment explains invariant
+
+Pre-existing tensions (mutable shared map) are not introduced by this fix.
+
+---
+
+## Findings
+
+**No RED findings.** No blocking issues detected.
+
+**ORANGE (advisory):**
+1. The guard comment must be explicit about WHY dedup is bypassed, not just THAT it is bypassed.
+   A vague comment like `// skip dedup for pre-alloc` is insufficient. The comment must state:
+   'executeStartWorkflow already created the session in the store; dropping this dispatch would
+   zombie it.'
+
+**YELLOW (notes):**
+1. The unit test for the bypass case should assert that `runWorkflowFn` is called exactly once
+   (not just called), to verify the session actually starts.
+2. Consider adding a log line in the bypass path: `console.log('[TriggerRouter] Pre-allocated session dispatched: workflowId=...')` for observability.
+
+---
+
+## Recommended Revisions
+
+1. Write the guard comment to match the invariant stated in the design doc:
+   ```typescript
+   // Pre-allocated session: executeStartWorkflow already created the session in the store.
+   // Deduplication must not apply here -- dropping this dispatch would zombie the session.
+   ```
+2. In the test: assert `calls` has exactly 1 entry (`toHaveLength(1)`) after the bypass dispatch.
+3. Optional: add a `console.log` in the bypass path for daemon observability.
+
+---
+
+## Residual Concerns
+
+None. The fix is sound, minimal, and directly models the documented invariant. All failure modes
+are either handled or pre-existing. The design is ready for implementation.

--- a/docs/design/dispatch-dedup-prealloc-bypass-implementation-plan.md
+++ b/docs/design/dispatch-dedup-prealloc-bypass-implementation-plan.md
@@ -1,0 +1,218 @@
+# Implementation Plan: Bypass Dispatch Dedup for Pre-Allocated Sessions
+
+**Date:** 2026-04-19
+**Branch:** fix/dispatch-dedup-prealloc-bypass
+**Scope:** src/trigger/trigger-router.ts only (src/mcp/ excluded)
+
+---
+
+## 1. Problem Statement
+
+`TriggerRouter.dispatch()` has a 30-second deduplication guard that compares incoming
+`goal::workspacePath` against `_recentAdaptiveDispatches`. When `dispatchAdaptivePipeline()`
+runs, it writes this key. Milliseconds later, `spawnSession()` calls `dispatch()` with the same
+goal and workspace (plus `_preAllocatedStartResponse`). The dedup guard fires, `queue.enqueue()`
+is never called, and the session that was already written to the store by `executeStartWorkflow()`
+zombies permanently.
+
+---
+
+## 2. Acceptance Criteria
+
+1. `dispatch()` called with `_preAllocatedStartResponse` set bypasses the dedup check and calls
+   `runWorkflowFn` exactly once.
+2. `dispatch()` called WITHOUT `_preAllocatedStartResponse` still deduplicates correctly within 30s.
+3. `npm run build` exits clean (no TypeScript errors).
+4. `npx vitest run tests/unit/trigger-router.test.ts` -- all tests pass including two new tests.
+5. `npx vitest run` -- no regressions in any other test file.
+6. PR merged to main via `gh pr merge <N> --squash`.
+7. Daemon rebuilt and reinstalled (`npm run build && node dist/cli-worktrain.js daemon --install`).
+8. `node dist/cli-worktrain.js trigger poll self-improvement` starts a session and `session_started`
+   appears in the event log within 30s.
+
+---
+
+## 3. Non-Goals
+
+- Do NOT touch `src/mcp/` (any file).
+- Do NOT implement Option B (remove dedup from dispatch() entirely).
+- Do NOT implement Option C (separate dedup maps).
+- Do NOT touch `route()` or `dispatchAdaptivePipeline()`.
+- Do NOT change the dedup TTL or map key format.
+
+---
+
+## 4. Philosophy-Driven Constraints
+
+- Guard comment must explain WHY, not what (CLAUDE.md: 'Document why, not what').
+- No code duplication: both the pre-alloc path and the normal path reach the same single
+  `queue.enqueue()` call (CLAUDE.md: 'Compose with small, pure functions').
+- Guard uses `!== undefined` not a falsy check (CLAUDE.md: 'Type safety as the first line of defense').
+
+---
+
+## 5. Invariants
+
+1. When `_preAllocatedStartResponse !== undefined`, `queue.enqueue()` MUST be called.
+2. When `_preAllocatedStartResponse === undefined`, the existing dedup check runs unchanged.
+3. `_recentAdaptiveDispatches` is not updated for pre-alloc dispatch calls (the entry from
+   `dispatchAdaptivePipeline()` remains and is the correct TTL anchor for top-level dedup).
+4. The `assertNever` exhaustiveness guard in the enqueue callback remains intact.
+
+---
+
+## 6. Selected Approach + Rationale
+
+**Approach:** Wrap the dedup block in `dispatch()` with:
+```typescript
+if (workflowTrigger._preAllocatedStartResponse === undefined) {
+  // ... existing dedup block ...
+}
+```
+Both the pre-alloc path and the normal (post-dedup) path fall through to the same single
+`void this.queue.enqueue(...)` call.
+
+**Rationale:** Minimal blast radius. Single guard. No code duplication. Directly models the
+documented invariant in `WorkflowTrigger._preAllocatedStartResponse` JSDoc.
+
+**Runner-up:** Early-return guard before the dedup block (Candidate A from design review).
+Lost because it risks duplicating the enqueue callback body. Structurally equivalent otherwise.
+
+---
+
+## 7. Vertical Slices
+
+### Slice 1: Implementation fix in trigger-router.ts
+
+**Scope:** `src/trigger/trigger-router.ts`, `dispatch()` method only (lines 847-933).
+
+**Change:**
+1. Add a guard comment before the dedup block explaining the pre-alloc invariant.
+2. Wrap the scoped dedup block `{...}` in `if (workflowTrigger._preAllocatedStartResponse === undefined)`.
+3. Add an optional `console.log` in the pre-alloc path for daemon observability.
+4. The existing `void this.queue.enqueue(...)` call remains after the if-block.
+
+**Acceptance criterion:** TypeScript compiles clean. The guard is visible and commented correctly.
+
+---
+
+### Slice 2: Unit tests in trigger-router.test.ts
+
+**Scope:** `tests/unit/trigger-router.test.ts`, new describe block or additions to existing
+'TriggerRouter.route and dispatch deduplication' describe block.
+
+**Two new tests:**
+
+**Test 1: dispatch() with _preAllocatedStartResponse bypasses dedup and calls runWorkflowFn**
+- Call `dispatchAdaptivePipeline(goal, workspace)` to prime the dedup map.
+- Then call `dispatch({ workflowId, goal, workspacePath: workspace, context: {}, _preAllocatedStartResponse: <fake> })`.
+- Flush the async queue.
+- Assert `calls.toHaveLength(1)` -- runWorkflowFn was called exactly once.
+
+**Test 2: dispatch() WITHOUT _preAllocatedStartResponse still deduplicates within 30s**
+- This test already exists at line 1604. Verify it still passes after the change.
+- No new test needed for this case; the existing test is the regression guard.
+
+**Acceptance criterion:** Both tests pass (`vitest run tests/unit/trigger-router.test.ts`).
+
+---
+
+### Slice 3: Build, test, PR, CI, merge
+
+**Steps:**
+1. `npm run build` -- clean
+2. `npx vitest run tests/unit/trigger-router.test.ts` -- all pass
+3. `npx vitest run` -- no regressions
+4. Create branch `fix/dispatch-dedup-prealloc-bypass`
+5. Commit: `fix(trigger): bypass dispatch dedup for pre-allocated sessions to prevent zombie sessions`
+6. Push + open PR
+7. Wait for CI
+8. Merge: `gh pr merge <N> --squash`
+
+---
+
+### Slice 4: Daemon reinstall and smoke test
+
+**Steps:**
+1. `npm run build && node dist/cli-worktrain.js daemon --install`
+2. `node dist/cli-worktrain.js trigger poll self-improvement`
+3. Watch for `session_started` in event log for at least 30s
+4. Confirm session is not zombie (status completes or progresses past `run_started`)
+
+---
+
+## 8. Test Design
+
+### New Test 1: Bypass case (primary regression test for this fix)
+
+```typescript
+it('dispatch(): bypasses dedup and calls runWorkflowFn when _preAllocatedStartResponse is set', async () => {
+  vi.useFakeTimers();
+  const { fn, calls } = makeFakeRunWorkflow();
+  const trigger = makeTrigger();
+  const router = new TriggerRouter(
+    makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn,
+    undefined, undefined, undefined, undefined, undefined,
+    FAKE_DEPS, executors,
+  );
+
+  const goal = trigger.goal;
+  const workspace = trigger.workspacePath;
+
+  // Prime the dedup map via dispatchAdaptivePipeline
+  await router.dispatchAdaptivePipeline(goal, workspace);
+
+  // Now dispatch with _preAllocatedStartResponse set -- must bypass dedup
+  router.dispatch({
+    workflowId: trigger.workflowId,
+    goal,
+    workspacePath: workspace,
+    context: {},
+    _preAllocatedStartResponse: {} as any, // non-undefined value triggers bypass
+  });
+
+  // Flush
+  await new Promise((r) => setImmediate(r));
+
+  // runWorkflowFn must have been called exactly once
+  expect(calls).toHaveLength(1);
+  vi.useRealTimers();
+});
+```
+
+### Existing Test (regression guard): dispatch() dedup still works without _preAllocatedStartResponse
+
+The test at line 1604-1644 of trigger-router.test.ts covers this. It will serve as the
+regression guard after the change.
+
+---
+
+## 9. Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Guard removed in future refactor | Low | High | Unit test catches it in CI |
+| Comment becomes stale | Low | Medium | Comment explains invariant, not mechanics -- less likely to stale |
+| _preAllocatedStartResponse type changes | Very low | Low | TypeScript would catch it at compile time |
+
+---
+
+## 10. PR Packaging Strategy
+
+Single PR. One commit. No breaking changes.
+
+Branch: `fix/dispatch-dedup-prealloc-bypass`
+Commit: `fix(trigger): bypass dispatch dedup for pre-allocated sessions to prevent zombie sessions`
+
+---
+
+## 11. Philosophy Alignment
+
+| Principle | Status | Why |
+|---|---|---|
+| Architectural fixes over patches | Satisfied | Guard models the root invariant, not a special-case |
+| Make illegal states unrepresentable | Satisfied | `_preAllocatedStartResponse !== undefined` is compile-time discriminator |
+| YAGNI with discipline | Satisfied | Minimal change, no speculative abstractions |
+| Document why, not what | Satisfied | Guard comment explains invariant |
+| Type safety as first line of defense | Satisfied | `!== undefined` check, typed optional field |
+| Immutability by default | Tension (pre-existing) | Shared mutable map; not introduced by this fix |

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -845,10 +845,14 @@ export class TriggerRouter {
    * @returns The workflowId that was dispatched.
    */
   dispatch(workflowTrigger: WorkflowTrigger): string {
-    // Deduplicate: if the same goal+workspace was dispatched within 30s, skip.
-    // WHY same map and pattern as route() and dispatchAdaptivePipeline():
-    // cross-path dedup is intentional -- a dispatch via any path sets the key.
-    {
+    // Pre-allocated session: executeStartWorkflow already created the session in the store.
+    // Deduplication must not apply here -- dropping this dispatch would zombie the session.
+    // The presence of _preAllocatedStartResponse is authoritative evidence that the caller
+    // explicitly intends to start this session. Skip the dedup block entirely.
+    if (workflowTrigger._preAllocatedStartResponse === undefined) {
+      // Deduplicate: if the same goal+workspace was dispatched within 30s, skip.
+      // WHY same map and pattern as route() and dispatchAdaptivePipeline():
+      // cross-path dedup is intentional -- a dispatch via any path sets the key.
       const dedupeKey = `${workflowTrigger.goal}::${workflowTrigger.workspacePath}`;
       const now = Date.now();
       // Cleanup-on-entry: purge stale entries before checking/inserting.
@@ -863,6 +867,8 @@ export class TriggerRouter {
         return workflowTrigger.workflowId;
       }
       this._recentAdaptiveDispatches.set(dedupeKey, now);
+    } else {
+      console.log(`[TriggerRouter] Pre-allocated session dispatched: workflowId=${workflowTrigger.workflowId} goal="${workflowTrigger.goal.slice(0, 60)}"`);
     }
 
     void this.queue.enqueue(workflowTrigger.workflowId, async () => {

--- a/tests/unit/trigger-router.test.ts
+++ b/tests/unit/trigger-router.test.ts
@@ -1882,3 +1882,150 @@ describe('TriggerRouter.dispatchAdaptivePipeline deduplication', () => {
     logSpy.mockRestore();
   });
 });
+
+// ---------------------------------------------------------------------------
+// TriggerRouter.dispatch: _preAllocatedStartResponse dedup bypass
+//
+// Verifies that dispatch() with _preAllocatedStartResponse set bypasses the
+// 30s dedup window and calls runWorkflowFn, even when the same goal+workspace
+// was recently dispatched via dispatchAdaptivePipeline().
+//
+// This is the regression guard for the zombie-session bug:
+// dispatchAdaptivePipeline() primes _recentAdaptiveDispatches with the same
+// goal::workspace key. Without the bypass, dispatch() returns early and the
+// pre-allocated session zombies in the store forever.
+// ---------------------------------------------------------------------------
+
+describe('TriggerRouter.dispatch _preAllocatedStartResponse bypass', () => {
+  /**
+   * Minimal fake AdaptiveCoordinatorDeps for priming the dedup map via
+   * dispatchAdaptivePipeline(). Only the fields called before executor dispatch
+   * need to be present. All others are cast.
+   */
+  const FAKE_DEPS_FOR_BYPASS = {
+    now: () => Date.now(),
+    nowIso: () => new Date().toISOString(),
+    writeFile: async () => {},
+    mkdir: async () => undefined,
+    stderr: () => {},
+    port: 0,
+    // fileExists: required by routeTask() for pitch.md detection (Rule 3).
+    // Returns false so routeTask() falls through to FULL mode.
+    fileExists: () => false,
+  } as unknown as AdaptiveCoordinatorDeps;
+
+  function makeFakeModeExecutorsForBypass(): ModeExecutors {
+    const outcome: PipelineOutcome = { kind: 'merged', prUrl: null };
+    const executor = async () => outcome;
+    return {
+      runQuickReview: executor,
+      runReviewOnly: executor,
+      runImplement: executor,
+      runFull: executor,
+    };
+  }
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('dispatch() with _preAllocatedStartResponse bypasses dedup and calls runWorkflowFn', async () => {
+    // WHY: proves the fix for the zombie-session bug. The dedup map contains goal::workspace
+    // from a prior dispatch. dispatch() with _preAllocatedStartResponse must bypass the dedup
+    // check and call runWorkflowFn. Without the fix, runWorkflowFn is never called (dedup fires)
+    // and the pre-allocated session zombies in the store.
+    //
+    // Scenario:
+    // 1. First dispatch() (no preAlloc) -- primes _recentAdaptiveDispatches['goal::workspace']
+    // 2. Second dispatch() (with preAlloc) -- must bypass dedup and call runWorkflowFn
+    //
+    // NOTE: We prime the dedup map via dispatch() rather than dispatchAdaptivePipeline()
+    // to avoid async complexity with fake timers. The bug fires whenever the map has the key,
+    // regardless of how it was set. Real timers are used so the queue drains normally.
+    const { fn, calls } = makeFakeRunWorkflow();
+    const trigger = makeTrigger();
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn);
+
+    const goal = trigger.goal;
+    const workspace = trigger.workspacePath;
+
+    // Step 1: First dispatch (no preAlloc) -- primes the dedup map AND calls runWorkflowFn (1st call)
+    router.dispatch({ workflowId: trigger.workflowId, goal, workspacePath: workspace, context: {} });
+
+    // Step 2: Second dispatch WITH _preAllocatedStartResponse -- must bypass dedup (2nd call)
+    router.dispatch({
+      workflowId: trigger.workflowId,
+      goal,
+      workspacePath: workspace,
+      context: {},
+      _preAllocatedStartResponse: {} as Parameters<typeof router.dispatch>[0]['_preAllocatedStartResponse'],
+    });
+
+    // Wait for the async queue to drain
+    await new Promise<void>((r) => setTimeout(r, 20));
+
+    // Both dispatches must have reached runWorkflowFn:
+    // - dispatch 1 (no preAlloc, first in window): primed map, called runWorkflowFn
+    // - dispatch 2 (with preAlloc): bypassed dedup map, called runWorkflowFn
+    // Total: exactly 2 calls
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.goal).toBe(goal);
+    expect(calls[1]?.goal).toBe(goal);
+  });
+
+  it('dispatch() WITHOUT _preAllocatedStartResponse still deduplicates within 30s after dispatchAdaptivePipeline', async () => {
+    // WHY: regression guard -- proves the dedup check still fires for normal dispatch()
+    // calls (without _preAllocatedStartResponse) after dispatchAdaptivePipeline() primes
+    // the map. This ensures the bypass only applies to pre-allocated sessions.
+    vi.useFakeTimers();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { fn, calls } = makeFakeRunWorkflow();
+    const trigger = makeTrigger();
+    const executors = makeFakeModeExecutorsForBypass();
+
+    const router = new TriggerRouter(
+      makeIndex(trigger),
+      FAKE_CTX,
+      FAKE_API_KEY,
+      fn,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      FAKE_DEPS_FOR_BYPASS,
+      executors,
+    );
+
+    const goal = trigger.goal;
+    const workspace = trigger.workspacePath;
+
+    // Prime the dedup map
+    await router.dispatchAdaptivePipeline(goal, workspace);
+
+    // Advance by 10s (within 30s TTL)
+    vi.advanceTimersByTime(10_000);
+
+    // dispatch() WITHOUT _preAllocatedStartResponse -- dedup must fire
+    router.dispatch({
+      workflowId: trigger.workflowId,
+      goal,
+      workspacePath: workspace,
+      context: {},
+      // no _preAllocatedStartResponse
+    });
+
+    await Promise.resolve();
+
+    // runWorkflowFn must NOT have been called (dedup blocked the dispatch)
+    expect(calls).toHaveLength(0);
+
+    // Skip log must have been emitted
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping duplicate dispatch'),
+    );
+
+    logSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes a zombie-session bug where `dispatch()` dedup guard silently drops calls from `spawnSession()`, leaving pre-allocated sessions stuck in the store with no agent loop running
- When `_preAllocatedStartResponse` is present on a `WorkflowTrigger`, the 30s deduplication check in `dispatch()` is now bypassed; the session was already created by `executeStartWorkflow` and must start
- Adds two unit tests: the bypass case (regression guard for the fix) and a non-bypass dedup regression test

## Root Cause

`dispatchAdaptivePipeline()` writes `goal::workspacePath` to `_recentAdaptiveDispatches` at t=0. Milliseconds later, `spawnSession()` calls `dispatch()` with the same key. The dedup guard fires, `queue.enqueue()` is never called, and the session zombies.

## Fix

In `dispatch()`, the dedup block is now wrapped in `if (workflowTrigger._preAllocatedStartResponse === undefined)`. Pre-allocated sessions bypass the check and reach `queue.enqueue()` directly. Normal dispatch calls are unaffected.

## Test plan

- [x] `npm run build` -- clean
- [x] `npx vitest run tests/unit/trigger-router.test.ts` -- all 62 tests pass (2 new)
- [x] `npx vitest run` -- no regressions (1 flaky port-binding test in standalone-console is pre-existing)
- [ ] After merge: `npm run build && node dist/cli-worktrain.js daemon --install`
- [ ] Force poll: `node dist/cli-worktrain.js trigger poll self-improvement`
- [ ] Verify `session_started` in event log within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)