### PR TITLE
refactor(engine): extract createCoordinatorDeps and fix circular dep

### DIFF
--- a/src/trigger/coordinator-deps.ts
+++ b/src/trigger/coordinator-deps.ts
@@ -101,6 +101,10 @@ export function createCoordinatorDeps(
 
   return {
     setDispatch(fn: (trigger: WorkflowTrigger) => void): void {
+      if (dispatch !== null) {
+        process.stderr.write('[WARN coordinator-deps] setDispatch() called more than once -- ignoring reassignment\n');
+        return;
+      }
       dispatch = fn;
     },
 

--- a/src/trigger/coordinator-deps.ts
+++ b/src/trigger/coordinator-deps.ts
@@ -1,0 +1,462 @@
+/**
+ * WorkRail Auto: Coordinator Deps Factory
+ *
+ * Provides createCoordinatorDeps() -- a factory that builds the AdaptiveCoordinatorDeps
+ * implementation used by the trigger listener's in-process adaptive pipeline coordinator.
+ *
+ * WHY a separate file (not inline in trigger-listener.ts):
+ * startTriggerListener() was ~920 lines with ~355 of those being anonymous AdaptiveCoordinatorDeps
+ * closures. Extracting them here improves readability and testability without changing behavior.
+ *
+ * WHY setDispatch() (not a constructor parameter):
+ * spawnSession() needs router.dispatch(), but TriggerRouter's constructor takes coordinatorDeps.
+ * This creates a circular construction order: coordinatorDeps must exist before TriggerRouter,
+ * but dispatch only exists after TriggerRouter is constructed. setDispatch() is the explicit
+ * late-binding that resolves this: it is called exactly once, immediately after TriggerRouter
+ * construction, at the composition root in startTriggerListener().
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { V2ToolContext } from '../mcp/types.js';
+import type { AdaptiveCoordinatorDeps } from '../coordinators/adaptive-pipeline.js';
+import { executeStartWorkflow } from '../mcp/handlers/v2-execution/start.js';
+import { parseContinueTokenOrFail } from '../mcp/handlers/v2-token-ops.js';
+import { createContextAssembler } from '../context-assembly/index.js';
+import { createListRecentSessions } from '../context-assembly/infra.js';
+import type { WorkflowTrigger } from '../daemon/workflow-runner.js';
+import type { ConsoleService } from '../v2/usecases/console-service.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Dependencies injected into createCoordinatorDeps().
+ *
+ * These correspond to the closed-over variables from startTriggerListener()
+ * that the coordinatorDeps closures previously captured implicitly.
+ */
+export interface CoordinatorDepsDependencies {
+  /** V2 tool context, used by spawnSession for executeStartWorkflow and token decoding. */
+  readonly ctx: V2ToolContext;
+  /**
+   * Promisified execFile, used for git/gh CLI calls.
+   * Kept as a parameter (not re-created internally) so test fakes can substitute it.
+   */
+  readonly execFileAsync: (
+    cmd: string,
+    args: string[],
+    opts?: object,
+  ) => Promise<{ stdout: string }>;
+  /**
+   * ConsoleService instance for in-process session polling.
+   * Null when ctx.v2.dataDir or ctx.v2.directoryListing are unavailable.
+   * WHY passed as parameter (not lazily imported here): ConsoleService is lazily
+   * imported in trigger-listener.ts to avoid circular module deps at load time.
+   * Passing the pre-constructed instance keeps coordinator-deps.ts free of that concern.
+   */
+  readonly consoleService: InstanceType<typeof ConsoleService> | null;
+}
+
+/**
+ * AdaptiveCoordinatorDeps with an additional setDispatch() method for late-binding.
+ *
+ * WHY the extension (not a separate injection): TriggerRouter's constructor takes
+ * AdaptiveCoordinatorDeps, so the type must already be fully constructed. setDispatch()
+ * is an implementation detail of the factory's circular-dep resolution strategy -- it is
+ * not part of the public AdaptiveCoordinatorDeps contract.
+ */
+export interface CoordinatorDepsWithDispatch extends AdaptiveCoordinatorDeps {
+  /**
+   * Bind the dispatch function from TriggerRouter after router construction.
+   *
+   * Call exactly once, immediately after `new TriggerRouter(...)`, passing
+   * `router.dispatch.bind(router)`. Until this is called, spawnSession() returns
+   * a typed error rather than crashing.
+   */
+  setDispatch(dispatch: (trigger: WorkflowTrigger) => void): void;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the AdaptiveCoordinatorDeps implementation for the trigger listener.
+ *
+ * All method bodies are extracted verbatim from startTriggerListener() in
+ * trigger-listener.ts. No logic changes.
+ */
+export function createCoordinatorDeps(
+  deps: CoordinatorDepsDependencies,
+): CoordinatorDepsWithDispatch {
+  const { ctx, execFileAsync, consoleService } = deps;
+
+  // Mutable dispatch function. Null until setDispatch() is called.
+  // WHY let (not const): assigned by setDispatch(), which is called after TriggerRouter construction.
+  let dispatch: ((trigger: WorkflowTrigger) => void) | null = null;
+
+  return {
+    setDispatch(fn: (trigger: WorkflowTrigger) => void): void {
+      dispatch = fn;
+    },
+
+    spawnSession: async (
+      workflowId: string,
+      goal: string,
+      workspace: string,
+      context?: Readonly<Record<string, unknown>>,
+      agentConfig?: Readonly<{ readonly maxSessionMinutes?: number; readonly maxTurns?: number }>,
+    ) => {
+      // WHY in-process (not HTTP): the coordinator runs inside the daemon process.
+      // POSTing to /api/v2/auto/dispatch would go out-of-process to itself, hitting
+      // the HTTP handler's LLM credential check which can fail even when the daemon
+      // is running correctly (the daemon already validated credentials at startup).
+      // Calling executeStartWorkflow + router.dispatch() directly bypasses the
+      // redundant credential check and eliminates the HTTP roundtrip.
+      // This mirrors the pattern used in console-routes.ts:810-863 (the HTTP handler
+      // uses this same flow: executeStartWorkflow -> _preAllocatedStartResponse -> dispatch).
+      if (dispatch === null) {
+        return { kind: 'err' as const, error: 'in-process router not initialized -- coordinator deps not ready' };
+      }
+
+      // Step 1: Allocate a session in the store synchronously.
+      // WHY _preAllocatedStartResponse: runWorkflow() skips its own executeStartWorkflow()
+      // call when this field is set, preventing double session creation.
+      const startResult = await executeStartWorkflow(
+        { workflowId, workspacePath: workspace, goal },
+        ctx,
+        { is_autonomous: 'true', workspacePath: workspace },
+      );
+      if (startResult.isErr()) {
+        const detail = `${startResult.error.kind}${'message' in startResult.error ? ': ' + (startResult.error as { message: string }).message : ''}`;
+        return { kind: 'err' as const, error: `Session creation failed: ${detail}` };
+      }
+
+      const startContinueToken = startResult.value.response.continueToken;
+      if (!startContinueToken) {
+        // Workflow completed immediately (single-step); no agent loop session needed.
+        // Use workflowId as fallback handle (matches console-routes.ts:854-856 behavior).
+        return { kind: 'ok' as const, value: workflowId };
+      }
+
+      // Step 2: Decode the session ID from the continueToken.
+      // WHY parseContinueTokenOrFail: V2StartWorkflowOutputSchema does not expose sessionId
+      // directly (to avoid a breaking schema change). Same approach as console-routes.ts:837-851.
+      const tokenResult = await parseContinueTokenOrFail(
+        startContinueToken,
+        ctx.v2.tokenCodecPorts,
+        ctx.v2.tokenAliasStore,
+      );
+      if (tokenResult.isErr()) {
+        process.stderr.write(
+          `[ERROR trigger-listener:spawnSession] Failed to decode session handle from new session: ${tokenResult.error.message}\n`,
+        );
+        return { kind: 'err' as const, error: 'Internal error: could not extract session handle from new session' };
+      }
+      const sessionHandle = tokenResult.value.sessionId;
+
+      // Step 3: Enqueue the agent loop via TriggerRouter's queue and semaphore.
+      // Pass _preAllocatedStartResponse so runWorkflow() skips executeStartWorkflow().
+      // WHY agentConfig forwarded: coordinator sets per-phase timeouts (e.g. 55m for discovery)
+      // that exceed DEFAULT_SESSION_TIMEOUT_MINUTES=30. Without forwarding, sessions die at 30m
+      // and the coordinator's phase budget is never consumed (discovery-loop-fix, RC1).
+      dispatch({
+        workflowId,
+        goal,
+        workspacePath: workspace,
+        context,
+        ...(agentConfig !== undefined ? { agentConfig } : {}),
+        _preAllocatedStartResponse: startResult.value.response,
+      });
+
+      return { kind: 'ok' as const, value: sessionHandle };
+    },
+
+    contextAssembler: createContextAssembler({
+      execGit: async (args: readonly string[], cwd: string) => {
+        try {
+          const { stdout } = await execFileAsync('git', [...args], { cwd });
+          return { kind: 'ok' as const, value: stdout };
+        } catch (e) {
+          return { kind: 'err' as const, error: e instanceof Error ? e.message : String(e) };
+        }
+      },
+      execGh: async (args: readonly string[], cwd: string) => {
+        try {
+          const { stdout } = await execFileAsync('gh', [...args], { cwd });
+          return { kind: 'ok' as const, value: stdout };
+        } catch (e) {
+          return { kind: 'err' as const, error: e instanceof Error ? e.message : String(e) };
+        }
+      },
+      listRecentSessions: createListRecentSessions(),
+      nowIso: () => new Date().toISOString(),
+    }),
+
+    // WHY in-process polling (not HTTP): see ConsoleService construction comment in trigger-listener.ts.
+    // SESSION_LOAD_FAILED on getSessionDetail() is treated as "not ready yet" (retry),
+    // not as failure. This handles the race where spawnSession() creates a session
+    // in-process but the event log is not yet complete enough to project.
+    awaitSessions: async (handles: readonly string[], timeoutMs: number) => {
+      const POLL_INTERVAL_MS = 3_000;
+
+      if (consoleService === null) {
+        process.stderr.write(
+          `[WARN coord:reason=await_degraded] awaitSessions: ConsoleService unavailable -- returning all ${handles.length} session(s) as failed.\n`,
+        );
+        return {
+          results: [...handles].map((h) => ({
+            handle: h,
+            outcome: 'failed' as const,
+            status: null,
+            durationMs: 0,
+          })),
+          allSucceeded: false,
+        };
+      }
+
+      const startMs = Date.now();
+      const pending = new Set(handles);
+      const results = new Map<string, { handle: string; outcome: 'success' | 'failed' | 'timeout'; status: string | null; durationMs: number }>();
+
+      while (pending.size > 0) {
+        const elapsed = Date.now() - startMs;
+        if (elapsed >= timeoutMs) {
+          break;
+        }
+
+        for (const handle of [...pending]) {
+          try {
+            const detail = await consoleService.getSessionDetail(handle);
+            if (detail.isErr()) {
+              // SESSION_LOAD_FAILED or NODE_NOT_FOUND: session not yet visible or corrupt.
+              // Retry on next poll cycle -- do not mark as failed.
+              continue;
+            }
+            const run = detail.value.runs[0];
+            if (!run) continue; // session started but no run yet
+
+            const status = run.status;
+            if (status === 'complete' || status === 'complete_with_gaps') {
+              results.set(handle, { handle, outcome: 'success', status, durationMs: Date.now() - startMs });
+              pending.delete(handle);
+            } else if (status === 'blocked') {
+              results.set(handle, { handle, outcome: 'failed', status, durationMs: Date.now() - startMs });
+              pending.delete(handle);
+            }
+            // in_progress: still running -- stay in pending
+          } catch {
+            // Unexpected throw (should not happen with ResultAsync, but defensive)
+            results.set(handle, { handle, outcome: 'failed', status: null, durationMs: Date.now() - startMs });
+            pending.delete(handle);
+          }
+        }
+
+        if (pending.size > 0) {
+          await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+        }
+      }
+
+      // Any remaining pending handles hit the timeout
+      for (const handle of pending) {
+        results.set(handle, { handle, outcome: 'timeout', status: null, durationMs: timeoutMs });
+      }
+
+      const resultsArray = [...results.values()];
+      return {
+        results: resultsArray,
+        allSucceeded: resultsArray.every((r) => r.outcome === 'success'),
+      };
+    },
+
+    getAgentResult: async (sessionHandle: string): Promise<{ recapMarkdown: string | null; artifacts: readonly unknown[] }> => {
+      const emptyResult = { recapMarkdown: null, artifacts: [] as readonly unknown[] };
+
+      if (consoleService === null) {
+        return emptyResult;
+      }
+
+      try {
+        const detailResult = await consoleService.getSessionDetail(sessionHandle);
+        if (detailResult.isErr()) return emptyResult;
+
+        const run = detailResult.value.runs[0];
+        if (!run) return emptyResult;
+
+        const tipNodeId = run.preferredTipNodeId;
+        if (!tipNodeId) return emptyResult;
+
+        const allNodeIds = run.nodes.map((n) => n.nodeId).filter((id): id is string => typeof id === 'string' && id !== '');
+        const nodeIdsToFetch = allNodeIds.length > 0 ? allNodeIds : [tipNodeId];
+
+        let recap: string | null = null;
+        const collectedArtifacts: unknown[] = [];
+
+        for (const nodeId of nodeIdsToFetch) {
+          try {
+            const nodeResult = await consoleService.getNodeDetail(sessionHandle, nodeId);
+            if (nodeResult.isErr()) continue;
+
+            if (nodeId === tipNodeId) {
+              recap = nodeResult.value.recapMarkdown;
+            }
+            if (nodeResult.value.artifacts.length > 0) {
+              collectedArtifacts.push(...nodeResult.value.artifacts);
+            }
+          } catch { continue; }
+        }
+
+        return { recapMarkdown: recap, artifacts: collectedArtifacts };
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        process.stderr.write(`[WARN coord:reason=exception handle=${sessionHandle.slice(0, 16)}] getAgentResult: ${msg}\n`);
+        return emptyResult;
+      }
+    },
+
+    listOpenPRs: async (workspace: string) => {
+      try {
+        const { stdout } = await execFileAsync('gh', ['pr', 'list', '--json', 'number,title,headRefName'], {
+          cwd: workspace,
+          timeout: 30_000,
+        });
+        const parsed = JSON.parse(stdout) as Array<{ number: number; title: string; headRefName: string }>;
+        return parsed.map((p) => ({ number: p.number, title: p.title, headRef: p.headRefName }));
+      } catch {
+        return [];
+      }
+    },
+
+    mergePR: async (prNumber: number, workspace: string) => {
+      try {
+        await execFileAsync('gh', ['pr', 'merge', String(prNumber), '--squash', '--auto'], {
+          cwd: workspace,
+          timeout: 60_000,
+        });
+        return { kind: 'ok' as const, value: undefined };
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { kind: 'err' as const, error: msg };
+      }
+    },
+
+    writeFile: async (filePath: string, content: string) => {
+      await fs.promises.writeFile(filePath, content, 'utf-8');
+    },
+
+    readFile: (filePath: string) => fs.promises.readFile(filePath, 'utf-8'),
+
+    appendFile: (filePath: string, content: string) =>
+      fs.promises.appendFile(filePath, content, 'utf-8'),
+
+    mkdir: (dirPath: string, opts: { recursive: boolean }) =>
+      fs.promises.mkdir(dirPath, opts),
+
+    homedir: os.homedir,
+    joinPath: path.join,
+    nowIso: () => new Date().toISOString(),
+    generateId: () => randomUUID(),
+
+    stderr: (line: string) => process.stderr.write(line + '\n'),
+    now: () => Date.now(),
+
+    // AdaptiveCoordinatorDeps extensions (beyond CoordinatorDeps)
+
+    fileExists: (p: string): boolean => fs.existsSync(p),
+
+    archiveFile: (src: string, dest: string): Promise<void> =>
+      fs.promises.rename(src, dest),
+
+    pollForPR: async (branchPattern: string, timeoutMs: number): Promise<string | null> => {
+      // Poll `gh pr list --head <branchPattern>` every 30 seconds until a PR is found
+      // or the timeout elapses. Returns the PR URL or null.
+      const pollIntervalMs = 30_000;
+      const deadline = Date.now() + timeoutMs;
+
+      while (Date.now() < deadline) {
+        try {
+          const { stdout } = await execFileAsync(
+            'gh',
+            ['pr', 'list', '--head', branchPattern, '--json', 'url', '--limit', '1'],
+            { timeout: 30_000 },
+          );
+          const parsed = JSON.parse(stdout) as Array<{ url: string }>;
+          if (parsed.length > 0 && parsed[0] && parsed[0].url) {
+            return parsed[0].url;
+          }
+        } catch {
+          // gh command failed -- continue polling (PR may not exist yet)
+        }
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) break;
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, Math.min(pollIntervalMs, remaining)),
+        );
+      }
+      return null;
+    },
+
+    postToOutbox: async (message: string, metadata: Readonly<Record<string, unknown>>): Promise<void> => {
+      const workrailDir = path.join(os.homedir(), '.workrail');
+      const outboxPath = path.join(workrailDir, 'outbox.jsonl');
+      await fs.promises.mkdir(workrailDir, { recursive: true });
+      const entry = JSON.stringify({
+        id: randomUUID(),
+        message,
+        metadata,
+        timestamp: new Date().toISOString(),
+      });
+      await fs.promises.appendFile(outboxPath, entry + '\n', 'utf-8');
+    },
+
+    pollOutboxAck: async (requestId: string, timeoutMs: number): Promise<'acked' | 'timeout'> => {
+      // Poll ~/.workrail/inbox-cursor.json every 5 minutes.
+      // The human acknowledges by running `worktrain inbox`, which advances the cursor.
+      // Resolve 'acked' when the cursor has advanced past the snapshot line count.
+      //
+      // WHY snapshot approach: postToOutbox appends a line to outbox.jsonl. The inbox
+      // command sets lastReadCount = total valid lines in outbox.jsonl. When the cursor
+      // advances beyond the snapshot count, the human has read the notification.
+      const pollIntervalMs = 5 * 60 * 1000; // 5 minutes
+      const workrailDir = path.join(os.homedir(), '.workrail');
+      const outboxPath = path.join(workrailDir, 'outbox.jsonl');
+      const cursorPath = path.join(workrailDir, 'inbox-cursor.json');
+
+      // Take snapshot of current outbox line count
+      let snapshotCount = 0;
+      try {
+        const outboxContent = await fs.promises.readFile(outboxPath, 'utf-8');
+        snapshotCount = outboxContent.split('\n').filter((l) => l.trim() !== '').length;
+      } catch {
+        // outbox.jsonl doesn't exist yet -- snapshot is 0
+      }
+
+      // Suppress unused parameter warning: requestId is for traceability in logs
+      void requestId;
+
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) break;
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, Math.min(pollIntervalMs, remaining)),
+        );
+
+        try {
+          const cursorContent = await fs.promises.readFile(cursorPath, 'utf-8');
+          const cursor = JSON.parse(cursorContent) as { lastReadCount?: number };
+          if (typeof cursor.lastReadCount === 'number' && cursor.lastReadCount > snapshotCount) {
+            return 'acked';
+          }
+        } catch {
+          // cursor file missing or malformed -- not yet acked, continue polling
+        }
+      }
+      return 'timeout';
+    },
+  };
+}

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -20,14 +20,8 @@
 import 'reflect-metadata';
 import express from 'express';
 import * as http from 'node:http';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { randomUUID } from 'node:crypto';
-import type { Result } from '../runtime/result.js';
-import { ok, err } from '../runtime/result.js';
 import type { V2ToolContext } from '../mcp/types.js';
 import { loadTriggerConfigFromFile, buildTriggerIndex } from './trigger-store.js';
 import type { TriggerStoreError } from './trigger-store.js';
@@ -42,15 +36,12 @@ import type { DaemonEventEmitter } from '../daemon/daemon-events.js';
 import { PollingScheduler } from './polling-scheduler.js';
 import { PolledEventStore } from './polled-event-store.js';
 import type { FetchFn } from './adapters/gitlab-poller.js';
-import { createContextAssembler } from '../context-assembly/index.js';
-import { createListRecentSessions } from '../context-assembly/infra.js';
-import type { AdaptiveCoordinatorDeps, ModeExecutors } from '../coordinators/adaptive-pipeline.js';
+import type { ModeExecutors } from '../coordinators/adaptive-pipeline.js';
 import { runQuickReviewPipeline } from '../coordinators/modes/quick-review.js';
 import { runReviewOnlyPipeline } from '../coordinators/modes/review-only.js';
 import { runImplementPipeline } from '../coordinators/modes/implement.js';
 import { runFullPipeline } from '../coordinators/modes/full-pipeline.js';
-import { executeStartWorkflow } from '../mcp/handlers/v2-execution/start.js';
-import { parseContinueTokenOrFail } from '../mcp/handlers/v2-token-ops.js';
+import { createCoordinatorDeps } from './coordinator-deps.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -417,10 +408,11 @@ export async function startTriggerListener(
   // fs/exec/HTTP implementations. This pattern mirrors the pr-review command in
   // cli-worktrain.ts (lines 958-1244), which uses the same deps interface.
   //
-  // WHY let routerRef (forward reference): coordinatorDeps must be constructed before
-  // TriggerRouter (it is a constructor argument). spawnSession needs the router to
-  // call router.dispatch() in-process. The forward-ref is assigned exactly once,
-  // immediately after new TriggerRouter(), and never mutated again.
+  // WHY createCoordinatorDeps + setDispatch (not inline): the method implementations
+  // are extracted into coordinator-deps.ts to reduce this function's line count.
+  // The circular construction order (coordinatorDeps before TriggerRouter, but spawnSession
+  // needs router.dispatch) is resolved via setDispatch() -- called once, immediately after
+  // router construction. See coordinator-deps.ts for the WHY comment.
   // ---------------------------------------------------------------------------
   const execFileAsync = promisify(execFile);
 
@@ -451,367 +443,7 @@ export async function startTriggerListener(
     });
   }
 
-  // Forward reference for in-process dispatch. Assigned after router construction.
-  // WHY let (not const): construction order requires coordinatorDeps before router.
-  // Assigned exactly once; never mutated after assignment.
-  let routerRef: TriggerRouter | undefined;
-
-  const coordinatorDeps: AdaptiveCoordinatorDeps = {
-    spawnSession: async (
-      workflowId: string,
-      goal: string,
-      workspace: string,
-      context?: Readonly<Record<string, unknown>>,
-      agentConfig?: Readonly<{ readonly maxSessionMinutes?: number; readonly maxTurns?: number }>,
-    ) => {
-      // WHY in-process (not HTTP): the coordinator runs inside the daemon process.
-      // POSTing to /api/v2/auto/dispatch would go out-of-process to itself, hitting
-      // the HTTP handler's LLM credential check which can fail even when the daemon
-      // is running correctly (the daemon already validated credentials at startup).
-      // Calling executeStartWorkflow + router.dispatch() directly bypasses the
-      // redundant credential check and eliminates the HTTP roundtrip.
-      // This mirrors the pattern used in console-routes.ts:810-863 (the HTTP handler
-      // uses this same flow: executeStartWorkflow -> _preAllocatedStartResponse -> dispatch).
-      if (routerRef === undefined) {
-        return { kind: 'err' as const, error: 'in-process router not initialized -- coordinator deps not ready' };
-      }
-
-      // Step 1: Allocate a session in the store synchronously.
-      // WHY _preAllocatedStartResponse: runWorkflow() skips its own executeStartWorkflow()
-      // call when this field is set, preventing double session creation.
-      const startResult = await executeStartWorkflow(
-        { workflowId, workspacePath: workspace, goal },
-        ctx,
-        { is_autonomous: 'true', workspacePath: workspace },
-      );
-      if (startResult.isErr()) {
-        const detail = `${startResult.error.kind}${'message' in startResult.error ? ': ' + (startResult.error as { message: string }).message : ''}`;
-        return { kind: 'err' as const, error: `Session creation failed: ${detail}` };
-      }
-
-      const startContinueToken = startResult.value.response.continueToken;
-      if (!startContinueToken) {
-        // Workflow completed immediately (single-step); no agent loop session needed.
-        // Use workflowId as fallback handle (matches console-routes.ts:854-856 behavior).
-        return { kind: 'ok' as const, value: workflowId };
-      }
-
-      // Step 2: Decode the session ID from the continueToken.
-      // WHY parseContinueTokenOrFail: V2StartWorkflowOutputSchema does not expose sessionId
-      // directly (to avoid a breaking schema change). Same approach as console-routes.ts:837-851.
-      const tokenResult = await parseContinueTokenOrFail(
-        startContinueToken,
-        ctx.v2.tokenCodecPorts,
-        ctx.v2.tokenAliasStore,
-      );
-      if (tokenResult.isErr()) {
-        process.stderr.write(
-          `[ERROR trigger-listener:spawnSession] Failed to decode session handle from new session: ${tokenResult.error.message}\n`,
-        );
-        return { kind: 'err' as const, error: 'Internal error: could not extract session handle from new session' };
-      }
-      const sessionHandle = tokenResult.value.sessionId;
-
-      // Step 3: Enqueue the agent loop via TriggerRouter's queue and semaphore.
-      // Pass _preAllocatedStartResponse so runWorkflow() skips executeStartWorkflow().
-      // WHY agentConfig forwarded: coordinator sets per-phase timeouts (e.g. 55m for discovery)
-      // that exceed DEFAULT_SESSION_TIMEOUT_MINUTES=30. Without forwarding, sessions die at 30m
-      // and the coordinator's phase budget is never consumed (discovery-loop-fix, RC1).
-      routerRef.dispatch({
-        workflowId,
-        goal,
-        workspacePath: workspace,
-        context,
-        ...(agentConfig !== undefined ? { agentConfig } : {}),
-        _preAllocatedStartResponse: startResult.value.response,
-      });
-
-      return { kind: 'ok' as const, value: sessionHandle };
-    },
-
-    contextAssembler: createContextAssembler({
-      execGit: async (args: readonly string[], cwd: string) => {
-        try {
-          const { stdout } = await execFileAsync('git', [...args], { cwd });
-          return { kind: 'ok' as const, value: stdout };
-        } catch (e) {
-          return { kind: 'err' as const, error: e instanceof Error ? e.message : String(e) };
-        }
-      },
-      execGh: async (args: readonly string[], cwd: string) => {
-        try {
-          const { stdout } = await execFileAsync('gh', [...args], { cwd });
-          return { kind: 'ok' as const, value: stdout };
-        } catch (e) {
-          return { kind: 'err' as const, error: e instanceof Error ? e.message : String(e) };
-        }
-      },
-      listRecentSessions: createListRecentSessions(),
-      nowIso: () => new Date().toISOString(),
-    }),
-
-    // WHY in-process polling (not HTTP): see ConsoleService construction comment above.
-    // SESSION_LOAD_FAILED on getSessionDetail() is treated as "not ready yet" (retry),
-    // not as failure. This handles the race where spawnSession() creates a session
-    // in-process but the event log is not yet complete enough to project.
-    awaitSessions: async (handles: readonly string[], timeoutMs: number) => {
-      const POLL_INTERVAL_MS = 3_000;
-
-      if (consoleService === null) {
-        process.stderr.write(
-          `[WARN coord:reason=await_degraded] awaitSessions: ConsoleService unavailable -- returning all ${handles.length} session(s) as failed.\n`,
-        );
-        return {
-          results: [...handles].map((h) => ({
-            handle: h,
-            outcome: 'failed' as const,
-            status: null,
-            durationMs: 0,
-          })),
-          allSucceeded: false,
-        };
-      }
-
-      const startMs = Date.now();
-      const pending = new Set(handles);
-      const results = new Map<string, { handle: string; outcome: 'success' | 'failed' | 'timeout'; status: string | null; durationMs: number }>();
-
-      while (pending.size > 0) {
-        const elapsed = Date.now() - startMs;
-        if (elapsed >= timeoutMs) {
-          break;
-        }
-
-        for (const handle of [...pending]) {
-          try {
-            const detail = await consoleService.getSessionDetail(handle);
-            if (detail.isErr()) {
-              // SESSION_LOAD_FAILED or NODE_NOT_FOUND: session not yet visible or corrupt.
-              // Retry on next poll cycle -- do not mark as failed.
-              continue;
-            }
-            const run = detail.value.runs[0];
-            if (!run) continue; // session started but no run yet
-
-            const status = run.status;
-            if (status === 'complete' || status === 'complete_with_gaps') {
-              results.set(handle, { handle, outcome: 'success', status, durationMs: Date.now() - startMs });
-              pending.delete(handle);
-            } else if (status === 'blocked') {
-              results.set(handle, { handle, outcome: 'failed', status, durationMs: Date.now() - startMs });
-              pending.delete(handle);
-            }
-            // in_progress: still running -- stay in pending
-          } catch {
-            // Unexpected throw (should not happen with ResultAsync, but defensive)
-            results.set(handle, { handle, outcome: 'failed', status: null, durationMs: Date.now() - startMs });
-            pending.delete(handle);
-          }
-        }
-
-        if (pending.size > 0) {
-          await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-        }
-      }
-
-      // Any remaining pending handles hit the timeout
-      for (const handle of pending) {
-        results.set(handle, { handle, outcome: 'timeout', status: null, durationMs: timeoutMs });
-      }
-
-      const resultsArray = [...results.values()];
-      return {
-        results: resultsArray,
-        allSucceeded: resultsArray.every((r) => r.outcome === 'success'),
-      };
-    },
-
-    getAgentResult: async (sessionHandle: string): Promise<{ recapMarkdown: string | null; artifacts: readonly unknown[] }> => {
-      const emptyResult = { recapMarkdown: null, artifacts: [] as readonly unknown[] };
-
-      if (consoleService === null) {
-        return emptyResult;
-      }
-
-      try {
-        const detailResult = await consoleService.getSessionDetail(sessionHandle);
-        if (detailResult.isErr()) return emptyResult;
-
-        const run = detailResult.value.runs[0];
-        if (!run) return emptyResult;
-
-        const tipNodeId = run.preferredTipNodeId;
-        if (!tipNodeId) return emptyResult;
-
-        const allNodeIds = run.nodes.map((n) => n.nodeId).filter((id): id is string => typeof id === 'string' && id !== '');
-        const nodeIdsToFetch = allNodeIds.length > 0 ? allNodeIds : [tipNodeId];
-
-        let recap: string | null = null;
-        const collectedArtifacts: unknown[] = [];
-
-        for (const nodeId of nodeIdsToFetch) {
-          try {
-            const nodeResult = await consoleService.getNodeDetail(sessionHandle, nodeId);
-            if (nodeResult.isErr()) continue;
-
-            if (nodeId === tipNodeId) {
-              recap = nodeResult.value.recapMarkdown;
-            }
-            if (nodeResult.value.artifacts.length > 0) {
-              collectedArtifacts.push(...nodeResult.value.artifacts);
-            }
-          } catch { continue; }
-        }
-
-        return { recapMarkdown: recap, artifacts: collectedArtifacts };
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        process.stderr.write(`[WARN coord:reason=exception handle=${sessionHandle.slice(0, 16)}] getAgentResult: ${msg}\n`);
-        return emptyResult;
-      }
-    },
-
-    listOpenPRs: async (workspace: string) => {
-      try {
-        const { stdout } = await execFileAsync('gh', ['pr', 'list', '--json', 'number,title,headRefName'], {
-          cwd: workspace,
-          timeout: 30_000,
-        });
-        const parsed = JSON.parse(stdout) as Array<{ number: number; title: string; headRefName: string }>;
-        return parsed.map((p) => ({ number: p.number, title: p.title, headRef: p.headRefName }));
-      } catch {
-        return [];
-      }
-    },
-
-    mergePR: async (prNumber: number, workspace: string) => {
-      try {
-        await execFileAsync('gh', ['pr', 'merge', String(prNumber), '--squash', '--auto'], {
-          cwd: workspace,
-          timeout: 60_000,
-        });
-        return { kind: 'ok' as const, value: undefined };
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return { kind: 'err' as const, error: msg };
-      }
-    },
-
-    writeFile: async (filePath: string, content: string) => {
-      await fs.promises.writeFile(filePath, content, 'utf-8');
-    },
-
-    readFile: (filePath: string) => fs.promises.readFile(filePath, 'utf-8'),
-
-    appendFile: (filePath: string, content: string) =>
-      fs.promises.appendFile(filePath, content, 'utf-8'),
-
-    mkdir: (dirPath: string, opts: { recursive: boolean }) =>
-      fs.promises.mkdir(dirPath, opts),
-
-    homedir: os.homedir,
-    joinPath: path.join,
-    nowIso: () => new Date().toISOString(),
-    generateId: () => randomUUID(),
-
-    stderr: (line: string) => process.stderr.write(line + '\n'),
-    now: () => Date.now(),
-
-    // AdaptiveCoordinatorDeps extensions (beyond CoordinatorDeps)
-
-    fileExists: (p: string): boolean => fs.existsSync(p),
-
-    archiveFile: (src: string, dest: string): Promise<void> =>
-      fs.promises.rename(src, dest),
-
-    pollForPR: async (branchPattern: string, timeoutMs: number): Promise<string | null> => {
-      // Poll `gh pr list --head <branchPattern>` every 30 seconds until a PR is found
-      // or the timeout elapses. Returns the PR URL or null.
-      const pollIntervalMs = 30_000;
-      const deadline = Date.now() + timeoutMs;
-
-      while (Date.now() < deadline) {
-        try {
-          const { stdout } = await execFileAsync(
-            'gh',
-            ['pr', 'list', '--head', branchPattern, '--json', 'url', '--limit', '1'],
-            { timeout: 30_000 },
-          );
-          const parsed = JSON.parse(stdout) as Array<{ url: string }>;
-          if (parsed.length > 0 && parsed[0] && parsed[0].url) {
-            return parsed[0].url;
-          }
-        } catch {
-          // gh command failed -- continue polling (PR may not exist yet)
-        }
-        const remaining = deadline - Date.now();
-        if (remaining <= 0) break;
-        await new Promise<void>((resolve) =>
-          setTimeout(resolve, Math.min(pollIntervalMs, remaining)),
-        );
-      }
-      return null;
-    },
-
-    postToOutbox: async (message: string, metadata: Readonly<Record<string, unknown>>): Promise<void> => {
-      const workrailDir = path.join(os.homedir(), '.workrail');
-      const outboxPath = path.join(workrailDir, 'outbox.jsonl');
-      await fs.promises.mkdir(workrailDir, { recursive: true });
-      const entry = JSON.stringify({
-        id: randomUUID(),
-        message,
-        metadata,
-        timestamp: new Date().toISOString(),
-      });
-      await fs.promises.appendFile(outboxPath, entry + '\n', 'utf-8');
-    },
-
-    pollOutboxAck: async (requestId: string, timeoutMs: number): Promise<'acked' | 'timeout'> => {
-      // Poll ~/.workrail/inbox-cursor.json every 5 minutes.
-      // The human acknowledges by running `worktrain inbox`, which advances the cursor.
-      // Resolve 'acked' when the cursor has advanced past the snapshot line count.
-      //
-      // WHY snapshot approach: postToOutbox appends a line to outbox.jsonl. The inbox
-      // command sets lastReadCount = total valid lines in outbox.jsonl. When the cursor
-      // advances beyond the snapshot count, the human has read the notification.
-      const pollIntervalMs = 5 * 60 * 1000; // 5 minutes
-      const workrailDir = path.join(os.homedir(), '.workrail');
-      const outboxPath = path.join(workrailDir, 'outbox.jsonl');
-      const cursorPath = path.join(workrailDir, 'inbox-cursor.json');
-
-      // Take snapshot of current outbox line count
-      let snapshotCount = 0;
-      try {
-        const outboxContent = await fs.promises.readFile(outboxPath, 'utf-8');
-        snapshotCount = outboxContent.split('\n').filter((l) => l.trim() !== '').length;
-      } catch {
-        // outbox.jsonl doesn't exist yet -- snapshot is 0
-      }
-
-      // Suppress unused parameter warning: requestId is for traceability in logs
-      void requestId;
-
-      const deadline = Date.now() + timeoutMs;
-      while (Date.now() < deadline) {
-        const remaining = deadline - Date.now();
-        if (remaining <= 0) break;
-        await new Promise<void>((resolve) =>
-          setTimeout(resolve, Math.min(pollIntervalMs, remaining)),
-        );
-
-        try {
-          const cursorContent = await fs.promises.readFile(cursorPath, 'utf-8');
-          const cursor = JSON.parse(cursorContent) as { lastReadCount?: number };
-          if (typeof cursor.lastReadCount === 'number' && cursor.lastReadCount > snapshotCount) {
-            return 'acked';
-          }
-        } catch {
-          // cursor file missing or malformed -- not yet acked, continue polling
-        }
-      }
-      return 'timeout';
-    },
-  };
+  const coordinatorDeps = createCoordinatorDeps({ ctx, execFileAsync, consoleService });
 
   // Mode executors: map the pipeline function names to the ModeExecutors interface.
   // WHY these names: the ModeExecutors interface uses short names (runQuickReview, etc.)
@@ -827,11 +459,11 @@ export async function startTriggerListener(
   // Create router and Express app
   const runWorkflowFn: RunWorkflowFn = options.runWorkflowFn ?? runWorkflow;
   const router = new TriggerRouter(triggerIndex, ctx, apiKey, runWorkflowFn, undefined, maxConcurrentSessions, options.emitter, notificationService, steerRegistry, abortRegistry, coordinatorDeps, modeExecutors);
-  // Populate the forward reference so spawnSession can dispatch in-process.
-  // WHY here (not before construction): routerRef is a forward-ref needed because
-  // coordinatorDeps must be constructed before TriggerRouter (it's a constructor arg).
-  // Assigned exactly once, immediately after construction.
-  routerRef = router;
+  // Bind the router's dispatch function so spawnSession can dispatch in-process.
+  // WHY after construction: coordinatorDeps must be created before TriggerRouter (it's
+  // a constructor arg), so dispatch can only be bound after the router exists.
+  // setDispatch() is called exactly once here; see coordinator-deps.ts for the WHY.
+  coordinatorDeps.setDispatch(router.dispatch.bind(router));
   const app = createTriggerApp(router);
 
   // Create and start the polling scheduler.


### PR DESCRIPTION
## Summary

Extracts the `AdaptiveCoordinatorDeps` implementations out of `startTriggerListener()` in `trigger-listener.ts` into a `createCoordinatorDeps()` factory in `src/trigger/coordinator-deps.ts`. Also fixes the circular dependency between coordinator deps and `TriggerRouter`.

**Problem:** `startTriggerListener()` was ~900 lines with `spawnSession`, `awaitSessions`, `getAgentResult`, `pollOutboxAck`, `pollForPR`, `postToOutbox`, `listOpenPRs`, `mergePR` all as anonymous inline closures. The circular dep (`spawnSession` needs `router.dispatch()`, but router takes `coordinatorDeps` in its constructor) was duct-taped with a mutable `let routerRef: TriggerRouter | undefined` forward reference.

**Fix:**
- `coordinator-deps.ts` (462 lines): all method bodies extracted verbatim; `dispatch` is late-bound via `setDispatch()`
- `trigger-listener.ts`: -368 lines, reduced from 920 to 552 lines
- `let routerRef` removed; replaced with `coordinatorDeps.setDispatch(router.dispatch.bind(router))` -- one explicit late-binding, clearly documented

Zero behavior change.

## Test plan

- [x] `npx vitest run` -- all tests pass (perf test flake is pre-existing, passes in isolation)
- [x] `npm run build` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)