### PR TITLE
fix(engine): fix commit SHA accumulation prompt to reference complete_step

### DIFF
--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -1493,7 +1493,7 @@ function getSchemas(): Record<string, any> {
         context: {
           type: 'object',
           additionalProperties: true,
-          description: 'Updated context variables (only changed values).',
+          description: 'Updated context variables (only changed values). Exception: metrics_commit_shas must always contain the FULL accumulated list of all commit SHAs from this session -- never send only new SHAs.',
         },
       },
       required: ['continueToken'],
@@ -1521,7 +1521,7 @@ function getSchemas(): Record<string, any> {
         context: {
           type: 'object',
           additionalProperties: true,
-          description: 'Updated context variables (only changed values). Omit entirely if no facts changed.',
+          description: 'Updated context variables (only changed values). Omit entirely if no facts changed. Exception: metrics_commit_shas must always contain the FULL accumulated list of all commit SHAs from this session -- never send only new SHAs.',
         },
       },
       required: ['notes'],

--- a/src/v2/durable-core/domain/prompt-renderer.ts
+++ b/src/v2/durable-core/domain/prompt-renderer.ts
@@ -3,6 +3,7 @@ import { err, ok } from 'neverthrow';
 import type { Workflow } from '../../../types/workflow.js';
 import { getStepById } from '../../../types/workflow.js';
 import type { AssessmentDefinition, PromptFragment } from '../../../types/workflow-definition.js';
+import { isLoopStepDefinition } from '../../../types/workflow-definition.js';
 import type { LoadedSessionTruthV2 } from '../../ports/session-event-log-store.port.js';
 import type { LoopPathFrameV1 } from '../schemas/execution-snapshot/index.js';
 import type { NodeId, RunId } from '../ids/index.js';
@@ -654,12 +655,27 @@ export function renderPendingPrompt(args: {
   // Placed after fragmentSuffix so system instructions trail all authored content
   // (most actionable position: last thing the agent reads before advancing).
   //
-  // isLastStep = last top-level step OR exit step of the last top-level loop.
-  // The parentLoopByStepId index covers exit steps (all loop body steps are indexed).
+  // isLastStep = last top-level step OR last non-exit body step of the last top-level loop.
+  //
+  // WHY non-exit: the exit/loop-control step's outputContract is wr.contracts.loop_control --
+  // it can only emit { kind: 'wr.loop_control', decision: 'continue'|'stop' }. Injecting the
+  // metrics footer there means the agent is in loop-decision mode and ignores the metrics
+  // fields entirely. The last non-exit body step is the actual final work step where the
+  // agent has full context to report commit SHAs, LOC, and outcome.
   const lastTopLevelStepId = args.workflow.definition.steps.at(-1)?.id;
   const isLastTopLevelStep = args.stepId === lastTopLevelStepId;
-  const isLastExitStep = isExitStep && resolveParentLoopStep(args.workflow, args.stepId)?.id === lastTopLevelStepId;
-  const isLastStep = isLastTopLevelStep || isLastExitStep;
+  const lastTopLevelStep = args.workflow.definition.steps.at(-1);
+  const isLastNonExitStepOfLastLoop = (() => {
+    if (!lastTopLevelStep || !isLoopStepDefinition(lastTopLevelStep)) return false;
+    const body = lastTopLevelStep.body;
+    if (!Array.isArray(body) || body.length === 0) return false;
+    // Find the last body step that is NOT an exit/loop-control step.
+    const lastNonExit = [...body].reverse().find(
+      (b) => b.outputContract?.contractRef !== LOOP_CONTROL_CONTRACT_REF,
+    );
+    return lastNonExit?.id === args.stepId;
+  })();
+  const isLastStep = isLastTopLevelStep || isLastNonExitStepOfLastLoop;
   const metricsSection = buildMetricsSection(args.workflow.definition.metricsProfile, isLastStep, cleanResponseFormat);
 
   // Array join avoids intermediate string allocations from the + chain.

--- a/src/v2/durable-core/domain/prompt-renderer.ts
+++ b/src/v2/durable-core/domain/prompt-renderer.ts
@@ -375,11 +375,11 @@ export function buildMetricsSection(
     case 'coding': {
       const shaFooter = cleanFormat
         ? '\n\nMetrics: update context.metrics_commit_shas with the FULL accumulated SHA list (shallow merge -- partial lists lose earlier commits).'
-        : '\n\n**METRICS (System):** This is a coding workflow. After each commit, update `context.metrics_commit_shas` with the FULL accumulated list of commit SHAs from this session -- not just the current step\'s commits. Context uses shallow merge: sending only new SHAs permanently loses earlier ones.\n\nCall `continue_workflow` with:\n- `context: { metrics_commit_shas: ["<sha1>", "<sha2>", ...] }` -- full list, every step that has commits';
+        : '\n\n**METRICS (System):** This is a coding workflow. After each commit, pass `context: { metrics_commit_shas: ["<sha1>", "<sha2>", ...] }` when advancing (via `complete_step` or `continue_workflow`). Always send the FULL accumulated list of all SHAs from this session -- not just the new SHA. Context uses shallow merge: sending only new SHAs permanently loses earlier ones.';
       if (!isLastStep) return shaFooter;
       const finalFooter = cleanFormat
         ? '\n\nMetrics (final): also set metrics_outcome (exactly one of: "success", "partial", "abandoned", "error"), metrics_pr_numbers, metrics_files_changed, metrics_lines_added, metrics_lines_removed in context.'
-        : '\n\n**METRICS (System):** This is the final step. Also report:\n- `metrics_outcome`: set to exactly one of these four strings -- no other values are valid: `"success"`, `"partial"`, `"abandoned"`, `"error"`. Do not describe what you did -- classify the outcome using only these values.\n- `metrics_pr_numbers`: array of integer PR numbers (not URLs)\n- `metrics_files_changed`: integer count\n- `metrics_lines_added`: integer count\n- `metrics_lines_removed`: integer count\n\nCall `continue_workflow` with all of the above in `context: { metrics_commit_shas: [...], metrics_outcome: "success", ... }`.';
+        : '\n\n**METRICS (System):** This is the final step. Also report:\n- `metrics_outcome`: set to exactly one of these four strings -- no other values are valid: `"success"`, `"partial"`, `"abandoned"`, `"error"`. Do not describe what you did -- classify the outcome using only these values.\n- `metrics_pr_numbers`: array of integer PR numbers (not URLs)\n- `metrics_files_changed`: integer count\n- `metrics_lines_added`: integer count\n- `metrics_lines_removed`: integer count\n\nPass all of the above in `context: { metrics_commit_shas: [...], metrics_outcome: "success", ... }` when calling `complete_step` or `continue_workflow`.';
       return shaFooter + finalFooter;
     }
     case 'review': {


### PR DESCRIPTION
## Problem

Commit SHAs were recorded in only ~7% of `wr.coding-task` sessions.

Root cause: the SHA accumulation footer in `buildMetricsSection()` said:
> "Call `continue_workflow` with: `context: { metrics_commit_shas: [...] }`"

But the daemon system prompt explicitly trains agents to use `complete_step` and never use `continue_workflow`. Agents saw a direct contradiction and resolved it by ignoring the metrics instruction entirely.

Secondary: the `context` field description on both tools said "only changed values" -- which contradicts the SHA accumulation requirement (always resend the full list, never just the new SHA).

## Fixes

- SHA footer is now tool-agnostic: "pass `context: { metrics_commit_shas: [...] }` when calling `complete_step` or `continue_workflow`"
- Final step footer has the same fix for the combined metrics block
- Both `complete_step` and `continue_workflow` `context` field descriptions now include: "Exception: `metrics_commit_shas` must always contain the FULL accumulated list -- never send only new SHAs"

## What's not fixed here (follow-up)

- SHA footer still appears on non-implementation steps (trains agents to suppress it) -- needs per-step annotation
- `phase-5-small-task-fast-path` has no correctly-wired final metrics step for Small tasks -- structural gap
- No validation/rejection for missing `metrics_commit_shas` -- silent failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)