### PR TITLE
fix(console): wire workflow catalog into standalone console so Workflows tab works without MCP server

### DIFF
--- a/src/console/standalone-console.ts
+++ b/src/console/standalone-console.ts
@@ -39,6 +39,8 @@ import { LocalPinnedWorkflowStoreV2 } from '../v2/infra/local/pinned-workflow-st
 import { LocalSessionEventLogStoreV2 } from '../v2/infra/local/session-store/index.js';
 import { ConsoleService } from '../v2/usecases/console-service.js';
 import { mountConsoleRoutes } from '../v2/usecases/console-routes.js';
+import { EnhancedMultiSourceWorkflowStorage } from '../infrastructure/storage/enhanced-multi-source-workflow-storage.js';
+import { EnvironmentFeatureFlagProvider } from '../config/feature-flags.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -152,24 +154,28 @@ export async function startStandaloneConsole(
   // ETag support for efficient browser caching of API responses.
   app.set('etag', 'strong');
 
+  // Construct a workflow reader so the Workflows tab (GET /api/v2/workflows)
+  // works in standalone mode without requiring the daemon or MCP server.
+  // gracefulDegradation defaults to true: if workflow directories don't exist,
+  // the reader returns an empty list rather than throwing.
+  const workflowReader = new EnhancedMultiSourceWorkflowStorage(
+    {},
+    new EnvironmentFeatureFlagProvider(),
+  );
+
   // Mount the console API routes and static file serving.
   // mountConsoleRoutes returns a disposer that closes the FSWatcher.
-  // workflowService and v2ToolContext are intentionally omitted:
-  // - Workflow catalog (GET /api/v2/workflows) requires a WorkflowService.
-  //   The standalone console does not load workflow definitions -- it only
-  //   displays session history. If this feature is needed in the future,
-  //   WorkflowService can be constructed here without daemon coupling.
-  // - AUTO dispatch (POST /api/v2/auto/dispatch) requires a V2ToolContext with
-  //   live session execution infrastructure. The standalone console is read-only;
-  //   dispatching new workflows is out of scope.
+  // v2ToolContext is intentionally omitted: AUTO dispatch (POST /api/v2/auto/dispatch)
+  // requires live session execution infrastructure. The standalone console is
+  // read-only; dispatching new workflows is out of scope.
   const stopWatcher = mountConsoleRoutes(
     app,
     consoleService,
-    undefined,   // workflowService -- not needed for session history view
-    undefined,   // timingRingBuffer -- no in-process tool call tracking
-    undefined,   // toolCallsPerfFile -- same as above
-    undefined,   // serverVersion -- no stamping needed
-    undefined,   // v2ToolContext -- no autonomous dispatch
+    workflowReader, // workflow catalog (GET /api/v2/workflows)
+    undefined,      // timingRingBuffer -- no in-process tool call tracking
+    undefined,      // toolCallsPerfFile -- same as above
+    undefined,      // serverVersion -- no stamping needed
+    undefined,      // v2ToolContext -- no autonomous dispatch
   );
 
   // Redirect / to /console for convenience (must be before 404 catch-all).

--- a/src/v2/usecases/console-routes.ts
+++ b/src/v2/usecases/console-routes.ts
@@ -18,7 +18,7 @@ import { promisify } from 'util';
 import type { ConsoleService } from './console-service.js';
 import { getWorktreeList, buildActiveSessionCounts, resolveRepoRoot, setEnrichmentCompleteCallback } from './worktree-service.js';
 import { toWorkflowSourceInfo } from '../../types/workflow.js';
-import type { WorkflowService } from '../../application/services/workflow-service.js';
+import type { IWorkflowReader } from '../../types/storage.js';
 import type { ToolCallTimingEntry, ToolCallTimingRingBuffer } from '../../mcp/tool-call-timing.js';
 import { isDevMode } from '../../mcp/dev-mode.js';
 import type { V2ToolContext } from '../../mcp/types.js';
@@ -131,7 +131,7 @@ function loadWorkflowTags(): WorkflowTagsFile {
 export function mountConsoleRoutes(
   app: Application,
   consoleService: ConsoleService,
-  workflowService?: WorkflowService,
+  workflowService?: IWorkflowReader,
   timingRingBuffer?: ToolCallTimingRingBuffer,
   toolCallsPerfFile?: string,
   serverVersion?: string,


### PR DESCRIPTION
## Summary

The Workflows tab in \`worktrain console\` showed HTTP 404 because \`mountConsoleRoutes()\` received \`undefined\` for \`workflowService\`.

## Changes

- \`src/v2/usecases/console-routes.ts\`: changed \`workflowService\` param type from \`WorkflowService\` to \`IWorkflowReader\` (uses only \`loadAllWorkflows\` and \`getWorkflowById\`)
- \`src/console/standalone-console.ts\`: construct \`EnhancedMultiSourceWorkflowStorage\` at startup and pass it -- reads bundled + user + project workflows from disk, no MCP server or daemon needed

## Test plan
- [ ] \`npx tsc --noEmit\` passes
- [ ] \`npx vitest run\` passes
- [ ] Workflows tab shows catalog when \`worktrain console\` runs standalone