### PR TITLE
fix(engine): remove WorkTrain-owned GitHub label writes and reads

### DIFF
--- a/src/cli/commands/worktrain-trigger-test.ts
+++ b/src/cli/commands/worktrain-trigger-test.ts
@@ -215,18 +215,6 @@ export async function executeWorktrainTriggerTestCommand(
       continue;
     }
 
-    // H3: worktrain:in-progress label (active/skip -- not a maturity level)
-    if (issueLabels.includes('worktrain:in-progress')) {
-      decisions.push({ kind: 'skip', issue, reason: 'active_session_or_in_progress' });
-      continue;
-    }
-
-    // H3: session ID pattern in body (active/skip)
-    if (/sess_[a-z0-9]+/.test(issue.body)) {
-      decisions.push({ kind: 'skip', issue, reason: 'active_session_or_in_progress' });
-      continue;
-    }
-
     // Per-issue idempotency check (conservative: any parse error = active)
     const idempotencyStatus = await deps.checkIdempotency(issue.number);
     if (idempotencyStatus === 'active') {

--- a/src/trigger/delivery-action.ts
+++ b/src/trigger/delivery-action.ts
@@ -742,43 +742,6 @@ export async function runDelivery(
   // Extract PR URL from gh output (typically the last line)
   const prUrl = prStdout.trim().split('\n').at(-1)?.trim() ?? '';
 
-  // Add worktrain:generated label to the PR.
-  //
-  // WHY non-fatal: label creation is best-effort. If gh label create or gh pr edit fails
-  // (permissions, network, API error), the PR was already opened successfully. Failing the
-  // entire delivery for a missing label would be a worse outcome than missing the label.
-  //
-  // WHY two calls (label create then pr edit): gh pr create --label requires the label to
-  // already exist. Creating it first is idempotent (2>/dev/null || true equivalent via
-  // try/catch). Then pr edit adds it to the specific PR by URL.
-  //
-  // WHY if (prUrl): gh pr edit requires a valid PR URL or number. If gh pr create returned
-  // empty output, prUrl is '' and gh pr edit would fail with an unhelpful error.
-  if (prUrl) {
-    try {
-      await execFn(
-        'gh',
-        ['label', 'create', 'worktrain:generated', '--description', 'PR authored by WorkTrain', '--color', '0075ca'],
-        { cwd: workspacePath, timeout: DELIVERY_TIMEOUT_MS },
-      );
-    } catch {
-      // Label may already exist -- ignore the error and proceed to gh pr edit.
-    }
-    try {
-      await execFn(
-        'gh',
-        ['pr', 'edit', prUrl, '--add-label', 'worktrain:generated'],
-        { cwd: workspacePath, timeout: DELIVERY_TIMEOUT_MS },
-      );
-    } catch (e: unknown) {
-      // Non-fatal: log the failure so operators can investigate, but do not change the result.
-      console.warn(
-        `[runDelivery] WARNING: Failed to add worktrain:generated label to PR ${prUrl}: ` +
-        `${e instanceof Error ? e.message : String(e)}`,
-      );
-    }
-  }
-
   return { _tag: 'pr_opened', url: prUrl };
 }
 

--- a/src/trigger/polling-scheduler.ts
+++ b/src/trigger/polling-scheduler.ts
@@ -503,12 +503,6 @@ export class PollingScheduler {
       const excludedLabel = queueConfig.excludeLabels.find((el) => issueLabels.includes(el));
       if (excludedLabel) { skipped.push({ issue, reason: `excluded_label: ${excludedLabel}` }); continue; }
 
-      // H3: worktrain:in-progress label (active/skip -- not a maturity level)
-      if (issueLabels.includes('worktrain:in-progress')) { skipped.push({ issue, reason: 'active_session_or_in_progress' }); continue; }
-
-      // H3: session ID pattern in body (active/skip)
-      if (/sess_[a-z0-9]+/.test(issue.body)) { skipped.push({ issue, reason: 'active_session_or_in_progress' }); continue; }
-
       // Fast in-memory idempotency check (I3: runs before sidecar scan).
       // Guards against duplicate dispatch within a single process lifetime for issues
       // whose dispatchAdaptivePipeline() Promise is still in flight.
@@ -620,9 +614,6 @@ export class PollingScheduler {
 
     // Capture the Promise without awaiting it (fire-and-forget semantics preserved).
     // I2: Cleanup in BOTH .then() and .catch() -- unconditional regardless of outcome.
-    // WHY Promise<PipelineOutcome> (not Promise<unknown>): the outcome is inspected
-    // to apply worktrain:in-progress label on escalation/dry_run, preventing re-selection.
-    // Without this type, the outcome is silently discarded (discovery-loop-fix, RC2).
     const dispatchP = (this.router as {
       dispatchAdaptivePipeline: (
         goal: string,
@@ -636,15 +627,9 @@ export class PollingScheduler {
     );
     const issueNumber = top.issue.number;
     void dispatchP
-      .then((outcome: PipelineOutcome) => {
+      .then(() => {
         this.dispatchingIssues.delete(issueNumber);
         console.log(`[QueuePoll] in-flight-clear #${issueNumber} reason=completed`);
-        // Apply worktrain:in-progress label on escalation or dry_run to prevent re-selection.
-        // WHY worktrain:in-progress (not a new label): already in excludeLabels (line 505).
-        // A new label has zero effect unless the user also adds it to queueConfig.excludeLabels.
-        if (outcome.kind === 'escalated' || outcome.kind === 'dry_run') {
-          void this.applyGitHubLabel(issueNumber, 'worktrain:in-progress', queueConfig.token, source.repo);
-        }
         // Delete sidecar on completion (pipeline resolved).
         void fs.unlink(sidecarPath).catch(() => {});
       })
@@ -667,45 +652,6 @@ export class PollingScheduler {
     await appendQueuePollLog({ event: 'poll_cycle_complete', selected: 1, skipped: skipped.length + candidates.length - 1, elapsed, ts: new Date().toISOString() });
   }
 
-  /**
-   * Apply a label to a GitHub issue via the GitHub API.
-   *
-   * Non-fatal: logs warn and returns on any error. Does not throw.
-   * WHY non-fatal: label application is a best-effort operation. The primary loop-prevention
-   * mechanism is the in-memory dispatchingIssues set and the existing excludeLabels check.
-   * A label failure should not disrupt the poll cycle or lose the pipeline outcome.
-   *
-   * Uses the injected fetchFn if available (for testing), falls back to globalThis.fetch.
-   */
-  private async applyGitHubLabel(
-    issueNumber: number,
-    label: string,
-    token: string,
-    repo: string,
-  ): Promise<void> {
-    const fetchFn = (this.fetchFn as QueueFetchFn | undefined) ?? globalThis.fetch;
-    const url = `https://api.github.com/repos/${repo}/issues/${issueNumber}/labels`;
-    try {
-      const response = await fetchFn(url, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Accept': 'application/vnd.github+json',
-          'Content-Type': 'application/json',
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
-        body: JSON.stringify({ labels: [label] }),
-      });
-      if (!response.ok) {
-        const text = await response.text().catch(() => '');
-        console.warn(`[QueuePoll] Failed to apply label '${label}' to issue #${issueNumber}: HTTP ${response.status} ${text.slice(0, 200)}`);
-      } else {
-        console.log(`[QueuePoll] Applied label '${label}' to issue #${issueNumber}`);
-      }
-    } catch (e: unknown) {
-      console.warn(`[QueuePoll] Failed to apply label '${label}' to issue #${issueNumber}: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/delivery-action.test.ts
+++ b/tests/unit/delivery-action.test.ts
@@ -281,13 +281,11 @@ describe('runDelivery', () => {
 
   describe('commit + PR (autoOpenPR: true)', () => {
     it('runs git add, git commit, then gh pr create with --body-file and returns pr_opened', async () => {
-      // 5 calls: git add, git commit, gh pr create, gh label create, gh pr edit
+      // 3 calls: git add, git commit, gh pr create
       const exec = vi.fn()
         .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
         .mockResolvedValueOnce({ stdout: '[main abc5678] feat(mcp): auto-commit\n 2 files changed', stderr: '' }) // git commit
-        .mockResolvedValueOnce({ stdout: 'https://github.com/owner/repo/pull/42\n', stderr: '' }) // gh pr create
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh label create
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) as ExecFn; // gh pr edit
+        .mockResolvedValueOnce({ stdout: 'https://github.com/owner/repo/pull/42\n', stderr: '' }) as ExecFn; // gh pr create
 
       const result = await runDelivery(
         makeArtifact(),
@@ -300,7 +298,7 @@ describe('runDelivery', () => {
         expect(result.url).toBe('https://github.com/owner/repo/pull/42');
       }
 
-      expect(exec).toHaveBeenCalledTimes(5);
+      expect(exec).toHaveBeenCalledTimes(3);
 
       const [prFile, prArgs] = (exec as ReturnType<typeof vi.fn>).mock.calls[2] as [string, string[]];
       expect(prFile).toBe('gh');
@@ -343,9 +341,7 @@ describe('runDelivery', () => {
       const exec = vi.fn()
         .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
         .mockResolvedValueOnce({ stdout: '[main abc1234] feat(mcp): auto-commit', stderr: '' }) // git commit
-        .mockResolvedValueOnce({ stdout: 'https://github.com/owner/repo/pull/1\n', stderr: '' }) // gh pr create
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh label create
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) as ExecFn; // gh pr edit
+        .mockResolvedValueOnce({ stdout: 'https://github.com/owner/repo/pull/1\n', stderr: '' }) as ExecFn; // gh pr create
 
       await runDelivery(
         makeArtifact({ prTitle: 'feat(mcp): add auto-commit support' }),
@@ -362,9 +358,7 @@ describe('runDelivery', () => {
       const exec = vi.fn()
         .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
         .mockResolvedValueOnce({ stdout: '[main abc1234] feat(mcp): auto-commit', stderr: '' }) // git commit
-        .mockResolvedValueOnce({ stdout: 'https://github.com/owner/repo/pull/1\n', stderr: '' }) // gh pr create
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh label create
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) as ExecFn; // gh pr edit
+        .mockResolvedValueOnce({ stdout: 'https://github.com/owner/repo/pull/1\n', stderr: '' }) as ExecFn; // gh pr create
 
       await runDelivery(
         makeArtifact({ prTitle: '[WT] feat(mcp): add auto-commit support' }),
@@ -425,73 +419,6 @@ describe('runDelivery', () => {
     });
   });
 
-  describe('gh pr edit --add-label called after PR creation', () => {
-    it('calls gh label create then gh pr edit with the PR URL after successful pr create', async () => {
-      const prUrl = 'https://github.com/owner/repo/pull/99';
-      const exec = vi.fn()
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
-        .mockResolvedValueOnce({ stdout: '[main abc1234] feat(mcp): auto-commit', stderr: '' }) // git commit
-        .mockResolvedValueOnce({ stdout: `${prUrl}\n`, stderr: '' }) // gh pr create
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh label create
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) as ExecFn; // gh pr edit
-
-      await runDelivery(
-        makeArtifact(),
-        '/workspace',
-        makeFlags({ autoCommit: true, autoOpenPR: true }),
-        exec,
-      );
-
-      const [labelFile, labelArgs] = (exec as ReturnType<typeof vi.fn>).mock.calls[3] as [string, string[]];
-      expect(labelFile).toBe('gh');
-      expect(labelArgs[0]).toBe('label');
-      expect(labelArgs[1]).toBe('create');
-      expect(labelArgs[2]).toBe('worktrain:generated');
-
-      const [editFile, editArgs] = (exec as ReturnType<typeof vi.fn>).mock.calls[4] as [string, string[]];
-      expect(editFile).toBe('gh');
-      expect(editArgs[0]).toBe('pr');
-      expect(editArgs[1]).toBe('edit');
-      expect(editArgs[2]).toBe(prUrl);
-      expect(editArgs[3]).toBe('--add-label');
-      expect(editArgs[4]).toBe('worktrain:generated');
-    });
-
-    it('does not call gh pr edit when prUrl is empty', async () => {
-      const exec = vi.fn()
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
-        .mockResolvedValueOnce({ stdout: '[main abc1234] feat(mcp): auto-commit', stderr: '' }) // git commit
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) as ExecFn; // gh pr create (empty output)
-
-      await runDelivery(
-        makeArtifact(),
-        '/workspace',
-        makeFlags({ autoCommit: true, autoOpenPR: true }),
-        exec,
-      );
-
-      expect(exec).toHaveBeenCalledTimes(3);
-    });
-
-    it('label failure is non-fatal -- still returns pr_opened', async () => {
-      const exec = vi.fn()
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
-        .mockResolvedValueOnce({ stdout: '[main abc1234] feat(mcp): auto-commit', stderr: '' }) // git commit
-        .mockResolvedValueOnce({ stdout: 'https://github.com/owner/repo/pull/1\n', stderr: '' }) // gh pr create
-        .mockRejectedValueOnce(new Error('gh: label already exists')) // gh label create (fails)
-        .mockRejectedValueOnce(new Error('gh: permission denied')) as ExecFn; // gh pr edit (fails)
-
-      const result = await runDelivery(
-        makeArtifact(),
-        '/workspace',
-        makeFlags({ autoCommit: true, autoOpenPR: true }),
-        exec,
-      );
-
-      expect(result._tag).toBe('pr_opened');
-    });
-  });
-
   describe('per-command identity (botIdentity)', () => {
     it('passes -c user.name and -c user.email flags to git commit when botIdentity is set', async () => {
       const exec = vi.fn()
@@ -545,9 +472,7 @@ describe('runDelivery', () => {
       const exec = vi.fn()
         .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git add
         .mockResolvedValueOnce({ stdout: '[main abc1234] feat(mcp): auto-commit', stderr: '' }) // git commit
-        .mockResolvedValueOnce({ stdout: 'https://github.com/owner/repo/pull/1\n', stderr: '' }) // gh pr create
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh label create
-        .mockResolvedValueOnce({ stdout: '', stderr: '' }) as ExecFn; // gh pr edit
+        .mockResolvedValueOnce({ stdout: 'https://github.com/owner/repo/pull/1\n', stderr: '' }) as ExecFn; // gh pr create
 
       await runDelivery(
         makeArtifact(),

--- a/tests/unit/discovery-loop-fix.test.ts
+++ b/tests/unit/discovery-loop-fix.test.ts
@@ -3,8 +3,7 @@
  *
  * Covers:
  * - Fix 1: spawnSession forwards agentConfig.maxSessionMinutes to routerRef.dispatch()
- * - Fix 2: On PipelineOutcome.kind === 'escalated', applyGitHubLabel is called with worktrain:in-progress
- * - Fix 2: On PipelineOutcome.kind === 'merged', no label is applied
+ * - Fix 2: No GitHub label is applied regardless of PipelineOutcome kind (label writes removed)
  * - Fix 3: Issue-ownership sidecar is written before dispatch and deleted on completion
  * - Fix 3: Expired sidecar returns 'clear' from checkIdempotency
  */
@@ -181,10 +180,10 @@ describe('Fix 1: agentConfig.maxSessionMinutes threads through to dispatch', () 
 });
 
 // ---------------------------------------------------------------------------
-// Fix 2: PipelineOutcome inspection and label application
+// Fix 2: No label writes on any PipelineOutcome
 // ---------------------------------------------------------------------------
 
-describe('Fix 2: applyGitHubLabel called on escalated/dry_run outcome', () => {
+describe('Fix 2: no GitHub label is applied for any pipeline outcome', () => {
   beforeEach(async () => {
     // Clean up any sidecar files that may have been written to the real sessions dir
     // by a previous test (sidecar is written to ~/.workrail/daemon-sessions/).
@@ -201,11 +200,11 @@ describe('Fix 2: applyGitHubLabel called on escalated/dry_run outcome', () => {
     vi.clearAllMocks();
   });
 
-  it('applies worktrain:in-progress label when outcome is escalated', async () => {
+  it('does NOT apply any label when outcome is escalated', async () => {
     const tmpDir = await makeTmpDir();
     const store = new PolledEventStore({ WORKRAIL_HOME: tmpDir });
 
-    // Capture label API calls
+    // Capture any label API calls (there should be none)
     const labelCalls: Array<{ url: string; body: string }> = [];
     const fetchFn: QueueFetchFn = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
       if (typeof url === 'string' && url.includes('/labels')) {
@@ -231,20 +230,16 @@ describe('Fix 2: applyGitHubLabel called on escalated/dry_run outcome', () => {
 
     await (scheduler as unknown as { doPoll(t: TriggerDefinition): Promise<void> }).doPoll(trigger);
 
-    // Drain microtasks so .then() handler fires (which calls applyGitHubLabel)
+    // Drain microtasks so .then() handler fires
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
-
-    // Wait a tick for the label API call to complete
     await new Promise(resolve => setTimeout(resolve, 10));
 
-    expect(labelCalls).toHaveLength(1);
-    expect(labelCalls[0]?.url).toContain('/repos/acme/my-project/issues/393/labels');
-    expect(labelCalls[0]?.body).toContain('worktrain:in-progress');
+    expect(labelCalls).toHaveLength(0);
   });
 
-  it('applies worktrain:in-progress label when outcome is dry_run', async () => {
+  it('does NOT apply any label when outcome is dry_run', async () => {
     const tmpDir = await makeTmpDir();
     const store = new PolledEventStore({ WORKRAIL_HOME: tmpDir });
 
@@ -273,11 +268,10 @@ describe('Fix 2: applyGitHubLabel called on escalated/dry_run outcome', () => {
     await Promise.resolve();
     await new Promise(resolve => setTimeout(resolve, 10));
 
-    expect(labelCalls).toHaveLength(1);
-    expect(labelCalls[0]?.body).toContain('worktrain:in-progress');
+    expect(labelCalls).toHaveLength(0);
   });
 
-  it('does NOT apply label when outcome is merged', async () => {
+  it('does NOT apply any label when outcome is merged', async () => {
     const tmpDir = await makeTmpDir();
     const store = new PolledEventStore({ WORKRAIL_HOME: tmpDir });
 
@@ -306,9 +300,7 @@ describe('Fix 2: applyGitHubLabel called on escalated/dry_run outcome', () => {
     await Promise.resolve();
     await new Promise(resolve => setTimeout(resolve, 10));
 
-    // No label calls for merged outcome
-    const labelApiCalls = labelCalls.filter(c => c.url.includes('/labels'));
-    expect(labelApiCalls).toHaveLength(0);
+    expect(labelCalls).toHaveLength(0);
   });
 });
 

--- a/tests/unit/github-queue-poller.test.ts
+++ b/tests/unit/github-queue-poller.test.ts
@@ -15,7 +15,7 @@
  * - Maturity H2: checklist items -> 'specced'
  * - Maturity H2: acceptance criteria heading -> 'specced'
  * - Maturity default: plain body -> 'idea'
- * - H3 exclusion: worktrain:in-progress label (in scheduler, not inferMaturity)
+ * - H3 exclusion: worktrain:in-progress label check removed (PR #765)
  * - Rate limit skip: X-RateLimit-Remaining < 100 -> ok([])
  */
 


### PR DESCRIPTION
## Summary

- Removes `worktrain:in-progress` skip check and `sess_` body regex from `polling-scheduler.ts` and `worktrain-trigger-test.ts` -- WorkTrain no longer reads GitHub labels to decide whether to skip an issue
- Removes `applyGitHubLabel()` method and its call on escalated/dry_run pipeline outcomes -- WorkTrain no longer writes labels to issues it picks up
- Removes `worktrain:generated` label creation and application from `delivery-action.ts` -- WorkTrain no longer writes labels to PRs it creates
- Updates `discovery-loop-fix.test.ts` Fix 2 tests to assert no label calls occur (was: assert label IS called on escalated/dry_run)
- Updates `delivery-action.test.ts` to remove the label assertion block and fix mock exec call counts

WorkTrain already has three internal mechanisms that handle deduplication correctly: sidecar files (`queue-issue-<N>.json`), the in-memory `dispatchingIssues` Set, and the session file scan via `checkIdempotency()`. The labels added external mutable state that WorkTrain does not reliably own. A crash between label write and cleanup left issues permanently blocked -- issue #393 was stuck for days because of this pattern.

**Migration note for existing labeled issues:** Issues currently labeled `worktrain:in-progress` on GitHub are unaffected. After this change, the read path is gone, so those issues are dispatched normally without any manual label removal.

**Observability note:** `worktrain:generated` PRs are still identifiable by branch name pattern (`worktrain/issue-N`) and the `[WT]` title prefix. The `Worktrain-Session` and `Co-authored-by` commit trailers are preserved.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run tests/unit/discovery-loop-fix.test.ts tests/unit/delivery-action.test.ts` passes (32 tests)
- [x] `grep -r 'applyGitHubLabel' src/` returns no results
- [x] `grep -r 'worktrain:in-progress' src/` returns no results
- [x] `grep -r 'worktrain:generated' src/` returns no results
- [x] `grep -r 'sess_\[a-z0-9\]' src/` returns no results
- [x] Pre-existing failures in `workflow-runner-load-session-notes.test.ts` confirmed to exist on main before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)