### PR TITLE
fix(daemon): write correct outcome to execution-stats.jsonl

### DIFF
--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -3334,10 +3334,13 @@ export async function runWorkflow(
   // Default 'unknown' is a valid data point (not silent data loss) if a future return
   // path is added without updating this variable.
   //
-  // CLOSURE NOTE: the finally block's async stats write reads sessionOutcome via closure
-  // reference inside a Promise .then() microtask. Microtasks fire after the synchronous
-  // return completes, so the .then() always sees the final value assigned before the return.
-  // This is standard JS closure + microtask sequencing -- it is correct, just subtle.
+  // sessionOutcome is set at each result path and written to execution-stats.jsonl
+  // via writeExecutionStats() at that path's return site. The finally block does NOT
+  // write stats for the agent-loop paths -- only for pre-agent-loop early exits.
+  // WHY: writeExecutionStats() takes outcome by value. Calling it in finally with
+  // sessionOutcome would always capture 'unknown' because the outcome assignments
+  // happen after the finally block exits. Each result path calls writeExecutionStats()
+  // directly with the correct outcome, mirroring the pre-agent-loop early exit pattern.
   let sessionOutcome: 'success' | 'error' | 'timeout' | 'stuck' | 'unknown' = 'unknown';
 
   // ---- Session ID (process-local, crash safety) ----
@@ -4223,14 +4226,6 @@ export async function runWorkflow(
     }
     console.log(`[WorkflowRunner] Agent loop ended: sessionId=${sessionId} stopReason=${stopReason}${errorMessage ? ` error=${errorMessage.slice(0, 120)}` : ''}`);
 
-    // ---- Execution stats (for timeout calibration) ----
-    // WHY fire-and-forget: a stats write failure must never crash the session or
-    // block the return path. This is observability data, not crash recovery state.
-    // WHY also in pre-try exits: 4 paths exit before the try block and never reach
-    // this finally clause (model validation, start_workflow failure, worktree creation
-    // failure, instant single-step completion). Each calls writeExecutionStats() directly.
-    // If adding a new result path inside the try block, update sessionOutcome instead.
-    writeExecutionStats(DAEMON_STATS_DIR, sessionId, trigger.workflowId, startMs, sessionOutcome, stepAdvanceCount);
   }
 
   // ---- Stuck result (repeated_tool_call or no_progress abort) ----
@@ -4248,7 +4243,7 @@ export async function runWorkflow(
       ...withWorkrailSession(workrailSessionId),
     });
     if (workrailSessionId !== null) daemonRegistry?.unregister(workrailSessionId, 'failed');
-    sessionOutcome = 'stuck'; // timing written in finally block
+    writeExecutionStats(DAEMON_STATS_DIR, sessionId, trigger.workflowId, startMs, 'stuck', stepAdvanceCount);
     return {
       _tag: 'stuck',
       workflowId: trigger.workflowId,
@@ -4272,7 +4267,7 @@ export async function runWorkflow(
     // WHY: a timed-out session is no longer in-flight. Leaving the file causes
     // countActiveSessions() to permanently inflate until daemon restart.
     await fs.unlink(path.join(DAEMON_SESSIONS_DIR, `${sessionId}.json`)).catch(() => {});
-    sessionOutcome = 'timeout'; // timing written in finally block
+    writeExecutionStats(DAEMON_STATS_DIR, sessionId, trigger.workflowId, startMs, 'timeout', stepAdvanceCount);
     return {
       _tag: 'timeout',
       workflowId: trigger.workflowId,
@@ -4306,7 +4301,7 @@ export async function runWorkflow(
     // WHY: an errored session is no longer in-flight. Leaving the file causes
     // countActiveSessions() to permanently inflate until daemon restart.
     await fs.unlink(path.join(DAEMON_SESSIONS_DIR, `${sessionId}.json`)).catch(() => {});
-    sessionOutcome = 'error'; // timing written in finally block
+    writeExecutionStats(DAEMON_STATS_DIR, sessionId, trigger.workflowId, startMs, 'error', stepAdvanceCount);
     return {
       _tag: 'error',
       workflowId: trigger.workflowId,
@@ -4347,8 +4342,7 @@ export async function runWorkflow(
 
   emitter?.emit({ kind: 'session_completed', sessionId, workflowId: trigger.workflowId, outcome: 'success', detail: stopReason, ...withWorkrailSession(workrailSessionId) });
   if (workrailSessionId !== null) daemonRegistry?.unregister(workrailSessionId, 'completed');
-
-  sessionOutcome = 'success'; // timing written in finally block
+  writeExecutionStats(DAEMON_STATS_DIR, sessionId, trigger.workflowId, startMs, 'success', stepAdvanceCount);
   return {
     _tag: 'success',
     workflowId: trigger.workflowId,

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -1493,7 +1493,7 @@ function getSchemas(): Record<string, any> {
         context: {
           type: 'object',
           additionalProperties: true,
-          description: 'Updated context variables (only changed values).',
+          description: 'Updated context variables (only changed values). Exception: metrics_commit_shas must always contain the FULL accumulated list of all commit SHAs from this session -- never send only new SHAs.',
         },
       },
       required: ['continueToken'],
@@ -1521,7 +1521,7 @@ function getSchemas(): Record<string, any> {
         context: {
           type: 'object',
           additionalProperties: true,
-          description: 'Updated context variables (only changed values). Omit entirely if no facts changed.',
+          description: 'Updated context variables (only changed values). Omit entirely if no facts changed. Exception: metrics_commit_shas must always contain the FULL accumulated list of all commit SHAs from this session -- never send only new SHAs.',
         },
       },
       required: ['notes'],

--- a/src/v2/durable-core/domain/prompt-renderer.ts
+++ b/src/v2/durable-core/domain/prompt-renderer.ts
@@ -3,6 +3,7 @@ import { err, ok } from 'neverthrow';
 import type { Workflow } from '../../../types/workflow.js';
 import { getStepById } from '../../../types/workflow.js';
 import type { AssessmentDefinition, PromptFragment } from '../../../types/workflow-definition.js';
+import { isLoopStepDefinition } from '../../../types/workflow-definition.js';
 import type { LoadedSessionTruthV2 } from '../../ports/session-event-log-store.port.js';
 import type { LoopPathFrameV1 } from '../schemas/execution-snapshot/index.js';
 import type { NodeId, RunId } from '../ids/index.js';
@@ -654,12 +655,27 @@ export function renderPendingPrompt(args: {
   // Placed after fragmentSuffix so system instructions trail all authored content
   // (most actionable position: last thing the agent reads before advancing).
   //
-  // isLastStep = last top-level step OR exit step of the last top-level loop.
-  // The parentLoopByStepId index covers exit steps (all loop body steps are indexed).
+  // isLastStep = last top-level step OR last non-exit body step of the last top-level loop.
+  //
+  // WHY non-exit: the exit/loop-control step's outputContract is wr.contracts.loop_control --
+  // it can only emit { kind: 'wr.loop_control', decision: 'continue'|'stop' }. Injecting the
+  // metrics footer there means the agent is in loop-decision mode and ignores the metrics
+  // fields entirely. The last non-exit body step is the actual final work step where the
+  // agent has full context to report commit SHAs, LOC, and outcome.
   const lastTopLevelStepId = args.workflow.definition.steps.at(-1)?.id;
   const isLastTopLevelStep = args.stepId === lastTopLevelStepId;
-  const isLastExitStep = isExitStep && resolveParentLoopStep(args.workflow, args.stepId)?.id === lastTopLevelStepId;
-  const isLastStep = isLastTopLevelStep || isLastExitStep;
+  const lastTopLevelStep = args.workflow.definition.steps.at(-1);
+  const isLastNonExitStepOfLastLoop = (() => {
+    if (!lastTopLevelStep || !isLoopStepDefinition(lastTopLevelStep)) return false;
+    const body = lastTopLevelStep.body;
+    if (!Array.isArray(body) || body.length === 0) return false;
+    // Find the last body step that is NOT an exit/loop-control step.
+    const lastNonExit = [...body].reverse().find(
+      (b) => b.outputContract?.contractRef !== LOOP_CONTROL_CONTRACT_REF,
+    );
+    return lastNonExit?.id === args.stepId;
+  })();
+  const isLastStep = isLastTopLevelStep || isLastNonExitStepOfLastLoop;
   const metricsSection = buildMetricsSection(args.workflow.definition.metricsProfile, isLastStep, cleanResponseFormat);
 
   // Array join avoids intermediate string allocations from the + chain.

--- a/src/v2/durable-core/domain/prompt-renderer.ts
+++ b/src/v2/durable-core/domain/prompt-renderer.ts
@@ -375,11 +375,11 @@ export function buildMetricsSection(
     case 'coding': {
       const shaFooter = cleanFormat
         ? '\n\nMetrics: update context.metrics_commit_shas with the FULL accumulated SHA list (shallow merge -- partial lists lose earlier commits).'
-        : '\n\n**METRICS (System):** This is a coding workflow. After each commit, update `context.metrics_commit_shas` with the FULL accumulated list of commit SHAs from this session -- not just the current step\'s commits. Context uses shallow merge: sending only new SHAs permanently loses earlier ones.\n\nCall `continue_workflow` with:\n- `context: { metrics_commit_shas: ["<sha1>", "<sha2>", ...] }` -- full list, every step that has commits';
+        : '\n\n**METRICS (System):** This is a coding workflow. After each commit, pass `context: { metrics_commit_shas: ["<sha1>", "<sha2>", ...] }` when advancing (via `complete_step` or `continue_workflow`). Always send the FULL accumulated list of all SHAs from this session -- not just the new SHA. Context uses shallow merge: sending only new SHAs permanently loses earlier ones.';
       if (!isLastStep) return shaFooter;
       const finalFooter = cleanFormat
         ? '\n\nMetrics (final): also set metrics_outcome (exactly one of: "success", "partial", "abandoned", "error"), metrics_pr_numbers, metrics_files_changed, metrics_lines_added, metrics_lines_removed in context.'
-        : '\n\n**METRICS (System):** This is the final step. Also report:\n- `metrics_outcome`: set to exactly one of these four strings -- no other values are valid: `"success"`, `"partial"`, `"abandoned"`, `"error"`. Do not describe what you did -- classify the outcome using only these values.\n- `metrics_pr_numbers`: array of integer PR numbers (not URLs)\n- `metrics_files_changed`: integer count\n- `metrics_lines_added`: integer count\n- `metrics_lines_removed`: integer count\n\nCall `continue_workflow` with all of the above in `context: { metrics_commit_shas: [...], metrics_outcome: "success", ... }`.';
+        : '\n\n**METRICS (System):** This is the final step. Also report:\n- `metrics_outcome`: set to exactly one of these four strings -- no other values are valid: `"success"`, `"partial"`, `"abandoned"`, `"error"`. Do not describe what you did -- classify the outcome using only these values.\n- `metrics_pr_numbers`: array of integer PR numbers (not URLs)\n- `metrics_files_changed`: integer count\n- `metrics_lines_added`: integer count\n- `metrics_lines_removed`: integer count\n\nPass all of the above in `context: { metrics_commit_shas: [...], metrics_outcome: "success", ... }` when calling `complete_step` or `continue_workflow`.';
       return shaFooter + finalFooter;
     }
     case 'review': {


### PR DESCRIPTION
## Problem

Every agent-loop session was recorded as `outcome: "unknown"` in `execution-stats.jsonl` regardless of actual result. The stats summary showed 31/58 sessions as unknown, 0 agent-loop completions as success.

## Root cause

`writeExecutionStats()` takes `outcome` by value. The `finally` block called it with `sessionOutcome` which was always `'unknown'` at that point -- all four outcome assignments (`'stuck'`, `'timeout'`, `'error'`, `'success'`) happen after the `finally` block exits.

The original inline stats write worked because it closed over `sessionOutcome` by reference inside a `.then()` microtask. Extracting it to a function broke the closure.

## Fix

Remove the `writeExecutionStats()` call from the `finally` block for agent-loop paths. Each result path now calls it directly with the correct outcome -- the same pattern already used by the four pre-agent-loop early exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)