### PR TITLE
chore: add missing @emnapi/core and @emnapi/runtime to lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1866,6 +1866,29 @@
         "win32"
       ]
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",


### PR DESCRIPTION
## Summary

`@rolldown/binding-wasm32-wasi` (wasm32 optional dev dep pulled in by vite/rolldown) declares `@emnapi/core@1.10.0` and `@emnapi/runtime@1.10.0` as dependencies, but neither had resolved entries in `package-lock.json`. The lockfile was generated on macOS where this optional package is not installed, so the entries were never written.

Linux CI runners were failing with `npm ci: Missing: @emnapi/core@1.10.0 from lock file` on every PR. Main passed intermittently only when runners had a warm npm cache that happened to include these packages.

**Fix:** Added the two missing `node_modules/` entries to `package-lock.json` directly from the npm registry (integrity hashes verified against `npm view --json`).

## Root cause / prevention

The lockfile was generated and committed from a macOS machine. Optional platform-specific packages (those with `"optional": true` and a specific `cpu`/`os` constraint) only get resolved and written to the lockfile when `npm install` is run on a matching platform. This will recur any time vite/rolldown updates these wasm bindings.

**Longer-term fix:** Add a CI job that runs `npm install` on Linux and commits any lockfile changes, or add `--include=optional` to lockfile generation. For now, the manual addition unblocks the 6 PRs stuck waiting for CI.

## Test plan
- [x] `npm run build` -- clean
- [x] `npx vitest run` -- 5629 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)