### PR TITLE
fix(daemon): abort in-flight agent loops on SIGTERM/SIGINT

### DIFF
--- a/.workrail/implementation_plan.md
+++ b/.workrail/implementation_plan.md
@@ -687,3 +687,160 @@ Commit: `feat(mcp): surface workflow validation failures in list_workflows respo
 `planConfidenceBand`: High
 `estimatedPRCount`: 1
 `followUpTickets`: ["inspect_workflow validation surface (broken workflows still NOT_FOUND, separate pitch)"]
+
+---
+---
+
+# Implementation Plan: Graceful Shutdown via AbortRegistry
+
+*Generated: 2026-04-23 | Workflow: wr.coding-task | Branch: fix/etienneb/graceful-shutdown*
+
+---
+
+## 1. Problem Statement
+
+SIGTERM/SIGINT does not abort in-flight `AgentLoop` instances in the WorkTrain daemon. `handle.stop()` closes the HTTP server and polling, but live `AgentLoop` instances keep making LLM API calls for up to 30 minutes. This breaks container orchestrators (Kubernetes, ECS), systemd, and rolling restarts.
+
+## 2. Acceptance Criteria
+
+1. SIGTERM causes all in-flight `AgentLoop` instances to receive `abort()` immediately.
+2. Process exits within ~5 seconds of SIGTERM rather than up to 30 minutes.
+3. `session_aborted` events are emitted before `abort()` (ordering preserved).
+4. `npm run build` exits 0.
+5. `npx vitest run` exits 0 (5 pre-existing `polling-scheduler` failures are unrelated).
+
+## 3. Non-Goals
+
+- No new HTTP endpoint for per-session abort.
+- No changes to the WorkRail MCP server (`src/mcp/`) or its shutdown path.
+- No mid-step graceful save -- sessions are hard-aborted; crash recovery handles the interrupted token.
+- No changes to `src/v2/durable-core/`.
+- No configurable drain window -- 5s is fixed.
+
+## 4. Philosophy-Driven Constraints
+
+- **YAGNI**: add exactly what the pitch specifies, no more.
+- **Dependency injection**: `abortRegistry` injected from composition root (`trigger-listener.ts`), not created inside `runWorkflow()` or `TriggerRouter`.
+- **Immutability under tension**: `Map` is mutable -- same accepted compromise as `SteerRegistry`.
+- **Document why**: WHY comments matching the `SteerRegistry` block pattern.
+
+## 5. Invariants
+
+- I1: `session_aborted` events emitted BEFORE any `abort()` call (ordering preserved).
+- I2: `abort()` called BEFORE `handle.stop()` closes the HTTP server.
+- I3: `handle.stop()` called BEFORE `resolve()` exits the shutdown promise.
+- I4: Drain window caps at exactly 5 seconds, regardless of session count.
+- I5: `abortRegistry.delete()` placed synchronously in `finally` alongside `steerRegistry.delete()`.
+- I6: `makeSpawnAgentTool()` does NOT pass `abortRegistry` to child sessions (consistent with `steerRegistry` treatment).
+
+## 6. Selected Approach + Rationale
+
+**Candidate A: Mirror SteerRegistry pattern exactly.**
+
+`AbortRegistry = Map<string, () => void>` -- maps workrailSessionId to abort callback. Threaded as optional 7th param through `runWorkflow()`, `RunWorkflowFn`, `TriggerRouter`, `TriggerListenerHandle`. Drain window: `Promise.race([5s timeout, registry-empty poll every 100ms])`.
+
+- Resolves: abort-fast + cleanup budget tensions.
+- Accepts: Map mutation at boundary (same as SteerRegistry).
+- Follows existing pattern exactly -- zero new abstractions.
+
+**Runner-up**: AbortController Map -- rejected because it requires `agent-loop.ts` changes excluded by pitch no-go.
+
+## 7. Vertical Slices
+
+### Slice 1: Add `AbortRegistry` type to `src/daemon/workflow-runner.ts`
+
+Export `AbortRegistry = Map<string, () => void>` alongside `SteerRegistry` (after line 665).
+
+**Done when**: `AbortRegistry` type is exported from `workflow-runner.ts`. Build clean.
+
+### Slice 2: Wire `AbortRegistry` through `runWorkflow()`
+
+Add `abortRegistry?: AbortRegistry` as optional 7th param to `runWorkflow()`.
+
+After `steerRegistry?.set()` at line 3498:
+```typescript
+if (workrailSessionId !== null) {
+  abortRegistry?.set(workrailSessionId, () => agent.abort());
+}
+```
+
+In `finally` block at line 4081, after `steerRegistry?.delete()`:
+```typescript
+if (workrailSessionId !== null) {
+  abortRegistry?.delete(workrailSessionId);
+}
+```
+
+**Done when**: `runWorkflow()` accepts and uses `abortRegistry`. Build clean.
+
+### Slice 3: Update `RunWorkflowFn` type and `TriggerRouter` in `src/trigger/trigger-router.ts`
+
+1. Add `abortRegistry?: AbortRegistry` as 7th param to `RunWorkflowFn` type.
+2. Add `private readonly abortRegistry: AbortRegistry | undefined` field to `TriggerRouter`.
+3. Add `abortRegistry?: AbortRegistry` to `TriggerRouter` constructor (after `steerRegistry`).
+4. Assign `this.abortRegistry = abortRegistry` in constructor body.
+5. Pass `this.abortRegistry` at both `runWorkflowFn` call sites (lines 765, 910).
+
+**Done when**: Both call sites pass `abortRegistry`. Build clean.
+
+### Slice 4: Expose `abortRegistry` from `TriggerListenerHandle` in `src/trigger/trigger-listener.ts`
+
+1. Import `AbortRegistry` from `workflow-runner.ts`.
+2. Add `readonly abortRegistry: AbortRegistry` to `TriggerListenerHandle` interface.
+3. Construct `const abortRegistry: AbortRegistry = new Map()` alongside `steerRegistry`.
+4. Pass `abortRegistry` to `TriggerRouter` constructor (after `steerRegistry`).
+5. Return `abortRegistry` on the handle object.
+
+**Done when**: `TriggerListenerHandle.abortRegistry` is typed, constructed, and returned. Build clean.
+
+### Slice 5: Update shutdown handler in `src/cli-worktrain.ts`
+
+Replace the shutdown sequence (lines 459-482) with:
+1. Emit `session_aborted` for each active session (unchanged from current).
+2. Emit `daemon_stopped` (unchanged from current).
+3. Call `abort()` for all `handle.abortRegistry.values()`.
+4. Drain window: `Promise.race([5s timeout, registry-empty poll every 100ms])`.
+5. Call `await handle.stop()`.
+6. Call `resolve()`.
+
+**Done when**: Shutdown handler drains correctly. Build and tests clean.
+
+## 8. Test Design
+
+No new unit tests for this change. The implementation is structural wiring (new optional param, registration/deregistration), not new logic. Verification:
+
+- `npm run build`: TypeScript catches any signature mismatches at all call sites.
+- `npx vitest run`: Existing tests exercise `runWorkflow()`, `TriggerRouter`, and `trigger-listener.ts` with the new optional param absent (which is valid).
+- Manual verification: SIGTERM behavior requires a running daemon -- not testable via unit tests without significant new test infrastructure (out of scope per pitch).
+
+## 9. Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Session registers in abortRegistry after abort-all fires | Very low | Low | Same ~50ms gap as steerRegistry; accepted |
+| Session finally block takes >5s | Very low | Low | Crash recovery handles incomplete sidecars |
+| TypeScript build error at call site | Low | Low | Build catches immediately |
+
+## 10. PR Packaging Strategy
+
+Single PR. Branch: `fix/etienneb/graceful-shutdown`. One commit.
+Commit: `fix(daemon): abort in-flight agent loops on SIGTERM with 5s drain window`
+
+## 11. Philosophy Alignment per Slice
+
+| Slice | Principle | Status |
+|---|---|---|
+| 1 (AbortRegistry type) | Explicit domain types | Satisfied -- named export, not inline |
+| 2 (runWorkflow) | Dependency injection | Satisfied -- injected from caller, not created inside |
+| 2 (runWorkflow) | Immutability under tension | Accepted -- Map mutation required for registry |
+| 3 (TriggerRouter) | YAGNI | Satisfied -- mirrors steerRegistry exactly |
+| 4 (TriggerListenerHandle) | Dependency injection | Satisfied -- composition root constructs registry |
+| 5 (Shutdown) | Document why | Satisfied -- WHY comments in drain window |
+| 5 (Shutdown) | Determinism | Satisfied -- 5s cap is fixed, not configurable |
+| All | Architectural fix | Satisfied -- registry pattern solves root cause, not a workaround |
+
+---
+`unresolvedUnknownCount`: 0
+`planConfidenceBand`: High
+`estimatedPRCount`: 1
+`followUpTickets`: []

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -461,12 +461,15 @@ program
               // Clear heartbeat before stopping -- prevents timer from firing after
               // the process is in teardown state.
               clearInterval(heartbeatInterval);
-              // WHY emit session_aborted before handle.stop(): in-flight sessions have
-              // their agent loops killed by handle.stop() but never emit session_completed.
-              // Without these events the JSONL log shows them as RUNNING forever, making
-              // `worktrain health` and `worktrain status` untrustworthy after restart.
-              // steerRegistry keys are workrailSessionIds of sessions currently in the
-              // agent loop. Emit before handle.stop() while I/O is still active.
+
+              // 1. Emit session_aborted for all in-flight sessions.
+              // WHY emit before abort(): in-flight sessions have their agent loops cancelled
+              // by abort() but never emit session_completed. Without these events the JSONL
+              // log shows them as RUNNING forever, making `worktrain health` and
+              // `worktrain status` untrustworthy after restart.
+              // WHY use steerRegistry keys: steerRegistry keys are workrailSessionIds of
+              // sessions currently in the agent loop. Emit before any abort() while I/O is
+              // still active.
               for (const workrailSessionId of handle.steerRegistry.keys()) {
                 emitter.emit({
                   kind: 'session_aborted',
@@ -477,6 +480,42 @@ program
                 });
               }
               emitter.emit({ kind: 'daemon_stopped', reason: 'graceful', ts: Date.now() });
+
+              // 2. Abort all in-flight AgentLoop instances simultaneously.
+              // WHY simultaneous (not sequential): all sessions should start aborting at
+              // the same time so the drain window is not wasted waiting for session N to
+              // abort before starting session N+1.
+              for (const abort of handle.abortRegistry.values()) {
+                abort();
+              }
+
+              // 3. Drain window: give sessions up to 5s to finish cleanup after abort.
+              // WHY 5 seconds: bounded wait for sessions' finally blocks (token persistence,
+              // stats write, steerRegistry.delete, abortRegistry.delete). Fire-and-forget
+              // writes are not awaited so cleanup is near-instantaneous in practice.
+              // WHY Promise.race: exits immediately when all sessions have deleted their
+              // abortRegistry entries (registry empty = all cleanup done), or after 5s cap
+              // whichever is first. Never blocks longer than 5s.
+              if (handle.abortRegistry.size > 0) {
+                await Promise.race([
+                  new Promise<void>(resolve => setTimeout(resolve, 5000)),
+                  // Sessions deregister from abortRegistry in their finally blocks;
+                  // when the registry is empty all sessions have exited.
+                  new Promise<void>(resolve => {
+                    const check = setInterval(() => {
+                      if (handle.abortRegistry.size === 0) {
+                        clearInterval(check);
+                        resolve();
+                      }
+                    }, 100);
+                  }),
+                ]);
+              }
+
+              // 4. Stop HTTP server and polling loop.
+              // WHY after abort+drain: ensures abort() is called before the HTTP server
+              // closes. If handle.stop() were called first, active sessions would have
+              // no way to complete their final continue_workflow calls.
               await handle.stop();
               resolve();
             };

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -2504,6 +2504,7 @@ export function makeSpawnAgentTool(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   schemas: Record<string, any>,
   emitter?: DaemonEventEmitter,
+  abortRegistry?: AbortRegistry,
 ): AgentTool {
   return {
     name: 'spawn_agent',
@@ -2624,6 +2625,8 @@ export function makeSpawnAgentTool(
         apiKey,
         undefined, // daemonRegistry: child sessions are not registered (no isLive tracking needed)
         emitter,
+        undefined, // steerRegistry: child sessions are not steerable by coordinator
+        abortRegistry, // WHY: thread abort registry so child sessions are abortable on SIGTERM
       ) as ChildWorkflowRunResult;
       // WHY cast to ChildWorkflowRunResult: runWorkflow() returns WorkflowRunResult (4 variants)
       // for TriggerRouter compatibility, but structurally only produces success/error/timeout.
@@ -3585,6 +3588,17 @@ export async function runWorkflow(
   // WHY registered here (not at top of function): same as SteerRegistry -- workrailSessionId
   // is the registry key and is only available after parseContinueTokenOrFail() succeeds.
   //
+  // WHY registered BEFORE AgentLoop construction: ensures the registry entry exists if SIGTERM
+  // fires during the context-loading phase (soul + workspace + session notes) between this point
+  // and the `const agent = new AgentLoop(...)` call below. The shutdown handler can safely call
+  // the callback at any point after registration.
+  //
+  // IMPORTANT: Any early-return path between this registration and `const agent = new AgentLoop`
+  // below MUST explicitly delete both steerRegistry and abortRegistry entries. Failing to do so
+  // leaves stale callbacks that will throw a TDZ ReferenceError when the shutdown handler fires
+  // (because `agent` is declared with `const` later in this scope and is never initialized on
+  // those paths).
+  //
   // WHY () => agent.abort() (not agent itself): the registry value is an opaque callback,
   // consistent with SteerRegistry pattern. The shutdown handler never needs to inspect the
   // agent directly.
@@ -3667,6 +3681,13 @@ export async function runWorkflow(
       console.error(`[WorkflowRunner] Worktree creation failed: sessionId=${sessionId} error=${errMsg}`);
       emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'error', detail: errMsg.slice(0, 200), ...withWorkrailSession(workrailSessionId) });
       if (workrailSessionId !== null) daemonRegistry?.unregister(workrailSessionId, 'failed');
+      // Clean up registry entries: agent was never constructed, so these callbacks are stale.
+      // Without cleanup, the shutdown handler would call the abort callback and hit a TDZ
+      // ReferenceError because `agent` is declared later in this function scope.
+      if (workrailSessionId !== null) {
+        steerRegistry?.delete(workrailSessionId);
+        abortRegistry?.delete(workrailSessionId);
+      }
       writeExecutionStats(DAEMON_STATS_DIR, sessionId, trigger.workflowId, startMs, 'error', 0);
       return {
         _tag: 'error',
@@ -3709,6 +3730,13 @@ export async function runWorkflow(
     }
     emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'success', detail: 'stop', ...withWorkrailSession(workrailSessionId) });
     if (workrailSessionId !== null) daemonRegistry?.unregister(workrailSessionId, 'completed');
+    // Clean up registry entries: agent was never constructed, so these callbacks are stale.
+    // Without cleanup, the shutdown handler would call the abort callback and hit a TDZ
+    // ReferenceError because `agent` is declared later in this function scope.
+    if (workrailSessionId !== null) {
+      steerRegistry?.delete(workrailSessionId);
+      abortRegistry?.delete(workrailSessionId);
+    }
     writeExecutionStats(DAEMON_STATS_DIR, sessionId, trigger.workflowId, startMs, 'success', 0); // stepCount=0: agent loop never ran; stepAdvanceCount tracks loop advances only
     return {
       _tag: 'success',
@@ -3806,6 +3834,7 @@ export async function runWorkflow(
       runWorkflow,
       schemas,
       emitter,
+      abortRegistry, // WHY: thread abort registry so child sessions are abortable on SIGTERM
     ),
     // WHY signal_coordinator is listed last: it is a mid-step observability tool,
     // not a control-flow tool. Placing it after the primary workflow tools ensures

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -678,6 +678,22 @@ export type ChildWorkflowRunResult = WorkflowRunSuccess | WorkflowRunError | Wor
 export type SteerRegistry = Map<string, (text: string) => void>;
 
 /**
+ * Registry mapping WorkRail session IDs to abort callbacks.
+ * Each runWorkflow() call registers () => agent.abort() on session start
+ * and deregisters on completion. The shutdown handler calls all callbacks
+ * to abort every in-flight AgentLoop simultaneously.
+ *
+ * WHY alongside SteerRegistry: mirrors the same composition-root injection
+ * pattern. Both are constructed in trigger-listener.ts (the composition root),
+ * injected through TriggerRouter -> runWorkflow(), and returned on
+ * TriggerListenerHandle so the shutdown handler can drain them.
+ *
+ * Daemon-only: only populated by daemon sessions. MCP-mode sessions do not
+ * register callbacks.
+ */
+export type AbortRegistry = Map<string, () => void>;
+
+/**
  * A session file found in DAEMON_SESSIONS_DIR during startup recovery.
  *
  * Each active runWorkflow() call writes a per-session file to DAEMON_SESSIONS_DIR.
@@ -3301,6 +3317,7 @@ export async function runWorkflow(
   daemonRegistry?: DaemonRegistry,
   emitter?: DaemonEventEmitter,
   steerRegistry?: SteerRegistry,
+  abortRegistry?: AbortRegistry,
 ): Promise<WorkflowRunResult> {
   // ---- Execution timing (for calibration of session timeouts) ----
   // WHY at entry: captures the true start before any early-exit paths (model validation,
@@ -3558,6 +3575,24 @@ export async function runWorkflow(
   // should retry once on 404 during session start-up.
   if (workrailSessionId !== null) {
     steerRegistry?.set(workrailSessionId, (text: string) => { pendingSteerParts.push(text); });
+  }
+
+  // ---- AbortRegistry: register abort callback for graceful shutdown ----
+  // The abort callback calls agent.abort(), which cancels any in-flight LLM API call
+  // and signals the agent loop to exit. Called by the daemon shutdown handler on
+  // SIGTERM/SIGINT to abort all in-flight sessions simultaneously.
+  //
+  // WHY registered here (not at top of function): same as SteerRegistry -- workrailSessionId
+  // is the registry key and is only available after parseContinueTokenOrFail() succeeds.
+  //
+  // WHY () => agent.abort() (not agent itself): the registry value is an opaque callback,
+  // consistent with SteerRegistry pattern. The shutdown handler never needs to inspect the
+  // agent directly.
+  //
+  // Registration gap: same ~50ms window as SteerRegistry. A session started in this window
+  // will not receive abort() from the shutdown handler. Acceptable -- same accepted tradeoff.
+  if (workrailSessionId !== null) {
+    abortRegistry?.set(workrailSessionId, () => { agent.abort(); });
   }
 
   // Crash safety: persist tokens before starting the agent loop. A crash between
@@ -4147,6 +4182,13 @@ export async function runWorkflow(
     // the endpoint return 200 (calling the closed-over callback) on a dead session.
     if (workrailSessionId !== null) {
       steerRegistry?.delete(workrailSessionId);
+    }
+    // Deregister abort callback so the shutdown handler does not call abort() on a session
+    // that has already exited. WHY synchronous / WHY in finally: same rationale as steerRegistry
+    // above. The drain window in the shutdown handler polls abortRegistry.size to determine
+    // when all sessions have completed cleanup -- this delete is the signal that cleanup is done.
+    if (workrailSessionId !== null) {
+      abortRegistry?.delete(workrailSessionId);
     }
     console.log(`[WorkflowRunner] Agent loop ended: sessionId=${sessionId} stopReason=${stopReason}${errorMessage ? ` error=${errorMessage.slice(0, 120)}` : ''}`);
 

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -32,7 +32,7 @@ import type { V2ToolContext } from '../mcp/types.js';
 import { loadTriggerConfigFromFile, buildTriggerIndex } from './trigger-store.js';
 import type { TriggerStoreError } from './trigger-store.js';
 import { TriggerRouter, type RunWorkflowFn } from './trigger-router.js';
-import type { SteerRegistry } from '../daemon/workflow-runner.js';
+import type { SteerRegistry, AbortRegistry } from '../daemon/workflow-runner.js';
 import { loadWorkrailConfigFile, loadWorkspacesFromConfigFile } from '../config/config-file.js';
 import { NotificationService } from './notification-service.js';
 import { runWorkflow, runStartupRecovery } from '../daemon/workflow-runner.js';
@@ -78,9 +78,16 @@ export interface TriggerListenerHandle {
   readonly router: TriggerRouter;
   /**
    * The steer registry shared with TriggerRouter.
-   * Used during daemon shutdown to abort in-flight sessions gracefully.
+   * Used during daemon shutdown to emit session_aborted events for in-flight sessions.
    */
   readonly steerRegistry: SteerRegistry;
+  /**
+   * The abort registry shared with TriggerRouter.
+   * Call each value to abort the corresponding in-flight AgentLoop.
+   * Used during daemon shutdown to stop all sessions immediately.
+   * Poll size to 0 to detect when all sessions have completed cleanup.
+   */
+  readonly abortRegistry: AbortRegistry;
   /**
    * The PollingScheduler instance created by this listener.
    * Used to manage the polling loop lifecycle (start/stop).
@@ -380,6 +387,12 @@ export async function startTriggerListener(
   // that wires TriggerRouter and the console route layer together. Both need the SAME registry instance
   // so the HTTP endpoint dispatches to callbacks registered by TriggerRouter's sessions.
   const steerRegistry: SteerRegistry = new Map();
+
+  // Create the abort registry for graceful shutdown on SIGTERM/SIGINT.
+  // WHY created here (not in TriggerRouter): same composition-root rationale as steerRegistry.
+  // The shutdown handler in cli-worktrain.ts reads handle.abortRegistry and calls each
+  // abort callback to stop all in-flight AgentLoop instances simultaneously.
+  const abortRegistry: AbortRegistry = new Map();
 
   // ---------------------------------------------------------------------------
   // Adaptive coordinator deps: wire real implementations for dispatchAdaptivePipeline.
@@ -798,7 +811,7 @@ export async function startTriggerListener(
 
   // Create router and Express app
   const runWorkflowFn: RunWorkflowFn = options.runWorkflowFn ?? runWorkflow;
-  const router = new TriggerRouter(triggerIndex, ctx, apiKey, runWorkflowFn, undefined, maxConcurrentSessions, options.emitter, notificationService, steerRegistry, coordinatorDeps, modeExecutors);
+  const router = new TriggerRouter(triggerIndex, ctx, apiKey, runWorkflowFn, undefined, maxConcurrentSessions, options.emitter, notificationService, steerRegistry, abortRegistry, coordinatorDeps, modeExecutors);
   // Populate the forward reference so spawnSession can dispatch in-process.
   // WHY here (not before construction): routerRef is a forward-ref needed because
   // coordinatorDeps must be constructed before TriggerRouter (it's a constructor arg).
@@ -876,6 +889,7 @@ export async function startTriggerListener(
         port: actualPort,
         router,
         steerRegistry,
+        abortRegistry,
         scheduler: pollingScheduler,
         stop: async () => {
           // Stop polling BEFORE closing the HTTP server to prevent dispatch()

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -27,7 +27,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import type { WorkflowTrigger, WorkflowRunResult, WorkflowDeliveryFailed, SteerRegistry } from '../daemon/workflow-runner.js';
+import type { WorkflowTrigger, WorkflowRunResult, WorkflowDeliveryFailed, SteerRegistry, AbortRegistry } from '../daemon/workflow-runner.js';
 import { DAEMON_SESSIONS_DIR } from '../daemon/workflow-runner.js';
 import { assertNever } from '../runtime/assert-never.js';
 import type { V2ToolContext } from '../mcp/types.js';
@@ -78,6 +78,7 @@ export type RunWorkflowFn = (
   daemonRegistry?: import('../v2/infra/in-memory/daemon-registry/index.js').DaemonRegistry,
   emitter?: DaemonEventEmitter,
   steerRegistry?: SteerRegistry,
+  abortRegistry?: AbortRegistry,
 ) => Promise<WorkflowRunResult>;
 
 // ---------------------------------------------------------------------------
@@ -495,6 +496,7 @@ export class TriggerRouter {
   private readonly emitter: DaemonEventEmitter | undefined;
   private readonly notificationService: NotificationService | undefined;
   private readonly steerRegistry: SteerRegistry | undefined;
+  private readonly abortRegistry: AbortRegistry | undefined;
   private readonly _coordinatorDeps: AdaptiveCoordinatorDeps | undefined;
   private readonly _modeExecutors: ModeExecutors | undefined;
 
@@ -568,6 +570,14 @@ export class TriggerRouter {
      */
     steerRegistry?: SteerRegistry,
     /**
+     * Optional abort registry for graceful daemon shutdown.
+     * When provided, daemon sessions register an abort callback on start and deregister
+     * on completion. The shutdown handler calls all registered callbacks to abort every
+     * in-flight AgentLoop simultaneously, then waits for sessions to finish cleanup.
+     * When absent, SIGTERM does not abort in-flight sessions (they run to completion).
+     */
+    abortRegistry?: AbortRegistry,
+    /**
      * Optional adaptive coordinator dependencies for in-process pipeline dispatch.
      * When provided, dispatchAdaptivePipeline() uses these as default deps.
      * When absent, dispatchAdaptivePipeline() logs a warning and returns an escalated outcome.
@@ -593,6 +603,7 @@ export class TriggerRouter {
     this.emitter = emitter;
     this.notificationService = notificationService;
     this.steerRegistry = steerRegistry;
+    this.abortRegistry = abortRegistry;
     this._coordinatorDeps = coordinatorDeps;
     this._modeExecutors = modeExecutors;
     // Validate and clamp: maxConcurrentSessions must be >= 1.
@@ -762,7 +773,7 @@ export class TriggerRouter {
       await this.semaphore.acquire();
       let result: WorkflowRunResult;
       try {
-        result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey, undefined, this.emitter, this.steerRegistry);
+        result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey, undefined, this.emitter, this.steerRegistry, this.abortRegistry);
       } finally {
         this.semaphore.release();
       }
@@ -907,7 +918,7 @@ export class TriggerRouter {
       await this.semaphore.acquire();
       let result: WorkflowRunResult;
       try {
-        result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey, undefined, this.emitter, this.steerRegistry);
+        result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey, undefined, this.emitter, this.steerRegistry, this.abortRegistry);
       } finally {
         this.semaphore.release();
       }

--- a/tests/unit/trigger-router.test.ts
+++ b/tests/unit/trigger-router.test.ts
@@ -1759,6 +1759,7 @@ describe('TriggerRouter.dispatchAdaptivePipeline deduplication', () => {
       undefined, // emitter
       undefined, // notificationService
       undefined, // steerRegistry
+      undefined, // abortRegistry
       FAKE_DEPS,
       executors,
     );
@@ -1810,7 +1811,8 @@ describe('TriggerRouter.dispatchAdaptivePipeline deduplication', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
+      undefined, // steerRegistry
+      undefined, // abortRegistry
       FAKE_DEPS,
       executors,
     );
@@ -1859,7 +1861,8 @@ describe('TriggerRouter.dispatchAdaptivePipeline deduplication', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
+      undefined, // steerRegistry
+      undefined, // abortRegistry
       FAKE_DEPS,
       executors,
     );
@@ -1993,7 +1996,8 @@ describe('TriggerRouter.dispatch _preAllocatedStartResponse bypass', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
+      undefined, // steerRegistry
+      undefined, // abortRegistry
       FAKE_DEPS_FOR_BYPASS,
       executors,
     );

--- a/tests/unit/workflow-runner-spawn-agent.test.ts
+++ b/tests/unit/workflow-runner-spawn-agent.test.ts
@@ -372,4 +372,51 @@ describe('makeSpawnAgentTool() result mapping', () => {
     // artifacts key must be present with value [] -- [] !== undefined, so the spread fires
     expect(parsed.artifacts).toEqual([]);
   });
+
+  it('threads abortRegistry through to child runWorkflowFn (F2: child sessions abortable on SIGTERM)', async () => {
+    // Verifies that makeSpawnAgentTool passes abortRegistry to the child runWorkflowFn call.
+    // Without this, child sessions created via spawn_agent are invisible to the shutdown handler
+    // and cannot be aborted on SIGTERM.
+    const abortRegistry = new Map<string, () => void>();
+    let capturedAbortRegistry: unknown;
+
+    // The stub captures the abortRegistry argument (7th positional param of runWorkflow:
+    // trigger, ctx, apiKey, daemonRegistry, emitter, steerRegistry, abortRegistry).
+    const runWorkflowStub: typeof import('../../src/daemon/workflow-runner.js').runWorkflow = async (
+      _trigger,
+      _ctx,
+      _apiKey,
+      _daemonRegistry,
+      _emitter,
+      _steerRegistry,
+      capturedReg,
+    ) => {
+      capturedAbortRegistry = capturedReg;
+      return {
+        _tag: 'success',
+        workflowId: 'test-workflow',
+        stopReason: 'completed',
+        lastStepNotes: 'done',
+      } as WorkflowRunSuccess;
+    };
+
+    const tool = makeSpawnAgentTool(
+      'sess-1',
+      FAKE_CTX,
+      FAKE_API_KEY,
+      'parent-session-id',
+      0,
+      3,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      runWorkflowStub as any,
+      FAKE_SCHEMAS,
+      undefined, // emitter
+      abortRegistry,
+    );
+
+    await tool.execute('call-1', FAKE_PARAMS);
+
+    // The abortRegistry passed to makeSpawnAgentTool MUST be forwarded to the child session.
+    expect(capturedAbortRegistry).toBe(abortRegistry);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `AbortRegistry = Map<string, () => void>` alongside the existing `SteerRegistry`
- Each `runWorkflow()` call registers `() => agent.abort()` keyed by WorkRail session ID
- Shutdown handler now: emits `session_aborted` events → calls all abort callbacks → 5s drain window → closes HTTP server → exits
- Process now exits within ~5 seconds of SIGTERM instead of up to 30 minutes

## Problem

SIGTERM/SIGINT stopped the HTTP server and polling scheduler but left in-flight `AgentLoop` instances making LLM API calls indefinitely. This broke container orchestrators (Kubernetes `terminationGracePeriodSeconds`), systemd `TimeoutStopSec`, and rolling restarts.

## Files changed

- `src/daemon/workflow-runner.ts` -- `AbortRegistry` type, `runWorkflow()` registers/deregisters abort callback
- `src/trigger/trigger-router.ts` -- threads `abortRegistry` through `RunWorkflowFn` and both dispatch call sites
- `src/trigger/trigger-listener.ts` -- constructs registry, wires into router, exposes on `TriggerListenerHandle`
- `src/cli-worktrain.ts` -- updated shutdown handler with abort-all + drain window
- `tests/unit/trigger-router.test.ts` -- updated call sites for new optional parameter

## Test plan
- [ ] `npm run build` passes
- [ ] `npx vitest run` passes (5 pre-existing `polling-scheduler` failures are unrelated)
- [ ] `session_aborted` events still emitted before abort (ordering preserved)
- [ ] No MCP server changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)