### PR TITLE
refactor(engine): introduce SessionScope and FileStateTracker for tool layer

### DIFF
--- a/.workrail/implementation_plan.md
+++ b/.workrail/implementation_plan.md
@@ -987,3 +987,142 @@ Commit: `refactor(engine): extract functional core from runWorkflow() for testab
 `planConfidenceBand`: High
 `estimatedPRCount`: 1
 `followUpTickets`: []
+
+---
+---
+
+# Implementation Plan: SessionScope and FileStateTracker
+
+*Generated: 2026-04-28 | Workflow: wr.coding-task | Branch: refactor/etienneb/session-scope*
+
+---
+
+## 1. Problem Statement
+
+In `src/daemon/workflow-runner.ts`, `constructTools()` receives a raw `Map<string, ReadFileState>` (from `session.readFileState`) and five other per-session callback/config params as positional arguments. The raw Map is implicit shared state handed to every tool factory. This plan encapsulates it behind a typed interface (`FileStateTracker`) and bundles all per-session tool dependencies into a single `SessionScope` object.
+
+## 2. Acceptance Criteria
+
+1. `src/daemon/session-scope.ts` exists and exports `FileStateTracker` (interface), `DefaultFileStateTracker` (class), `SessionScope` (interface).
+2. `constructTools()` signature changes to `(session, ctx, apiKey, schemas, scope: SessionScope)` -- no longer takes `emitter`, `abortRegistry`, `onAdvance`, `onComplete`, `maxIssueSummaries` as positional params.
+3. `runWorkflow()` constructs a `SessionScope` before calling `constructTools()`.
+4. Tool factory signatures (`makeReadTool`, `makeWriteTool`, `makeEditTool`) are unchanged.
+5. `ReadFileState` type stays in `workflow-runner.ts`.
+6. `npm run build` exits 0.
+7. `npx vitest run` exits 0 -- all 365 tests pass.
+
+## 3. Non-Goals
+
+- Do NOT change `makeReadTool`, `makeWriteTool`, `makeEditTool`, or any other tool factory signatures.
+- Do NOT move `ReadFileState` type out of `workflow-runner.ts`.
+- Do NOT rename `constructTools`.
+- Do NOT change any behavior -- pure interface extraction and DI refactor.
+
+## 4. Philosophy-Driven Constraints
+
+- **Immutability by default**: all `SessionScope` fields are `readonly`.
+- **Explicit DI**: per-session dependencies injected via `SessionScope`, not positional params.
+- **Prefer explicit domain types**: `FileStateTracker` replaces raw `Map<string, ReadFileState>`.
+- **Document why not what**: WHY comments on `toMap()` and `SessionScope` fields, following `TurnEndSubscriberContext` pattern.
+- **YAGNI**: no speculative changes beyond what is specified.
+
+## 5. Invariants
+
+- I1: `DefaultFileStateTracker.toMap()` returns `this._map` (same instance) -- required for read-before-write checks to work correctly.
+- I2: `constructTools()` must not be exported (it was not exported before; it must not become exported).
+- I3: Tool factory signatures unchanged -- tests call them directly with `Map<string, ReadFileState>`.
+- I4: `ReadFileState` stays exported from `workflow-runner.ts`.
+
+## 6. Selected Approach + Rationale
+
+**FileStateTracker interface + DefaultFileStateTracker (with toMap() getter) + SessionScope bundle**
+
+`SessionScope` contains: `fileTracker`, `onAdvance`, `onComplete`, `workrailSessionId`, `emitter`, `sessionId`, `workflowId`, `abortRegistry`, `maxIssueSummaries`.
+
+`constructTools()` signature: `(session, ctx, apiKey, schemas, scope: SessionScope)`.
+
+Inside `constructTools()`: extracts `scope.fileTracker.toMap()` and passes it to tool factories unchanged.
+
+**Runner-up**: Raw Map in SessionScope -- rejected because task explicitly requires `FileStateTracker`.
+
+**Architecture rationale**: Follows `TurnEndSubscriberContext` and `FinalizationContext` patterns exactly. `toMap()` is the only seam and it is contained (constructTools is not exported).
+
+## 7. Vertical Slices
+
+### Slice 1: Create `src/daemon/session-scope.ts`
+
+**File**: `src/daemon/session-scope.ts` (new)
+
+Contents:
+- Import `ReadFileState` from `./workflow-runner.js`
+- Import `DaemonEventEmitter` from `./daemon-events.js`
+- Import `AbortRegistry` from `./workflow-runner.js`
+- `FileStateTracker` interface with `recordRead`, `getReadState`, `hasBeenRead` methods
+- `DefaultFileStateTracker` class implementing `FileStateTracker`:
+  - `private readonly _map = new Map<string, ReadFileState>()`
+  - `recordRead(path, content, isPartialView)`: calls `_map.set()`
+  - `getReadState(path)`: calls `_map.get()`
+  - `hasBeenRead(path)`: calls `_map.has()`
+  - `toMap()`: returns `this._map` (with WHY comment)
+- `SessionScope` interface with all required fields as `readonly`
+
+**Done when**: Build clean. File exists with correct exports.
+
+### Slice 2: Update `constructTools()` in `workflow-runner.ts`
+
+**File**: `src/daemon/workflow-runner.ts`
+
+Changes:
+1. Import `SessionScope` from `./session-scope.js`
+2. Change `constructTools()` signature to `(session, ctx, apiKey, schemas, scope: SessionScope)`
+3. Inside `constructTools()`: extract needed values from `scope.*`
+4. Pass `scope.fileTracker.toMap()` to `makeReadTool`, `makeWriteTool`, `makeEditTool`
+
+**Done when**: Build clean. constructTools() uses scope.
+
+### Slice 3: Update call site in `runWorkflow()`
+
+**File**: `src/daemon/workflow-runner.ts`
+
+Changes:
+1. Import `DefaultFileStateTracker` from `./session-scope.js`
+2. Create `DefaultFileStateTracker` at call site wrapping `session.readFileState`
+3. Construct `scope: SessionScope` with `fileTracker` + other values
+4. Update `constructTools()` call to pass `scope`
+
+Note: Keep `readFileState` on `PreAgentSession` unchanged (initialized in `buildPreAgentSession()`). Just wrap it at the call site.
+
+**Done when**: Build clean. All tests pass.
+
+## 8. Test Design
+
+No new tests required. Verification: `npx vitest run` (365 tests must pass). The existing file-tools tests (`workflow-runner-file-tools.test.ts`) call tool factories directly with Maps -- these must still pass unchanged.
+
+## 9. Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| toMap() returns different Map than _map | Very Low | High | DefaultFileStateTracker.toMap() returns `this._map` directly |
+| Circular import (session-scope imports from workflow-runner) | Low | Low | Check: workflow-runner imports session-scope (one direction only) |
+
+## 10. PR Packaging Strategy
+
+Single PR. Branch: `refactor/etienneb/session-scope`.
+Commit: `refactor(engine): introduce SessionScope and FileStateTracker for tool layer`
+
+## 11. Philosophy Alignment per Slice
+
+| Slice | Principle | Status |
+|-------|-----------|--------|
+| 1 (session-scope.ts) | Explicit domain types | Satisfied -- FileStateTracker replaces raw Map |
+| 1 (session-scope.ts) | Immutability by default | Satisfied -- readonly SessionScope fields |
+| 1 (session-scope.ts) | Document why not what | Satisfied -- WHY comment on toMap() |
+| 2 (constructTools) | Explicit DI | Satisfied -- scope passed explicitly |
+| 3 (call site) | YAGNI | Satisfied -- readFileState kept on PreAgentSession, wrapped at call site |
+| All | Architectural fix over patch | Satisfied -- makes implicit shared state explicit |
+
+---
+`unresolvedUnknownCount`: 0
+`planConfidenceBand`: High
+`estimatedPRCount`: 1
+`followUpTickets`: ["future: update tool factory signatures to take FileStateTracker instead of Map"]

--- a/src/daemon/session-scope.ts
+++ b/src/daemon/session-scope.ts
@@ -1,0 +1,189 @@
+/**
+ * Per-session tool dependency injection types for the WorkTrain daemon.
+ *
+ * WHY this module exists: `constructTools()` in workflow-runner.ts previously
+ * took a raw `Map<string, ReadFileState>` (plus several individual callback params)
+ * as positional arguments. This module introduces:
+ *
+ *   1. `FileStateTracker` -- a named interface that encapsulates the Map, making
+ *      read-before-write state access explicit and documentable.
+ *
+ *   2. `DefaultFileStateTracker` -- the standard implementation backed by a plain Map.
+ *
+ *   3. `SessionScope` -- a typed bundle of all per-session dependencies that
+ *      `constructTools()` needs. Follows the same pattern as `TurnEndSubscriberContext`
+ *      and `FinalizationContext` elsewhere in this file.
+ *
+ * CIRCULAR IMPORT NOTE: This module uses `import type` from workflow-runner.ts
+ * to avoid runtime circular dependencies. Type-only imports are erased at compile
+ * time and do not create module-level cycles.
+ */
+
+import type { ReadFileState, AbortRegistry } from './workflow-runner.js';
+import type { DaemonEventEmitter } from './daemon-events.js';
+
+// ---------------------------------------------------------------------------
+// FileStateTracker
+// ---------------------------------------------------------------------------
+
+/**
+ * Tracks per-session file read state to enforce read-before-write invariants.
+ *
+ * WHY an interface (not a raw Map): makes the dependency on file-state explicit,
+ * gives each operation a name that documents its intent, and allows future
+ * implementations (e.g. a test double or a tracker that also emits telemetry)
+ * without changing tool factory signatures.
+ */
+export interface FileStateTracker {
+  /**
+   * Record that a file was read in this session.
+   * Must be called by the Read tool after every successful file read.
+   */
+  recordRead(filePath: string, content: string, timestamp: number, isPartialView: boolean): void;
+
+  /**
+   * Retrieve the last-recorded read state for a file, or undefined if the file
+   * has not been read in this session.
+   */
+  getReadState(filePath: string): ReadFileState | undefined;
+
+  /**
+   * Returns true if the file has been read at least once in this session.
+   */
+  hasBeenRead(filePath: string): boolean;
+
+  /**
+   * Returns the underlying Map for backward compatibility with tool factories
+   * that accept `Map<string, ReadFileState>` directly.
+   *
+   * WHY on the interface: `constructTools()` calls this to pass the Map to
+   * tool factories whose signatures cannot change (tests call them directly
+   * with Maps). Having it on the interface avoids an `instanceof` check
+   * and allows test doubles to implement it cleanly.
+   *
+   * Contract: the returned Map must be the same instance used internally by
+   * the tracker. Reads and writes by tool factories must be visible through
+   * the tracker's other methods (recordRead, getReadState, hasBeenRead).
+   */
+  toMap(): Map<string, ReadFileState>;
+}
+
+// ---------------------------------------------------------------------------
+// DefaultFileStateTracker
+// ---------------------------------------------------------------------------
+
+/**
+ * Standard `FileStateTracker` implementation backed by a plain Map.
+ *
+ * Constructed once per `runWorkflow()` call (one per session).
+ */
+export class DefaultFileStateTracker implements FileStateTracker {
+  // WHY readonly: the Map reference is fixed; only its contents change.
+  private readonly _map: Map<string, ReadFileState>;
+
+  /**
+   * Create a new tracker.
+   *
+   * @param existingMap Optional existing Map to wrap. When provided, the tracker
+   *   shares the same Map instance rather than creating a new one. This allows
+   *   `constructTools()` to wrap `session.readFileState` (which was initialized
+   *   in `buildPreAgentSession()`) without copying it, preserving the exact same
+   *   Map instance that tool factories mutate via `.get()` and `.set()`.
+   */
+  constructor(existingMap?: Map<string, ReadFileState>) {
+    this._map = existingMap ?? new Map<string, ReadFileState>();
+  }
+
+  recordRead(filePath: string, content: string, timestamp: number, isPartialView: boolean): void {
+    this._map.set(filePath, { content, timestamp, isPartialView });
+  }
+
+  getReadState(filePath: string): ReadFileState | undefined {
+    return this._map.get(filePath);
+  }
+
+  hasBeenRead(filePath: string): boolean {
+    return this._map.has(filePath);
+  }
+
+  /**
+   * Returns the underlying Map for backward compatibility with tool factories
+   * that accept `Map<string, ReadFileState>` directly.
+   *
+   * WHY this method exists: `makeReadTool`, `makeWriteTool`, and `makeEditTool`
+   * are exported and tested directly with raw Maps. Changing their signatures
+   * would break tests. `constructTools()` calls this method to obtain the Map
+   * and passes it to those factories. Do not use this method in new code --
+   * prefer the tracker interface methods instead.
+   *
+   * WHY the same Map instance is returned: the tool factories call `.get()` and
+   * `.set()` on this Map to enforce read-before-write invariants. If a copy were
+   * returned, those mutations would not be visible to the tracker, breaking staleness
+   * detection.
+   */
+  toMap(): Map<string, ReadFileState> {
+    return this._map;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SessionScope
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-session typed contract for what the tool construction layer is allowed to touch.
+ *
+ * Constructed once per `runWorkflow()` call and passed to `constructTools()`.
+ * All fields are readonly -- `constructTools()` reads but does not replace them.
+ *
+ * WHY a named interface (not positional params): matches the pattern of
+ * `TurnEndSubscriberContext` and `FinalizationContext` in workflow-runner.ts.
+ * Named fields document intent and prevent accidental param ordering errors.
+ */
+export interface SessionScope {
+  /** Tracks which files have been read in this session (read-before-write enforcement). */
+  readonly fileTracker: FileStateTracker;
+
+  /**
+   * Called by `complete_step` / `continue_workflow` tools when the agent advances
+   * to the next step. Updates mutable session state in runWorkflow().
+   */
+  readonly onAdvance: (stepText: string, continueToken: string) => void;
+
+  /**
+   * Called by `complete_step` tool when the workflow completes.
+   * Updates mutable session state in runWorkflow().
+   */
+  readonly onComplete: (notes: string | undefined, artifacts?: readonly unknown[]) => void;
+
+  /**
+   * The WorkRail session ID (decoded from the continue token), or null if the
+   * session has not yet been started.
+   */
+  readonly workrailSessionId: string | null;
+
+  /**
+   * Event emitter for daemon observability events. May be undefined in
+   * test contexts or when the daemon is started without observability.
+   */
+  readonly emitter: DaemonEventEmitter | undefined;
+
+  /** The daemon-local session identifier (a UUID). */
+  readonly sessionId: string;
+
+  /** The workflow ID being executed (e.g. "wr.coding-task"). */
+  readonly workflowId: string;
+
+  /**
+   * Registry mapping workrailSessionId -> abort callback.
+   * Used by `spawn_agent` to register/deregister child sessions.
+   * May be undefined if graceful shutdown is not enabled.
+   */
+  readonly abortRegistry: AbortRegistry | undefined;
+
+  /**
+   * Maximum number of issue summaries to collect during this session.
+   * Passed to `report_issue` tool construction.
+   */
+  readonly maxIssueSummaries: number;
+}

--- a/src/daemon/session-scope.ts
+++ b/src/daemon/session-scope.ts
@@ -171,7 +171,11 @@ export interface SessionScope {
   /** The daemon-local session identifier (a UUID). */
   readonly sessionId: string;
 
-  /** The workflow ID being executed (e.g. "wr.coding-task"). */
+  /**
+   * The workflow ID being executed (e.g. "wr.coding-task").
+   * Not destructured inside constructTools() in this PR -- will be consumed by
+   * individual tool factories in A4 when they move to their own files.
+   */
   readonly workflowId: string;
 
   /**

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -53,6 +53,7 @@ import { evaluateRecovery } from './session-recovery-policy.js';
 import { writeStatsSummary } from './stats-summary.js';
 import { injectPendingSteps } from './turn-end/step-injector.js';
 import { flushConversation } from './turn-end/conversation-flusher.js';
+import { type SessionScope, DefaultFileStateTracker } from './session-scope.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -4345,15 +4346,21 @@ function constructTools(
   apiKey: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   schemas: Record<string, any>,
-  emitter: DaemonEventEmitter | undefined,
-  abortRegistry: AbortRegistry | undefined,
-  onAdvance: (stepText: string, continueToken: string) => void,
-  onComplete: (notes: string | undefined, artifacts?: readonly unknown[]) => void,
-  maxIssueSummaries: number,
+  scope: SessionScope,
 ): readonly AgentTool[] {
-  const { state, sessionId: sid, sessionWorkspacePath, readFileState, spawnCurrentDepth, spawnMaxDepth } = session;
-  // Alias for readability -- workrailSessionId is read-only after buildPreAgentSession
-  const workrailSid = state.workrailSessionId;
+  const { state, sessionWorkspacePath, spawnCurrentDepth, spawnMaxDepth } = session;
+  const { fileTracker, onAdvance, onComplete, emitter, abortRegistry, maxIssueSummaries } = scope;
+  const sid = scope.sessionId;
+  // WHY from scope (not state.workrailSessionId): scope.workrailSessionId is set at
+  // SessionScope construction time in runWorkflow() and is read-only. This mirrors
+  // how TurnEndSubscriberContext captures workflowId once at construction.
+  const workrailSid = scope.workrailSessionId;
+  // WHY toMap(): tool factories (makeReadTool, makeWriteTool, makeEditTool) accept
+  // Map<string, ReadFileState> directly. Their public signatures cannot change because
+  // tests call them directly with Maps. toMap() is defined on the FileStateTracker
+  // interface and returns the same Map instance the tracker uses internally, so
+  // read-before-write checks remain valid across all tool invocations.
+  const readFileStateMap = fileTracker.toMap();
 
   return [
     makeCompleteStepTool(
@@ -4375,11 +4382,11 @@ function constructTools(
     // WHY sessionWorkspacePath: when branchStrategy === 'worktree', all agent file operations
     // must target the isolated worktree, not the main checkout.
     makeBashTool(sessionWorkspacePath, schemas, sid, emitter, workrailSid),
-    makeReadTool(readFileState, schemas, sid, emitter, workrailSid),
-    makeWriteTool(readFileState, schemas, sid, emitter, workrailSid),
+    makeReadTool(readFileStateMap, schemas, sid, emitter, workrailSid),
+    makeWriteTool(readFileStateMap, schemas, sid, emitter, workrailSid),
     makeGlobTool(sessionWorkspacePath, schemas, sid, emitter, workrailSid),
     makeGrepTool(sessionWorkspacePath, schemas, sid, emitter, workrailSid),
-    makeEditTool(sessionWorkspacePath, readFileState, schemas, sid, emitter, workrailSid),
+    makeEditTool(sessionWorkspacePath, readFileStateMap, schemas, sid, emitter, workrailSid),
     makeReportIssueTool(sid, emitter, workrailSid, undefined, (summary: string) => {
       if (state.issueSummaries.length < maxIssueSummaries) {
         state.issueSummaries.push(summary);
@@ -4733,7 +4740,22 @@ export async function runWorkflow(
 
   // ---- Schemas + tool construction ----
   const schemas = getSchemas();
-  const tools = constructTools(session, ctx, apiKey, schemas, emitter, abortRegistry, onAdvance, onComplete, MAX_ISSUE_SUMMARIES);
+  // WHY SessionScope: bundles all per-session tool dependencies into a single typed
+  // object instead of individual positional params. Follows the TurnEndSubscriberContext
+  // and FinalizationContext patterns. fileTracker wraps session.readFileState in the
+  // FileStateTracker interface while preserving the same Map instance for tool factories.
+  const scope: SessionScope = {
+    fileTracker: new DefaultFileStateTracker(session.readFileState),
+    onAdvance,
+    onComplete,
+    workrailSessionId: state.workrailSessionId,
+    emitter,
+    sessionId,
+    workflowId: trigger.workflowId,
+    abortRegistry,
+    maxIssueSummaries: MAX_ISSUE_SUMMARIES,
+  };
+  const tools = constructTools(session, ctx, apiKey, schemas, scope);
 
   // ---- I/O phase: load context (soul + workspace + session notes) ----
   // WHY: load before Agent construction -- the system prompt is set at init

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -4351,9 +4351,9 @@ function constructTools(
   const { state, sessionWorkspacePath, spawnCurrentDepth, spawnMaxDepth } = session;
   const { fileTracker, onAdvance, onComplete, emitter, abortRegistry, maxIssueSummaries } = scope;
   const sid = scope.sessionId;
-  // WHY from scope (not state.workrailSessionId): scope.workrailSessionId is set at
-  // SessionScope construction time in runWorkflow() and is read-only. This mirrors
-  // how TurnEndSubscriberContext captures workflowId once at construction.
+  // WHY from scope (not state directly): SessionScope is the typed boundary for what
+  // constructTools() is allowed to see. Passing state directly would leak all mutable
+  // session fields to the tool layer; scope captures only the subset tools need.
   const workrailSid = scope.workrailSessionId;
   // WHY toMap(): tool factories (makeReadTool, makeWriteTool, makeEditTool) accept
   // Map<string, ReadFileState> directly. Their public signatures cannot change because


### PR DESCRIPTION
## Summary

- Introduces `src/daemon/session-scope.ts` with two new types:
  - `FileStateTracker` interface -- encapsulates the raw `Map<string, ReadFileState>` behind named methods (`recordRead`, `getReadState`, `hasBeenRead`), replacing the implicit shared Map that was passed as a positional parameter to every tool factory
  - `SessionScope` interface -- typed bundle of all per-session dependencies that `constructTools()` needs: `fileTracker`, `onAdvance`, `onComplete`, `workrailSessionId`, `emitter`, `sessionId`, `workflowId`, `abortRegistry`, `maxIssueSummaries`
  - `DefaultFileStateTracker` class -- standard implementation backed by a plain Map
- `constructTools()` signature simplified: `(session, ctx, apiKey, schemas, scope: SessionScope)` instead of 9+ positional params
- Zero behavior change

## Notes

`FileStateTracker` exposes a `toMap()` method for backward compatibility with `makeReadTool`, `makeWriteTool`, `makeEditTool` -- these are exported and tested directly with raw Maps so their signatures cannot change in this PR. `toMap()` returns the same Map instance (mutations by tool factories remain visible through the tracker). Full encapsulation completes in A4 when the tool factories move to individual files.

## Test plan

- [x] `npx vitest run` -- all tests pass (5637 passing, 5 skipped)
- [x] `npm run build` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)