### PR TITLE
test(validation): add regression test for unknown workflow field rejection and remove misleading strict: false

### DIFF
--- a/src/application/validation.ts
+++ b/src/application/validation.ts
@@ -8,7 +8,7 @@ import { ok, err, type Result } from 'neverthrow';
 
 const schemaPath = path.resolve(__dirname, '../../spec/workflow.schema.json');
 const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8'));
-const ajv = new Ajv({ allErrors: true, strict: false });
+const ajv = new Ajv({ allErrors: true });
 const validate = ajv.compile(schema);
 
 export interface WorkflowValidationResult {

--- a/tests/unit/validate-workflow-registry.test.ts
+++ b/tests/unit/validate-workflow-registry.test.ts
@@ -1100,7 +1100,41 @@ describe('Phase 5: God-Tier Validation Regression Tests', () => {
   });
 
   // ───────────────────────────────────────────────────────────────────────────
-  // 13. Fixture-vs-File Drift Detection (deferred to Phase 6)
+  // 13. Schema Enforcement (Tier 1 Regression)
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('Schema Enforcement (Tier 1 Regression)', () => {
+    it('36b. Unknown top-level field in raw file → schema_failed (additionalProperties: false regression)', () => {
+      // Uses real validateWorkflowSchema (not a mock) to verify the Tier 1 enforcement
+      // path calls schema validation. This test ensures additionalProperties: false in
+      // workflow.schema.json is enforced at the raw-file validation boundary. If this
+      // test fails, the schema enforcement layer has been broken.
+      const definitionWithUnknownField = {
+        ...def('schema-enforcement-test'),
+        unknownFieldForTesting: true,
+      } as unknown as WorkflowDefinition;
+
+      const rawFile: RawWorkflowFile = {
+        kind: 'parsed',
+        filePath: 'test.json',
+        relativeFilePath: 'test.json',
+        definition: definitionWithUnknownField,
+        variantKind: 'standard',
+      };
+
+      const snapshot = fakeSnapshot({ rawFiles: [rawFile] });
+      const deps = fakePipelineDeps(); // Uses real validateWorkflowSchema by default
+
+      const report = validateRegistry(snapshot, deps);
+
+      expect(report.isValid).toBe(false);
+      expect(report.tier1FailedRawFiles).toBe(1);
+      expect(report.rawFileResults[0]!.tier1Outcome.kind).toBe('schema_failed');
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 14. Fixture-vs-File Drift Detection (deferred to Phase 6)
   // ───────────────────────────────────────────────────────────────────────────
 
   describe('Fixture-vs-File Drift Detection', () => {


### PR DESCRIPTION
## Summary

Adds a regression test documenting that unknown top-level fields in workflow JSON files are rejected by \`validate:registry\`. Also removes a misleading \`strict: false\` from the Ajv constructor.

## Background

We incorrectly believed \`strict: false\` was disabling \`additionalProperties\` enforcement. Investigation showed this was wrong -- \`strict: false\` only controls whether Ajv warns about unknown JSON Schema keywords in the schema itself, not data validation. The actual enforcement was working all along.

The real gap: no test documented this invariant, making it invisible to future refactors.

## Changes

- \`tests/unit/validate-workflow-registry.test.ts\`: new test case asserting a workflow with \`unknownFieldForTesting: true\` produces \`tier1Outcome.kind === 'schema_failed'\`
- \`src/application/validation.ts\`: remove \`strict: false\` (no behavior change, removes misleading implication)

## Test plan
- [ ] \`npx tsc --noEmit\` passes
- [ ] \`npx vitest run tests/unit/validate-workflow-registry.test.ts\` passes (48 tests)