### PR TITLE
feat(mcp): surface workflow validation failures in list_workflows response

### DIFF
--- a/.workrail/implementation_plan.md
+++ b/.workrail/implementation_plan.md
@@ -416,3 +416,274 @@ Title: `fix(coordinator): queue poll tasks route to FULL/IMPLEMENT not REVIEW_ON
 `planConfidenceBand`: High
 `estimatedPRCount`: 1
 `followUpTickets`: [type-level enforcement: split AdaptivePipelineOpts into QueueDispatchOpts/TriggerDispatchOpts discriminated union]
+
+---
+---
+
+# Implementation Plan: Workflow Validation Regression Test
+
+*Generated: 2026-04-23 | Workflow: coding-task-workflow-agentic*
+
+---
+
+## 1. Problem Statement
+
+No test documents that unknown top-level fields in workflow JSON files are rejected by `validate:registry`. The invariant is correct in production (Ajv enforces `additionalProperties: false`), but invisible. A future refactor could remove the enforcement without any test catching it.
+
+## 2. Acceptance Criteria
+
+- `tests/unit/validate-workflow-registry.test.ts` contains a test that passes a `ParsedRawWorkflowFile` with an unknown top-level field through `validateRegistry` using real `validateWorkflowSchema`
+- Test asserts: `report.isValid === false`, `report.tier1FailedRawFiles === 1`, `report.rawFileResults[0].tier1Outcome.kind === 'schema_failed'`
+- Test includes a comment explaining it uses real `validateWorkflowSchema` to verify the Tier 1 enforcement path
+- `strict: false` removed from Ajv constructor in `src/application/validation.ts`
+- `npx tsc --noEmit` passes
+- `npx vitest run tests/unit/validate-workflow-registry.test.ts` passes with the new test included
+
+## 3. Non-Goals
+
+- Do NOT add schema validation to any new code path
+- Do NOT change `spec/workflow.schema.json`
+- Do NOT add a custom Ajv plugin, format, or keyword handler
+- Do NOT change `additionalProperties` settings anywhere in the schema
+- Do NOT address deployment sequencing or binary/schema versioning
+- Do NOT add tests for any other validation invariants
+
+## 4. Philosophy-Driven Constraints
+
+- Prefer fakes over mocks: use real `validateWorkflowSchema` (already the default in `fakePipelineDeps()`)
+- Document why not what: test must include explanatory comment
+- YAGNI: exactly two files, nothing more
+
+## 5. Invariants
+
+- I1: `validateRegistry` must call `deps.schemaValidate` for each raw file via `validateRawFileTier1`
+- I2: `additionalProperties: false` in `spec/workflow.schema.json` must cause `schemaValidate` to return `err()`
+- I3: The Ajv constructor must not carry settings that imply intentional relaxation of validation without documented reason
+
+## 6. Selected Approach
+
+Direct `fakeSnapshot` injection with real `validateWorkflowSchema`. Construct a `ParsedRawWorkflowFile` with an extra field, inject into `fakeSnapshot({ rawFiles: [...] })`, call `validateRegistry` with default `fakePipelineDeps()`, assert `schema_failed`.
+
+Runner-up: none (all candidates converge).
+
+## 7. Vertical Slices
+
+### Slice 1: Add regression test
+
+**File**: `tests/unit/validate-workflow-registry.test.ts`
+
+Add a new describe block "Schema Enforcement (Tier 1 Regression)" after the existing section 12 (File Discovery). Test case:
+- Construct definition with `unknownFieldForTesting: true` as `unknown as WorkflowDefinition`
+- Wrap in `ParsedRawWorkflowFile` with `kind: 'parsed'`, `filePath: 'test.json'`, `relativeFilePath: 'test.json'`, `variantKind: 'standard'`
+- `fakeSnapshot({ rawFiles: [rawFile] })` + `fakePipelineDeps()` (no overrides -- real validateWorkflowSchema)
+- Assert `report.isValid === false`, `report.tier1FailedRawFiles === 1`, `report.rawFileResults[0]!.tier1Outcome.kind === 'schema_failed'`
+- Comment: "Uses real validateWorkflowSchema (not a mock) to verify the Tier 1 enforcement path calls schema validation. This test ensures additionalProperties: false in workflow.schema.json is enforced at the raw-file validation boundary. If this test fails, the schema enforcement layer has been broken."
+
+**Done when**: Test passes.
+
+### Slice 2: Remove misleading Ajv option
+
+**File**: `src/application/validation.ts`
+
+Change `new Ajv({ allErrors: true, strict: false })` to `new Ajv({ allErrors: true })`.
+
+**Done when**: `npx tsc --noEmit` passes, `npx vitest run` passes.
+
+## 8. Test Design
+
+See Slice 1. No new test file -- add to existing `validate-workflow-registry.test.ts`.
+
+## 9. Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Ajv strict removal causes schema compile error | Very Low | Low | Empirically verified: tsc clean before changes |
+| Unknown field stripped before Ajv | None | N/A | createWorkflow does not serialize/deserialize |
+
+## 10. PR Packaging Strategy
+
+Single PR. Branch: `fix/etienneb/workflow-validation-regression-test`. One commit.
+Commit: `test(validation): add regression test for unknown workflow field rejection`
+
+## 11. Philosophy Alignment
+
+| Slice | Principle | Status |
+|-------|-----------|--------|
+| 1 (Test) | Prefer fakes over mocks | Satisfied -- real validateWorkflowSchema |
+| 1 (Test) | Document why not what | Satisfied -- explanatory comment |
+| 1 (Test) | Errors are data | Satisfied -- Result type used throughout |
+| 2 (Ajv) | YAGNI with discipline | Satisfied -- 1-line removal, no new abstractions |
+| All | Architectural fixes over patches | Satisfied -- documents correct invariant, not a patch |
+
+---
+`unresolvedUnknownCount`: 0
+`planConfidenceBand`: High
+`estimatedPRCount`: 1
+`followUpTickets`: []
+
+---
+---
+
+# Implementation Plan: list_workflows Validation Warnings
+
+*Generated: 2026-04-23 | Workflow: coding-task-workflow-agentic*
+
+---
+
+## 1. Problem Statement
+
+When a non-bundled workflow file fails JSON schema validation, `SchemaValidatingWorkflowStorage` and `SchemaValidatingCompositeWorkflowStorage` silently discard the workflow (logging to stderr only). Users calling `list_workflows` see no signal: their workflow is simply absent with no explanation. This turns a trivial typo fix into a multi-minute debugging session.
+
+## 2. Acceptance Criteria
+
+1. `list_workflows` response includes `validationWarnings` array when any non-bundled workflow fails JSON schema validation.
+2. Each warning entry has `workflowId: string`, `sourceKind: string`, `errors: string[]`.
+3. Bundled workflow failures (unexpected) are NOT included in `validationWarnings` -- they log to stderr as before.
+4. Valid workflows still appear in `workflows[]` unchanged.
+5. `IWorkflowStorage` interface is unchanged.
+6. `validationWarnings` is absent (not `[]`) when all workflows pass validation.
+7. Call-scoped: no instance-level state, no state leak between calls.
+8. `ctx.workflowService` singleton fallback path (no workspace signal) returns no `validationWarnings` (field absent).
+9. All three `handleV2ListWorkflows` payload assembly sites include `validationWarnings`.
+10. `npm run build` exits 0.
+11. `npx vitest run` exits 0 with no regressions.
+12. Unit tests for `loadAllWorkflowsWithWarnings()` on both classes.
+13. Handler integration test verifying `validationWarnings` appears in response.
+
+## 3. Non-Goals
+
+- Do NOT change `IWorkflowStorage` interface.
+- Do NOT surface bundled workflow failures in `validationWarnings`.
+- Do NOT add a `validate_workflow` MCP tool.
+- Do NOT change `inspect_workflow` NOT_FOUND behavior.
+- Do NOT add `validationWarnings` to any response other than `list_workflows`.
+
+## 4. Philosophy-Driven Constraints
+
+- **Errors are data:** `loadAllWorkflowsWithWarnings()` returns `{ workflows, warnings }` -- not thrown, not a side effect.
+- **Immutability by default:** `readonly ValidationWarning[]` in all return types.
+- **Explicit domain types:** `ValidationWarning` struct (`workflowId`, `sourceKind`, `errors[]`), not flat strings.
+- **Functional/declarative over imperative:** Paired return method, not callback injection.
+- **YAGNI with discipline:** Add only what is needed -- `IWorkflowStorage` stays untouched.
+- **Type safety as first line of defense:** `HasValidationWarnings` named interface for compile-time safety.
+- **Validate at boundaries, trust inside:** Bundled exclusion at storage method level.
+
+## 5. Invariants
+
+- I1: `IWorkflowStorage` interface signature is unchanged.
+- I2: Existing `loadAllWorkflows()` behavior is unchanged -- valid workflows still filter identically.
+- I3: `validationWarnings` absent (not present with empty array) when no failures.
+- I4: `source.kind !== 'bundled'` guard in `loadAllWorkflowsWithWarnings()` prevents bundled failures from appearing.
+- I5: `reportValidationFailure()` (stderr logging) still called for every filtered workflow -- no monitoring regression.
+- I6: Call-scoped: method creates a fresh `warnings` array per call; no instance state.
+
+## 6. Selected Approach + Rationale
+
+**Candidate A: Paired return method with `HasValidationWarnings` interface**
+
+Add `loadAllWorkflowsWithWarnings()` to both `SchemaValidatingWorkflowStorage` and `SchemaValidatingCompositeWorkflowStorage`, returning `{ workflows: readonly Workflow[]; warnings: readonly ValidationWarning[] }`. Export `HasValidationWarnings` TypeScript interface. In `handleV2ListWorkflows`, type-narrow to `HasValidationWarnings` and call the new method; thread `validationWarnings` into all 3 payload sites.
+
+**Runner-up:** Candidate B (optional callback) -- rejected because imperative callbacks conflict with the repo's functional style.
+
+**Architecture rationale:** Resolves interface stability (IWorkflowStorage untouched), call-scoped safety (no instance state), and signal completeness (bundled excluded at the boundary). Follows the `managedStoreError` side-channel precedent.
+
+## 7. Vertical Slices
+
+### Slice 1: Storage layer -- `ValidationWarning` type + `HasValidationWarnings` interface + `loadAllWorkflowsWithWarnings()` method
+
+**File:** `src/infrastructure/storage/schema-validating-workflow-storage.ts`
+
+Changes:
+1. Export `ValidationWarning` interface: `{ readonly workflowId: string; readonly sourceKind: string; readonly errors: string[] }`
+2. Export `HasValidationWarnings` interface: `{ loadAllWorkflowsWithWarnings(): Promise<{ workflows: readonly Workflow[]; warnings: readonly ValidationWarning[] }> }`
+3. Add `loadAllWorkflowsWithWarnings()` to `SchemaValidatingWorkflowStorage` -- same loop as `loadAllWorkflows()` but collects `ValidationWarning` entries for non-bundled failures.
+4. Add `loadAllWorkflowsWithWarnings()` to `SchemaValidatingCompositeWorkflowStorage` -- same.
+5. Both methods still call `reportValidationFailure()` (invariant I5).
+
+**Done when:** Build clean. Method exists on both classes, returns correct type, still calls `reportValidationFailure`.
+
+### Slice 2: Output schema -- `V2ValidationWarningSchema` + optional `validationWarnings` field
+
+**File:** `src/mcp/output-schemas.ts`
+
+Changes:
+1. Add `export const V2ValidationWarningSchema = z.object({ workflowId: z.string().min(1), sourceKind: z.string().min(1), errors: z.array(z.string().min(1)).min(1) })`
+2. Add `validationWarnings: z.array(V2ValidationWarningSchema).optional().describe(...)` to `V2WorkflowListOutputSchema`.
+
+**Done when:** Build clean. New schema type exported.
+
+### Slice 3: Handler -- type-narrow + call new method + thread to all 3 payload sites
+
+**File:** `src/mcp/handlers/v2-workflow.ts`
+
+Changes:
+1. Import `HasValidationWarnings`, `ValidationWarning` from storage module.
+2. Replace `withTimeout(workflowReader.loadAllWorkflows(), ...)` with: type-narrow to `HasValidationWarnings`; if available call `loadAllWorkflowsWithWarnings()` (wrapped in same `withTimeout`); extract `allWorkflows` and `validationWarnings` (absent if no failures); else fall through to `loadAllWorkflows()` with `validationWarnings = undefined`.
+3. Add `...(validationWarnings ? { validationWarnings } : {})` to all 3 payload assembly sites.
+4. Update `_nextStep` hint: when `validationWarnings` is non-empty (and no `tagSummaryEntry`), include a hint telling the agent to fix errors and retry `list_workflows`.
+
+**Done when:** Build clean. All 3 payload sites include `validationWarnings` spread. Handler integration test passes.
+
+### Slice 4: Tests
+
+**Files:**
+- `tests/unit/schema-validating-composite-workflow-storage.test.ts` (extend existing)
+- `tests/unit/mcp/v2-workflow-source-catalog-output.test.ts` (extend or new file for handler test)
+
+Tests required:
+1. `loadAllWorkflowsWithWarnings()` returns warning entry for non-bundled workflow with bad schema.
+2. `loadAllWorkflowsWithWarnings()` does NOT include bundled workflow failures.
+3. `loadAllWorkflowsWithWarnings()` returns empty `warnings` array (not absent) when all pass -- `validationWarnings` field absent in handler response.
+4. Handler integration test: create temp dir with one invalid workflow JSON, call `handleV2ListWorkflows`, verify `validationWarnings` present with correct structure.
+
+**Done when:** All new tests pass. `npx vitest run` exits 0.
+
+## 8. Test Design
+
+Storage unit tests (extend `schema-validating-composite-workflow-storage.test.ts`):
+- Use `InMemoryWorkflowStorage` with a workflow definition that will fail schema validation (add unknown top-level field or remove required field like `steps`).
+- Call `loadAllWorkflowsWithWarnings()` on `SchemaValidatingCompositeWorkflowStorage`.
+- Assert: `warnings` has one entry, `workflowId` matches, `sourceKind` matches, `errors` non-empty.
+- For bundled test: use `createBundledSource()` for the invalid workflow -- assert `warnings` is empty.
+
+Handler integration test (extend `v2-workflow-source-catalog-output.test.ts` or new file):
+- Write an invalid workflow JSON to a temp directory (missing required field).
+- Call `handleV2ListWorkflows` with `workspacePath` pointing at temp dir.
+- Assert response includes `validationWarnings` with correct structure.
+- Assert valid workflows still present in `workflows[]`.
+
+## 9. Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Missing one of 3 payload sites | Low | Medium | All 3 sites updated in Slice 3; verified by test exercising primary path + code review |
+| `withTimeout` not applied to new method | Very Low | Low | Wrap in same `withTimeout(workflowReader.loadAllWorkflowsWithWarnings(), TIMEOUT_MS, ...)` |
+| Rename of `loadAllWorkflowsWithWarnings` breaks handler | Very Low | Low | `HasValidationWarnings` interface -- TypeScript compile catches rename |
+| Bundled failures appear in `validationWarnings` | None | N/A | `source.kind !== 'bundled'` guard at collection level + dedicated test |
+| `reportValidationFailure` no longer called | Very Low | Low | Both methods explicitly call it (invariant I5) |
+
+## 10. PR Packaging Strategy
+
+**Single PR.** Branch: `feat/etienneb/list-workflows-validation-warnings`. One commit.
+Commit: `feat(mcp): surface workflow validation failures in list_workflows response`
+
+## 11. Philosophy Alignment per Slice
+
+| Slice | Principle | Status |
+|-------|-----------|--------|
+| 1 (Storage) | Errors are data | Satisfied -- ValidationWarning returned as value |
+| 1 (Storage) | Immutability by default | Satisfied -- readonly return types |
+| 1 (Storage) | Explicit domain types | Satisfied -- ValidationWarning struct, not flat string |
+| 1 (Storage) | Functional/declarative | Satisfied -- paired return, no callback/mutation |
+| 1 (Storage) | YAGNI | Satisfied -- IWorkflowStorage untouched |
+| 2 (Schema) | Explicit domain types | Satisfied -- V2ValidationWarningSchema |
+| 3 (Handler) | Type safety as first line | Satisfied -- HasValidationWarnings interface |
+| 3 (Handler) | Validate at boundaries | Satisfied -- bundled check in storage, handler trusts result |
+| 4 (Tests) | Prefer fakes over mocks | Satisfied -- InMemoryWorkflowStorage, real handler |
+| All | Document why not what | Satisfied -- comments explain bundled exclusion, call-scoped invariant |
+
+---
+`unresolvedUnknownCount`: 0
+`planConfidenceBand`: High
+`estimatedPRCount`: 1
+`followUpTickets`: ["inspect_workflow validation surface (broken workflows still NOT_FOUND, separate pitch)"]

--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -88,7 +88,7 @@ export interface SessionMetricsV2 {
   readonly endGitSha: string | null;
   readonly gitBranch: string | null;
   readonly agentCommitShas: readonly string[];
-  readonly captureConfidence: 'high' | 'medium' | 'none';
+  readonly captureConfidence: 'high' | 'none';
   readonly durationMs: number | undefined;
   // From context_set metrics_* keys (agent-reported, each independently nullable)
   readonly outcome: 'success' | 'partial' | 'abandoned' | 'error' | null;

--- a/src/application/validation.ts
+++ b/src/application/validation.ts
@@ -8,7 +8,7 @@ import { ok, err, type Result } from 'neverthrow';
 
 const schemaPath = path.resolve(__dirname, '../../spec/workflow.schema.json');
 const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8'));
-const ajv = new Ajv({ allErrors: true, strict: false });
+const ajv = new Ajv({ allErrors: true });
 const validate = ajv.compile(schema);
 
 export interface WorkflowValidationResult {

--- a/src/infrastructure/storage/schema-validating-workflow-storage.ts
+++ b/src/infrastructure/storage/schema-validating-workflow-storage.ts
@@ -46,19 +46,49 @@ function reportValidationFailure(workflowId: string, sourceKind: string, error: 
   console.error(`${VALIDATION_ERROR_PREFIX} ${sourceKind}/${workflowId}: ${error}`);
 }
 
+// ---------------------------------------------------------------------------
+// Validation warning types
+//
+// These are exposed for consumers that want structured error data from
+// loadAllWorkflowsWithWarnings(). The HasValidationWarnings interface enables
+// compile-time-safe duck-typing in the handler without touching IWorkflowStorage.
+// ---------------------------------------------------------------------------
+
+/** A structured record of a workflow that failed schema validation during loading. */
+export interface ValidationWarning {
+  readonly workflowId: string;
+  readonly sourceKind: string;
+  readonly errors: string[];
+}
+
+/**
+ * Compile-time-safe interface for type-narrowing in callers that want validation
+ * diagnostics alongside the loaded workflows.
+ *
+ * Only the concrete validating wrappers implement this -- IWorkflowStorage does not.
+ * The handler type-narrows to this interface so the duck-typing check has a named,
+ * stable contract rather than an inline property-access string.
+ */
+export interface HasValidationWarnings {
+  loadAllWorkflowsWithWarnings(): Promise<{
+    readonly workflows: readonly Workflow[];
+    readonly warnings: readonly ValidationWarning[];
+  }>;
+}
+
 /**
  * Decorator that validates workflows against the JSON schema.
- * 
+ *
  * Validates the definition portion of workflows on load.
  * Invalid workflows are reported via structured logging and filtered out (graceful degradation).
- * 
+ *
  * Phase 4 (Option B — temporary containment):
  * - Runtime still filters invalid workflows for safety
  * - Every filter action is reported with workflow ID, source kind, and error
  * - listWorkflowSummaries() validates through loadAllWorkflows() (no bypass)
  * - The CI gate (Phases 2-3) is the hard failure path; runtime remains soft
  */
-export class SchemaValidatingWorkflowStorage implements IWorkflowStorage {
+export class SchemaValidatingWorkflowStorage implements IWorkflowStorage, HasValidationWarnings {
   public readonly kind = 'single' as const;
   // Use the module-level singleton to avoid recompiling the schema per instance.
   private readonly validator: ValidateFunction = MODULE_WORKFLOW_VALIDATOR;
@@ -84,9 +114,9 @@ export class SchemaValidatingWorkflowStorage implements IWorkflowStorage {
 
   async loadAllWorkflows(): Promise<readonly Workflow[]> {
     const workflows = await this.inner.loadAllWorkflows();
-    
+
     const validWorkflows: Workflow[] = [];
-    
+
     for (const workflow of workflows) {
       try {
         if (this.validateDefinition(workflow.definition, workflow.source.kind)) {
@@ -100,8 +130,48 @@ export class SchemaValidatingWorkflowStorage implements IWorkflowStorage {
         );
       }
     }
-    
+
     return validWorkflows;
+  }
+
+  /**
+   * Load all workflows, returning valid ones alongside structured diagnostics for failures.
+   *
+   * Call-scoped: each call creates a fresh warnings array -- no instance-level state.
+   * Bundled workflow failures are excluded from `warnings` (pre-validated by CI; should never
+   * fail). All failures still log to stderr via reportValidationFailure() so monitoring is not
+   * regressed.
+   */
+  async loadAllWorkflowsWithWarnings(): Promise<{
+    readonly workflows: readonly Workflow[];
+    readonly warnings: readonly ValidationWarning[];
+  }> {
+    const workflows = await this.inner.loadAllWorkflows();
+    const validWorkflows: Workflow[] = [];
+    const warnings: ValidationWarning[] = [];
+
+    for (const workflow of workflows) {
+      try {
+        if (this.validateDefinition(workflow.definition, workflow.source.kind)) {
+          validWorkflows.push(workflow);
+        }
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        reportValidationFailure(workflow.definition.id, workflow.source.kind, errorMessage);
+        // Bundled workflows are pre-validated by CI and should never fail at runtime.
+        // If they do, log to stderr (above) but do not surface to the caller -- bundled
+        // failures indicate a product bug, not a user-fixable authoring error.
+        if (workflow.source.kind !== 'bundled') {
+          warnings.push({
+            workflowId: workflow.definition.id,
+            sourceKind: workflow.source.kind,
+            errors: [errorMessage],
+          });
+        }
+      }
+    }
+
+    return { workflows: validWorkflows, warnings };
   }
 
   async getWorkflowById(id: string): Promise<Workflow | null> {
@@ -146,7 +216,7 @@ export class SchemaValidatingWorkflowStorage implements IWorkflowStorage {
  * Schema validator for composite storage.
  * Same Phase 4 improvements as SchemaValidatingWorkflowStorage.
  */
-export class SchemaValidatingCompositeWorkflowStorage implements ICompositeWorkflowStorage {
+export class SchemaValidatingCompositeWorkflowStorage implements ICompositeWorkflowStorage, HasValidationWarnings {
   public readonly kind = 'composite' as const;
   // Use the module-level singleton to avoid recompiling the schema per instance.
   private readonly validator: ValidateFunction = MODULE_WORKFLOW_VALIDATOR;
@@ -175,7 +245,7 @@ export class SchemaValidatingCompositeWorkflowStorage implements ICompositeWorkf
 
   async loadAllWorkflows(): Promise<readonly Workflow[]> {
     const workflows = await this.inner.loadAllWorkflows();
-    
+
     const validWorkflows: Workflow[] = [];
     for (const workflow of workflows) {
       try {
@@ -190,13 +260,53 @@ export class SchemaValidatingCompositeWorkflowStorage implements ICompositeWorkf
         );
       }
     }
-    
+
     return validWorkflows;
+  }
+
+  /**
+   * Load all workflows, returning valid ones alongside structured diagnostics for failures.
+   *
+   * Call-scoped: each call creates a fresh warnings array -- no instance-level state.
+   * Bundled workflow failures are excluded from `warnings` (pre-validated by CI; should never
+   * fail). All failures still log to stderr via reportValidationFailure() so monitoring is not
+   * regressed.
+   */
+  async loadAllWorkflowsWithWarnings(): Promise<{
+    readonly workflows: readonly Workflow[];
+    readonly warnings: readonly ValidationWarning[];
+  }> {
+    const workflows = await this.inner.loadAllWorkflows();
+    const validWorkflows: Workflow[] = [];
+    const warnings: ValidationWarning[] = [];
+
+    for (const workflow of workflows) {
+      try {
+        if (this.validateDefinition(workflow.definition, workflow.source.kind)) {
+          validWorkflows.push(workflow);
+        }
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        reportValidationFailure(workflow.definition.id, workflow.source.kind, errorMessage);
+        // Bundled workflows are pre-validated by CI and should never fail at runtime.
+        // If they do, log to stderr (above) but do not surface to the caller -- bundled
+        // failures indicate a product bug, not a user-fixable authoring error.
+        if (workflow.source.kind !== 'bundled') {
+          warnings.push({
+            workflowId: workflow.definition.id,
+            sourceKind: workflow.source.kind,
+            errors: [errorMessage],
+          });
+        }
+      }
+    }
+
+    return { workflows: validWorkflows, warnings };
   }
 
   async getWorkflowById(id: string): Promise<Workflow | null> {
     const workflow = await this.inner.getWorkflowById(id);
-    
+
     if (!workflow) return null;
     
     try {

--- a/src/mcp/handlers/v2-workflow.ts
+++ b/src/mcp/handlers/v2-workflow.ts
@@ -15,6 +15,7 @@ import type { CryptoPortV2 } from '../../v2/durable-core/canonical/hashing.js';
 import type { PinnedWorkflowStorePortV2 } from '../../v2/ports/pinned-workflow-store.port.js';
 import type { Workflow } from '../../types/workflow.js';
 import type { IWorkflowReader, ICompositeWorkflowStorage } from '../../types/storage.js';
+import type { HasValidationWarnings, ValidationWarning } from '../../infrastructure/storage/schema-validating-workflow-storage.js';
 
 import { compileV1WorkflowToV2PreviewSnapshot } from '../../v2/read-only/v1-to-v2-shim.js';
 import { workflowHashForCompiledSnapshot } from '../../v2/durable-core/canonical/hashing.js';
@@ -282,11 +283,28 @@ export async function handleV2ListWorkflows(
     ? [`Managed workflow source store was temporarily unavailable (${managedStoreError}). Managed sources were not loaded.`]
     : undefined;
 
+  // Type-narrow to HasValidationWarnings to collect structured diagnostics for workflows
+  // that failed schema validation. When the reader supports it (i.e. it is one of the
+  // validating wrapper classes), we call loadAllWorkflowsWithWarnings() to get both the
+  // valid workflows and the failure diagnostics in one pass. When the reader is the
+  // ctx.workflowService singleton fallback (no workspace signal), it does not implement
+  // HasValidationWarnings -- we fall through to loadAllWorkflows() and omit the field.
+  const hasValidationWarnings = (r: unknown): r is HasValidationWarnings =>
+    typeof (r as Record<string, unknown>).loadAllWorkflowsWithWarnings === 'function';
+
   // Load all workflows in a single pass and build a Map for O(1) access.
   // Previously this called listWorkflowSummaries() then fanned out to N
   // individual getWorkflowById() calls -- one per workflow (N+1 pattern).
+  let capturedValidationWarnings: readonly ValidationWarning[] | undefined;
   return ResultAsync.fromPromise(
-    withTimeout(workflowReader.loadAllWorkflows(), TIMEOUT_MS, 'list_workflows'),
+    hasValidationWarnings(workflowReader)
+      ? withTimeout(workflowReader.loadAllWorkflowsWithWarnings(), TIMEOUT_MS, 'list_workflows').then(
+          ({ workflows, warnings }) => {
+            capturedValidationWarnings = warnings.length > 0 ? warnings : undefined;
+            return workflows;
+          }
+        )
+      : withTimeout(workflowReader.loadAllWorkflows(), TIMEOUT_MS, 'list_workflows'),
     (err) => mapUnknownErrorToToolError(err)
   )
     .andThen((allWorkflows) => {
@@ -339,14 +357,22 @@ export async function handleV2ListWorkflows(
         return buildTagSummary(WORKFLOW_TAGS, sortedIds);
       })();
 
-      // _nextStep: guide the agent when tagSummary is returned (no tags filter).
+      // _nextStep: guide the agent when tagSummary is returned (no tags filter),
+      // or when validationWarnings are present (tell the agent to fix the errors).
       // staleRoots: maintenance signal — only surface in source catalog mode (includeSources).
       // In tag-discovery mode it is noise: the agent cannot act on stale source paths.
-      const nextStepHint = tagSummaryEntry
-        ? 'Pick a tag from tagSummary that fits the user\'s goal, then call list_workflows with tags=["<tagId>"]. ' +
-          'If a workflow ID in examples[] already matches, call start_workflow directly — no second list call needed. ' +
-          'If multiple tags could apply, pick the most specific one.'
-        : undefined;
+      const nextStepHint = (() => {
+        if (tagSummaryEntry) {
+          return 'Pick a tag from tagSummary that fits the user\'s goal, then call list_workflows with tags=["<tagId>"]. ' +
+            'If a workflow ID in examples[] already matches, call start_workflow directly — no second list call needed. ' +
+            'If multiple tags could apply, pick the most specific one.';
+        }
+        if (capturedValidationWarnings) {
+          return 'One or more workflow files failed validation and were excluded from the workflows list. ' +
+            'Fix the errors listed in validationWarnings in the workflow file(s) and retry list_workflows to confirm.';
+        }
+        return undefined;
+      })();
 
       if (!input.includeSources) {
         // staleRoots is suppressed when tagSummary is present (compact first-call mode):
@@ -359,6 +385,7 @@ export async function handleV2ListWorkflows(
           ...(nextStepHint ? { _nextStep: nextStepHint } : {}),
           ...(includeStaleRoots ? { staleRoots: [...stalePaths] } : {}),
           ...(warnings ? { warnings } : {}),
+          ...(capturedValidationWarnings ? { validationWarnings: [...capturedValidationWarnings] } : {}),
         };
         return okAsync(success(payload) as ToolResult<unknown>);
       }
@@ -375,6 +402,7 @@ export async function handleV2ListWorkflows(
           ...(nextStepHint ? { _nextStep: nextStepHint } : {}),
           ...(stalePaths.length > 0 ? { staleRoots: [...stalePaths] } : {}),
           ...(warnings ? { warnings } : {}),
+          ...(capturedValidationWarnings ? { validationWarnings: [...capturedValidationWarnings] } : {}),
           sources: [],
         };
         return okAsync(success(payload) as ToolResult<unknown>);
@@ -389,6 +417,7 @@ export async function handleV2ListWorkflows(
           ...(nextStepHint ? { _nextStep: nextStepHint } : {}),
           ...(stalePaths.length > 0 ? { staleRoots: [...stalePaths] } : {}),
           ...(warnings ? { warnings } : {}),
+          ...(capturedValidationWarnings ? { validationWarnings: [...capturedValidationWarnings] } : {}),
           sources: [...sources] as z.infer<typeof V2WorkflowListOutputSchema>['sources'],
         };
         return success(payload) as ToolResult<unknown>;

--- a/src/mcp/output-schemas.ts
+++ b/src/mcp/output-schemas.ts
@@ -155,6 +155,12 @@ export const TagSummaryItemSchema = z.object({
   examples: z.array(z.string()).describe('Representative workflow IDs for this tag.'),
 });
 
+export const V2ValidationWarningSchema = z.object({
+  workflowId: z.string().min(1),
+  sourceKind: z.string().min(1),
+  errors: z.array(z.string().min(1)).min(1),
+});
+
 export const V2WorkflowListOutputSchema = z.object({
   workflows: z.array(V2WorkflowListItemSchema),
   tagSummary: z.array(TagSummaryItemSchema).optional().describe(
@@ -177,6 +183,13 @@ export const V2WorkflowListOutputSchema = z.object({
   sources: z.array(V2WorkflowSourceCatalogEntrySchema).optional().describe(
     'Source catalog for this workspace. Only present when includeSources was true in the request. ' +
     'Shows where workflows come from with effective and shadowed counts per source.'
+  ),
+  validationWarnings: z.array(V2ValidationWarningSchema).optional().describe(
+    'Structured validation errors for non-bundled workflow files that failed JSON schema validation ' +
+    'and were excluded from the workflows list. Each entry identifies which workflow failed ' +
+    '(workflowId), which source it came from (sourceKind), and the specific validation errors (errors[]). ' +
+    'Absent when all workflows pass validation. Fix the listed errors in the workflow file and retry ' +
+    'list_workflows to confirm. Bundled (built-in) workflow failures are never included here.'
   ),
 });
 

--- a/src/v2/projections/session-metrics.ts
+++ b/src/v2/projections/session-metrics.ts
@@ -23,7 +23,7 @@ export interface SessionMetricsV2 {
   readonly endGitSha: string | null;
   readonly gitBranch: string | null;
   readonly agentCommitShas: readonly string[];
-  readonly captureConfidence: 'high' | 'medium' | 'none';
+  readonly captureConfidence: 'high' | 'none';
   /**
    * Wall-clock duration of the run in milliseconds.
    * undefined (not null) when either timestamp is unavailable -- consistent
@@ -110,11 +110,8 @@ export function projectSessionMetricsV2(
   const durationMs =
     typeof d.durationMs === 'number' && Number.isFinite(d.durationMs) ? d.durationMs : undefined;
 
-  // Schema emits 'high' | 'none'; 'medium' is reserved in SessionMetricsV2 for future use.
-  // Widen to string before the guard so this compiles when the schema union expands.
-  const captureConfidenceRaw: string = d.captureConfidence ?? '';
-  const captureConfidence: 'high' | 'medium' | 'none' =
-    captureConfidenceRaw === 'high' || captureConfidenceRaw === 'medium' ? captureConfidenceRaw : 'none';
+  const captureConfidence: 'high' | 'none' =
+    d.captureConfidence === 'high' ? 'high' : 'none';
 
   // Extract agent-reported fields from metricsContext.
   const outcomeRaw = metricsContext['metrics_outcome'];

--- a/src/v2/projections/session-metrics.ts
+++ b/src/v2/projections/session-metrics.ts
@@ -39,28 +39,6 @@ export interface SessionMetricsV2 {
 }
 
 // ---------------------------------------------------------------------------
-// Internal defensive cast interface
-// ---------------------------------------------------------------------------
-
-/**
- * Internal contract for run_completed.data fields.
- *
- * STEP 2 CLEANUP: when run_completed is added to DomainEventV1Schema,
- * replace the defensive cast below with proper TS type narrowing and delete
- * this interface. The cleanup is a single localized change -- replace the cast,
- * verify these 6 field names match: startGitSha, endGitSha, gitBranch,
- * agentCommitShas, captureConfidence, durationMs. No other changes.
- */
-interface RunCompletedDataExpected {
-  readonly startGitSha?: unknown;
-  readonly endGitSha?: unknown;
-  readonly gitBranch?: unknown;
-  readonly agentCommitShas?: unknown;
-  readonly captureConfidence?: unknown;
-  readonly durationMs?: unknown;
-}
-
-// ---------------------------------------------------------------------------
 // Projection
 // ---------------------------------------------------------------------------
 
@@ -82,26 +60,20 @@ export function projectSessionMetricsV2(
   events: readonly DomainEventV1[],
 ): SessionMetricsV2 | null {
   // Find the first run_completed event by event order.
-  // run_completed is not yet in DomainEventV1Schema (step 2), so we use a
-  // defensive cast via RunCompletedDataExpected.
-  let runCompletedData: RunCompletedDataExpected | null = null;
-  let runCompletedRunId: string | null = null;
+  let runCompleted: Extract<DomainEventV1, { kind: 'run_completed' }> | null = null;
 
   for (const e of events) {
-    // run_completed is not yet in DomainEventV1Schema (step 2 adds it).
-    // Cast to unknown first to bypass the discriminated union exhaustiveness check.
-    const asUnknown = e as unknown as { kind: string; data: RunCompletedDataExpected; scope?: { runId?: string } };
-    if (asUnknown.kind === 'run_completed') {
-      runCompletedData = asUnknown.data;
-      // run_completed follows the same scope pattern as run_started: { runId }
-      runCompletedRunId = asUnknown.scope?.runId ?? null;
+    if (e.kind === 'run_completed') {
+      runCompleted = e;
       break; // first run_completed by event order wins
     }
   }
 
-  if (runCompletedData === null) {
+  if (runCompleted === null) {
     return null;
   }
+
+  const runCompletedRunId = runCompleted.scope.runId;
 
   // Collect the last context_set metrics_* values for the matching runId.
   // Each context_set is a full snapshot, not a delta -- the last event for a
@@ -110,11 +82,7 @@ export function projectSessionMetricsV2(
 
   for (const e of events) {
     if (e.kind !== EVENT_KIND.CONTEXT_SET) continue;
-    // Only process context_set events for the run that completed.
-    // WHY null check: if run_completed had no scope.runId, disable the filter so
-    // all context_set events contribute. context_set enforces non-empty runId in schema
-    // so this path only occurs with legacy or manually-constructed events.
-    if (runCompletedRunId !== null && e.scope?.runId !== runCompletedRunId) continue;
+    if (e.scope?.runId !== runCompletedRunId) continue;
 
     const ctx = e.data.context;
     if (!ctx || typeof ctx !== 'object' || Array.isArray(ctx)) continue;
@@ -128,32 +96,25 @@ export function projectSessionMetricsV2(
     }
   }
 
-  // Extract engine fields from run_completed.data.
-  const d = runCompletedData;
+  // Extract engine fields from run_completed.data -- fully typed via DomainEventV1Schema.
+  const d = runCompleted.data;
 
+  // Coerce nullable string fields to null when absent -- defensive against schema-bypassing
+  // casts (e.g. test fixtures using `as unknown as DomainEventV1`).
   const startGitSha = typeof d.startGitSha === 'string' ? d.startGitSha : null;
   const endGitSha = typeof d.endGitSha === 'string' ? d.endGitSha : null;
   const gitBranch = typeof d.gitBranch === 'string' ? d.gitBranch : null;
-
-  const agentCommitShas: string[] = [];
-  if (Array.isArray(d.agentCommitShas)) {
-    for (const sha of d.agentCommitShas) {
-      if (typeof sha === 'string') {
-        agentCommitShas.push(sha);
-      }
-    }
-  }
-
-  const captureConfidenceRaw = d.captureConfidence;
-  const captureConfidence: 'high' | 'medium' | 'none' =
-    captureConfidenceRaw === 'high' || captureConfidenceRaw === 'medium' || captureConfidenceRaw === 'none'
-      ? captureConfidenceRaw
-      : 'none';
-
+  const agentCommitShas = Array.isArray(d.agentCommitShas)
+    ? d.agentCommitShas.filter((s): s is string => typeof s === 'string')
+    : [];
   const durationMs =
-    typeof d.durationMs === 'number' && Number.isFinite(d.durationMs)
-      ? d.durationMs
-      : undefined;
+    typeof d.durationMs === 'number' && Number.isFinite(d.durationMs) ? d.durationMs : undefined;
+
+  // Schema emits 'high' | 'none'; 'medium' is reserved in SessionMetricsV2 for future use.
+  // Widen to string before the guard so this compiles when the schema union expands.
+  const captureConfidenceRaw: string = d.captureConfidence ?? '';
+  const captureConfidence: 'high' | 'medium' | 'none' =
+    captureConfidenceRaw === 'high' || captureConfidenceRaw === 'medium' ? captureConfidenceRaw : 'none';
 
   // Extract agent-reported fields from metricsContext.
   const outcomeRaw = metricsContext['metrics_outcome'];
@@ -172,36 +133,28 @@ export function projectSessionMetricsV2(
     }
   }
 
+  // Use agent-reported metrics_commit_shas as override when present;
+  // otherwise fall back to what run_completed.data.agentCommitShas provided.
   const commitShasRaw = metricsContext['metrics_commit_shas'];
   const metricCommitShas: string[] = [];
   if (Array.isArray(commitShasRaw)) {
     for (const sha of commitShasRaw) {
-      if (typeof sha === 'string') {
-        metricCommitShas.push(sha);
-      }
+      if (typeof sha === 'string') metricCommitShas.push(sha);
     }
   }
-  // Use agent-reported commit shas (metrics_commit_shas) as agentCommitShas override
-  // when present; otherwise fall back to what run_completed.data.agentCommitShas provided.
   const finalAgentCommitShas = metricCommitShas.length > 0 ? metricCommitShas : agentCommitShas;
 
   const filesChangedRaw = metricsContext['metrics_files_changed'];
   const filesChanged =
-    typeof filesChangedRaw === 'number' && Number.isFinite(filesChangedRaw)
-      ? filesChangedRaw
-      : null;
+    typeof filesChangedRaw === 'number' && Number.isFinite(filesChangedRaw) ? filesChangedRaw : null;
 
   const linesAddedRaw = metricsContext['metrics_lines_added'];
   const linesAdded =
-    typeof linesAddedRaw === 'number' && Number.isFinite(linesAddedRaw)
-      ? linesAddedRaw
-      : null;
+    typeof linesAddedRaw === 'number' && Number.isFinite(linesAddedRaw) ? linesAddedRaw : null;
 
   const linesRemovedRaw = metricsContext['metrics_lines_removed'];
   const linesRemoved =
-    typeof linesRemovedRaw === 'number' && Number.isFinite(linesRemovedRaw)
-      ? linesRemovedRaw
-      : null;
+    typeof linesRemovedRaw === 'number' && Number.isFinite(linesRemovedRaw) ? linesRemovedRaw : null;
 
   return {
     startGitSha,

--- a/tests/unit/mcp/v2-workflow-source-catalog-output.test.ts
+++ b/tests/unit/mcp/v2-workflow-source-catalog-output.test.ts
@@ -404,6 +404,72 @@ describe('v2 workflow source catalog output', () => {
     expect(data.warnings!.some((w) => w.includes('MANAGED_SOURCE_IO_ERROR'))).toBe(true);
   });
 
+  describe('validationWarnings', () => {
+    it('surfaces validation warnings in response when a non-bundled workflow fails schema validation', async () => {
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-v2-validation-warnings-'));
+      const workspace = path.join(tempRoot, 'workspace');
+      const workflowsDir = path.join(workspace, 'workflows');
+      fs.mkdirSync(workflowsDir, { recursive: true });
+
+      // Write an invalid workflow file (missing required 'steps' field)
+      fs.writeFileSync(
+        path.join(workflowsDir, 'bad-workflow.v2.json'),
+        JSON.stringify({ id: 'bad-workflow', name: 'Bad Workflow', description: 'desc', version: '0.0.1' }),
+        'utf8',
+      );
+      // Write a valid workflow to confirm valid ones still appear
+      writeWorkflow(workflowsDir, 'good-workflow', 'Good Workflow');
+
+      // Use includeSources to get full workflow list (bypasses tag-first filter so all
+      // project workflows appear directly in the response, not just tag-matched ones)
+      const result = await handleV2ListWorkflows(
+        { workspacePath: workspace, includeSources: true },
+        buildCtx(rememberedRootsStore()),
+      );
+
+      expect(result.type).toBe('success');
+      if (result.type !== 'success') return;
+
+      const data = result.data as {
+        workflows: Array<{ workflowId: string }>;
+        validationWarnings?: Array<{ workflowId: string; sourceKind: string; errors: string[] }>;
+        _nextStep?: string;
+      };
+
+      // Valid workflow is still present
+      expect(data.workflows.some((w) => w.workflowId === 'good-workflow')).toBe(true);
+
+      // Invalid workflow is absent from the list
+      expect(data.workflows.some((w) => w.workflowId === 'bad-workflow')).toBe(false);
+
+      // validationWarnings is present with the correct structure
+      expect(Array.isArray(data.validationWarnings)).toBe(true);
+      expect(data.validationWarnings!).toHaveLength(1);
+      expect(data.validationWarnings![0]!.workflowId).toBe('bad-workflow');
+      expect(data.validationWarnings![0]!.sourceKind).toBe('project');
+      expect(data.validationWarnings![0]!.errors).toHaveLength(1);
+      expect(data.validationWarnings![0]!.errors[0]).toBeTruthy();
+    });
+
+    it('omits validationWarnings when all workflows pass validation', async () => {
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-v2-validation-clean-'));
+      const workspace = path.join(tempRoot, 'workspace');
+      const workflowsDir = path.join(workspace, 'workflows');
+      writeWorkflow(workflowsDir, 'clean-workflow', 'Clean Workflow');
+
+      const result = await handleV2ListWorkflows(
+        { workspacePath: workspace, includeSources: true },
+        buildCtx(rememberedRootsStore()),
+      );
+
+      expect(result.type).toBe('success');
+      if (result.type !== 'success') return;
+
+      const data = result.data as Record<string, unknown>;
+      expect(data.validationWarnings).toBeUndefined();
+    });
+  });
+
   it('does not create duplicate catalog entry when managed source path matches WORKFLOW_STORAGE_PATH', async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wr-v2-source-catalog-env-dedup-'));
     const workspace = path.join(tempRoot, 'workspace');

--- a/tests/unit/schema-validating-composite-workflow-storage.test.ts
+++ b/tests/unit/schema-validating-composite-workflow-storage.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import { InvalidWorkflowError } from '../../src/core/error-handler';
 import { InMemoryWorkflowStorage } from '../../src/infrastructure/storage/in-memory-storage';
-import { SchemaValidatingCompositeWorkflowStorage } from '../../src/infrastructure/storage/schema-validating-workflow-storage';
+import { SchemaValidatingCompositeWorkflowStorage, SchemaValidatingWorkflowStorage } from '../../src/infrastructure/storage/schema-validating-workflow-storage';
 import { EnhancedMultiSourceWorkflowStorage } from '../../src/infrastructure/storage/enhanced-multi-source-workflow-storage';
 import type { WorkflowDefinition } from '../../src/types/workflow';
 import { createBundledSource, createProjectDirectorySource } from '../../src/types/workflow';
@@ -91,5 +91,105 @@ describe('SchemaValidatingCompositeWorkflowStorage namespace enforcement', () =>
     const storage = new SchemaValidatingCompositeWorkflowStorage(inner);
 
     await expect(storage.save(def('legacy_id'))).rejects.toThrow(InvalidWorkflowError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadAllWorkflowsWithWarnings() -- validation warnings surface
+// ---------------------------------------------------------------------------
+
+describe('SchemaValidatingCompositeWorkflowStorage.loadAllWorkflowsWithWarnings()', () => {
+  it('returns warning entry for non-bundled workflow that fails schema validation', async () => {
+    const projectSource = createProjectDirectorySource(path.join(os.tmpdir(), 'wr-test-warnings'));
+    // A definition missing 'steps' will fail Ajv validation (steps is required).
+    const invalidDef = { id: 'invalid-workflow', name: 'Bad', description: 'desc', version: '1.0.0' } as unknown as WorkflowDefinition;
+    const project = new InMemoryWorkflowStorage([invalidDef], projectSource);
+
+    const base = new EnhancedMultiSourceWorkflowStorage({
+      includeBundled: false,
+      includeUser: false,
+      includeProject: false,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (base as any).storageInstances = [project];
+
+    const storage = new SchemaValidatingCompositeWorkflowStorage(base);
+    const { workflows, warnings } = await storage.loadAllWorkflowsWithWarnings();
+
+    expect(workflows).toHaveLength(0);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.workflowId).toBe('invalid-workflow');
+    expect(warnings[0]!.sourceKind).toBe('project');
+    expect(warnings[0]!.errors).toHaveLength(1);
+    expect(warnings[0]!.errors[0]).toBeTruthy();
+  });
+
+  it('does NOT include bundled workflow failures in warnings', async () => {
+    const bundledSource = createBundledSource();
+    const invalidDef = { id: 'wr.invalid', name: 'Bad', description: 'desc', version: '1.0.0' } as unknown as WorkflowDefinition;
+    const bundled = new InMemoryWorkflowStorage([invalidDef], bundledSource);
+
+    const base = new EnhancedMultiSourceWorkflowStorage({
+      includeBundled: false,
+      includeUser: false,
+      includeProject: false,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (base as any).storageInstances = [bundled];
+
+    const storage = new SchemaValidatingCompositeWorkflowStorage(base);
+    const { workflows, warnings } = await storage.loadAllWorkflowsWithWarnings();
+
+    // Bundled failure should be excluded from warnings (still filtered from workflows)
+    expect(workflows).toHaveLength(0);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('returns empty warnings when all workflows pass validation', async () => {
+    const projectSource = createProjectDirectorySource(path.join(os.tmpdir(), 'wr-test-valid'));
+    const project = new InMemoryWorkflowStorage([def('valid-workflow')], projectSource);
+
+    const base = new EnhancedMultiSourceWorkflowStorage({
+      includeBundled: false,
+      includeUser: false,
+      includeProject: false,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (base as any).storageInstances = [project];
+
+    const storage = new SchemaValidatingCompositeWorkflowStorage(base);
+    const { workflows, warnings } = await storage.loadAllWorkflowsWithWarnings();
+
+    expect(workflows).toHaveLength(1);
+    expect(warnings).toHaveLength(0);
+  });
+});
+
+describe('SchemaValidatingWorkflowStorage.loadAllWorkflowsWithWarnings()', () => {
+  it('returns warning entry for non-bundled workflow that fails schema validation', async () => {
+    const projectSource = createProjectDirectorySource(path.join(os.tmpdir(), 'wr-test-single-warnings'));
+    const invalidDef = { id: 'invalid-single', name: 'Bad', description: 'desc', version: '1.0.0' } as unknown as WorkflowDefinition;
+    const inner = new InMemoryWorkflowStorage([invalidDef], projectSource);
+
+    const storage = new SchemaValidatingWorkflowStorage(inner);
+    const { workflows, warnings } = await storage.loadAllWorkflowsWithWarnings();
+
+    expect(workflows).toHaveLength(0);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.workflowId).toBe('invalid-single');
+    expect(warnings[0]!.sourceKind).toBe('project');
+    expect(warnings[0]!.errors).toHaveLength(1);
+  });
+
+  it('does NOT include bundled workflow failures in warnings', async () => {
+    const bundledSource = createBundledSource();
+    const invalidDef = { id: 'wr.invalid-single', name: 'Bad', description: 'desc', version: '1.0.0' } as unknown as WorkflowDefinition;
+    const inner = new InMemoryWorkflowStorage([invalidDef], bundledSource);
+
+    const storage = new SchemaValidatingWorkflowStorage(inner);
+    const { workflows, warnings } = await storage.loadAllWorkflowsWithWarnings();
+
+    expect(workflows).toHaveLength(0);
+    expect(warnings).toHaveLength(0);
   });
 });

--- a/tests/unit/v2/session-metrics-projection.test.ts
+++ b/tests/unit/v2/session-metrics-projection.test.ts
@@ -47,7 +47,7 @@ function makeRunCompletedEvent(args: {
   endGitSha?: string | null;
   gitBranch?: string | null;
   agentCommitShas?: string[];
-  captureConfidence?: 'high' | 'medium' | 'none';
+  captureConfidence?: 'high' | 'none';
   durationMs?: number;
 }): DomainEventV1 {
   return {
@@ -55,8 +55,7 @@ function makeRunCompletedEvent(args: {
     eventId: `evt_${args.eventIndex}`,
     eventIndex: args.eventIndex,
     sessionId: 'sess_1',
-    // run_completed is not yet in DomainEventV1Schema -- cast to bypass TS checks
-    kind: 'run_completed' as unknown as DomainEventV1['kind'],
+    kind: 'run_completed',
     dedupeKey: `run_completed:sess_1:${args.runId}`,
     scope: { runId: args.runId },
     data: {
@@ -67,7 +66,7 @@ function makeRunCompletedEvent(args: {
       captureConfidence: args.captureConfidence ?? 'none',
       durationMs: args.durationMs,
     },
-  } as unknown as DomainEventV1;
+  };
 }
 
 function makeContextSetEvent(args: {
@@ -312,7 +311,7 @@ describe('projectSessionMetricsV2', () => {
         startGitSha: 'run2-start',
         endGitSha: 'run2-end',
         gitBranch: 'branch-run2',
-        captureConfidence: 'medium',
+        captureConfidence: 'none',
         durationMs: 2000,
       }),
       // context_set for run_1 (the winning run)

--- a/tests/unit/validate-workflow-registry.test.ts
+++ b/tests/unit/validate-workflow-registry.test.ts
@@ -1100,7 +1100,41 @@ describe('Phase 5: God-Tier Validation Regression Tests', () => {
   });
 
   // ───────────────────────────────────────────────────────────────────────────
-  // 13. Fixture-vs-File Drift Detection (deferred to Phase 6)
+  // 13. Schema Enforcement (Tier 1 Regression)
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('Schema Enforcement (Tier 1 Regression)', () => {
+    it('36b. Unknown top-level field in raw file → schema_failed (additionalProperties: false regression)', () => {
+      // Uses real validateWorkflowSchema (not a mock) to verify the Tier 1 enforcement
+      // path calls schema validation. This test ensures additionalProperties: false in
+      // workflow.schema.json is enforced at the raw-file validation boundary. If this
+      // test fails, the schema enforcement layer has been broken.
+      const definitionWithUnknownField = {
+        ...def('schema-enforcement-test'),
+        unknownFieldForTesting: true,
+      } as unknown as WorkflowDefinition;
+
+      const rawFile: RawWorkflowFile = {
+        kind: 'parsed',
+        filePath: 'test.json',
+        relativeFilePath: 'test.json',
+        definition: definitionWithUnknownField,
+        variantKind: 'standard',
+      };
+
+      const snapshot = fakeSnapshot({ rawFiles: [rawFile] });
+      const deps = fakePipelineDeps(); // Uses real validateWorkflowSchema by default
+
+      const report = validateRegistry(snapshot, deps);
+
+      expect(report.isValid).toBe(false);
+      expect(report.tier1FailedRawFiles).toBe(1);
+      expect(report.rawFileResults[0]!.tier1Outcome.kind).toBe('schema_failed');
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 14. Fixture-vs-File Drift Detection (deferred to Phase 6)
   // ───────────────────────────────────────────────────────────────────────────
 
   describe('Fixture-vs-File Drift Detection', () => {

--- a/triggers.yml
+++ b/triggers.yml
@@ -3,7 +3,7 @@ triggers:
   # Use for one-off tasks when you don't want to go through the queue.
   - id: test-task
     provider: generic
-    workflowId: coding-task-workflow-agentic
+    workflowId: wr.coding-task
     workspacePath: /Users/etienneb/git/personal/workrail
     goalTemplate: "{{$.goal}}"
     concurrencyMode: parallel
@@ -19,7 +19,7 @@ triggers:
   # Dispatch manually: POST /webhook/mr-review {"pull_request": {"title": "PR #123: ...", "number": 123}}
   - id: mr-review
     provider: generic
-    workflowId: mr-review-workflow-agentic
+    workflowId: wr.mr-review
     workspacePath: /Users/etienneb/git/personal/workrail
     goalTemplate: "Review PR {{$.pull_request.number}}: {{$.pull_request.title}}"
     concurrencyMode: parallel


### PR DESCRIPTION
## Summary

When a non-bundled workflow file fails JSON schema validation it is silently dropped from the registry. Users have no way to know why their workflow disappeared from `list_workflows`. This PR adds `validationWarnings` to the response.

## Changes

- `src/infrastructure/storage/schema-validating-workflow-storage.ts`: new `loadAllWorkflowsWithWarnings()` paired method with call-scoped error collection (no state leak, `IWorkflowStorage` interface unchanged)
- `src/mcp/output-schemas.ts`: optional `validationWarnings` field added to `V2WorkflowListOutputSchema`
- `src/mcp/handlers/v2-workflow.ts`: type-narrows `workflowReader`, calls the new method, threads warnings into all 3 payload paths; `_nextStep` hint fires when warnings present

## Invariants
- Field absent (not `[]`) when no failures -- zero overhead for clean setups
- Bundled workflow failures excluded (npm package schema/workflow are always in sync)
- Valid workflows completely unaffected
- `IWorkflowStorage` interface unchanged (C3 architectural fix deferred)

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` passes
- [ ] `list_workflows` response includes `validationWarnings` when a non-bundled workflow has a schema error