### PR TITLE
fix(engine): add size-capped rotation for queue-poll.jsonl at 10 MB

### DIFF
--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -682,7 +682,7 @@ program
   .action(async (options: { follow?: boolean; session?: string }) => {
     const eventsDir = path.join(os.homedir(), '.workrail', 'events', 'daemon');
 
-    // WHY constants: queue-poll and stderr are permanent files that never rotate.
+    // WHY constants: queue-poll uses size-based rotation (not date-based); stderr does not rotate.
     // Only the daemon event file uses todayFilePath() to handle midnight rotation.
     const queuePollPath = path.join(os.homedir(), '.workrail', 'queue-poll.jsonl');
     const stderrPath = path.join(os.homedir(), '.workrail', 'logs', 'daemon.stderr.log');
@@ -889,8 +889,8 @@ program
     }
 
     // Poll every 500ms for new lines from all three sources.
-    // WHY midnight rotation only on daemon file: queue-poll.jsonl and daemon.stderr.log
-    // are permanent files -- they do not rotate at midnight.
+    // WHY midnight rotation only on daemon file: queue-poll.jsonl uses size-based rotation
+    // (handled below with shrink detection); daemon.stderr.log does not rotate.
     // eslint-disable-next-line no-constant-condition
     while (true) {
       await new Promise<void>((resolve) => setTimeout(resolve, 500));
@@ -911,7 +911,18 @@ program
         offset = daemonPoll.newOffset;
       }
 
-      // Queue poll file (permanent path, no rotation).
+      // Queue poll file: size-based rotation. Detect shrinkage (file was rotated)
+      // and reset offset to read from the beginning of the new file. Without this,
+      // the stale offset causes readNewLines to see size <= offset and permanently
+      // stop yielding new events after a rotation.
+      try {
+        const queueStat = fs.statSync(queuePollPath);
+        if (queueStat.size < queuePollOffset) {
+          queuePollOffset = 0; // File was rotated; read from the new file's start.
+        }
+      } catch {
+        // File does not exist yet -- nothing to reset.
+      }
       const queuePoll = readNewLines(queuePollPath, queuePollOffset);
       if (queuePoll !== null && queuePoll.lines.length > 0) {
         printQueuePollLines(queuePoll.lines);

--- a/src/trigger/polling-scheduler.ts
+++ b/src/trigger/polling-scheduler.ts
@@ -875,9 +875,30 @@ async function countActiveSessions(sessionsDir: string): Promise<number> {
   }
 }
 
+/**
+ * Maximum size of queue-poll.jsonl before rotation.
+ * When the file reaches this size, it is renamed to queue-poll.jsonl.1
+ * (overwriting any existing backup) and a fresh log file is started.
+ * WHY 10 MB: conservative cap holding ~5 weeks of history at 5-minute polling intervals.
+ */
+const MAX_QUEUE_POLL_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
 async function appendQueuePollLog(entry: Record<string, unknown>): Promise<void> {
   const logPath = path.join(os.homedir(), '.workrail', 'queue-poll.jsonl');
   try {
+    try {
+      const stat = await fs.stat(logPath);
+      if (stat.size >= MAX_QUEUE_POLL_FILE_SIZE) {
+        // Rotate: rename current log to .1 (overwrites any existing backup),
+        // then let the appendFile below create a fresh log file.
+        await fs.rename(logPath, logPath + '.1');
+      }
+    } catch {
+      // File does not exist yet or stat/rename failed -- proceed to append.
+      // On ENOENT: appendFile will create the file. On other errors: log entry
+      // will still be written to the existing (potentially oversized) file,
+      // and console.warn is emitted by the outer catch if appendFile itself fails.
+    }
     await fs.appendFile(logPath, JSON.stringify(entry) + '\n', 'utf8');
   } catch (e) {
     console.warn(`[QueuePoll] Failed to write queue-poll.jsonl: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/trigger/polling-scheduler.ts
+++ b/src/trigger/polling-scheduler.ts
@@ -883,6 +883,8 @@ async function countActiveSessions(sessionsDir: string): Promise<number> {
  */
 const MAX_QUEUE_POLL_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
+// NOTE: rotation path not covered by unit tests -- mocking os.homedir() requires
+// test infrastructure changes not currently in place.
 async function appendQueuePollLog(entry: Record<string, unknown>): Promise<void> {
   const logPath = path.join(os.homedir(), '.workrail', 'queue-poll.jsonl');
   try {


### PR DESCRIPTION
## Summary

`queue-poll.jsonl` was never rotated, growing indefinitely (~8.7 MB/month at 5-min polling intervals). This PR adds size-capped rotation at 10 MB and fixes the `worktrain logs --follow` reader to handle rotation correctly.

## Changes

- **`src/trigger/polling-scheduler.ts`**: `appendQueuePollLog()` now stats the file before each append; if size >= 10 MB, renames to `queue-poll.jsonl.1` (overwriting any existing backup), then appends to the new empty file. Fire-and-forget, errors swallowed.
- **`src/cli-worktrain.ts`**: Added shrink detection in the `--follow` poll loop -- if current file size < tracked offset, reset offset to 0. Also updated two stale "permanent file that never rotates" comments.

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` passes (14 pre-existing failures in workflow-runner-load-session-notes.test.ts, 5 in polling-scheduler.test.ts -- both pre-existing on main)
- [ ] `queue-poll.jsonl` never exceeds ~10 MB + one write cycle
- [ ] `queue-poll.jsonl.1` exists after first rotation
- [ ] `worktrain logs --follow` continues showing events after rotation