### PR TITLE
chore: remove wasm32-only optional entry from lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2883,25 +2883,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",


### PR DESCRIPTION
## Summary

`@rolldown/binding-wasm32-wasi` has `cpu: [wasm32]` and `optional: true`. It is never installed on macOS or Linux x64, but its presence in `package-lock.json` caused `npm ci` to fail with `Missing: @emnapi/core@1.10.0 from lock file` because npm validates all deps of all locked packages -- even optional ones for other platforms.

**Fix:** Remove the `node_modules/@rolldown/binding-wasm32-wasi` entry from the lockfile entirely. Without the entry, npm doesn't check its transitive deps on non-wasm32 platforms.

**Why this survives semantic-release:** semantic-release runs `npm install` which regenerates the lockfile on Linux. Since the package is wasm32-only and optional, `npm install` on Linux won't add it back -- it will remain absent.

**Why it's safe:** The package is a dev-only wasm32 binding for rolldown (vite's bundler). It's never needed to build, test, or run this project.

## Test plan
- [x] `npm run build` -- clean
- [x] `npx vitest run` -- 5644 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)