### PR TITLE
refactor(engine): extract buildSessionContext() from runWorkflow() (Phase 2)

### DIFF
--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -86,7 +86,7 @@ const MAX_SESSION_NOTE_CHARS = 800;
  * If the agent loop does not complete within this window, runWorkflow() aborts
  * the agent and returns { _tag: 'timeout', reason: 'wall_clock' }.
  */
-const DEFAULT_SESSION_TIMEOUT_MINUTES = 30;
+export const DEFAULT_SESSION_TIMEOUT_MINUTES = 30;
 
 /**
  * Default maximum number of LLM turns per agent session.
@@ -100,7 +100,7 @@ const DEFAULT_SESSION_TIMEOUT_MINUTES = 30;
  * exploration) without being the bottleneck -- wall-clock maxSessionMinutes is
  * the primary cap for runaway sessions.
  */
-const DEFAULT_MAX_TURNS = 200;
+export const DEFAULT_MAX_TURNS = 200;
 
 /**
  * Conditionally spreads workrailSessionId into a daemon event object.
@@ -3871,12 +3871,6 @@ export interface SessionContextInputs {
   readonly sessionNotes: readonly string[];
   /** The first step's pending prompt from executeStartWorkflow / _preAllocatedStartResponse */
   readonly firstStepPrompt: string;
-  /** Optional assembled context summary from trigger.context.assembledContextSummary */
-  readonly assembledContextSummary?: string;
-  /** Optional reference URLs from trigger.referenceUrls */
-  readonly referenceUrls?: readonly string[];
-  /** Trigger context for injection into the initial prompt */
-  readonly triggerContext?: Readonly<Record<string, unknown>>;
 }
 
 /**
@@ -3923,9 +3917,6 @@ export function buildSessionContext(
   // directs the agent to complete the step work before calling complete_step. Without
   // this, the agent may produce a "thinking aloud" turn before the first tool call,
   // which wastes tokens and delays step execution.
-  // WHY triggerContext (not inputs.triggerContext): both refer to the same data.
-  // The inputs field documents the I/O boundary; trigger.context is the authoritative
-  // source. Using trigger.context directly keeps the shape consistent with buildSystemPrompt.
   const contextJson = trigger.context
     ? `\n\nTrigger context:\n\`\`\`json\n${JSON.stringify(trigger.context, null, 2)}\n\`\`\``
     : '';
@@ -4486,11 +4477,6 @@ export async function runWorkflow(
     workspaceContext,
     sessionNotes,
     firstStepPrompt: firstStep.pending?.prompt ?? 'No step content available',
-    assembledContextSummary: typeof trigger.context?.['assembledContextSummary'] === 'string'
-      ? trigger.context['assembledContextSummary'] as string
-      : undefined,
-    referenceUrls: trigger.referenceUrls,
-    triggerContext: trigger.context,
   });
 
   // ---- Observability callbacks for AgentLoop ----

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -3853,6 +3853,100 @@ export async function finalizeSession(
 }
 
 // ---------------------------------------------------------------------------
+// buildSessionContext -- pure session configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Pre-loaded I/O results passed into buildSessionContext().
+ * Each field is the result of a specific I/O operation that the shell performs
+ * before calling buildSessionContext(). Keeping these separate makes the I/O
+ * boundary explicit and the pure function testable without any I/O setup.
+ */
+export interface SessionContextInputs {
+  /** Result of loadDaemonSoul() */
+  readonly soulContent: string;
+  /** Result of loadWorkspaceContext() -- null if no context files found */
+  readonly workspaceContext: string | null;
+  /** Result of loadSessionNotes() -- empty array if none */
+  readonly sessionNotes: readonly string[];
+  /** The first step's pending prompt from executeStartWorkflow / _preAllocatedStartResponse */
+  readonly firstStepPrompt: string;
+  /** Optional assembled context summary from trigger.context.assembledContextSummary */
+  readonly assembledContextSummary?: string;
+  /** Optional reference URLs from trigger.referenceUrls */
+  readonly referenceUrls?: readonly string[];
+  /** Trigger context for injection into the initial prompt */
+  readonly triggerContext?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Everything the agent loop needs, produced by buildSessionContext().
+ * Pure value -- no I/O, no closures, no mutable state.
+ */
+export interface SessionContext {
+  readonly systemPrompt: string;
+  readonly initialPrompt: string;
+  readonly sessionTimeoutMs: number;
+  readonly maxTurns: number;
+}
+
+/**
+ * Build the session configuration from pre-loaded I/O results.
+ *
+ * This function is intentionally synchronous and pure -- all I/O (soul file,
+ * workspace context, session notes) is resolved by the caller before invoking
+ * this function. WHY: keeps the function unit-testable by passing pre-loaded
+ * strings directly, without requiring any I/O or mocking in tests.
+ *
+ * @param trigger - The workflow trigger (provides agentConfig limits and context).
+ * @param inputs - Pre-loaded I/O results (soul content, workspace context, etc.).
+ * @returns SessionContext containing systemPrompt, initialPrompt, and session limits.
+ */
+export function buildSessionContext(
+  trigger: WorkflowTrigger,
+  inputs: SessionContextInputs,
+): SessionContext {
+  // ---- System prompt ----
+  // buildSystemPrompt() is synchronous and pure. It reads assembledContextSummary
+  // and referenceUrls from trigger.context and trigger.referenceUrls directly,
+  // so the SessionContextInputs fields for those are supplementary documentation
+  // of what the trigger carries; the authoritative values flow through trigger.
+  const sessionState = buildSessionRecap(inputs.sessionNotes);
+  const systemPrompt = buildSystemPrompt(trigger, sessionState, inputs.soulContent, inputs.workspaceContext);
+
+  // ---- Initial prompt ----
+  // WHY no continueToken in the initial prompt: the daemon uses complete_step which
+  // manages the token internally. Including the token would invite the LLM to store
+  // it and call continue_workflow (deprecated) instead of complete_step, defeating
+  // the purpose of the new tool.
+  // WHY closing directive: an explicit imperative at the end of the initial prompt
+  // directs the agent to complete the step work before calling complete_step. Without
+  // this, the agent may produce a "thinking aloud" turn before the first tool call,
+  // which wastes tokens and delays step execution.
+  // WHY triggerContext (not inputs.triggerContext): both refer to the same data.
+  // The inputs field documents the I/O boundary; trigger.context is the authoritative
+  // source. Using trigger.context directly keeps the shape consistent with buildSystemPrompt.
+  const contextJson = trigger.context
+    ? `\n\nTrigger context:\n\`\`\`json\n${JSON.stringify(trigger.context, null, 2)}\n\`\`\``
+    : '';
+
+  const initialPrompt =
+    inputs.firstStepPrompt +
+    contextJson +
+    '\n\nComplete all step work, then call complete_step with your notes to advance.';
+
+  // ---- Session limits ----
+  // Resolved from trigger.agentConfig with hardcoded defaults as fallback.
+  // WHY: per-trigger configurability lets operators tune limits per workflow type
+  // (e.g. a fast code-review trigger vs. a slow coding-task trigger).
+  const sessionTimeoutMs =
+    (trigger.agentConfig?.maxSessionMinutes ?? DEFAULT_SESSION_TIMEOUT_MINUTES) * 60 * 1000;
+  const maxTurns = trigger.agentConfig?.maxTurns ?? DEFAULT_MAX_TURNS;
+
+  return { systemPrompt, initialPrompt, sessionTimeoutMs, maxTurns };
+}
+
+// ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
@@ -4359,7 +4453,7 @@ export async function runWorkflow(
     makeSignalCoordinatorTool(sessionId, emitter, state.workrailSessionId),
   ];
 
-  // ---- Context loading (soul + workspace + session notes) ----
+  // ---- I/O phase: load context (soul + workspace + session notes) ----
   // WHY: load before Agent construction -- the system prompt is set at init
   // time and is not mutable after. All loads are best-effort; errors are
   // logged but never abort the session.
@@ -4373,33 +4467,31 @@ export async function runWorkflow(
   // pre-step-1 injection point.
   // trigger.soulFile is already cascade-resolved by trigger-store.ts:
   //   trigger soulFile -> workspace soulFile -> undefined (global fallback in loadDaemonSoul)
+  // NOTE: use trigger.workspacePath (not sessionWorkspacePath) for context loading.
+  // For worktree sessions, the context files (CLAUDE.md / AGENTS.md) live in the
+  // main checkout, not the isolated worktree. The worktree only contains the agent's
+  // working changes.
   const [soulContent, workspaceContext, sessionNotes] = await Promise.all([
     loadDaemonSoul(trigger.soulFile),
     loadWorkspaceContext(trigger.workspacePath),
     startContinueToken ? loadSessionNotes(startContinueToken, ctx) : Promise.resolve([] as readonly string[]),
   ]);
 
-  const sessionState = buildSessionRecap(sessionNotes);
-
-  // ---- Initial prompt: first step content from start_workflow ----
-  // The daemon has already called executeStartWorkflow() and has the first step.
-  // Pass the step content directly -- the LLM starts working on step 1 immediately.
-  // WHY no continueToken in the initial prompt: the daemon uses complete_step which
-  // manages the token internally. Including the token would invite the LLM to store
-  // it and call continue_workflow (deprecated) instead of complete_step, defeating
-  // the purpose of the new tool.
-  // WHY closing directive: an explicit imperative at the end of the initial prompt
-  // directs the agent to complete the step work before calling complete_step. Without
-  // this, the agent may produce a "thinking aloud" turn before the first tool call,
-  // which wastes tokens and delays step execution.
-  const contextJson = trigger.context
-    ? `\n\nTrigger context:\n\`\`\`json\n${JSON.stringify(trigger.context, null, 2)}\n\`\`\``
-    : '';
-
-  const initialPrompt =
-    (firstStep.pending?.prompt ?? 'No step content available') +
-    contextJson +
-    '\n\nComplete all step work, then call complete_step with your notes to advance.';
+  // ---- Pure phase: build session configuration from pre-loaded I/O ----
+  // buildSessionContext() is synchronous and pure -- it assembles the system
+  // prompt, initial prompt, and session limits from the loaded data and trigger config.
+  // WHY separated from I/O: makes prompt assembly testable without any fs or LLM mocking.
+  const sessionCtx = buildSessionContext(trigger, {
+    soulContent,
+    workspaceContext,
+    sessionNotes,
+    firstStepPrompt: firstStep.pending?.prompt ?? 'No step content available',
+    assembledContextSummary: typeof trigger.context?.['assembledContextSummary'] === 'string'
+      ? trigger.context['assembledContextSummary'] as string
+      : undefined,
+    referenceUrls: trigger.referenceUrls,
+    triggerContext: trigger.context,
+  });
 
   // ---- Observability callbacks for AgentLoop ----
   // Wire structured event emission for LLM turns and tool calls.
@@ -4452,7 +4544,7 @@ export async function runWorkflow(
   // package dependency. The client (Anthropic or AnthropicBedrock) is injected --
   // AgentLoop has no knowledge of API keys or AWS credentials.
   const agent = new AgentLoop({
-    systemPrompt: buildSystemPrompt(trigger, sessionState, soulContent, workspaceContext),
+    systemPrompt: sessionCtx.systemPrompt,
     modelId,
     tools,
     client: agentClient,
@@ -4469,12 +4561,9 @@ export async function runWorkflow(
   });
 
   // ---- Session limits (wall-clock timeout + max-turn limit) ----
-  // Resolved from trigger.agentConfig with hardcoded defaults as fallback.
-  // WHY: per-trigger configurability lets operators tune limits per workflow type
-  // (e.g. a fast code-review trigger vs. a slow coding-task trigger).
-  const sessionTimeoutMs =
-    (trigger.agentConfig?.maxSessionMinutes ?? DEFAULT_SESSION_TIMEOUT_MINUTES) * 60 * 1000;
-  const maxTurns = trigger.agentConfig?.maxTurns ?? DEFAULT_MAX_TURNS;
+  // Provided by buildSessionContext() -- resolved from trigger.agentConfig with
+  // hardcoded defaults as fallback. Destructured here for clarity.
+  const { sessionTimeoutMs, maxTurns } = sessionCtx;
 
   // ---- Stuck detection configuration ----
   // WHY resolved here: these are read-only trigger config values. They do not change
@@ -4650,7 +4739,7 @@ export async function runWorkflow(
       }, sessionTimeoutMs);
     });
     console.log(`[WorkflowRunner] Agent loop started: sessionId=${sessionId} workflowId=${trigger.workflowId} modelId=${modelId}`);
-    await Promise.race([agent.prompt(buildUserMessage(initialPrompt)), timeoutPromise])
+    await Promise.race([agent.prompt(buildUserMessage(sessionCtx.initialPrompt)), timeoutPromise])
       .catch((err: unknown) => {
         agent.abort();
         throw err;

--- a/tests/unit/workflow-runner-pure-functions.test.ts
+++ b/tests/unit/workflow-runner-pure-functions.test.ts
@@ -26,6 +26,8 @@ import {
   createSessionState,
   buildSessionContext,
   DAEMON_SOUL_DEFAULT,
+  DEFAULT_SESSION_TIMEOUT_MINUTES,
+  DEFAULT_MAX_TURNS,
 } from '../../src/daemon/workflow-runner.js';
 import type { SessionState, StuckConfig, SessionContextInputs } from '../../src/daemon/workflow-runner.js';
 import type { WorkflowRunResult, WorkflowTrigger } from '../../src/daemon/workflow-runner.js';
@@ -371,9 +373,6 @@ describe('evaluateStuckSignals', () => {
 // Tests for the pure function that assembles the session configuration from
 // pre-loaded I/O results. No I/O is performed in these tests.
 
-const DEFAULT_SESSION_TIMEOUT_MINUTES = 30;
-const DEFAULT_MAX_TURNS = 200;
-
 /** Helper to build a minimal WorkflowTrigger for buildSessionContext tests. */
 function makeSessionTrigger(overrides: Partial<WorkflowTrigger> = {}): WorkflowTrigger {
   return {
@@ -446,6 +445,13 @@ describe('buildSessionContext', () => {
     const trigger = makeSessionTrigger(); // no context field
     const { initialPrompt } = buildSessionContext(trigger, makeInputs());
     expect(initialPrompt).not.toContain('Trigger context:');
+  });
+
+  it('initial prompt contains the closing directive to call complete_step', () => {
+    const { initialPrompt } = buildSessionContext(makeSessionTrigger(), makeInputs());
+    expect(initialPrompt).toContain(
+      'Complete all step work, then call complete_step with your notes to advance.',
+    );
   });
 
   it('initial prompt contains reference URL section when referenceUrls is set', () => {

--- a/tests/unit/workflow-runner-pure-functions.test.ts
+++ b/tests/unit/workflow-runner-pure-functions.test.ts
@@ -8,6 +8,7 @@
  * - `buildAgentClient(trigger, apiKey, env)` -- pure model selection / client construction
  * - `evaluateStuckSignals(state, config)` -- pure stuck detection logic
  * - `createSessionState(initialToken)` -- factory for SessionState
+ * - `buildSessionContext(trigger, inputs)` -- pure session configuration assembly
  *
  * ## Why pure function tests here (not inline with runWorkflow() tests)
  *
@@ -23,8 +24,10 @@ import {
   buildAgentClient,
   evaluateStuckSignals,
   createSessionState,
+  buildSessionContext,
+  DAEMON_SOUL_DEFAULT,
 } from '../../src/daemon/workflow-runner.js';
-import type { SessionState, StuckConfig } from '../../src/daemon/workflow-runner.js';
+import type { SessionState, StuckConfig, SessionContextInputs } from '../../src/daemon/workflow-runner.js';
 import type { WorkflowRunResult, WorkflowTrigger } from '../../src/daemon/workflow-runner.js';
 import { tmpPath } from '../helpers/platform.js';
 
@@ -360,5 +363,175 @@ describe('evaluateStuckSignals', () => {
       expect(signal.turnCount).toBe(80);
       expect(signal.maxTurns).toBe(100);
     }
+  });
+});
+
+// ── buildSessionContext ────────────────────────────────────────────────────────
+//
+// Tests for the pure function that assembles the session configuration from
+// pre-loaded I/O results. No I/O is performed in these tests.
+
+const DEFAULT_SESSION_TIMEOUT_MINUTES = 30;
+const DEFAULT_MAX_TURNS = 200;
+
+/** Helper to build a minimal WorkflowTrigger for buildSessionContext tests. */
+function makeSessionTrigger(overrides: Partial<WorkflowTrigger> = {}): WorkflowTrigger {
+  return {
+    workflowId: 'wr.coding-task',
+    goal: 'test goal',
+    workspacePath: tmpPath('test-workspace'),
+    ...overrides,
+  };
+}
+
+/** Helper to build a minimal SessionContextInputs. */
+function makeInputs(overrides: Partial<SessionContextInputs> = {}): SessionContextInputs {
+  return {
+    soulContent: DAEMON_SOUL_DEFAULT,
+    workspaceContext: null,
+    sessionNotes: [],
+    firstStepPrompt: 'Step 1: Do the work.',
+    ...overrides,
+  };
+}
+
+describe('buildSessionContext', () => {
+  // ---- System prompt ----
+
+  it('system prompt contains the soul content', () => {
+    const { systemPrompt } = buildSessionContext(makeSessionTrigger(), makeInputs({
+      soulContent: 'custom-soul-content-marker',
+    }));
+    expect(systemPrompt).toContain('custom-soul-content-marker');
+  });
+
+  it('system prompt contains workspace context when present', () => {
+    const { systemPrompt } = buildSessionContext(makeSessionTrigger(), makeInputs({
+      workspaceContext: '## Agent Rules\n- Use TypeScript strict mode',
+    }));
+    expect(systemPrompt).toContain('## Workspace Context (from AGENTS.md / CLAUDE.md)');
+    expect(systemPrompt).toContain('## Agent Rules');
+    expect(systemPrompt).toContain('Use TypeScript strict mode');
+  });
+
+  it('system prompt omits workspace context section when workspaceContext is null', () => {
+    const { systemPrompt } = buildSessionContext(makeSessionTrigger(), makeInputs({
+      workspaceContext: null,
+    }));
+    expect(systemPrompt).not.toContain('## Workspace Context');
+  });
+
+  // ---- Initial prompt ----
+
+  it('initial prompt contains the first step prompt', () => {
+    const { initialPrompt } = buildSessionContext(makeSessionTrigger(), makeInputs({
+      firstStepPrompt: 'unique-first-step-marker-12345',
+    }));
+    expect(initialPrompt).toContain('unique-first-step-marker-12345');
+  });
+
+  it('initial prompt contains trigger context JSON when trigger.context is present', () => {
+    const trigger = makeSessionTrigger({
+      context: { task: 'implement-oauth', priority: 'high' },
+    });
+    const { initialPrompt } = buildSessionContext(trigger, makeInputs());
+    expect(initialPrompt).toContain('Trigger context:');
+    expect(initialPrompt).toContain('"task"');
+    expect(initialPrompt).toContain('"implement-oauth"');
+    expect(initialPrompt).toContain('"priority"');
+    expect(initialPrompt).toContain('"high"');
+  });
+
+  it('initial prompt omits context JSON block when trigger.context is absent', () => {
+    const trigger = makeSessionTrigger(); // no context field
+    const { initialPrompt } = buildSessionContext(trigger, makeInputs());
+    expect(initialPrompt).not.toContain('Trigger context:');
+  });
+
+  it('initial prompt contains reference URL section when referenceUrls is set', () => {
+    const trigger = makeSessionTrigger({
+      referenceUrls: ['https://example.com/spec.md', 'https://example.com/design.md'],
+    });
+    // referenceUrls appear in the system prompt, not the initial prompt
+    // (they are injected by buildSystemPrompt via trigger.referenceUrls)
+    const { systemPrompt } = buildSessionContext(trigger, makeInputs());
+    expect(systemPrompt).toContain('## Reference documents');
+    expect(systemPrompt).toContain('https://example.com/spec.md');
+    expect(systemPrompt).toContain('https://example.com/design.md');
+  });
+
+  // ---- Session limits ----
+
+  it('sessionTimeoutMs = trigger.agentConfig.maxSessionMinutes * 60 * 1000 when set', () => {
+    const trigger = makeSessionTrigger({
+      agentConfig: { maxSessionMinutes: 45 },
+    });
+    const { sessionTimeoutMs } = buildSessionContext(trigger, makeInputs());
+    expect(sessionTimeoutMs).toBe(45 * 60 * 1000);
+  });
+
+  it('sessionTimeoutMs = DEFAULT_SESSION_TIMEOUT_MINUTES * 60 * 1000 when agentConfig absent', () => {
+    const trigger = makeSessionTrigger(); // no agentConfig
+    const { sessionTimeoutMs } = buildSessionContext(trigger, makeInputs());
+    expect(sessionTimeoutMs).toBe(DEFAULT_SESSION_TIMEOUT_MINUTES * 60 * 1000);
+  });
+
+  it('maxTurns = trigger.agentConfig.maxTurns when set', () => {
+    const trigger = makeSessionTrigger({
+      agentConfig: { maxTurns: 50 },
+    });
+    const { maxTurns } = buildSessionContext(trigger, makeInputs());
+    expect(maxTurns).toBe(50);
+  });
+
+  it('maxTurns = DEFAULT_MAX_TURNS when agentConfig.maxTurns is absent', () => {
+    const trigger = makeSessionTrigger(); // no agentConfig
+    const { maxTurns } = buildSessionContext(trigger, makeInputs());
+    expect(maxTurns).toBe(DEFAULT_MAX_TURNS);
+  });
+
+  // ---- Session recap in system prompt ----
+
+  it('session recap appears in system prompt when sessionNotes is non-empty', () => {
+    const { systemPrompt } = buildSessionContext(makeSessionTrigger(), makeInputs({
+      sessionNotes: ['Prior step note: found 3 bugs.', 'Step 2: fixed all 3.'],
+    }));
+    // buildSessionRecap wraps notes in <workrail_session_state>
+    expect(systemPrompt).toContain('Prior step note: found 3 bugs.');
+    expect(systemPrompt).toContain('Step 2: fixed all 3.');
+    expect(systemPrompt).toContain('<workrail_session_state>');
+  });
+
+  it('assembled context summary appears in system prompt when provided via trigger.context', () => {
+    const trigger = makeSessionTrigger({
+      context: { assembledContextSummary: 'prior-session-diff-summary' },
+    });
+    const { systemPrompt } = buildSessionContext(trigger, makeInputs());
+    expect(systemPrompt).toContain('## Prior Context');
+    expect(systemPrompt).toContain('prior-session-diff-summary');
+  });
+
+  // ---- Purity guarantee ----
+
+  it('buildSessionContext is a pure function: same inputs always produce the same output', () => {
+    const trigger = makeSessionTrigger({
+      referenceUrls: ['https://example.com/spec.md'],
+      context: { task: 'test' },
+      agentConfig: { maxSessionMinutes: 20, maxTurns: 100 },
+    });
+    const inputs = makeInputs({
+      soulContent: 'soul-marker',
+      workspaceContext: 'workspace-marker',
+      sessionNotes: ['prior note'],
+      firstStepPrompt: 'Do the work',
+    });
+
+    const result1 = buildSessionContext(trigger, inputs);
+    const result2 = buildSessionContext(trigger, inputs);
+
+    expect(result1.systemPrompt).toBe(result2.systemPrompt);
+    expect(result1.initialPrompt).toBe(result2.initialPrompt);
+    expect(result1.sessionTimeoutMs).toBe(result2.sessionTimeoutMs);
+    expect(result1.maxTurns).toBe(result2.maxTurns);
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 of the functional-core/imperative-shell refactor for the WorkTrain daemon. Extracts the session configuration assembly from `runWorkflow()`'s setup phase into a testable pure function, continuing the pattern established in Phase 1 (PR #818).

- **Add `SessionContextInputs` interface** -- documents the pre-loaded I/O boundary (soul content, workspace context, session notes, first step prompt)
- **Add `SessionContext` interface** -- pure output value (system prompt, initial prompt, session limits)
- **Extract `buildSessionContext(trigger, inputs): SessionContext`** -- synchronous pure function that assembles system prompt, initial prompt, `sessionTimeoutMs`, and `maxTurns` from pre-loaded data and trigger config
- **Restructure `runWorkflow()` setup phase** -- explicit `// ---- I/O phase ----` comment before `Promise.all([loadDaemonSoul, loadWorkspaceContext, loadSessionNotes])`, explicit `// ---- Pure phase ----` comment before `buildSessionContext()` call
- **Add 14 unit tests** to `tests/unit/workflow-runner-pure-functions.test.ts` covering system prompt, initial prompt, session limits, session recap, assembled context, and purity guarantee

`buildSystemPrompt()` is still called (via `buildSessionContext()`) -- not inlined or duplicated.

## Test plan

- [x] `npm run build` passes (no TypeScript errors)
- [x] `npx vitest run` passes -- 365 test files, 5561 tests, 5 skipped
- [x] `buildSessionContext()` exported with 14 unit tests
- [x] `SessionContext` and `SessionContextInputs` exported interfaces
- [x] `runWorkflow()` setup phase clearly separates I/O from pure config assembly
- [x] Initial prompt and system prompt construction no longer inline in `runWorkflow()`
- [x] `buildSystemPrompt()` still called via `buildSessionContext()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)