### PR TITLE
fix(engine): inject apiKey into runStartupRecovery via parameter

### DIFF
--- a/docs/history/worktrain-journal.md
+++ b/docs/history/worktrain-journal.md
@@ -5,6 +5,46 @@ Not a backlog -- use `docs/ideas/backlog.md` and `docs/roadmap/` for actionable 
 
 ---
 
+## WorkTrain / WorkRail session: Apr 29, 2026 (continued) -- daemon Phase 3 refactor
+
+### What shipped (PRs #835, #837)
+
+**PR #835: Turn_end subscriber extraction + tool param validation**
+
+Extracted the 126-line inline turn_end subscriber from `runWorkflow()` into `buildTurnEndSubscriber(ctx: TurnEndSubscriberContext)`. The mutable `lastFlushedMessageCount` counter became `lastFlushedRef: { count: number }` -- a plain object shared by reference between the subscriber and the `finally`-block final flush. `runWorkflow()` body reduced from ~426 to ~539 lines... wait, wrong direction. From 539 → 426 lines.
+
+Also added required-field validation at the top of 8 tool `execute()` functions (Bash, Read, Write, Glob, Grep, Edit, spawn_agent, report_issue, signal_coordinator). `complete_step` already validated; `continue_workflow` delegates to the engine. Each validation throws `Error` with a clear message -- `AgentLoop._executeTools()` catches all throws and converts to `isError` tool_results so the LLM can self-correct. 22 new unit tests in `workflow-runner-tool-validation.test.ts`.
+
+**PR #837: buildAgentCallbacks + buildSessionResult extractions + test flakiness fix**
+
+Extracted the 40-line inline `agentCallbacks` object into `buildAgentCallbacks(sessionId, state, modelId, emitter, stuckRepeatThreshold): AgentLoopCallbacks`. The `onToolCallStarted` callback still mutates `state.lastNToolCalls` -- that's intentional and documented.
+
+Extracted the 82-line result-building block into `buildSessionResult(state, stopReason, errorMessage, trigger, sessionId, sessionWorktreePath): WorkflowRunResult` -- a pure function. `runWorkflow()` calls it and then delegates all I/O to the existing `finalizeSession()`. `runWorkflow()` body: 426 → 308 lines.
+
+13 new unit tests covering all 4 result paths (stuck/timeout/error/success), the stuck-over-timeout priority invariant, issueSummaries threading, wall_clock vs max_turns messages, worktree path threading, and botIdentity threading.
+
+Also fixed a pre-existing test flakiness issue: `writeExecutionStats()` is fire-and-forget, and under load with 4 parallel vitest workers its async write chain sometimes didn't complete before tests read the stats file. Fix: added `settleFireAndForget()` before `readStatsFile()` in the stats contract tests (waits for `stats-summary.json` which is written last in the chain), and added `retry: 2` to the vitest config for all test projects.
+
+### runWorkflow() line count progression
+
+| After PR | Lines |
+|---|---|
+| Pre-refactor (original) | ~880 (body only, in 4900-line file) |
+| PR #818 (Phase 1) | ~700 |
+| PR #830 (Phase 2: buildPreAgentSession, constructTools) | ~539 |
+| PR #835 (Phase 3a: buildTurnEndSubscriber) | ~426 |
+| PR #837 (Phase 3b: buildAgentCallbacks, buildSessionResult) | ~308 |
+
+### What's still open
+
+- `CriticalEffect<T>` / `ObservabilityEffect` type distinction -- deferred (requires changing all fire-and-forget call sites)
+- `StateRef` mutation wrapper -- deferred as YAGNI
+- `ContextBundle` with layer provenance -- deferred as YAGNI (no consumer)
+- Zod tool param validation (replacing manual `typeof` checks) -- deferred (requires zodToJsonSchema or accepting two sources of truth)
+- `wr.refactoring` workflow -- captured in backlog
+
+---
+
 ## WorkTrain / WorkRail session: Apr 28-29, 2026 -- architecture, engine bug fix, workflow improvements
 
 ### What shipped (PR #830)

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -145,10 +145,16 @@ The shell then does:
 - `sidecardLifecycleFor()` pure function with `assertNever` exhaustiveness
 - TDZ hazard fixed: `abortRegistry.set()` now registered after `const agent = new AgentLoop()`
 
-**Still deferred (not in Phase 2):**
-- `CriticalEffect<T>` for `persistTokens` callers -- requires changing return type + all tool factory call sites
+**Phase 3 (PRs #835, #837)** continued the refactor:
+- `buildTurnEndSubscriber()` extracted -- runWorkflow() body: 539 → 426 lines
+- Tool param validation at LLM boundary (8 tool factories)
+- `buildAgentCallbacks()` + `buildSessionResult()` pure functions -- body: 426 → 308 lines
+- Test flakiness fix: `settleFireAndForget()` + `retry: 2` in vitest config
+
+**Still deferred:**
+- `CriticalEffect<T>` / `ObservabilityEffect` type distinction
 - `StateRef` mutation wrapper
-- Zod tool param validation at LLM boundary
+- Zod tool param validation (replacing manual typeof checks -- requires zodToJsonSchema or two sources of truth)
 - `wr.refactoring` workflow (see backlog entry above)
 
 ---
@@ -1096,6 +1102,7 @@ WorkTrain is a persistent background daemon that initiates workflows autonomousl
 - Per-trigger crash safety (`persistTokens`)
 - Worktree orphan cleanup on delivery failure
 - runWorkflow() Phase 2 architecture (PR #830): `PreAgentSession`/`buildPreAgentSession`, `constructTools`, `persistTokens` Result type, `sidecardLifecycleFor` pure function, TDZ hazard fix for abort registry
+- runWorkflow() Phase 3 architecture (PRs #835, #837): `buildTurnEndSubscriber` (539→426 lines), tool param validation at LLM boundary (8 factories), `buildAgentCallbacks` + `buildSessionResult` pure functions (426→308 lines), test flakiness fix (settleFireAndForget + retry:2)
 
 ### WorkRail engine / MCP features
 

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -989,6 +989,10 @@ export async function readAllDaemonSessions(
  * @param _runWorkflowFn - Injectable runWorkflow implementation for testing.
  *   Used in the resume path to start a new agent loop from the current step.
  *   Defaults to the real runWorkflow(). Passed as fire-and-forget in production.
+ * @param apiKey - Anthropic API key forwarded to runWorkflow() on the resume path.
+ *   Injected by the caller (startTriggerListener) rather than read from process.env
+ *   so this function stays boundary-clean. Defaults to '' for tests that do not
+ *   exercise the resume path.
  */
 export async function runStartupRecovery(
   sessionsDir: string = DAEMON_SESSIONS_DIR,

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -997,6 +997,10 @@ export async function runStartupRecovery(
   _countStepAdvancesFn: typeof countOrphanStepAdvances = countOrphanStepAdvances,
   _executeContinueWorkflowFn: typeof executeContinueWorkflow = executeContinueWorkflow,
   _runWorkflowFn: typeof runWorkflow = runWorkflow,
+  // WHY last / default '': adding after all injectable params keeps every existing call
+  // site valid without positional changes. Production passes the key from startTriggerListener;
+  // tests that don't exercise the resume path can omit it.
+  apiKey: string = '',
 ): Promise<void> {
   // Phase A: Delete all queue-issue-*.json sidecars unconditionally.
   // WHY first: queue-issue cleanup is independent of session state and must
@@ -1210,7 +1214,7 @@ export async function runStartupRecovery(
           void _runWorkflowFn(
             recoveredTrigger,
             ctx!,
-            process.env['ANTHROPIC_API_KEY'] ?? '',
+            apiKey,
           ).then((result) => {
             console.log(
               `[WorkflowRunner] Startup recovery: resumed session ${session.sessionId} completed: ${result._tag}`,

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -861,7 +861,7 @@ export async function startTriggerListener(
   // throws from the function's own error-handling path.
   // WHY pass ctx: enables resume-path logic (decode token, count step advances,
   // call executeContinueWorkflow with intent: 'rehydrate' for sessions with progress).
-  await runStartupRecovery(undefined, undefined, ctx).catch((err: unknown) => {
+  await runStartupRecovery(undefined, undefined, ctx, undefined, undefined, undefined, apiKey).catch((err: unknown) => {
     console.warn(
       '[TriggerListener] Startup recovery encountered an unexpected error:',
       err instanceof Error ? err.message : String(err),

--- a/tests/unit/workflow-runner-crash-recovery.test.ts
+++ b/tests/unit/workflow-runner-crash-recovery.test.ts
@@ -542,8 +542,10 @@ describe('runStartupRecovery() with ctx -- resume and discard paths', () => {
     await writeSession(tmpDir, sessionId, sessionDataWithContext('ct_resume_me'));
 
     const runWorkflowTriggers: import('../../src/daemon/workflow-runner.js').WorkflowTrigger[] = [];
-    const fakeRunWorkflow = async (trigger: import('../../src/daemon/workflow-runner.js').WorkflowTrigger) => {
+    const capturedApiKeys: string[] = [];
+    const fakeRunWorkflow = async (trigger: import('../../src/daemon/workflow-runner.js').WorkflowTrigger, _ctx: unknown, key: string) => {
       runWorkflowTriggers.push(trigger);
+      capturedApiKeys.push(key);
       return { _tag: 'success', workflowId: trigger.workflowId, stopReason: 'done' } as import('../../src/daemon/workflow-runner.js').WorkflowRunResult;
     };
 
@@ -554,6 +556,7 @@ describe('runStartupRecovery() with ctx -- resume and discard paths', () => {
       async () => 1, // stepAdvances = 1 -> resume
       async () => fakeRehydrateOk(),
       fakeRunWorkflow as Parameters<typeof runStartupRecovery>[5],
+      'test-api-key',
     );
 
     // runWorkflow IS called with the reconstructed trigger
@@ -564,6 +567,8 @@ describe('runStartupRecovery() with ctx -- resume and discard paths', () => {
     expect(runWorkflowTriggers[0]!.branchStrategy).toBe('none');
     expect(runWorkflowTriggers[0]!._preAllocatedStartResponse).toBeDefined();
     expect(runWorkflowTriggers[0]!._preAllocatedStartResponse?.continueToken).toBe('ct_fake_rehydrated');
+    // apiKey is forwarded to runWorkflow -- a regression here would pass all other assertions silently
+    expect(capturedApiKeys[0]).toBe('test-api-key');
 
     // Sidecar is NOT deleted by runStartupRecovery (runWorkflow manages its own lifecycle)
     await expect(fs.access(path.join(tmpDir, `${sessionId}.json`))).resolves.toBeUndefined();
@@ -650,8 +655,10 @@ describe('runStartupRecovery() with ctx -- resume and discard paths', () => {
     });
 
     const runWorkflowTriggers: import('../../src/daemon/workflow-runner.js').WorkflowTrigger[] = [];
-    const fakeRunWorkflow = async (trigger: import('../../src/daemon/workflow-runner.js').WorkflowTrigger) => {
+    const capturedApiKeys: string[] = [];
+    const fakeRunWorkflow = async (trigger: import('../../src/daemon/workflow-runner.js').WorkflowTrigger, _ctx: unknown, key: string) => {
       runWorkflowTriggers.push(trigger);
+      capturedApiKeys.push(key);
       return { _tag: 'success', workflowId: trigger.workflowId, stopReason: 'done' } as import('../../src/daemon/workflow-runner.js').WorkflowRunResult;
     };
 
@@ -662,6 +669,7 @@ describe('runStartupRecovery() with ctx -- resume and discard paths', () => {
       async () => 1, // stepAdvances = 1 -> resume attempted
       async () => fakeRehydrateOk(),
       fakeRunWorkflow as Parameters<typeof runStartupRecovery>[5],
+      'test-api-key',
     );
 
     // Worktree exists -> _runWorkflowFn IS called
@@ -669,6 +677,7 @@ describe('runStartupRecovery() with ctx -- resume and discard paths', () => {
     // effectiveWorkspacePath should be the worktree path, not the original workspacePath
     expect(runWorkflowTriggers[0]!.workspacePath).toBe(fakeWorktreePath);
     expect(runWorkflowTriggers[0]!.branchStrategy).toBe('none');
+    expect(capturedApiKeys[0]).toBe('test-api-key');
 
     // Sidecar is NOT deleted (runWorkflow manages its own lifecycle)
     await expect(fs.access(path.join(tmpDir, `${sessionId}.json`))).resolves.toBeUndefined();
@@ -711,8 +720,10 @@ describe('runStartupRecovery() with ctx -- resume and discard paths', () => {
     await writeSession(tmpDir, id2, { ...sessionDataWithContext('ct_token2'), workflowId: 'wr.wf2' });
 
     const runWorkflowIds: string[] = [];
-    const fakeRunWorkflow = async (trigger: import('../../src/daemon/workflow-runner.js').WorkflowTrigger) => {
+    const capturedApiKeys: string[] = [];
+    const fakeRunWorkflow = async (trigger: import('../../src/daemon/workflow-runner.js').WorkflowTrigger, _ctx: unknown, key: string) => {
       runWorkflowIds.push(trigger.workflowId);
+      capturedApiKeys.push(key);
       return { _tag: 'success', workflowId: trigger.workflowId, stopReason: 'done' } as import('../../src/daemon/workflow-runner.js').WorkflowRunResult;
     };
 
@@ -723,10 +734,14 @@ describe('runStartupRecovery() with ctx -- resume and discard paths', () => {
       async () => 2, // both have advances
       async () => fakeRehydrateOk(),
       fakeRunWorkflow as Parameters<typeof runStartupRecovery>[5],
+      'test-api-key',
     );
 
     // Both sessions get runWorkflow called
     expect(runWorkflowIds.sort()).toEqual(['wr.wf1', 'wr.wf2'].sort());
+    // apiKey forwarded to both sessions
+    expect(capturedApiKeys).toHaveLength(2);
+    expect(capturedApiKeys.every(k => k === 'test-api-key')).toBe(true);
 
     // Sidecars are NOT deleted by runStartupRecovery (runWorkflow manages its own lifecycle)
     await expect(fs.access(path.join(tmpDir, `${id1}.json`))).resolves.toBeUndefined();


### PR DESCRIPTION
## Summary

- `runStartupRecovery()` was the only exported function in `workflow-runner.ts` that read `process.env['ANTHROPIC_API_KEY']` directly instead of accepting it as a parameter
- `startTriggerListener()` (the sole production caller) already has the key -- now passes it through
- Added `apiKey` as the last parameter with default `''` so all 44 existing test call sites remain valid without changes

## Test plan

- [x] All 44 crash recovery unit tests pass (`workflow-runner-crash-recovery.test.ts`)
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)