### PR TITLE
fix(engine): validate metrics_outcome enum in checkContextBudget

### DIFF
--- a/src/mcp/handlers/v2-context-budget.ts
+++ b/src/mcp/handlers/v2-context-budget.ts
@@ -19,6 +19,7 @@ import {
   PAYLOAD_KIND,
   MAX_CONTEXT_BYTES,
   MAX_CONTEXT_DEPTH,
+  VALID_METRICS_OUTCOME,
 } from '../../v2/durable-core/constants.js';
 import { normalizeTokenErrorMessage } from './v2-error-mapping.js';
 import type { ToolFailure } from './v2-execution-helpers.js';
@@ -44,7 +45,8 @@ type ContextValidationDetails =
   | { readonly kind: 'context_circular_reference'; readonly tool: ContextToolNameV2; readonly path: string }
   | { readonly kind: 'context_too_deep'; readonly tool: ContextToolNameV2; readonly path: string; readonly maxDepth: number }
   | { readonly kind: 'context_not_canonical_json'; readonly tool: ContextToolNameV2; readonly measuredAs: 'jcs_utf8_bytes'; readonly code: string; readonly message: string }
-  | { readonly kind: 'context_budget_exceeded'; readonly tool: ContextToolNameV2; readonly measuredBytes: number; readonly maxBytes: number; readonly measuredAs: 'jcs_utf8_bytes' };
+  | { readonly kind: 'context_budget_exceeded'; readonly tool: ContextToolNameV2; readonly measuredBytes: number; readonly maxBytes: number; readonly measuredAs: 'jcs_utf8_bytes' }
+  | { readonly kind: 'context_invalid_metrics_outcome'; readonly tool: ContextToolNameV2; readonly invalidValue: string; readonly validValues: readonly string[] };
 
 export type ContextBudgetCheck = { readonly ok: true } | { readonly ok: false; readonly error: ToolFailure };
 
@@ -223,6 +225,43 @@ export function checkContextBudget(args: { readonly tool: ContextToolNameV2; rea
         }
       ) as ToolFailure,
     };
+  }
+
+  // ── Semantic key validation ───────────────────────────────────────────
+  // WHY this check lives here (not in validateAdvanceInputs or the Zod schema):
+  // checkContextBudget is the canonical context validation gate -- all context
+  // rejections flow through here with the VALIDATION_ERROR + errNotRetryable
+  // error shape. This ensures the agent receives an immediate, actionable error
+  // before any session I/O occurs. validateAdvanceInputs would use
+  // 'invariant_violation' (opaque to the agent); the Zod schema would require
+  // mixing semantic business rules into the structural schema layer.
+  //
+  // NOTE: if full metrics_* namespace validation (metrics_files_changed, etc.)
+  // is added in the future, extract this block into a separate
+  // validateMetricsContext() function to keep checkContextBudget focused.
+
+  const rawMetricsOutcome = (contextObj as Record<string, unknown>)['metrics_outcome'];
+  if (rawMetricsOutcome !== undefined && rawMetricsOutcome !== null) {
+    if (!(VALID_METRICS_OUTCOME as readonly unknown[]).includes(rawMetricsOutcome)) {
+      const details = {
+        kind: 'context_invalid_metrics_outcome',
+        tool: args.tool,
+        invalidValue: String(rawMetricsOutcome),
+        validValues: [...VALID_METRICS_OUTCOME],
+      } satisfies ContextValidationDetails & JsonObject;
+
+      return {
+        ok: false,
+        error: errNotRetryable(
+          'VALIDATION_ERROR',
+          `context.metrics_outcome has invalid value "${String(rawMetricsOutcome)}" for ${args.tool}. Valid values: ${VALID_METRICS_OUTCOME.map(v => `"${v}"`).join(', ')}.`,
+          {
+            suggestion: 'Set metrics_outcome to one of the valid enum values listed in validValues.',
+            details: details as unknown as JsonValue,
+          }
+        ) as ToolFailure,
+      };
+    }
   }
 
   return { ok: true };

--- a/src/v2/durable-core/constants.ts
+++ b/src/v2/durable-core/constants.ts
@@ -404,3 +404,25 @@ export const AUTONOMY_MODE = {
 } as const;
 
 export type AutonomyModeV1 = typeof AUTONOMY_MODE[keyof typeof AUTONOMY_MODE];
+
+// =============================================================================
+// Session Metrics: metrics_outcome enum
+// =============================================================================
+
+/**
+ * Closed set of valid values for the agent-reported `context.metrics_outcome` key.
+ *
+ * Why a named constant here: this enum is referenced in three places --
+ * `checkContextBudget` (validation), `projectSessionMetricsV2` (projection),
+ * and `buildMetricsSection` (prompt injection as inline text). Centralising the
+ * array here ensures all validation and projection code stays in sync when the
+ * enum evolves. The prompt renderer uses string literals and must be updated
+ * manually if a new value is added.
+ *
+ * Why these four values: they mirror the standard outcome vocabulary used in
+ * software delivery (success / partial / abandoned / error) and are injected
+ * into every final-step prompt via `buildMetricsSection`.
+ */
+export const VALID_METRICS_OUTCOME = ['success', 'partial', 'abandoned', 'error'] as const;
+
+export type MetricsOutcome = (typeof VALID_METRICS_OUTCOME)[number];

--- a/src/v2/projections/session-metrics.ts
+++ b/src/v2/projections/session-metrics.ts
@@ -1,5 +1,6 @@
 import type { DomainEventV1 } from '../durable-core/schemas/session/index.js';
-import { EVENT_KIND } from '../durable-core/constants.js';
+import { EVENT_KIND, VALID_METRICS_OUTCOME } from '../durable-core/constants.js';
+import type { MetricsOutcome } from '../durable-core/constants.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -114,10 +115,14 @@ export function projectSessionMetricsV2(
     d.captureConfidence === 'high' ? 'high' : 'none';
 
   // Extract agent-reported fields from metricsContext.
+  // WHY: VALID_METRICS_OUTCOME is the single source of truth for the enum.
+  // checkContextBudget validates against it at the tool boundary; this projection
+  // still coerces invalid values to null as defense-in-depth for events already
+  // stored before the validation check was added.
   const outcomeRaw = metricsContext['metrics_outcome'];
-  const outcome: 'success' | 'partial' | 'abandoned' | 'error' | null =
-    outcomeRaw === 'success' || outcomeRaw === 'partial' || outcomeRaw === 'abandoned' || outcomeRaw === 'error'
-      ? outcomeRaw
+  const outcome: MetricsOutcome | null =
+    (VALID_METRICS_OUTCOME as readonly unknown[]).includes(outcomeRaw)
+      ? (outcomeRaw as MetricsOutcome)
       : null;
 
   const prNumbers: number[] = [];

--- a/tests/unit/v2/context-budget-metrics-outcome.test.ts
+++ b/tests/unit/v2/context-budget-metrics-outcome.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for metrics_outcome enum validation in checkContextBudget.
+ *
+ * Why this matters: agents set context.metrics_outcome to free-text values
+ * (e.g. 'recommendation_delivered', 'pitch_written') and received no feedback
+ * because the projection silently mapped invalid values to null. These tests
+ * verify that checkContextBudget closes that enforcement loop by rejecting
+ * invalid values with a VALIDATION_ERROR before any session I/O occurs.
+ */
+import { describe, it, expect } from 'vitest';
+import { checkContextBudget } from '../../../src/mcp/handlers/v2-context-budget.js';
+import { VALID_METRICS_OUTCOME } from '../../../src/v2/durable-core/constants.js';
+
+describe('checkContextBudget: metrics_outcome validation', () => {
+  describe('invalid values are rejected', () => {
+    it('rejects a free-text value that looks like a task outcome', () => {
+      const result = checkContextBudget({
+        tool: 'continue_workflow',
+        context: { metrics_outcome: 'pitch_written' },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('VALIDATION_ERROR');
+        expect(result.error.message).toContain('"pitch_written"');
+        // All four valid values must appear in the error message
+        for (const v of VALID_METRICS_OUTCOME) {
+          expect(result.error.message).toContain(`"${v}"`);
+        }
+      }
+    });
+
+    it('rejects another common free-text value', () => {
+      const result = checkContextBudget({
+        tool: 'continue_workflow',
+        context: { metrics_outcome: 'recommendation_delivered' },
+      });
+
+      expect(result.ok).toBe(false);
+    });
+
+    it('populates details.details.kind = context_invalid_metrics_outcome', () => {
+      const result = checkContextBudget({
+        tool: 'continue_workflow',
+        context: { metrics_outcome: 'not_valid' },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        // errNotRetryable's third argument is { suggestion, details } where
+        // details is the ContextValidationDetails object.
+        const payload = (result.error as unknown as { details?: Record<string, unknown> }).details;
+        expect(payload).toBeDefined();
+        if (payload) {
+          const innerDetails = payload['details'] as Record<string, unknown> | undefined;
+          expect(innerDetails).toBeDefined();
+          expect(innerDetails?.['kind']).toBe('context_invalid_metrics_outcome');
+        }
+      }
+    });
+
+    it('populates details.details.invalidValue with the submitted value', () => {
+      const result = checkContextBudget({
+        tool: 'continue_workflow',
+        context: { metrics_outcome: 'bad_value' },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const payload = (result.error as unknown as { details?: Record<string, unknown> }).details;
+        if (payload) {
+          const innerDetails = payload['details'] as Record<string, unknown> | undefined;
+          expect(innerDetails?.['invalidValue']).toBe('bad_value');
+        }
+      }
+    });
+
+    it('populates details.details.validValues with all four valid values', () => {
+      const result = checkContextBudget({
+        tool: 'continue_workflow',
+        context: { metrics_outcome: 'wrong' },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const payload = (result.error as unknown as { details?: Record<string, unknown> }).details;
+        if (payload) {
+          const innerDetails = payload['details'] as Record<string, unknown> | undefined;
+          const validValues = innerDetails?.['validValues'];
+          expect(Array.isArray(validValues)).toBe(true);
+          if (Array.isArray(validValues)) {
+            expect(validValues).toHaveLength(4);
+            for (const v of VALID_METRICS_OUTCOME) {
+              expect(validValues).toContain(v);
+            }
+          }
+        }
+      }
+    });
+  });
+
+  describe('valid enum values pass through', () => {
+    for (const validValue of VALID_METRICS_OUTCOME) {
+      it(`accepts "${validValue}"`, () => {
+        const result = checkContextBudget({
+          tool: 'continue_workflow',
+          context: { metrics_outcome: validValue },
+        });
+
+        expect(result.ok).toBe(true);
+      });
+    }
+  });
+
+  describe('absent and null values pass through (backward compat)', () => {
+    it('passes when metrics_outcome is absent from context', () => {
+      const result = checkContextBudget({
+        tool: 'continue_workflow',
+        context: {},
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('passes when metrics_outcome is null', () => {
+      const result = checkContextBudget({
+        tool: 'continue_workflow',
+        context: { metrics_outcome: null },
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('passes when context has no metrics_outcome key at all', () => {
+      const result = checkContextBudget({
+        tool: 'continue_workflow',
+        context: { someOtherKey: 'anything' },
+      });
+
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('other context keys are unaffected', () => {
+    it('does not validate non-metrics_outcome context keys', () => {
+      const result = checkContextBudget({
+        tool: 'continue_workflow',
+        context: {
+          metrics_files_changed: 'not_a_number', // would fail if we validated this key
+          metrics_lines_added: 'also_not_a_number',
+          someOtherKey: 'any_value',
+        },
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('passes a valid metrics_outcome alongside other keys', () => {
+      const result = checkContextBudget({
+        tool: 'continue_workflow',
+        context: {
+          metrics_outcome: 'success',
+          metrics_pr_numbers: [123, 456],
+          ticketId: 'TICKET-1',
+        },
+      });
+
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('error message is actionable', () => {
+    it('error message names the invalid value', () => {
+      const result = checkContextBudget({
+        tool: 'continue_workflow',
+        context: { metrics_outcome: 'my_custom_outcome' },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('my_custom_outcome');
+      }
+    });
+
+    it('error message includes the tool name', () => {
+      const result = checkContextBudget({
+        tool: 'continue_workflow',
+        context: { metrics_outcome: 'bad' },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('continue_workflow');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Agents were setting `context.metrics_outcome` to free-text values like `'recommendation_delivered'`, `'pitch_written'`, `'discovery_complete'` instead of the valid enum. The projection silently mapped these to `null` with no feedback, so agents never knew they were wrong.

## Fix

Adds a `VALIDATION_ERROR` at the `continue_workflow` boundary when `metrics_outcome` is present, non-null, and not in the valid enum.

## Changes

- `src/v2/durable-core/constants.ts`: new `VALID_METRICS_OUTCOME` constant + `MetricsOutcome` type (single source of truth)
- `src/mcp/handlers/v2-context-budget.ts`: new `context_invalid_metrics_outcome` variant + validation check
- `src/v2/projections/session-metrics.ts`: uses shared constant instead of inline comparison
- `tests/unit/v2/context-budget-metrics-outcome.test.ts`: 16 new tests

## Invariants

- Absent/null values pass through unchanged (backward compat)
- Invalid non-null values produce clear error listing valid values
- Fires before any session I/O

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] 16 new tests pass
- [ ] `npx vitest run` passes