### PR TITLE
feat(console): add session metrics display and diff-summary endpoint to session detail

### DIFF
--- a/console/src/api/hooks.ts
+++ b/console/src/api/hooks.ts
@@ -1,14 +1,9 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
-import type { ApiResponse, ConsoleSessionListResponse, ConsoleSessionDetail, ConsoleNodeDetail, ConsoleWorktreeListResponse, ConsoleWorkflowListResponse, ConsoleWorkflowDetail, PerfToolCallsResponse, TriggerListResponse, AutoDispatchRequest, AutoDispatchResponse } from './types';
+import type { ApiResponse, ConsoleSessionListResponse, ConsoleSessionDetail, ConsoleNodeDetail, ConsoleWorktreeListResponse, ConsoleWorkflowListResponse, ConsoleWorkflowDetail, PerfToolCallsResponse, TriggerListResponse, AutoDispatchRequest, AutoDispatchResponse, DiffSummaryResponse } from './types';
 import { mapPerfQueryToResult } from './perf-state';
 
-/** Response shape for GET /api/v2/sessions/:id/diff-summary */
-export interface DiffSummaryResponse {
-  readonly linesAdded: number;
-  readonly linesRemoved: number;
-  readonly filesChanged: number;
-}
+export type { DiffSummaryResponse };
 
 // Typed HTTP error so callers can check status without brittle string parsing.
 export class HttpError extends Error {

--- a/console/src/api/hooks.ts
+++ b/console/src/api/hooks.ts
@@ -3,6 +3,13 @@ import { useEffect } from 'react';
 import type { ApiResponse, ConsoleSessionListResponse, ConsoleSessionDetail, ConsoleNodeDetail, ConsoleWorktreeListResponse, ConsoleWorkflowListResponse, ConsoleWorkflowDetail, PerfToolCallsResponse, TriggerListResponse, AutoDispatchRequest, AutoDispatchResponse } from './types';
 import { mapPerfQueryToResult } from './perf-state';
 
+/** Response shape for GET /api/v2/sessions/:id/diff-summary */
+export interface DiffSummaryResponse {
+  readonly linesAdded: number;
+  readonly linesRemoved: number;
+  readonly filesChanged: number;
+}
+
 // Typed HTTP error so callers can check status without brittle string parsing.
 export class HttpError extends Error {
   constructor(public readonly status: number, statusText: string) {
@@ -44,6 +51,28 @@ export function useNodeDetail(sessionId: string, nodeId: string | null) {
     queryKey: ['node', sessionId, nodeId],
     queryFn: () => fetchApi<ConsoleNodeDetail>(`/api/v2/sessions/${sessionId}/nodes/${nodeId}`),
     enabled: !!nodeId,
+  });
+}
+
+/**
+ * On-demand hook for fetching git diff statistics for a session.
+ *
+ * WHY enabled=false by default: the diff-summary endpoint runs a git subprocess
+ * and must never be called automatically on page load. Users must explicitly click
+ * 'Load diff' to trigger the fetch. Callers call `query.refetch()` in the click handler.
+ *
+ * enabled param: passed by the caller to control whether refetch is allowed.
+ * Prevents the query from firing until explicitly requested.
+ */
+export function useDiffSummary(sessionId: string, enabled: boolean) {
+  return useQuery({
+    queryKey: ['diff-summary', sessionId],
+    queryFn: () => fetchApi<DiffSummaryResponse>(`/api/v2/sessions/${sessionId}/diff-summary`),
+    enabled,
+    staleTime: Infinity,   // diff results don't change -- SHAs are fixed
+    refetchInterval: false, // never auto-refetch
+    refetchOnWindowFocus: false,
+    retry: false,           // don't retry on error -- user can click again if needed
   });
 }
 

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -211,6 +211,17 @@ export interface ConsoleSessionDetail {
   readonly sessionTitle: string | null;
   readonly health: ConsoleSessionHealth;
   readonly runs: readonly ConsoleDagRun[];
+  /**
+   * Structured outcome metrics for the session's first completed run.
+   * Null for sessions still in progress or sessions that predate the run_completed feature.
+   * Mirror of ConsoleSessionDetail.metrics in src/v2/usecases/console-types.ts.
+   */
+  readonly metrics: SessionMetricsV2 | null;
+  /**
+   * Absolute filesystem path to the repo root. Used by the diff-summary endpoint.
+   * Mirror of ConsoleSessionDetail.repoRoot in src/v2/usecases/console-types.ts.
+   */
+  readonly repoRoot: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -378,3 +378,10 @@ export interface AutoDispatchResponse {
   readonly status: 'dispatched';
   readonly workflowId: string;
 }
+
+/** Response from GET /api/v2/sessions/:id/diff-summary */
+export interface DiffSummaryResponse {
+  readonly linesAdded: number;
+  readonly linesRemoved: number;
+  readonly filesChanged: number;
+}

--- a/console/src/hooks/__tests__/useSessionDetailViewModel.test.tsx
+++ b/console/src/hooks/__tests__/useSessionDetailViewModel.test.tsx
@@ -16,6 +16,8 @@ const FAKE_SESSION: ConsoleSessionDetail = {
   sessionId: 'sess-001',
   sessionTitle: 'Fix auth bug',
   health: 'healthy',
+  metrics: null,
+  repoRoot: null,
   runs: [
     {
       runId: 'run-001',

--- a/console/src/views/SessionDetail.tsx
+++ b/console/src/views/SessionDetail.tsx
@@ -5,8 +5,9 @@ import { StatusBadge } from '../components/StatusBadge';
 import { HealthBadge } from '../components/HealthBadge';
 import { NodeDetailSection } from '../components/NodeDetailSection';
 import { CutCornerBox } from '../components/CutCornerBox';
-import type { ConsoleSessionDetail, ConsoleDagRun } from '../api/types';
+import type { ConsoleSessionDetail, ConsoleDagRun, SessionMetricsV2 } from '../api/types';
 import type { UseSessionDetailViewModelResult } from '../hooks/useSessionDetailViewModel';
+import { useDiffSummary } from '../api/hooks';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -80,6 +81,220 @@ function SessionMetaCard({ data }: { data: ConsoleSessionDetail }) {
 }
 
 // ---------------------------------------------------------------------------
+// SessionMetricsSection
+// ---------------------------------------------------------------------------
+
+/** Diff loading state machine. Linear transitions: idle -> loading -> loaded | error. */
+type DiffState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'loaded'; readonly linesAdded: number; readonly linesRemoved: number; readonly filesChanged: number }
+  | { readonly kind: 'error'; readonly message: string };
+
+function formatDuration(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.round((ms % 60_000) / 1000);
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+/**
+ * SessionMetricsSection -- shows structured outcome metrics for a completed session run.
+ *
+ * Inline sub-panel (console/CLAUDE.md: inline sub-panel exception applies -- co-located
+ * with SessionDetail, ViewModel lifetime matches section visibility).
+ *
+ * Invariants:
+ * - Only rendered when metrics !== null (caller is responsible for the null check)
+ * - Agent-reported values always labeled "(agent-reported)" -- never omitted
+ * - Diff never auto-fetched -- user must click Load diff
+ * - Load diff button hidden when startGitSha or endGitSha is null
+ */
+function SessionMetricsSection({ sessionId, metrics }: { sessionId: string; metrics: SessionMetricsV2 }) {
+  const [diffState, setDiffState] = useState<DiffState>({ kind: 'idle' });
+  const diffQuery = useDiffSummary(sessionId, false); // enabled=false: never auto-fetch
+
+  const canLoadDiff = metrics.startGitSha !== null && metrics.endGitSha !== null;
+
+  const handleLoadDiff = async () => {
+    setDiffState({ kind: 'loading' });
+    try {
+      const result = await diffQuery.refetch();
+      if (result.isSuccess && result.data) {
+        setDiffState({
+          kind: 'loaded',
+          linesAdded: result.data.linesAdded,
+          linesRemoved: result.data.linesRemoved,
+          filesChanged: result.data.filesChanged,
+        });
+      } else {
+        const errorMsg = result.error instanceof Error
+          ? result.error.message
+          : 'Diff computation failed';
+        setDiffState({ kind: 'error', message: errorMsg });
+      }
+    } catch (e) {
+      const errorMsg = e instanceof Error ? e.message : 'Diff computation failed';
+      setDiffState({ kind: 'error', message: errorMsg });
+    }
+  };
+
+  return (
+    <div className="bg-[var(--bg-card)] border border-[var(--border)] px-5 py-4 corner-brackets space-y-4" style={{ backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)' }}>
+      {/* Section header */}
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-[0.30em] text-[var(--text-muted)]">
+          Session Metrics
+        </span>
+        <span className="font-mono text-[10px] text-[var(--text-muted)]">
+          Session-level totals across all runs.
+        </span>
+      </div>
+
+      {/* Chip row: compact summary of most important non-null values */}
+      <div className="flex flex-wrap gap-2">
+        {metrics.outcome !== null && (
+          <span className="px-2 py-1 text-xs font-mono border border-[var(--border)] text-[var(--text-secondary)] bg-[var(--bg-card)]">
+            {metrics.outcome}
+          </span>
+        )}
+        {metrics.durationMs !== undefined && (
+          <span className="px-2 py-1 text-xs font-mono border border-[var(--border)] text-[var(--text-secondary)] bg-[var(--bg-card)]">
+            {formatDuration(metrics.durationMs)}
+          </span>
+        )}
+        {metrics.filesChanged !== null && (
+          <span className="px-2 py-1 text-xs font-mono border border-[var(--border)] text-[var(--text-secondary)] bg-[var(--bg-card)]">
+            {metrics.filesChanged} file{metrics.filesChanged !== 1 ? 's' : ''} changed
+          </span>
+        )}
+        {metrics.captureConfidence !== 'none' && (
+          <span className="px-2 py-1 text-xs font-mono border border-[var(--border)] text-[var(--text-muted)] bg-[var(--bg-card)]">
+            {metrics.captureConfidence} confidence
+          </span>
+        )}
+      </div>
+
+      {/* Detail grid: all available metrics fields */}
+      <dl className="grid grid-cols-[auto_1fr] gap-x-8 gap-y-2">
+        {/* Engine-authoritative fields (from run_completed event) */}
+        {metrics.gitBranch !== null && (
+          <>
+            <dt className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] self-center">Git Branch</dt>
+            <dd className="font-mono text-xs text-[var(--text-secondary)] self-center">{metrics.gitBranch}</dd>
+          </>
+        )}
+        {metrics.startGitSha !== null && (
+          <>
+            <dt className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] self-center">Start SHA</dt>
+            <dd className="font-mono text-xs text-[var(--text-secondary)] self-center">{metrics.startGitSha.slice(0, 12)}</dd>
+          </>
+        )}
+        {metrics.endGitSha !== null && (
+          <>
+            <dt className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] self-center">End SHA</dt>
+            <dd className="font-mono text-xs text-[var(--text-secondary)] self-center">{metrics.endGitSha.slice(0, 12)}</dd>
+          </>
+        )}
+        {metrics.durationMs !== undefined && (
+          <>
+            <dt className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] self-center">Duration</dt>
+            <dd className="font-mono text-xs text-[var(--text-secondary)] self-center">{formatDuration(metrics.durationMs)}</dd>
+          </>
+        )}
+        {metrics.agentCommitShas.length > 0 && (
+          <>
+            <dt className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] self-start">Commits</dt>
+            <dd className="font-mono text-xs text-[var(--text-secondary)]">
+              {metrics.agentCommitShas.map((sha) => (
+                <div key={sha}>{sha.slice(0, 12)}</div>
+              ))}
+            </dd>
+          </>
+        )}
+
+        {/* Agent-reported fields (from metrics_* context_set keys) -- labeled accordingly */}
+        {metrics.outcome !== null && (
+          <>
+            <dt className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] self-center">Outcome</dt>
+            <dd className="text-xs text-[var(--text-secondary)] self-center">{metrics.outcome} <span className="text-[var(--text-muted)]">(agent-reported)</span></dd>
+          </>
+        )}
+        {metrics.filesChanged !== null && (
+          <>
+            <dt className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] self-center">Files Changed</dt>
+            <dd className="text-xs text-[var(--text-secondary)] self-center">{metrics.filesChanged} <span className="text-[var(--text-muted)]">(agent-reported)</span></dd>
+          </>
+        )}
+        {metrics.linesAdded !== null && (
+          <>
+            <dt className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] self-center">Lines Added</dt>
+            <dd className="text-xs text-[var(--text-secondary)] self-center">{metrics.linesAdded} <span className="text-[var(--text-muted)]">(agent-reported)</span></dd>
+          </>
+        )}
+        {metrics.linesRemoved !== null && (
+          <>
+            <dt className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] self-center">Lines Removed</dt>
+            <dd className="text-xs text-[var(--text-secondary)] self-center">{metrics.linesRemoved} <span className="text-[var(--text-muted)]">(agent-reported)</span></dd>
+          </>
+        )}
+        {metrics.prNumbers.length > 0 && (
+          <>
+            <dt className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] self-center">PRs</dt>
+            <dd className="text-xs text-[var(--text-secondary)] self-center">
+              {metrics.prNumbers.join(', ')} <span className="text-[var(--text-muted)]">(agent-reported)</span>
+            </dd>
+          </>
+        )}
+
+        {/* Diff-computed LOC rows -- replace Load diff button when loaded */}
+        {diffState.kind === 'loaded' && (
+          <>
+            <dt className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] self-center">LOC Added</dt>
+            <dd className="text-xs text-[var(--text-secondary)] self-center">{diffState.linesAdded} <span className="text-[var(--text-muted)]">(git diff)</span></dd>
+            <dt className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] self-center">LOC Removed</dt>
+            <dd className="text-xs text-[var(--text-secondary)] self-center">{diffState.linesRemoved} <span className="text-[var(--text-muted)]">(git diff)</span></dd>
+          </>
+        )}
+      </dl>
+
+      {/* Diff action area: Load diff button (idle), spinner (loading), or error (error state) */}
+      {canLoadDiff && diffState.kind !== 'loaded' && (
+        <div className="flex items-center gap-3 pt-1">
+          {diffState.kind === 'idle' && (
+            <button
+              type="button"
+              onClick={() => { void handleLoadDiff(); }}
+              className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)] hover:text-[var(--text-primary)] border border-[var(--border)] px-3 py-1.5 transition-colors"
+            >
+              Load diff
+            </button>
+          )}
+          {diffState.kind === 'loading' && (
+            <span className="font-mono text-[10px] uppercase tracking-[0.25em] text-[var(--text-muted)]">
+              Computing...
+            </span>
+          )}
+          {diffState.kind === 'error' && (
+            <span className="text-xs text-[var(--error)]">
+              {diffState.message}
+              {' '}
+              <button
+                type="button"
+                onClick={() => { void handleLoadDiff(); }}
+                className="underline text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+              >
+                Retry
+              </button>
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // HintBanner
 // ---------------------------------------------------------------------------
 
@@ -131,6 +346,12 @@ export function SessionDetail({ viewModel }: Props) {
     <>
       <div className="space-y-4">
         <SessionMetaCard data={data} />
+
+        {/* SessionMetricsSection: only rendered when metrics is non-null.
+            Completely absent (no empty card, no placeholder) when metrics === null. */}
+        {data.metrics !== null && (
+          <SessionMetricsSection sessionId={sessionId} metrics={data.metrics} />
+        )}
 
         {data.runs.length === 0 ? (
           <div className="text-center py-16 text-[var(--text-secondary)]">

--- a/src/v2/usecases/console-routes.ts
+++ b/src/v2/usecases/console-routes.ts
@@ -13,6 +13,8 @@ import type { Application, Request, Response } from 'express';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import type { ConsoleService } from './console-service.js';
 import { getWorktreeList, buildActiveSessionCounts, resolveRepoRoot, setEnrichmentCompleteCallback } from './worktree-service.js';
 import { toWorkflowSourceInfo } from '../../types/workflow.js';
@@ -666,6 +668,104 @@ export function mountConsoleRoutes(
         res.status(status).json({ success: false, error: error.message });
       },
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Diff summary endpoint
+  //
+  // GET /api/v2/sessions/:sessionId/diff-summary
+  //
+  // Runs `git diff startGitSha..endGitSha --shortstat` in the session's repo root
+  // and returns parsed LOC statistics. Never auto-fetched -- only called on explicit
+  // user action via the 'Load diff' button in the console session detail view.
+  //
+  // Best-effort: git errors, timeouts, and missing SHAs are returned as { error }
+  // with the appropriate HTTP status rather than propagating as 500s.
+  //
+  // WHY execFile not exec: AGENTS.md requires execFile for all subprocess calls
+  // to avoid shell injection via user-controlled content.
+  // ---------------------------------------------------------------------------
+  const execFileAsync = promisify(execFile);
+  /** 10-second ceiling for git diff operations. Large repos may have many changed files. */
+  const DIFF_GIT_TIMEOUT_MS = 10_000;
+
+  /**
+   * Discriminate child_process execution errors from programmer errors.
+   * Mirrors the isExecError helper in worktree-service.ts.
+   */
+  function isDiffExecError(e: unknown): boolean {
+    if (!(e instanceof Error)) return false;
+    if ('killed' in e) return true; // ExecFileException (non-zero exit, timeout)
+    const sys = (e as NodeJS.ErrnoException).syscall ?? '';
+    return sys.startsWith('spawn'); // ENOENT/EACCES from spawn (bad cwd or missing binary)
+  }
+
+  app.get('/api/v2/sessions/:sessionId/diff-summary', async (req: Request, res: Response) => {
+    const { sessionId } = req.params;
+
+    // Load session detail to get metrics (SHAs) and repoRoot.
+    const sessionResult = await consoleService.getSessionDetail(sessionId);
+    if (sessionResult.isErr()) {
+      const status = sessionResult.error.code === 'SESSION_LOAD_FAILED' ? 404 : 500;
+      res.status(status).json({ success: false, error: sessionResult.error.message });
+      return;
+    }
+
+    const sessionDetail = sessionResult.value;
+    const metrics = sessionDetail.metrics;
+    if (!metrics) {
+      res.status(422).json({ success: false, error: 'No metrics available for this session' });
+      return;
+    }
+
+    const { startGitSha, endGitSha } = metrics;
+    if (!startGitSha || !endGitSha) {
+      res.status(422).json({ success: false, error: 'Git SHAs not available in session metrics' });
+      return;
+    }
+
+    const repoRoot = sessionDetail.repoRoot;
+    if (!repoRoot) {
+      res.status(422).json({ success: false, error: 'Repo root not available for this session' });
+      return;
+    }
+
+    try {
+      const { stdout } = await execFileAsync(
+        'git',
+        ['diff', `${startGitSha}..${endGitSha}`, '--shortstat'],
+        { cwd: repoRoot, encoding: 'utf-8', timeout: DIFF_GIT_TIMEOUT_MS },
+      );
+
+      // Parse `git diff --shortstat` output. Example formats:
+      //   "3 files changed, 45 insertions(+), 12 deletions(-)"
+      //   "1 file changed, 2 insertions(+)"
+      //   "1 file changed, 1 deletion(-)"
+      //   "2 files changed"  (binary/renamed files only)
+      const match = stdout.trim().match(
+        /(\d+) files? changed(?:, (\d+) insertions?\(\+\))?(?:, (\d+) deletions?\(-\))?/,
+      );
+      if (!match) {
+        // Output did not match expected shortstat format (e.g. identical commits, empty diff).
+        res.json({ success: true, data: { linesAdded: 0, linesRemoved: 0, filesChanged: 0 } });
+        return;
+      }
+
+      const filesChanged = parseInt(match[1] ?? '0', 10);
+      const linesAdded = parseInt(match[2] ?? '0', 10);
+      const linesRemoved = parseInt(match[3] ?? '0', 10);
+      res.json({ success: true, data: { linesAdded, linesRemoved, filesChanged } });
+    } catch (e: unknown) {
+      if (isDiffExecError(e)) {
+        const errMsg = e instanceof Error && 'killed' in e && (e as NodeJS.ErrnoException & { killed?: boolean }).killed
+          ? 'Diff timed out: repository too large or slow'
+          : `Diff failed: git unavailable or invalid SHAs`;
+        res.status(503).json({ success: false, error: errMsg });
+        return;
+      }
+      // Programmer error -- re-throw
+      throw e;
+    }
   });
 
   // Workflow catalog endpoints. Only mounted when a workflowService is provided.

--- a/src/v2/usecases/console-service.ts
+++ b/src/v2/usecases/console-service.ts
@@ -371,12 +371,22 @@ export class ConsoleService {
         message: `Failed to load session ${sessionIdStr}: ${storeErr.message}`,
       }))
       .andThen((truth) => {
+        // Compute session-level aggregates from events BEFORE the dagErr fork.
+        // WHY before fork: these are session-level projections that apply regardless of DAG health.
+        // Both the dagErr early-return path and the normal path need metrics and repoRoot.
+        const metrics = projectSessionMetricsV2(truth.events);
+        const repoRoot = extractRepoRoot(truth.events);
+
         const dagRes = projectRunDagV2(truth.events);
 
         const detailRA = (() => {
           if (dagRes.isErr()) {
             return resolveRunCompletion(truth.events, this.ports.snapshotStore)
-              .map((completionMap) => projectSessionDetail(sessionId, truth, completionMap, {}, {}));
+              .map((completionMap) => ({
+                ...projectSessionDetail(sessionId, truth, completionMap, {}, {}),
+                metrics,
+                repoRoot,
+              }));
           }
           const dag = dagRes.value;
 
@@ -384,9 +394,11 @@ export class ConsoleService {
             resolveRunCompletion(truth.events, this.ports.snapshotStore),
             resolveStepLabels(dag, this.ports.snapshotStore, this.ports.pinnedWorkflowStore),
             resolveWorkflowNames(dag, this.ports.pinnedWorkflowStore),
-          ] as const).map(([completionMap, stepLabels, workflowNames]) =>
-            projectSessionDetail(sessionId, truth, completionMap, stepLabels, workflowNames)
-          );
+          ] as const).map(([completionMap, stepLabels, workflowNames]) => ({
+            ...projectSessionDetail(sessionId, truth, completionMap, stepLabels, workflowNames),
+            metrics,
+            repoRoot,
+          }));
         })();
 
         // Attach liveActivity when the session is currently live.
@@ -1138,7 +1150,9 @@ function projectSessionDetail(
 
   const dagRes = projectRunDagV2(events);
   if (dagRes.isErr()) {
-    return { sessionId, sessionTitle, health: sessionHealth, runs: [] };
+    // metrics and repoRoot are null here as placeholders; the caller (getSessionDetail)
+    // always overrides these with the actual computed values via spread.
+    return { sessionId, sessionTitle, health: sessionHealth, runs: [], metrics: null, repoRoot: null };
   }
 
   const statusRes = sortedEventsRes.isOk() ? projectRunStatusSignalsV2(sortedEventsRes.value) : err(sortedEventsRes.error);
@@ -1225,7 +1239,9 @@ function projectSessionDetail(
     };
   });
 
-  return { sessionId, sessionTitle, health: sessionHealth, runs };
+  // metrics and repoRoot are null here as placeholders; the caller (getSessionDetail)
+  // always overrides these with the actual computed values via spread.
+  return { sessionId, sessionTitle, health: sessionHealth, runs, metrics: null, repoRoot: null };
 }
 
 /**

--- a/src/v2/usecases/console-types.ts
+++ b/src/v2/usecases/console-types.ts
@@ -171,10 +171,18 @@ export interface ConsoleSessionDetail {
    */
   readonly liveActivity?: readonly ConsoleToolActivity[] | null;
   /**
-   * TODO(step-5): Add `metrics: SessionMetricsV2 | null` here and wire it in
-   * `getSessionDetail()` in console-service.ts so the session detail view can
-   * display structured outcome metrics. Blocked on step-5 console display PR.
+   * Structured outcome metrics for the session's first completed run.
+   * Null for sessions still in progress or sessions that predate the run_completed feature.
+   * Engine-authoritative fields are directly from run_completed event.
+   * Agent-reported fields come from metrics_* context_set keys.
    */
+  readonly metrics: SessionMetricsV2 | null;
+  /**
+   * Absolute filesystem path to the repo root.
+   * Derived from repo_root observation event or workspacePath context_set fallback.
+   * Used by the diff-summary endpoint to run git diff in the correct directory.
+   */
+  readonly repoRoot: string | null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Backend**: Add `metrics: SessionMetricsV2 | null` and `repoRoot: string | null` to `ConsoleSessionDetail` (both `src/v2/usecases/console-types.ts` and `console/src/api/types.ts`). Wire `projectSessionMetricsV2` into `getSessionDetail()` in `console-service.ts` -- computed before the dagErr fork so sessions with corrupt DAGs still get metrics when they have a `run_completed` event.
- **Backend**: Add `GET /api/v2/sessions/:id/diff-summary` endpoint in `console-routes.ts` -- runs `git diff startGitSha..endGitSha --shortstat` via `execFile` with 10s timeout. Returns `{ linesAdded, linesRemoved, filesChanged }` or `{ error }` with appropriate HTTP status. Never called automatically.
- **Frontend**: Add `useDiffSummary` React Query hook with `enabled=false` (requires explicit `refetch()` call to trigger). Add `SessionMetricsSection` inline sub-component in `SessionDetail.tsx` with chip summary row, detail grid labeled with `(agent-reported)` for agent-sourced values, Load diff button (hidden when SHAs missing), and diff state machine via `useState`.

This is step 5 of 6 in the session metrics display sequence. All prior steps (1a, 1b, 2, 3, 4) are merged to main.

## Key invariants
- `metrics === null` -- `SessionMetricsSection` renders nothing at all (no placeholder, no empty card)
- All agent-reported values labeled `(agent-reported)` in the detail grid
- Diff endpoint never called automatically; user must click Load diff
- Load diff button hidden when `startGitSha` or `endGitSha` is null

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] `npx vitest run` -- only pre-existing failures (`workflow-runner-load-session-notes.test.ts`, `polling-scheduler.test.ts`) -- no new failures
- [ ] `useSessionDetailViewModel.test.tsx` tests pass (updated `FAKE_SESSION` with new required fields)
- [ ] Session detail API response includes `metrics` and `repoRoot` fields
- [ ] `GET /api/v2/sessions/:id/diff-summary` returns `{ linesAdded, linesRemoved, filesChanged }` for sessions with both SHAs
- [ ] Returns 422 when session has no metrics or SHAs are null
- [ ] Returns 503 on git timeout or unavailability

🤖 Generated with [Claude Code](https://claude.com/claude-code)