### PR TITLE
refactor(engine): add SessionSource discriminated union and AllocatedSession

### DIFF
--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -472,6 +472,73 @@ export interface WorkflowTrigger {
   readonly branchPrefix?: string;
 }
 
+// ---------------------------------------------------------------------------
+// SessionSource discriminated union (A8)
+// ---------------------------------------------------------------------------
+
+/**
+ * A session that was fully allocated by the caller before the agent loop.
+ * Used when the caller needs the session ID synchronously (console dispatch,
+ * spawnSession, crash recovery).
+ *
+ * WHY this type: replaces the implicit contract encoded in
+ * WorkflowTrigger._preAllocatedStartResponse with an explicit, named type.
+ * Callers that pre-allocate a session now hold an AllocatedSession value
+ * rather than an ad-hoc optional field on WorkflowTrigger.
+ */
+export interface AllocatedSession {
+  /** Continue token from executeStartWorkflow response. */
+  readonly continueToken: string;
+  readonly checkpointToken?: string | null;
+  /** First step prompt from the session. May be empty if isComplete. */
+  readonly firstStepPrompt: string;
+  readonly isComplete: boolean;
+  /** Source of this session (daemon trigger or MCP client). */
+  readonly triggerSource: 'daemon' | 'mcp';
+}
+
+/**
+ * Explicit discriminated union for session creation source.
+ *
+ * WHY: replaces the _preAllocatedStartResponse optional escape-hatch on
+ * WorkflowTrigger with a typed discriminant that makes the two paths explicit.
+ * 'allocate' -> buildPreAgentSession calls executeStartWorkflow internally.
+ * 'pre_allocated' -> executeStartWorkflow was already called by the caller.
+ *
+ * MIGRATION: existing code still uses WorkflowTrigger._preAllocatedStartResponse
+ * directly. New callers should construct SessionSource directly. Existing callers
+ * can use sessionSourceFromTrigger() to adapt a legacy WorkflowTrigger.
+ */
+export type SessionSource =
+  | { readonly kind: 'allocate'; readonly trigger: WorkflowTrigger }
+  | { readonly kind: 'pre_allocated'; readonly trigger: WorkflowTrigger; readonly session: AllocatedSession };
+
+/**
+ * Convert a legacy WorkflowTrigger to a SessionSource.
+ *
+ * WHY: allows gradual migration -- callers that still use WorkflowTrigger
+ * can wrap with this helper; new callers construct SessionSource directly.
+ * When _preAllocatedStartResponse is set, maps the full schema response to
+ * the narrower AllocatedSession shape (only the fields runWorkflow actually uses).
+ */
+export function sessionSourceFromTrigger(trigger: WorkflowTrigger): SessionSource {
+  if (trigger._preAllocatedStartResponse !== undefined) {
+    const r = trigger._preAllocatedStartResponse;
+    return {
+      kind: 'pre_allocated',
+      trigger,
+      session: {
+        continueToken: r.continueToken ?? '',
+        checkpointToken: r.checkpointToken,
+        firstStepPrompt: r.pending?.prompt ?? '',
+        isComplete: r.isComplete,
+        triggerSource: 'daemon',
+      },
+    };
+  }
+  return { kind: 'allocate', trigger };
+}
+
 /** Successful completion of a workflow run. */
 export interface WorkflowRunSuccess {
   readonly _tag: 'success';

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -520,8 +520,21 @@ export type SessionSource =
  * can wrap with this helper; new callers construct SessionSource directly.
  * When _preAllocatedStartResponse is set, maps the full schema response to
  * the narrower AllocatedSession shape (only the fields runWorkflow actually uses).
+ *
+ * WHY triggerSource parameter: _preAllocatedStartResponse is set by both daemon
+ * (TriggerRouter.dispatch, spawnSession) and console (console-routes.ts HTTP dispatch).
+ * Hardcoding 'daemon' would misattribute console-dispatched sessions. Callers must
+ * pass the correct source explicitly.
+ *
+ * WHY AllocatedSession omits preferences/nextIntent/nextCall:
+ * Those fields are unused by runWorkflow() -- only continueToken, checkpointToken,
+ * pending.prompt, and isComplete matter for session initialization. Narrowing here
+ * prevents future callers from accidentally depending on schema fields that may change.
  */
-export function sessionSourceFromTrigger(trigger: WorkflowTrigger): SessionSource {
+export function sessionSourceFromTrigger(
+  trigger: WorkflowTrigger,
+  triggerSource: 'daemon' | 'mcp' = 'daemon',
+): SessionSource {
   if (trigger._preAllocatedStartResponse !== undefined) {
     const r = trigger._preAllocatedStartResponse;
     return {
@@ -529,10 +542,13 @@ export function sessionSourceFromTrigger(trigger: WorkflowTrigger): SessionSourc
       trigger,
       session: {
         continueToken: r.continueToken ?? '',
+        // WHY string | null | undefined: the Zod schema uses .optional() (no null),
+        // but the module convention at line ~2707 normalises absent to null via ?? null.
+        // Preserving undefined here keeps the wrapper lossless; consumers normalise downstream.
         checkpointToken: r.checkpointToken,
         firstStepPrompt: r.pending?.prompt ?? '',
         isComplete: r.isComplete,
-        triggerSource: 'daemon',
+        triggerSource,
       },
     };
   }

--- a/tests/unit/session-source.test.ts
+++ b/tests/unit/session-source.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { sessionSourceFromTrigger } from '../../src/daemon/workflow-runner.js';
+import type { WorkflowTrigger } from '../../src/daemon/workflow-runner.js';
+
+const BASE_TRIGGER: WorkflowTrigger = {
+  workflowId: 'wr.coding-task',
+  goal: 'test goal',
+  workspacePath: '/workspace',
+};
+
+describe('sessionSourceFromTrigger', () => {
+  it('returns allocate when _preAllocatedStartResponse is absent', () => {
+    const src = sessionSourceFromTrigger(BASE_TRIGGER);
+    expect(src.kind).toBe('allocate');
+    expect(src.trigger).toBe(BASE_TRIGGER);
+  });
+
+  it('returns pre_allocated when _preAllocatedStartResponse is set', () => {
+    const trigger: WorkflowTrigger = {
+      ...BASE_TRIGGER,
+      _preAllocatedStartResponse: {
+        continueToken: 'ct_abc',
+        checkpointToken: 'ckpt_abc',
+        isComplete: false,
+        pending: { prompt: 'step 1 prompt', stepId: 's1' },
+        preferences: undefined,
+        nextIntent: undefined,
+        nextCall: undefined,
+      },
+    };
+    const src = sessionSourceFromTrigger(trigger);
+    expect(src.kind).toBe('pre_allocated');
+    if (src.kind !== 'pre_allocated') return;
+    expect(src.session.continueToken).toBe('ct_abc');
+    expect(src.session.checkpointToken).toBe('ckpt_abc');
+    expect(src.session.firstStepPrompt).toBe('step 1 prompt');
+    expect(src.session.isComplete).toBe(false);
+    expect(src.session.triggerSource).toBe('daemon');
+  });
+
+  it('defaults triggerSource to daemon', () => {
+    const trigger: WorkflowTrigger = {
+      ...BASE_TRIGGER,
+      _preAllocatedStartResponse: {
+        continueToken: 'ct_x',
+        isComplete: false,
+        pending: { prompt: 'p', stepId: 's' },
+        preferences: undefined,
+        nextIntent: undefined,
+        nextCall: undefined,
+      },
+    };
+    const src = sessionSourceFromTrigger(trigger);
+    if (src.kind !== 'pre_allocated') throw new Error('expected pre_allocated');
+    expect(src.session.triggerSource).toBe('daemon');
+  });
+
+  it('respects explicit triggerSource mcp', () => {
+    const trigger: WorkflowTrigger = {
+      ...BASE_TRIGGER,
+      _preAllocatedStartResponse: {
+        continueToken: 'ct_y',
+        isComplete: false,
+        pending: { prompt: 'p', stepId: 's' },
+        preferences: undefined,
+        nextIntent: undefined,
+        nextCall: undefined,
+      },
+    };
+    const src = sessionSourceFromTrigger(trigger, 'mcp');
+    if (src.kind !== 'pre_allocated') throw new Error('expected pre_allocated');
+    expect(src.session.triggerSource).toBe('mcp');
+  });
+
+  it('handles absent continueToken with empty string fallback', () => {
+    const trigger: WorkflowTrigger = {
+      ...BASE_TRIGGER,
+      _preAllocatedStartResponse: {
+        continueToken: undefined,
+        isComplete: true,
+        pending: undefined,
+        preferences: undefined,
+        nextIntent: undefined,
+        nextCall: undefined,
+      },
+    };
+    const src = sessionSourceFromTrigger(trigger);
+    if (src.kind !== 'pre_allocated') throw new Error('expected pre_allocated');
+    expect(src.session.continueToken).toBe('');
+    expect(src.session.firstStepPrompt).toBe('');
+    expect(src.session.isComplete).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds three new exports to `workflow-runner.ts` as the vocabulary for future migration away from `_preAllocatedStartResponse`:

- `AllocatedSession` -- a session that was fully allocated by the caller before the agent loop (`continueToken`, `checkpointToken`, `firstStepPrompt`, `isComplete`, `triggerSource`)
- `SessionSource` -- discriminated union: `{ kind: 'allocate', trigger }` | `{ kind: 'pre_allocated', trigger, session }`
- `sessionSourceFromTrigger(trigger)` -- bridges legacy `WorkflowTrigger._preAllocatedStartResponse` to the new typed union

No existing code modified. `WorkflowTrigger`, `buildPreAgentSession`, `runWorkflow`, all function signatures unchanged. New exports have zero callers in this PR -- they ship the typed vocabulary; migration of call sites follows incrementally.

## Test plan
- [x] `npx vitest run` -- 5636 passing
- [x] `npm run build` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)