### PR TITLE
feat(engine): add maxQueueDepth per-trigger queue cap with HTTP 429

### DIFF
--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -284,6 +284,25 @@ export interface DaemonHeartbeatEvent {
 }
 
 /**
+ * A dispatch was rejected because the per-trigger serialization queue was at capacity.
+ *
+ * WHY: emitted on every HTTP 429 rejection so operators can observe backpressure events
+ * in the daemon event log. This is the daemon-side counterpart to the HTTP 429 response --
+ * the HTTP layer tells the caller, this event records the rejection in the event log.
+ *
+ * WHY reason is a closed union: make illegal states unrepresentable. Only 'queue_full'
+ * is possible today; future rejection reasons (e.g. 'trigger_paused') can be added here.
+ */
+export interface SessionDroppedEvent {
+  readonly kind: 'session_dropped';
+  readonly triggerId: string;
+  readonly workflowId: string;
+  readonly reason: 'queue_full';
+  readonly queueDepth: number;
+  readonly maxQueueDepth: number;
+}
+
+/**
  * Emitted when the agent calls signal_coordinator to record a coordinator signal.
  *
  * WHY a separate event kind: coordinator signals are categorically different from
@@ -361,6 +380,7 @@ export type DaemonEvent =
   | TriggerFiredEvent
   | SessionQueuedEvent
   | SessionStartedEvent
+  | SessionDroppedEvent
   | ToolCalledEvent
   | ToolErrorEvent
   | StepAdvancedEvent

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -217,6 +217,17 @@ export function createTriggerApp(router: TriggerRouter): express.Application {
         case 'payload_error':
           res.status(400).json({ error: result.error.message });
           return;
+        case 'queue_full':
+          // WHY Retry-After: the value comes from route() which has access to the trigger's
+          // maxSessionMinutes. It is an approximation of the worst-case drain time for one slot.
+          res.status(429)
+            .set('Retry-After', String(result.error.retryAfterSeconds))
+            .json({
+              error: 'Trigger queue is full',
+              queueDepth: result.error.queueDepth,
+              maxQueueDepth: result.error.maxQueueDepth,
+            });
+          return;
       }
     }
 

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -61,7 +61,24 @@ const execFileAsync = promisify(execFile) as ExecFn;
 export type RouteError =
   | { readonly kind: 'not_found'; readonly triggerId: string }
   | { readonly kind: 'hmac_invalid' }
-  | { readonly kind: 'payload_error'; readonly message: string };
+  | { readonly kind: 'payload_error'; readonly message: string }
+  | {
+      readonly kind: 'queue_full';
+      readonly triggerId: string;
+      readonly queueDepth: number;
+      readonly maxQueueDepth: number;
+      /**
+       * Suggested Retry-After value in seconds.
+       *
+       * WHY computed in route() (not in the listener): route() has access to the
+       * trigger definition where maxSessionMinutes lives. The listener only receives
+       * the RouteResult -- it does not re-look up the trigger.
+       *
+       * Value: (agentConfig.maxSessionMinutes ?? 30) * 60. This is an approximation
+       * of the worst-case drain time for a single session slot. It is advisory only.
+       */
+      readonly retryAfterSeconds: number;
+    };
 
 export type RouteResult =
   | { readonly _tag: 'enqueued'; readonly triggerId: string }
@@ -683,6 +700,44 @@ export class TriggerRouter {
           `(${payloadPath}=${actual} !== ${equals}) for triggerId=${trigger.id}`,
         );
         return { _tag: 'enqueued', triggerId: trigger.id };
+      }
+    }
+
+    // Queue depth guard: reject before accepting if the per-trigger serialization queue
+    // is at capacity. Only applies to serial-mode triggers -- parallel triggers use a
+    // unique UUID queue key per invocation, so depth() always returns 0 for any given key.
+    //
+    // WHY here (after dispatchCondition, before workflowTrigger): the depth check must
+    // happen BEFORE the 202 response is sent (the listener sends 202 only on _tag: 'enqueued').
+    // route() must return synchronously, and the depth read is synchronous. JavaScript is
+    // single-threaded, so no race can occur between the depth read and the enqueue() call.
+    //
+    // WHY default 10 at use time (not at parse time): trigger-store.ts leaves maxQueueDepth
+    // undefined when absent so validateTriggerStrict can emit the 'missing-max-queue-depth'
+    // advisory distinguishing "not set" from "explicitly set to 10".
+    if (trigger.concurrencyMode !== 'parallel') {
+      const maxDepth = trigger.maxQueueDepth ?? 10;
+      const currentDepth = this.queue.depth(trigger.id);
+      if (currentDepth >= maxDepth) {
+        const retryAfterSeconds = (trigger.agentConfig?.maxSessionMinutes ?? 30) * 60;
+        this.emitter?.emit({
+          kind: 'session_dropped',
+          triggerId: trigger.id,
+          workflowId: trigger.workflowId,
+          reason: 'queue_full',
+          queueDepth: currentDepth,
+          maxQueueDepth: maxDepth,
+        });
+        return {
+          _tag: 'error',
+          error: {
+            kind: 'queue_full',
+            triggerId: trigger.id,
+            queueDepth: currentDepth,
+            maxQueueDepth: maxDepth,
+            retryAfterSeconds,
+          },
+        };
       }
     }
 

--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -103,6 +103,7 @@ interface ParsedTriggerRaw {
   // the YAML parser returns all scalars as strings. Numeric conversion and
   // validation happen in validateAndResolveTrigger at the boundary.
   agentConfig?: { model?: string; maxSessionMinutes?: string; maxTurns?: string; maxOutputTokens?: string; stuckAbortPolicy?: string };
+  maxQueueDepth?: string;  // numeric string; parsed and validated in validateAndResolveTrigger
   onComplete?: { runOn?: string; workflowId?: string; goal?: string };
   autoCommit?: string;   // 'true' | 'false' scalar
   autoOpenPR?: string;   // 'true' | 'false' scalar
@@ -538,6 +539,7 @@ function setTriggerField(trigger: ParsedTriggerRaw, key: string, value: string):
     case 'branchPrefix':     trigger.branchPrefix = value; break;
     case 'queueType':        trigger.queueType = value; break;
     case 'queueLabel':       trigger.queueLabel = value; break;
+    case 'maxQueueDepth':    trigger.maxQueueDepth = value; break;
     // contextMapping, agentConfig, onComplete, source handled as sub-object blocks
     default:
       // Unknown fields silently ignored for forward compatibility
@@ -912,6 +914,24 @@ function validateAndResolveTrigger(
     });
   }
   const concurrencyMode: 'serial' | 'parallel' = rawConcurrencyMode === 'parallel' ? 'parallel' : 'serial';
+
+  // maxQueueDepth: parse and validate as a positive integer when present.
+  // Default (10) is intentionally NOT applied here -- it is applied at use time in route()
+  // so that validateTriggerStrict() can distinguish "absent" from "explicitly set to 10".
+  let maxQueueDepth: number | undefined;
+  if (raw.maxQueueDepth !== undefined) {
+    // WHY Number.isInteger: same rationale as maxSessionMinutes -- parseInt('5.5', 10) would
+    // silently accept a float; Number.isInteger catches both non-numeric strings and floats.
+    const asNumber = Number(raw.maxQueueDepth);
+    if (!Number.isInteger(asNumber) || asNumber < 1) {
+      return err({
+        kind: 'invalid_field_value',
+        field: 'maxQueueDepth (must be a positive integer >= 1)',
+        triggerId: rawId,
+      });
+    }
+    maxQueueDepth = asNumber;
+  }
 
   // onComplete: emit load-time warning for unsupported runOn values.
   // Why: runOn !== 'success' is parsed and stored but NOT executed in the MVP.
@@ -1307,6 +1327,8 @@ function validateAndResolveTrigger(
     ...(branchPrefix !== undefined ? { branchPrefix } : {}),
     // Dispatch condition for generic webhook triggers (payload-based dispatch gate).
     ...(dispatchCondition !== undefined ? { dispatchCondition } : {}),
+    // maxQueueDepth: only spread when explicitly set in YAML (undefined = apply default 10 in route()).
+    ...(maxQueueDepth !== undefined ? { maxQueueDepth } : {}),
   };
 
   return ok(trigger);
@@ -1574,6 +1596,24 @@ export function validateTriggerStrict(
       message:
         'autoCommit: true with branchStrategy: none commits directly to the main checkout; ' +
         'concurrent sessions will corrupt the checkout -- use branchStrategy: worktree instead',
+    });
+  }
+
+  // Rule: missing-max-queue-depth (info)
+  // Only applies to serial-mode triggers. Parallel triggers are not subject to the queue depth
+  // limit (each fire gets a unique queue key, so depth() always returns 0 for any given key).
+  // When absent on a serial trigger, the default of 10 applies in route(). The advisory
+  // surfaces this to operators who may want to tune the cap for their burst characteristics.
+  if (trigger.concurrencyMode !== 'parallel' && trigger.maxQueueDepth === undefined) {
+    issues.push({
+      rule: 'missing-max-queue-depth',
+      severity: 'info',
+      triggerId: id,
+      message:
+        'maxQueueDepth not set for serial trigger -- default of 10 will apply; ' +
+        'set maxQueueDepth explicitly to control the per-trigger queue depth limit ' +
+        '(at 30-minute sessions, depth 10 implies a worst-case wait of ~5 hours)',
+      suggestedFix: 'maxQueueDepth: 10',
     });
   }
 

--- a/src/trigger/types.ts
+++ b/src/trigger/types.ts
@@ -742,9 +742,7 @@ export type TriggerValidationRule =
   /** autoCommit: true AND branchStrategy: 'none' explicit -- latent danger in serial mode */
   | 'autocommit-on-main-checkout'
   /** serial trigger has no maxQueueDepth -- using default of 10 */
-  | 'missing-max-queue-depth'
-  /** maxQueueDepth < 1 -- value is invalid (hard error) */
-  | 'invalid-max-queue-depth';
+  | 'missing-max-queue-depth';
 
 // ---------------------------------------------------------------------------
 // TriggerValidationIssue: a single named validation issue for a trigger.

--- a/src/trigger/types.ts
+++ b/src/trigger/types.ts
@@ -504,6 +504,24 @@ export interface TriggerDefinition {
   readonly concurrencyMode: 'serial' | 'parallel';
 
   /**
+   * Maximum number of dispatches that may wait in the serialization queue for this trigger.
+   * Only applies to concurrencyMode: 'serial'. Parallel-mode triggers are unaffected.
+   *
+   * When the queue for a trigger is already at this depth, route() returns an error
+   * with kind: 'queue_full' and the listener responds with HTTP 429 and a Retry-After
+   * header. This bounds worst-case wait time and prevents unbounded memory growth under
+   * burst load.
+   *
+   * Default: 10 (applied in route() at use time, NOT at parse time here -- this lets
+   * worktrain trigger validate distinguish "not set" from "explicitly set to 10").
+   * Must be >= 1 if present (validated at parse time; 0 or negative is a hard error).
+   *
+   * In YAML:
+   *   maxQueueDepth: 5
+   */
+  readonly maxQueueDepth?: number;
+
+  /**
    * Optional HTTP(S) callback URL. When set, TriggerRouter POSTs the
    * WorkflowRunResult JSON to this URL after runWorkflow() completes,
    * regardless of whether the workflow succeeded or failed.
@@ -722,7 +740,11 @@ export type TriggerValidationRule =
   /** agentConfig.maxTurns absent -- no turn limit will apply */
   | 'missing-max-turns'
   /** autoCommit: true AND branchStrategy: 'none' explicit -- latent danger in serial mode */
-  | 'autocommit-on-main-checkout';
+  | 'autocommit-on-main-checkout'
+  /** serial trigger has no maxQueueDepth -- using default of 10 */
+  | 'missing-max-queue-depth'
+  /** maxQueueDepth < 1 -- value is invalid (hard error) */
+  | 'invalid-max-queue-depth';
 
 // ---------------------------------------------------------------------------
 // TriggerValidationIssue: a single named validation issue for a trigger.

--- a/src/v2/infra/in-memory/keyed-async-queue/index.ts
+++ b/src/v2/infra/in-memory/keyed-async-queue/index.ts
@@ -18,7 +18,26 @@
 export class KeyedAsyncQueue {
   private readonly queues = new Map<string, Promise<void>>();
 
+  /**
+   * Per-key pending dispatch counter.
+   *
+   * WHY a separate Map (not derived from `queues`): `queues` tracks the tail promise
+   * for serialization, not a count. A single entry in `queues` may represent any number
+   * of chained dispatches. The counter increments synchronously at the top of enqueue()
+   * (before the promise chain is constructed) so callers can read an accurate depth
+   * synchronously between enqueue() calls -- the single-threaded JS event loop guarantees
+   * no race between the read and the increment.
+   *
+   * The counter decrements unconditionally at the start of the .finally() block (before
+   * the tail identity check). Every increment has exactly one corresponding decrement.
+   */
+  private readonly _depths = new Map<string, number>();
+
   enqueue<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    // Increment synchronously before constructing the chain so depth() is accurate
+    // from the caller's perspective immediately after enqueue() returns.
+    this._depths.set(key, (this._depths.get(key) ?? 0) + 1);
+
     let resolve!: (value: T | PromiseLike<T>) => void;
     let reject!: (reason?: unknown) => void;
     const result = new Promise<T>((res, rej) => {
@@ -34,6 +53,20 @@ export class KeyedAsyncQueue {
         // The error already propagated to the caller via `result`.
       })
       .finally(() => {
+        // Decrement unconditionally: every enqueue() that incremented must decrement
+        // exactly once, regardless of whether this tail is still the current tail.
+        // WHY before the identity check: the decrement is per-dispatch accounting;
+        // the identity check below is per-key cleanup of the `queues` Map. They are
+        // independent. Placing the decrement inside the identity-check branch would
+        // cause under-decrement when a newer enqueue replaces the tail before this
+        // .finally() fires.
+        const prev = this._depths.get(key) ?? 0;
+        if (prev <= 1) {
+          this._depths.delete(key);
+        } else {
+          this._depths.set(key, prev - 1);
+        }
+
         // Only clean up if no newer enqueue has replaced this tail.
         if (this.queues.get(key) === tail) {
           this.queues.delete(key);
@@ -42,6 +75,20 @@ export class KeyedAsyncQueue {
 
     this.queues.set(key, tail);
     return result;
+  }
+
+  /**
+   * Number of pending (enqueued but not yet complete) dispatches for the given key.
+   *
+   * Returns 0 if no dispatches are pending for this key.
+   * Includes the currently-executing dispatch (if any) in the count.
+   *
+   * WHY: used by TriggerRouter.route() to check queue depth before accepting a
+   * new dispatch for a serial-mode trigger. The count is accurate to read synchronously
+   * between route() calls because the JS event loop is single-threaded.
+   */
+  depth(key: string): number {
+    return this._depths.get(key) ?? 0;
   }
 
   /** Number of keys with active or pending work. Useful for testing. */

--- a/tests/unit/trigger-router-queue-depth.test.ts
+++ b/tests/unit/trigger-router-queue-depth.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for TriggerRouter queue depth guard (maxQueueDepth).
+ *
+ * Covers:
+ * - queue_full returned when serial queue is at maxQueueDepth
+ * - enqueued returned when queue is below maxQueueDepth
+ * - default maxQueueDepth of 10 applied when absent
+ * - session_dropped event emitted on queue_full
+ * - parallel triggers not subject to depth check
+ * - Retry-After based on agentConfig.maxSessionMinutes
+ * - Retry-After defaults to 30*60 when agentConfig absent
+ */
+
+import { describe, expect, it } from 'vitest';
+import { TriggerRouter } from '../../src/trigger/trigger-router.js';
+import type { RunWorkflowFn } from '../../src/trigger/trigger-router.js';
+import type { TriggerDefinition, WebhookEvent } from '../../src/trigger/types.js';
+import { asTriggerId } from '../../src/trigger/types.js';
+import type { V2ToolContext } from '../../src/mcp/types.js';
+import type { DaemonEvent, DaemonEventEmitter } from '../../src/daemon/daemon-events.js';
+
+// ---------------------------------------------------------------------------
+// Fakes and helpers
+// ---------------------------------------------------------------------------
+
+const FAKE_CTX = {} as V2ToolContext;
+const FAKE_API_KEY = 'test-api-key';
+
+function makeTrigger(overrides: Partial<TriggerDefinition> = {}): TriggerDefinition {
+  return {
+    id: asTriggerId('test-trigger'),
+    provider: 'generic',
+    workflowId: 'wr.coding-task',
+    workspacePath: '/workspace',
+    goal: 'Review this MR',
+    concurrencyMode: 'serial',
+    ...overrides,
+  };
+}
+
+function makeIndex(trigger: TriggerDefinition): ReadonlyMap<string, TriggerDefinition> {
+  return new Map([[trigger.id, trigger]]);
+}
+
+function makeEvent(overrides: Partial<WebhookEvent> = {}): WebhookEvent {
+  const payload = { pull_request: { html_url: 'https://example.com/mr/1', title: 'My MR' } };
+  const rawBody = Buffer.from(JSON.stringify(payload), 'utf8');
+  return {
+    triggerId: asTriggerId('test-trigger'),
+    rawBody,
+    payload,
+    ...overrides,
+  };
+}
+
+/**
+ * Make a blocking RunWorkflowFn that does not resolve until the returned releasePromise resolves.
+ * The returned `release()` function resolves the workflow immediately.
+ *
+ * WHY async setup: `blockingFn` is called inside queue.enqueue()'s async chain (a microtask),
+ * not synchronously when route() returns. After calling route(), callers must await at least
+ * one microtask (e.g. await Promise.resolve()) before calling release() to avoid calling it
+ * before blockingFn() has been invoked.
+ */
+function makeBlockingWorkflow(workflowId: string): {
+  blockingFn: RunWorkflowFn;
+  waitForStart: () => Promise<void>;
+  release: () => void;
+} {
+  let release!: () => void;
+  let onStart!: () => void;
+
+  const startedPromise = new Promise<void>((res) => { onStart = res; });
+
+  const blockingFn: RunWorkflowFn = () => {
+    onStart();
+    return new Promise((res) => {
+      release = () => res({ _tag: 'success', workflowId, stopReason: 'stop' });
+    });
+  };
+
+  return {
+    blockingFn,
+    waitForStart: () => startedPromise,
+    release: () => release(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TriggerRouter queue depth guard', () => {
+  it('returns queue_full when serial queue is at maxQueueDepth', async () => {
+    const trigger = makeTrigger({ concurrencyMode: 'serial', maxQueueDepth: 1 });
+    const { blockingFn, waitForStart, release } = makeBlockingWorkflow(trigger.workflowId);
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, blockingFn);
+
+    // First route -- should be enqueued (depth becomes 1 synchronously)
+    const first = router.route(makeEvent());
+    expect(first._tag).toBe('enqueued');
+
+    // Second route -- queue is at maxQueueDepth (1), should be rejected
+    const second = router.route(makeEvent());
+    expect(second._tag).toBe('error');
+    if (second._tag !== 'error') return;
+    expect(second.error.kind).toBe('queue_full');
+    if (second.error.kind !== 'queue_full') return;
+    expect(second.error.queueDepth).toBe(1);
+    expect(second.error.maxQueueDepth).toBe(1);
+    expect(typeof second.error.retryAfterSeconds).toBe('number');
+    expect(second.error.retryAfterSeconds).toBeGreaterThan(0);
+
+    // Wait for blockingFn to be called, then release so the queue drains
+    await waitForStart();
+    release();
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
+  it('accepts route when queue is below maxQueueDepth', async () => {
+    const trigger = makeTrigger({ concurrencyMode: 'serial', maxQueueDepth: 2 });
+    const { blockingFn, waitForStart, release } = makeBlockingWorkflow(trigger.workflowId);
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, blockingFn);
+
+    // First route (depth becomes 1, maxQueueDepth is 2 -- should pass)
+    const first = router.route(makeEvent());
+    expect(first._tag).toBe('enqueued');
+
+    // Second route (depth is 1, maxQueueDepth is 2 -- should also pass, not rejected)
+    const second = router.route(makeEvent());
+    expect(second._tag).toBe('enqueued');
+
+    await waitForStart();
+    release();
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
+  it('applies default maxQueueDepth of 10 when absent', async () => {
+    // Trigger with goalTemplate so each unique payload produces a unique goal,
+    // bypassing the 30s deduplication window (which dedupes on goal+workspace).
+    const trigger = makeTrigger({
+      concurrencyMode: 'serial',
+      goalTemplate: '{{$.goal}}',
+    }); // no maxQueueDepth -- default 10 applies
+    const { blockingFn, waitForStart, release } = makeBlockingWorkflow(trigger.workflowId);
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, blockingFn);
+
+    // Make a helper to create events with unique goals (avoids 30s dedup window)
+    function makeUniqueEvent(n: number): WebhookEvent {
+      const payload = { goal: `unique-goal-${n}` };
+      return {
+        triggerId: asTriggerId('test-trigger'),
+        rawBody: Buffer.from(JSON.stringify(payload), 'utf8'),
+        payload,
+      };
+    }
+
+    // First route (depth becomes 1)
+    router.route(makeUniqueEvent(1));
+
+    // Routes 2-10 should all be enqueued (depth 2-10 before each check, limit is 10)
+    for (let i = 2; i <= 10; i++) {
+      const result = router.route(makeUniqueEvent(i));
+      expect(result._tag).toBe('enqueued');
+    }
+
+    // 11th route should fail (depth is 10, maxQueueDepth default is 10)
+    const eleventh = router.route(makeUniqueEvent(11));
+    expect(eleventh._tag).toBe('error');
+    if (eleventh._tag !== 'error') return;
+    expect(eleventh.error.kind).toBe('queue_full');
+    if (eleventh.error.kind !== 'queue_full') return;
+    expect(eleventh.error.maxQueueDepth).toBe(10);
+
+    await waitForStart();
+    release();
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  it('emits session_dropped event on queue_full', async () => {
+    const trigger = makeTrigger({ concurrencyMode: 'serial', maxQueueDepth: 1 });
+    const { blockingFn, waitForStart, release } = makeBlockingWorkflow(trigger.workflowId);
+
+    const emittedEvents: DaemonEvent[] = [];
+    const fakeEmitter = {
+      emit: (event: DaemonEvent) => { emittedEvents.push(event); },
+    } as DaemonEventEmitter;
+
+    const router = new TriggerRouter(
+      makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, blockingFn,
+      undefined, undefined, fakeEmitter,
+    );
+
+    // First route -- fills the queue to maxQueueDepth
+    router.route(makeEvent());
+
+    // Second route -- triggers queue_full, should emit session_dropped synchronously
+    router.route(makeEvent());
+
+    const droppedEvent = emittedEvents.find((e) => e.kind === 'session_dropped');
+    expect(droppedEvent).toBeDefined();
+    if (!droppedEvent || droppedEvent.kind !== 'session_dropped') return;
+    expect(droppedEvent.triggerId).toBe(trigger.id);
+    expect(droppedEvent.workflowId).toBe(trigger.workflowId);
+    expect(droppedEvent.reason).toBe('queue_full');
+    expect(droppedEvent.queueDepth).toBe(1);
+    expect(droppedEvent.maxQueueDepth).toBe(1);
+
+    await waitForStart();
+    release();
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
+  it('does NOT apply queue depth check for parallel triggers', async () => {
+    // Parallel triggers use unique UUID queue keys per invocation, so depth() returns 0
+    const trigger = makeTrigger({ concurrencyMode: 'parallel', maxQueueDepth: 1 });
+    const { fn } = {
+      fn: async (t: { workflowId: string }) => ({
+        _tag: 'success' as const,
+        workflowId: t.workflowId,
+        stopReason: 'stop' as const,
+      }),
+    };
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn);
+
+    const first = router.route(makeEvent());
+    const second = router.route(makeEvent());
+
+    expect(first._tag).toBe('enqueued');
+    expect(second._tag).toBe('enqueued');
+
+    await new Promise((r) => setTimeout(r, 20));
+  });
+
+  it('computes Retry-After from agentConfig.maxSessionMinutes', async () => {
+    const trigger = makeTrigger({
+      concurrencyMode: 'serial',
+      maxQueueDepth: 1,
+      agentConfig: { maxSessionMinutes: 60 },
+    });
+    const { blockingFn, waitForStart, release } = makeBlockingWorkflow(trigger.workflowId);
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, blockingFn);
+
+    router.route(makeEvent());
+    const second = router.route(makeEvent());
+
+    expect(second._tag).toBe('error');
+    if (second._tag !== 'error') return;
+    expect(second.error.kind).toBe('queue_full');
+    if (second.error.kind !== 'queue_full') return;
+    // 60 minutes * 60 seconds = 3600
+    expect(second.error.retryAfterSeconds).toBe(3600);
+
+    await waitForStart();
+    release();
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
+  it('defaults Retry-After to 30 * 60 when agentConfig absent', async () => {
+    const trigger = makeTrigger({ concurrencyMode: 'serial', maxQueueDepth: 1 });
+    const { blockingFn, waitForStart, release } = makeBlockingWorkflow(trigger.workflowId);
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, blockingFn);
+
+    router.route(makeEvent());
+    const second = router.route(makeEvent());
+
+    expect(second._tag).toBe('error');
+    if (second._tag !== 'error') return;
+    expect(second.error.kind).toBe('queue_full');
+    if (second.error.kind !== 'queue_full') return;
+    expect(second.error.retryAfterSeconds).toBe(1800); // 30 * 60
+
+    await waitForStart();
+    release();
+    await new Promise((r) => setTimeout(r, 10));
+  });
+});

--- a/tests/unit/trigger-router.test.ts
+++ b/tests/unit/trigger-router.test.ts
@@ -2033,3 +2033,4 @@ describe('TriggerRouter.dispatch _preAllocatedStartResponse bypass', () => {
     logSpy.mockRestore();
   });
 });
+

--- a/tests/unit/trigger-store.test.ts
+++ b/tests/unit/trigger-store.test.ts
@@ -1644,3 +1644,159 @@ triggers:
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// maxQueueDepth parsing and validation
+// ---------------------------------------------------------------------------
+
+describe('maxQueueDepth', () => {
+  it('parses maxQueueDepth correctly when set to a positive integer', () => {
+    const yaml = `
+triggers:
+  - id: t1
+    provider: generic
+    workflowId: wr.coding-task
+    workspacePath: /workspace
+    goal: Test
+    maxQueueDepth: 5
+`;
+    const result = loadTriggerConfig(yaml, {});
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.triggers).toHaveLength(1);
+      expect(result.value.triggers[0]?.maxQueueDepth).toBe(5);
+    }
+  });
+
+  it('leaves maxQueueDepth undefined when absent', () => {
+    const yaml = `
+triggers:
+  - id: t1
+    provider: generic
+    workflowId: wr.coding-task
+    workspacePath: /workspace
+    goal: Test
+`;
+    const result = loadTriggerConfig(yaml, {});
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.triggers[0]?.maxQueueDepth).toBeUndefined();
+    }
+  });
+
+  it('rejects maxQueueDepth: 0 as a hard error (trigger skipped)', () => {
+    const yaml = `
+triggers:
+  - id: bad-trigger
+    provider: generic
+    workflowId: wr.coding-task
+    workspacePath: /workspace
+    goal: Test
+    maxQueueDepth: 0
+`;
+    const result = loadTriggerConfig(yaml, {});
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      // Trigger is skipped due to invalid maxQueueDepth
+      expect(result.value.triggers).toHaveLength(0);
+    }
+  });
+
+  it('rejects maxQueueDepth: -1 as a hard error (trigger skipped)', () => {
+    const yaml = `
+triggers:
+  - id: bad-trigger
+    provider: generic
+    workflowId: wr.coding-task
+    workspacePath: /workspace
+    goal: Test
+    maxQueueDepth: -1
+`;
+    const result = loadTriggerConfig(yaml, {});
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.triggers).toHaveLength(0);
+    }
+  });
+
+  it('rejects non-integer maxQueueDepth (float) as a hard error', () => {
+    const yaml = `
+triggers:
+  - id: bad-trigger
+    provider: generic
+    workflowId: wr.coding-task
+    workspacePath: /workspace
+    goal: Test
+    maxQueueDepth: 5.5
+`;
+    const result = loadTriggerConfig(yaml, {});
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.value.triggers).toHaveLength(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateTriggerStrict: maxQueueDepth advisory rules
+// ---------------------------------------------------------------------------
+
+describe('validateTriggerStrict maxQueueDepth rules', () => {
+  it('emits info advisory for serial trigger without maxQueueDepth', async () => {
+    const { validateTriggerStrict } = await import('../../src/trigger/trigger-store.js');
+    const { asTriggerId } = await import('../../src/trigger/types.js');
+
+    const trigger = {
+      id: asTriggerId('t1'),
+      provider: 'generic',
+      workflowId: 'wr.coding-task',
+      workspacePath: '/workspace',
+      goal: 'Test',
+      concurrencyMode: 'serial' as const,
+      // maxQueueDepth absent
+    };
+
+    const issues = validateTriggerStrict(trigger);
+    const depthIssue = issues.find((i) => i.rule === 'missing-max-queue-depth');
+    expect(depthIssue).toBeDefined();
+    expect(depthIssue?.severity).toBe('info');
+  });
+
+  it('does NOT emit missing-max-queue-depth advisory for parallel trigger', async () => {
+    const { validateTriggerStrict } = await import('../../src/trigger/trigger-store.js');
+    const { asTriggerId } = await import('../../src/trigger/types.js');
+
+    const trigger = {
+      id: asTriggerId('t1'),
+      provider: 'generic',
+      workflowId: 'wr.coding-task',
+      workspacePath: '/workspace',
+      goal: 'Test',
+      concurrencyMode: 'parallel' as const,
+      // maxQueueDepth absent, but parallel -- no advisory
+    };
+
+    const issues = validateTriggerStrict(trigger);
+    const depthIssue = issues.find((i) => i.rule === 'missing-max-queue-depth');
+    expect(depthIssue).toBeUndefined();
+  });
+
+  it('does NOT emit missing-max-queue-depth advisory when maxQueueDepth is set', async () => {
+    const { validateTriggerStrict } = await import('../../src/trigger/trigger-store.js');
+    const { asTriggerId } = await import('../../src/trigger/types.js');
+
+    const trigger = {
+      id: asTriggerId('t1'),
+      provider: 'generic',
+      workflowId: 'wr.coding-task',
+      workspacePath: '/workspace',
+      goal: 'Test',
+      concurrencyMode: 'serial' as const,
+      maxQueueDepth: 5,
+    };
+
+    const issues = validateTriggerStrict(trigger);
+    const depthIssue = issues.find((i) => i.rule === 'missing-max-queue-depth');
+    expect(depthIssue).toBeUndefined();
+  });
+});

--- a/tests/unit/v2/keyed-async-queue.test.ts
+++ b/tests/unit/v2/keyed-async-queue.test.ts
@@ -89,4 +89,82 @@ describe('KeyedAsyncQueue', () => {
     ]);
     expect(results).toEqual([1, 2, 3]);
   });
+
+  describe('depth()', () => {
+    it('returns 0 for an unknown key', () => {
+      const queue = new KeyedAsyncQueue();
+      expect(queue.depth('unknown-key')).toBe(0);
+    });
+
+    it('increments when enqueued, decrements after completion', async () => {
+      const queue = new KeyedAsyncQueue();
+
+      let releaseFirst!: () => void;
+      const firstStarted = new Promise<void>((resolve) => {
+        // Enqueue a task that holds open until we release it
+        void queue.enqueue('key', () => new Promise<void>((res) => {
+          releaseFirst = res;
+          resolve();
+        }));
+      });
+
+      await firstStarted;
+      expect(queue.depth('key')).toBe(1);
+
+      // Enqueue a second task (will wait for the first)
+      const second = queue.enqueue('key', () => Promise.resolve());
+      expect(queue.depth('key')).toBe(2);
+
+      releaseFirst();
+      await second;
+
+      // Allow .finally() microtasks to drain
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(queue.depth('key')).toBe(0);
+    });
+
+    it('depth is independent per key', async () => {
+      const queue = new KeyedAsyncQueue();
+
+      let releaseA!: () => void;
+      const aEnqueued = queue.enqueue('a', () => new Promise<void>((res) => {
+        releaseA = res;
+      }));
+      // 'b' enqueues and completes immediately
+      await queue.enqueue('b', () => Promise.resolve());
+      // Allow .finally() microtasks from 'b' to drain
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // 'a' is still pending; 'b' has fully completed
+      expect(queue.depth('a')).toBe(1);
+      expect(queue.depth('b')).toBe(0);
+
+      releaseA();
+      await aEnqueued;
+      // Allow .finally() microtasks from 'a' to drain
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(queue.depth('a')).toBe(0);
+    });
+
+    it('decrements even when fn() rejects', async () => {
+      const queue = new KeyedAsyncQueue();
+
+      // enqueue() increments depth synchronously
+      const promise = queue.enqueue('key', () => Promise.reject(new Error('fail')));
+
+      // Catch the rejection so the test doesn't fail on unhandled rejection
+      await promise.catch(() => {});
+
+      // Allow .finally() microtasks to drain
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(queue.depth('key')).toBe(0);
+    });
+  });
 });

--- a/tests/unit/worktrain-trigger-validate.test.ts
+++ b/tests/unit/worktrain-trigger-validate.test.ts
@@ -44,6 +44,7 @@ const BASE_TRIGGER: TriggerDefinition = {
   branchStrategy: 'worktree',
   baseBranch: 'main',
   branchPrefix: 'worktrain/',
+  maxQueueDepth: 10,
   agentConfig: {
     maxSessionMinutes: 60,
     maxTurns: 50,


### PR DESCRIPTION
## Summary

- Serial-mode triggers previously accepted every burst webhook into an unbounded promise queue, with 202 responses for each even when the effective wait time could exceed hours
- Add `maxQueueDepth` per-trigger field (default 10) that causes `route()` to return HTTP 429 with `Retry-After` header before sending a 202, when the queue is at capacity
- Add `session_dropped` daemon event emitted on every queue-full rejection
- Add `KeyedAsyncQueue.depth(key)` method backed by a synchronous counter for pre-202 depth checks
- Add info advisory in `worktrain trigger validate` for serial triggers without explicit `maxQueueDepth`

## Test plan

- [ ] `npm run build` passes
- [ ] `npx vitest run` passes (5477 tests, 0 failures)
- [ ] New test file `tests/unit/trigger-router-queue-depth.test.ts` (7 tests): queue_full, below-limit acceptance, default-10 enforcement, session_dropped emission, parallel skip, Retry-After computation
- [ ] `tests/unit/v2/keyed-async-queue.test.ts` extended with 4 depth() tests
- [ ] `tests/unit/trigger-store.test.ts` extended with 8 maxQueueDepth parse/validation tests
- [ ] No changes to WorkRail MCP server or MCP-facing APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)