### PR TITLE
feat(schema): add run_completed event emitted on successful session completion

### DIFF
--- a/src/mcp/handlers/v2-advance-core/outcome-success.ts
+++ b/src/mcp/handlers/v2-advance-core/outcome-success.ts
@@ -3,7 +3,40 @@
  * Handles the path when an advance succeeds (not blocked).
  */
 
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { ResultAsync as RA, errAsync as neErrorAsync } from 'neverthrow';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Read a string observation value from the session event log.
+ * Returns null if no matching observation_recorded event is found.
+ */
+function readObservation(events: readonly import('../../../v2/durable-core/schemas/session/index.js').DomainEventV1[], key: string): string | null {
+  for (const e of events) {
+    if (e.kind !== 'observation_recorded') continue;
+    const d = e.data as Record<string, unknown>;
+    if (d['key'] !== key) continue;
+    const val = d['value'] as Record<string, unknown> | undefined;
+    if (val && typeof val['value'] === 'string') return val['value'];
+  }
+  return null;
+}
+
+/**
+ * Resolve endGitSha by running `git rev-parse HEAD` in repoRoot.
+ * Best-effort: returns null on any failure (git not found, not a git repo, timeout).
+ */
+async function resolveEndGitSha(repoRoot: string | null): Promise<string | null> {
+  if (!repoRoot) return null;
+  try {
+    const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repoRoot, timeout: 5000 });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
 import type { SessionIndex } from '../../../v2/durable-core/session-index.js';
 import type { ExecutionSnapshotFileV1 } from '../../../v2/durable-core/schemas/execution-snapshot/index.js';
 import type { SessionId, RunId, NodeId, WorkflowHash } from '../../../v2/durable-core/ids/index.js';
@@ -28,6 +61,7 @@ import {
   buildContextSetEvent,
   buildSuccessValidationEvent,
   buildDecisionTraceEvent,
+  buildRunCompletedEvent,
 } from '../v2-advance-events.js';
 import type { AdvanceMode, AdvanceContext, ComputedAdvanceResults, AdvanceCorePorts } from './index.js';
 import type { ValidatedAdvanceInputs } from './input-validation.js';
@@ -225,6 +259,59 @@ export function buildSuccessOutcome(args: {
     }
 
     const outputsToAppend = [...notesOutputs, ...artifactOutputsRes.value];
+
+    // Emit run_completed when the session finishes successfully.
+    // WHY here (inside andThen): newEngineState is available, and async git I/O is
+    // safe inside a ResultAsync chain. resolveEndGitSha is best-effort (never throws).
+    if (newEngineState.kind === 'complete') {
+      const repoRoot = readObservation(truth.events, 'repo_root');
+      const startGitSha = readObservation(truth.events, 'git_head_sha');
+      const gitBranch = readObservation(truth.events, 'git_branch');
+
+      // Extract agent-reported commit SHAs from the last context_set with metrics_commit_shas.
+      // WHY last: agents accumulate the full list on each step; the last value is authoritative.
+      let agentCommitShas: string[] = [];
+      for (const e of truth.events) {
+        if (e.kind !== 'context_set') continue;
+        const ctx = (e.data as Record<string, unknown>)['context'];
+        if (ctx && typeof ctx === 'object' && !Array.isArray(ctx)) {
+          const shas = (ctx as Record<string, unknown>)['metrics_commit_shas'];
+          if (Array.isArray(shas) && shas.every(s => typeof s === 'string')) {
+            agentCommitShas = shas as string[];
+          }
+        }
+      }
+
+      // durationMs: first event timestampMs to last event timestampMs.
+      const firstTs = truth.events[0]?.timestampMs;
+      const lastTs = truth.events[truth.events.length - 1]?.timestampMs;
+      const durationMs = (firstTs !== undefined && lastTs !== undefined) ? (lastTs - firstTs) : undefined;
+
+      return RA.fromPromise(
+        resolveEndGitSha(repoRoot),
+        (e) => ({ kind: 'advance_apply_failed' as const, message: String(e) }),
+      ).andThen((endGitSha) => {
+        const captureConfidence: 'high' | 'none' = agentCommitShas.length > 0 ? 'high' : 'none';
+        extraEventsToAppend.push(buildRunCompletedEvent({
+          sessionId: String(sessionId),
+          runId: String(runId),
+          startGitSha,
+          endGitSha,
+          gitBranch,
+          agentCommitShas,
+          captureConfidence,
+          durationMs,
+          idFactory,
+        }));
+        return buildAndAppendPlan({
+          kind: 'advanced',
+          truth, lockedIndex: args.lockedIndex, sessionId, runId, currentNodeId, attemptId, workflowHash,
+          extraEventsToAppend, toNodeKind: successNodeKind(mode),
+          snapshotRef: newSnapshotRef, outputsToAppend,
+          sessionStore, idFactory, lock,
+        });
+      });
+    }
 
     return buildAndAppendPlan({
       kind: 'advanced',

--- a/src/mcp/handlers/v2-advance-core/outcome-success.ts
+++ b/src/mcp/handlers/v2-advance-core/outcome-success.ts
@@ -6,37 +6,6 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { ResultAsync as RA, errAsync as neErrorAsync } from 'neverthrow';
-
-const execFileAsync = promisify(execFile);
-
-/**
- * Read a string observation value from the session event log.
- * Returns null if no matching observation_recorded event is found.
- */
-function readObservation(events: readonly import('../../../v2/durable-core/schemas/session/index.js').DomainEventV1[], key: string): string | null {
-  for (const e of events) {
-    if (e.kind !== 'observation_recorded') continue;
-    const d = e.data as Record<string, unknown>;
-    if (d['key'] !== key) continue;
-    const val = d['value'] as Record<string, unknown> | undefined;
-    if (val && typeof val['value'] === 'string') return val['value'];
-  }
-  return null;
-}
-
-/**
- * Resolve endGitSha by running `git rev-parse HEAD` in repoRoot.
- * Best-effort: returns null on any failure (git not found, not a git repo, timeout).
- */
-async function resolveEndGitSha(repoRoot: string | null): Promise<string | null> {
-  if (!repoRoot) return null;
-  try {
-    const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repoRoot, timeout: 5000 });
-    return stdout.trim() || null;
-  } catch {
-    return null;
-  }
-}
 import type { SessionIndex } from '../../../v2/durable-core/session-index.js';
 import type { ExecutionSnapshotFileV1 } from '../../../v2/durable-core/schemas/execution-snapshot/index.js';
 import type { SessionId, RunId, NodeId, WorkflowHash } from '../../../v2/durable-core/ids/index.js';
@@ -67,6 +36,41 @@ import type { AdvanceMode, AdvanceContext, ComputedAdvanceResults, AdvanceCorePo
 import type { ValidatedAdvanceInputs } from './input-validation.js';
 import { buildAndAppendPlan, buildNotesOutputs, buildArtifactOutputs } from './event-builders.js';
 import { buildAssessmentRecordedEvent } from '../../../v2/durable-core/domain/assessment-recorded-event-builder.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Read a string observation value from the session event log.
+ * Returns null if no matching observation_recorded event is found.
+ *
+ * WHY direct field access (no cast): after `e.kind === 'observation_recorded'` narrows
+ * the union, `e.data` is typed as the observation_recorded data shape. All four value
+ * types (`short_string`, `git_sha1`, `sha256`, `path`) have `.value: string`.
+ */
+function readObservation(events: readonly DomainEventV1[], key: string): string | null {
+  for (const e of events) {
+    if (e.kind !== 'observation_recorded') continue;
+    if (e.data.key !== key) continue;
+    return e.data.value.value;
+  }
+  return null;
+}
+
+/**
+ * Resolve endGitSha by running `git rev-parse HEAD` in repoRoot.
+ * Best-effort: returns null on any failure (git not found, not a git repo, timeout).
+ * WHY 2000ms timeout: sessions complete in the MCP response path; a slow git call
+ * should not add more than 2s of latency to session completion.
+ */
+async function resolveEndGitSha(repoRoot: string | null): Promise<string | null> {
+  if (!repoRoot) return null;
+  try {
+    const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repoRoot, timeout: 2000 });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
 
 type PartialEvent = Omit<DomainEventV1, 'eventIndex' | 'sessionId' | 'timestampMs'>;
 

--- a/src/mcp/handlers/v2-advance-events.ts
+++ b/src/mcp/handlers/v2-advance-events.ts
@@ -255,3 +255,32 @@ export function buildDecisionTraceEvent(args: {
     })
   );
 }
+
+export function buildRunCompletedEvent(args: {
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly startGitSha: string | null;
+  readonly endGitSha: string | null;
+  readonly gitBranch: string | null;
+  readonly agentCommitShas: string[];
+  readonly captureConfidence: 'high' | 'none';
+  readonly durationMs: number | undefined;
+  readonly idFactory: AdvanceCorePorts['idFactory'];
+}): PartialEvent {
+  const { sessionId, runId, startGitSha, endGitSha, gitBranch, agentCommitShas, captureConfidence, durationMs, idFactory } = args;
+  return partialEvent({
+    v: 1 as const,
+    eventId: idFactory.mintEventId(),
+    kind: EVENT_KIND.RUN_COMPLETED,
+    dedupeKey: `run-completed:${sessionId}:${runId}`,
+    scope: { runId },
+    data: {
+      startGitSha,
+      endGitSha,
+      gitBranch,
+      agentCommitShas,
+      captureConfidence,
+      ...(durationMs !== undefined ? { durationMs } : {}),
+    },
+  });
+}

--- a/src/v2/durable-core/constants.ts
+++ b/src/v2/durable-core/constants.ts
@@ -273,6 +273,7 @@ export const EVENT_KIND = {
   CONTEXT_SET: 'context_set',
   DIVERGENCE_RECORDED: 'divergence_recorded',
   DECISION_TRACE_APPENDED: 'decision_trace_appended',
+  RUN_COMPLETED: 'run_completed',
 } as const;
 
 export type EventKindV1 = typeof EVENT_KIND[keyof typeof EVENT_KIND];

--- a/src/v2/durable-core/schemas/session/events.ts
+++ b/src/v2/durable-core/schemas/session/events.ts
@@ -317,6 +317,22 @@ export const DomainEventV1Schema = z.discriminatedUnion('kind', [
         { message: `Decision trace total bytes exceeds ${MAX_DECISION_TRACE_TOTAL_BYTES}` }
       ),
   }),
+  DomainEventEnvelopeV1Schema.extend({
+    kind: z.literal('run_completed'),
+    scope: z.object({ runId: z.string().min(1) }),
+    data: z.object({
+      startGitSha: z.string().nullable(),
+      endGitSha: z.string().nullable(),
+      gitBranch: z.string().nullable(),
+      agentCommitShas: z.array(z.string()),
+      captureConfidence: z.enum(['high', 'none']),
+      durationMs: z.number().optional(),
+    }).superRefine((d, ctx) => {
+      if (d.captureConfidence === 'high' && d.agentCommitShas.length === 0) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "captureConfidence 'high' requires at least one agentCommitSha" });
+      }
+    }),
+  }),
 ]);
 
 export type DomainEventV1 = z.infer<typeof DomainEventV1Schema>;

--- a/tests/unit/mcp-v2-advance-recorded.test.ts
+++ b/tests/unit/mcp-v2-advance-recorded.test.ts
@@ -225,6 +225,8 @@ describe('v2 continue_workflow (ack path) records advance_recorded idempotently'
       expect(truth.events.filter((e) => e.kind === 'edge_created').length).toBe(1);
       // root node + advanced node
       expect(truth.events.filter((e) => e.kind === 'node_created').length).toBe(2);
+      // run_completed emitted on session completion
+      expect(truth.events.filter((e) => e.kind === 'run_completed').length).toBe(1);
     } finally {
       process.env.WORKRAIL_DATA_DIR = prev;
     }

--- a/tests/unit/v2/schema-locks.test.ts
+++ b/tests/unit/v2/schema-locks.test.ts
@@ -64,6 +64,7 @@ describe('event-kinds-closed-set: event kind discriminated union is exhaustive',
     'gap_recorded',
     'divergence_recorded',
     'decision_trace_appended',
+    'run_completed',
   ] as const;
 
   interface TestCase {
@@ -197,6 +198,20 @@ describe('event-kinds-closed-set: event kind discriminated union is exhaustive',
       data: {
         traceId: 'tr_123',
         entries: [{ kind: 'selected_next_step', summary: 'Chose step X' }],
+      },
+      expectValid: true,
+    },
+
+    {
+      kind: 'run_completed',
+      scope: { runId: 'run_123' },
+      data: {
+        startGitSha: 'abc123',
+        endGitSha: 'def456',
+        gitBranch: 'main',
+        agentCommitShas: ['abc123'],
+        captureConfidence: 'high',
+        durationMs: 12345,
       },
       expectValid: true,
     },
@@ -846,6 +861,7 @@ describe('schema-additive-within-version: event kind additions are locked', () =
       'gap_recorded',
       'divergence_recorded',
       'decision_trace_appended',
+      'run_completed',
     ];
 
     currentKinds.forEach((kind) => {


### PR DESCRIPTION
## Summary

Adds a new `run_completed` event variant to `DomainEventV1Schema`, emitted at `buildSuccessOutcome()` when `newEngineState.kind === 'complete'`. This enables session duration tracking, git attribution, and the `projectSessionMetricsV2` projection (step 4).

## Changes

- `src/v2/durable-core/constants.ts`: `RUN_COMPLETED: 'run_completed'`
- `src/v2/durable-core/schemas/session/events.ts`: new `run_completed` variant with `startGitSha`, `endGitSha`, `gitBranch`, `agentCommitShas`, `captureConfidence`, `durationMs`
- `src/mcp/handlers/v2-advance-events.ts`: `buildRunCompletedEvent()` pure builder
- `src/mcp/handlers/v2-advance-core/outcome-success.ts`: async git helper + event injection on session completion
- `tests/unit/v2/schema-locks.test.ts`: `run_completed` added to closed-set test (was CI-blocking)

## Design decisions
- `captureConfidence`: `'high'` when agent reported commit SHAs, `'none'` otherwise (medium deferred)
- `durationMs`: `lastEvent.timestampMs - firstEvent.timestampMs` -- requires step 1b (timestampMs required) to be fully accurate
- Git operations are best-effort: any failure sets `endGitSha = null`
- `agentCommitShas`: taken from last `context_set` with `metrics_commit_shas` key (full accumulated list)

## Dependencies
- Depends on PR #768 (timestampMs optional, merged)
- Should be reviewed after PR #772 (timestampMs required) merges -- `durationMs` will be undefined until then on existing sessions

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` passes (pre-existing failures only)
- [ ] `schema-locks.test.ts`: 87 tests passing including new `run_completed` fixture