### PR TITLE
refactor(engine): remove _preAllocatedStartResponse via SessionSource

### DIFF
--- a/src/daemon/tools/spawn-agent.ts
+++ b/src/daemon/tools/spawn-agent.ts
@@ -14,7 +14,7 @@ import { assertNever } from '../../runtime/assert-never.js';
 import { withWorkrailSession } from './_shared.js';
 // WHY import type: runWorkflow is passed as a parameter (runWorkflowFn), not called
 // directly. The type reference is erased at compile time -- no runtime circular dep.
-import type { runWorkflow, ChildWorkflowRunResult } from '../workflow-runner.js';
+import type { runWorkflow, ChildWorkflowRunResult, SessionSource, AllocatedSession } from '../workflow-runner.js';
 import type { ActiveSessionSet } from '../active-sessions.js';
 
 /**
@@ -162,27 +162,40 @@ export function makeSpawnAgentTool(
       // a global Semaphore. Calling it from inside a running session would deadlock.
       // Direct await runWorkflow() is naturally blocking -- the parent's AgentLoop is paused
       // inside execute() until the child completes (AgentLoop.execute() is sequential).
+      const childTrigger = {
+        workflowId: String(params.workflowId),
+        goal: String(params.goal),
+        workspacePath: String(params.workspacePath),
+        context: params.context as Readonly<Record<string, unknown>> | undefined,
+        // WHY spawnDepth: child session constructs its own spawn_agent tool at depth+1.
+        // This is the mechanism by which depth limits propagate through the tree.
+        spawnDepth: currentDepth + 1,
+        // WHY parentSessionId: threads the parent link through runWorkflow -> executeStartWorkflow
+        // for context_set injection (alongside the session_created.data written above).
+        parentSessionId: thisWorkrailSessionId,
+      };
+      // WHY SessionSource: the session is already created above. runWorkflow() MUST NOT
+      // call executeStartWorkflow() again (invariant). SessionSource replaces the removed
+      // WorkflowTrigger._preAllocatedStartResponse field (A9 migration).
+      const r = startResult.value.response;
+      const childAllocatedSession: AllocatedSession = {
+        continueToken: r.continueToken ?? '',
+        checkpointToken: r.checkpointToken,
+        firstStepPrompt: r.pending?.prompt ?? '',
+        isComplete: r.isComplete,
+        triggerSource: 'daemon',
+      };
+      const childSource: SessionSource = { kind: 'pre_allocated', trigger: childTrigger, session: childAllocatedSession };
       const childResult = await runWorkflowFn(
-        {
-          workflowId: String(params.workflowId),
-          goal: String(params.goal),
-          workspacePath: String(params.workspacePath),
-          context: params.context as Readonly<Record<string, unknown>> | undefined,
-          // WHY spawnDepth: child session constructs its own spawn_agent tool at depth+1.
-          // This is the mechanism by which depth limits propagate through the tree.
-          spawnDepth: currentDepth + 1,
-          // WHY parentSessionId: threads the parent link through runWorkflow -> executeStartWorkflow
-          // for context_set injection (alongside the session_created.data written above).
-          parentSessionId: thisWorkrailSessionId,
-          // WHY _preAllocatedStartResponse: the session is already created above.
-          // runWorkflow() MUST NOT call executeStartWorkflow() again (invariant).
-          _preAllocatedStartResponse: startResult.value.response,
-        },
+        childTrigger,
         ctx,
         apiKey,
         undefined, // daemonRegistry: child sessions are not registered (no isLive tracking needed)
         emitter,
         activeSessionSet, // WHY: thread session set so child sessions are abortable on SIGTERM
+        undefined, // _statsDir: use default
+        undefined, // _sessionsDir: use default
+        childSource,
       ) as ChildWorkflowRunResult;
       // WHY cast to ChildWorkflowRunResult: runWorkflow() returns WorkflowRunResult (4 variants)
       // for TriggerRouter compatibility, but structurally only produces success/error/timeout.

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -473,7 +473,13 @@ export interface AllocatedSession {
   /** First step prompt from the session. May be empty if isComplete. */
   readonly firstStepPrompt: string;
   readonly isComplete: boolean;
-  /** Source of this session (daemon trigger or MCP client). */
+  /**
+   * Source of this session (daemon trigger or MCP client).
+   * WHY stored here: feeds the "Session trigger source attribution" backlog item --
+   * writing this to the run_started event makes daemon vs MCP attribution permanent
+   * and queryable from the event log. Not yet wired to the event; the field is in
+   * place so the wire-up is a one-liner when that work is done.
+   */
   readonly triggerSource: 'daemon' | 'mcp';
 }
 
@@ -489,24 +495,6 @@ export type SessionSource =
   | { readonly kind: 'allocate'; readonly trigger: WorkflowTrigger }
   | { readonly kind: 'pre_allocated'; readonly trigger: WorkflowTrigger; readonly session: AllocatedSession };
 
-/**
- * Wrap a WorkflowTrigger in a SessionSource with kind 'allocate'.
- *
- * WHY kept: retained for backward-compat and any callers that hold a bare
- * WorkflowTrigger and want a typed SessionSource without constructing one
- * manually. Now always returns kind: 'allocate' because
- * WorkflowTrigger._preAllocatedStartResponse has been removed (A9 migration).
- * Callers that need pre_allocated should construct SessionSource directly.
- *
- * @param trigger - The workflow trigger to wrap.
- * @param _triggerSource - Ignored. Kept for call-site backward compatibility.
- */
-export function sessionSourceFromTrigger(
-  trigger: WorkflowTrigger,
-  _triggerSource?: 'daemon' | 'mcp',
-): SessionSource {
-  return { kind: 'allocate', trigger };
-}
 
 /** Successful completion of a workflow run. */
 export interface WorkflowRunSuccess {

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -371,26 +371,6 @@ export interface WorkflowTrigger {
     readonly noProgressAbortEnabled?: boolean;
   };
   /**
-   * Pre-allocated session start result from a caller that already called executeStartWorkflow().
-   *
-   * WHY: The dispatch HTTP handler and the spawn_agent tool both call executeStartWorkflow()
-   * synchronously so they can obtain a session ID before the agent loop starts. They pass
-   * the resulting response here so runWorkflow() skips its own executeStartWorkflow() call
-   * and starts the agent loop from the pre-created session.
-   *
-   * INVARIANT: When set, runWorkflow() MUST NOT call executeStartWorkflow() again.
-   * The session is already created -- calling it again would create a duplicate session.
-   *
-   * WHY store the full response (not just the continueToken): runWorkflow() uses
-   * `response.pending?.prompt` to build the initial LLM prompt and `response.isComplete`
-   * to detect single-step workflows that complete immediately. Both are needed.
-   *
-   * WHY underscore prefix: signals this is an internal implementation detail, not
-   * a user-facing field. Script authors do not set this -- it is set only by the
-   * dispatch HTTP handler or the spawn_agent tool.
-   */
-  readonly _preAllocatedStartResponse?: import('zod').infer<typeof V2StartWorkflowOutputSchema>;
-  /**
    * WorkRail session ID of the parent session that spawned this one.
    *
    * WHY: Written to the `session_created` event in the session store so the parent-child
@@ -403,7 +383,7 @@ export interface WorkflowTrigger {
    *
    * NOTE: This field is not read by runWorkflow() directly. The actual parentSessionId
    * write to session_created.data is performed by makeSpawnAgentTool's executeStartWorkflow()
-   * call (via internalContext). runWorkflow() uses _preAllocatedStartResponse for child
+   * call (via internalContext). runWorkflow() receives a pre_allocated SessionSource for child
    * sessions and skips its own executeStartWorkflow() call. This field exists for
    * documentation purposes and potential future use.
    */
@@ -481,10 +461,10 @@ export interface WorkflowTrigger {
  * Used when the caller needs the session ID synchronously (console dispatch,
  * spawnSession, crash recovery).
  *
- * WHY this type: replaces the implicit contract encoded in
- * WorkflowTrigger._preAllocatedStartResponse with an explicit, named type.
- * Callers that pre-allocate a session now hold an AllocatedSession value
- * rather than an ad-hoc optional field on WorkflowTrigger.
+ * WHY this type: replaces the former implicit contract encoded in the
+ * removed WorkflowTrigger._preAllocatedStartResponse field with an explicit,
+ * named type. Callers that pre-allocate a session now hold an AllocatedSession
+ * value passed via SessionSource rather than an ad-hoc optional field.
  */
 export interface AllocatedSession {
   /** Continue token from executeStartWorkflow response. */
@@ -500,58 +480,31 @@ export interface AllocatedSession {
 /**
  * Explicit discriminated union for session creation source.
  *
- * WHY: replaces the _preAllocatedStartResponse optional escape-hatch on
+ * WHY: replaces the former _preAllocatedStartResponse optional escape-hatch on
  * WorkflowTrigger with a typed discriminant that makes the two paths explicit.
  * 'allocate' -> buildPreAgentSession calls executeStartWorkflow internally.
  * 'pre_allocated' -> executeStartWorkflow was already called by the caller.
- *
- * MIGRATION: existing code still uses WorkflowTrigger._preAllocatedStartResponse
- * directly. New callers should construct SessionSource directly. Existing callers
- * can use sessionSourceFromTrigger() to adapt a legacy WorkflowTrigger.
  */
 export type SessionSource =
   | { readonly kind: 'allocate'; readonly trigger: WorkflowTrigger }
   | { readonly kind: 'pre_allocated'; readonly trigger: WorkflowTrigger; readonly session: AllocatedSession };
 
 /**
- * Convert a legacy WorkflowTrigger to a SessionSource.
+ * Wrap a WorkflowTrigger in a SessionSource with kind 'allocate'.
  *
- * WHY: allows gradual migration -- callers that still use WorkflowTrigger
- * can wrap with this helper; new callers construct SessionSource directly.
- * When _preAllocatedStartResponse is set, maps the full schema response to
- * the narrower AllocatedSession shape (only the fields runWorkflow actually uses).
+ * WHY kept: retained for backward-compat and any callers that hold a bare
+ * WorkflowTrigger and want a typed SessionSource without constructing one
+ * manually. Now always returns kind: 'allocate' because
+ * WorkflowTrigger._preAllocatedStartResponse has been removed (A9 migration).
+ * Callers that need pre_allocated should construct SessionSource directly.
  *
- * WHY triggerSource parameter: _preAllocatedStartResponse is set by both daemon
- * (TriggerRouter.dispatch, spawnSession) and console (console-routes.ts HTTP dispatch).
- * Hardcoding 'daemon' would misattribute console-dispatched sessions. Callers must
- * pass the correct source explicitly.
- *
- * WHY AllocatedSession omits preferences/nextIntent/nextCall:
- * Those fields are unused by runWorkflow() -- only continueToken, checkpointToken,
- * pending.prompt, and isComplete matter for session initialization. Narrowing here
- * prevents future callers from accidentally depending on schema fields that may change.
+ * @param trigger - The workflow trigger to wrap.
+ * @param _triggerSource - Ignored. Kept for call-site backward compatibility.
  */
 export function sessionSourceFromTrigger(
   trigger: WorkflowTrigger,
-  triggerSource: 'daemon' | 'mcp' = 'daemon',
+  _triggerSource?: 'daemon' | 'mcp',
 ): SessionSource {
-  if (trigger._preAllocatedStartResponse !== undefined) {
-    const r = trigger._preAllocatedStartResponse;
-    return {
-      kind: 'pre_allocated',
-      trigger,
-      session: {
-        continueToken: r.continueToken ?? '',
-        // WHY string | null | undefined: the Zod schema uses .optional() (no null),
-        // but the module convention at line ~2707 normalises absent to null via ?? null.
-        // Preserving undefined here keeps the wrapper lossless; consumers normalise downstream.
-        checkpointToken: r.checkpointToken,
-        firstStepPrompt: r.pending?.prompt ?? '',
-        isComplete: r.isComplete,
-        triggerSource,
-      },
-    };
-  }
   return { kind: 'allocate', trigger };
 }
 
@@ -1005,7 +958,7 @@ export async function readAllDaemonSessions(
  *   count advance_recorded events in the WorkRail session event log, and apply
  *   the binary evaluateRecovery() policy:
  *   - stepAdvances >= 1 -> attempt resume: rehydrate via executeContinueWorkflow, reconstruct
- *     WorkflowTrigger with _preAllocatedStartResponse, call runWorkflow fire-and-forget.
+ *     WorkflowTrigger with a pre_allocated SessionSource, call runWorkflow fire-and-forget.
  *     Falls through to discard if sidecar lacks recovery context fields (backward compat),
  *     if the worktree directory is gone, if rehydrate fails, or if the session is complete.
  *   - stepAdvances === 0 -> discard (sidecar deleted; issue re-dispatched)
@@ -1211,21 +1164,17 @@ export async function runStartupRecovery(
             break;
           }
 
-          // Build the _preAllocatedStartResponse adapter.
-          // WHY: runWorkflow() uses _preAllocatedStartResponse to skip executeStartWorkflow()
-          // (preventing a duplicate session). V2ContinueWorkflowOutputSchema 'ok' variant and
-          // V2StartWorkflowOutputSchema share the fields we care about: continueToken,
-          // checkpointToken, isComplete, pending, preferences, nextIntent, nextCall.
-          // V2StartWorkflowOutputSchema has optional staleRoots/warnings not present here --
-          // they are optional so their absence is correct.
-          const preAllocated: import('zod').infer<typeof V2StartWorkflowOutputSchema> = {
+          // Build a SessionSource to pass to runWorkflow() so it skips executeStartWorkflow().
+          // WHY SessionSource (not _preAllocatedStartResponse): _preAllocatedStartResponse was
+          // removed from WorkflowTrigger in A9. SessionSource is the typed replacement.
+          // V2ContinueWorkflowOutputSchema 'ok' variant shares the fields we care about with
+          // AllocatedSession: continueToken, checkpointToken, isComplete, and pending.prompt.
+          const recoveryAllocatedSession: AllocatedSession = {
             continueToken: rehydrated.continueToken ?? '',
             checkpointToken: rehydrated.checkpointToken,
+            firstStepPrompt: rehydrated.pending.prompt ?? '',
             isComplete: rehydrated.isComplete,
-            pending: rehydrated.pending,
-            preferences: rehydrated.preferences,
-            nextIntent: rehydrated.nextIntent, // 'rehydrate_only' from rehydrate call; runWorkflow() does not read this field
-            nextCall: rehydrated.nextCall,
+            triggerSource: 'daemon',
           };
 
           // Determine effective workspace: use the worktree path if the session had one
@@ -1239,7 +1188,11 @@ export async function runStartupRecovery(
             goal: session.goal ?? 'Resumed session (crash recovery)',
             workspacePath: effectiveWorkspacePath,
             branchStrategy,
-            _preAllocatedStartResponse: preAllocated,
+          };
+          const recoverySource: SessionSource = {
+            kind: 'pre_allocated',
+            trigger: recoveredTrigger,
+            session: recoveryAllocatedSession,
           };
 
           console.log(
@@ -1258,6 +1211,12 @@ export async function runStartupRecovery(
             recoveredTrigger,
             ctx!,
             apiKey,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            recoverySource,
           ).then((result) => {
             console.log(
               `[WorkflowRunner] Startup recovery: resumed session ${session.sessionId} completed: ${result._tag}`,
@@ -2500,7 +2459,15 @@ export interface PreAgentSession {
   readonly checkpointToken: string | null;
   readonly sessionWorkspacePath: string;
   readonly sessionWorktreePath: string | undefined;
-  readonly firstStep: import('zod').infer<typeof V2StartWorkflowOutputSchema>;
+  /**
+   * The first step's pending prompt text.
+   *
+   * WHY string (not the full V2StartWorkflowOutputSchema): only the prompt text
+   * is needed downstream (buildSessionContext, buildAgentReadySession). Narrowing
+   * to a string here prevents future callers from accidentally depending on
+   * schema fields that may change, and removes the dependency on the Zod type.
+   */
+  readonly firstStepPrompt: string;
   readonly state: SessionState;           // mutable; explicit to document impurity
   readonly spawnCurrentDepth: number;
   readonly spawnMaxDepth: number;
@@ -2708,7 +2675,7 @@ export interface SessionContext {
  * @param trigger - The workflow trigger (provides agentConfig limits and context).
  * @param context - The ContextBundle from DefaultContextLoader.loadSession().
  * @param firstStepPrompt - The first step's pending prompt from executeStartWorkflow
- *   or _preAllocatedStartResponse.
+ *   or the pre-allocated AllocatedSession.
  * @returns SessionContext containing systemPrompt, initialPrompt, and session limits.
  */
 export function buildSessionContext(
@@ -2783,6 +2750,10 @@ export function buildSessionContext(
  * WHY pure + I/O separation: the caller (runWorkflow) provides sessionId and
  * startMs so that timing and identity are consistent across both phases.
  *
+ * @param source - Optional session source. When provided with kind 'pre_allocated',
+ *   executeStartWorkflow is skipped (the caller already allocated the session).
+ *   When absent or kind 'allocate', executeStartWorkflow is called internally.
+ *
  * Returns { kind: 'complete', result } for all early-exit cases.
  * Returns { kind: 'ready', session } when the agent loop should run.
  */
@@ -2797,6 +2768,7 @@ export async function buildPreAgentSession(
   emitter: DaemonEventEmitter | undefined,
   daemonRegistry: DaemonRegistry | undefined,
   activeSessionSet: ActiveSessionSet | undefined,
+  source?: SessionSource,
 ): Promise<PreAgentSessionResult> {
   // ---- Model setup ----
   let agentClient: Anthropic | AnthropicBedrock;
@@ -2822,10 +2794,22 @@ export async function buildPreAgentSession(
   // ---- Session state ----
   const state = createSessionState('');
 
-  // ---- executeStartWorkflow (or pre-allocated) ----
-  let firstStep: import('zod').infer<typeof V2StartWorkflowOutputSchema>;
-  if (trigger._preAllocatedStartResponse !== undefined) {
-    firstStep = trigger._preAllocatedStartResponse;
+  // ---- executeStartWorkflow (or pre-allocated via SessionSource) ----
+  // WHY SessionSource: replaces the removed WorkflowTrigger._preAllocatedStartResponse
+  // field (A9 migration). Callers that pre-allocate a session pass source.kind === 'pre_allocated';
+  // callers that want buildPreAgentSession to allocate pass 'allocate' or omit source entirely.
+  let continueToken: string;
+  let checkpointToken: string | null;
+  let firstStepPrompt: string;
+  let isComplete: boolean;
+
+  const effectiveSource = source ?? { kind: 'allocate' as const, trigger };
+  if (effectiveSource.kind === 'pre_allocated') {
+    const s = effectiveSource.session;
+    continueToken = s.continueToken;
+    checkpointToken = s.checkpointToken ?? null;
+    firstStepPrompt = s.firstStepPrompt;
+    isComplete = s.isComplete;
   } else {
     const startResult = await executeStartWorkflow(
       { workflowId: trigger.workflowId, workspacePath: trigger.workspacePath, goal: trigger.goal },
@@ -2844,11 +2828,12 @@ export async function buildPreAgentSession(
         },
       };
     }
-    firstStep = startResult.value.response;
+    const r = startResult.value.response;
+    continueToken = r.continueToken ?? '';
+    checkpointToken = r.checkpointToken ?? null;
+    firstStepPrompt = r.pending?.prompt ?? '';
+    isComplete = r.isComplete;
   }
-
-  const continueToken = firstStep.continueToken ?? '';
-  const checkpointToken = firstStep.checkpointToken ?? null;
   state.currentContinueToken = continueToken;
 
   // ---- Decode WorkRail session ID ----
@@ -2950,7 +2935,7 @@ export async function buildPreAgentSession(
   // ---- Single-step completion (must check AFTER registry setup) ----
   // WHY after registration: the session is observable in the console from this point.
   // A session that completes immediately should still appear as 'completed' not 'not found'.
-  if (firstStep.isComplete) {
+  if (isComplete) {
     const lifecycle = sidecardLifecycleFor('success', trigger.branchStrategy);
     if (lifecycle.kind === 'delete_now') {
       await fs.unlink(path.join(sessionsDir, `${sessionId}.json`)).catch(() => {});
@@ -2983,7 +2968,7 @@ export async function buildPreAgentSession(
       checkpointToken,
       sessionWorkspacePath,
       sessionWorktreePath,
-      firstStep,
+      firstStepPrompt,
       state,
       spawnCurrentDepth: trigger.spawnDepth ?? 0,
       spawnMaxDepth: trigger.agentConfig?.maxSubagentDepth ?? 3,
@@ -3333,7 +3318,7 @@ async function buildAgentReadySession(
   daemonRegistry: DaemonRegistry | undefined,
   activeSessionSet: ActiveSessionSet | undefined,
 ): Promise<AgentReadySession> {
-  const { state, firstStep, sessionWorkspacePath, sessionWorktreePath, agentClient, modelId } = preAgentSession;
+  const { state, firstStepPrompt, sessionWorkspacePath, sessionWorktreePath, agentClient, modelId } = preAgentSession;
   const startContinueToken = preAgentSession.continueToken;
   const handle = preAgentSession.handle;
 
@@ -3409,7 +3394,7 @@ async function buildAgentReadySession(
   const sessionCtx = buildSessionContext(
     trigger,
     contextBundle,
-    firstStep.pending?.prompt ?? 'No step content available',
+    firstStepPrompt || 'No step content available',
   );
 
   // ---- Observability callbacks for AgentLoop ----
@@ -3649,6 +3634,16 @@ export async function runWorkflow(
   // without touching real ~/.workrail/data or ~/.workrail/daemon-sessions directories.
   _statsDir?: string,
   _sessionsDir?: string,
+  /**
+   * Optional pre-allocated session source.
+   *
+   * WHY: replaces WorkflowTrigger._preAllocatedStartResponse (removed in A9).
+   * Callers that pre-allocate a session (console dispatch, coordinator spawnSession,
+   * spawn_agent, crash recovery) pass kind: 'pre_allocated' so buildPreAgentSession
+   * skips its own executeStartWorkflow() call. Callers that want the default flow
+   * (allocate internally) pass kind: 'allocate' or omit this parameter entirely.
+   */
+  source?: SessionSource,
 ): Promise<WorkflowRunResult> {
   // ---- Resolved dirs (injectable for tests) ----
   const statsDir = _statsDir ?? DAEMON_STATS_DIR;
@@ -3688,6 +3683,7 @@ export async function runWorkflow(
   const preResult = await buildPreAgentSession(
     trigger, ctx, apiKey, sessionId, startMs,
     statsDir, sessionsDir, emitter, daemonRegistry, activeSessionSet,
+    source,
   );
   if (preResult.kind === 'complete') {
     return preResult.result;

--- a/src/trigger/coordinator-deps.ts
+++ b/src/trigger/coordinator-deps.ts
@@ -26,7 +26,7 @@ import { executeStartWorkflow } from '../mcp/handlers/v2-execution/start.js';
 import { parseContinueTokenOrFail } from '../mcp/handlers/v2-token-ops.js';
 import { createContextAssembler } from '../context-assembly/index.js';
 import { createListRecentSessions } from '../context-assembly/infra.js';
-import type { WorkflowTrigger } from '../daemon/workflow-runner.js';
+import type { WorkflowTrigger, SessionSource, AllocatedSession } from '../daemon/workflow-runner.js';
 import type { ConsoleService } from '../v2/usecases/console-service.js';
 
 // ---------------------------------------------------------------------------
@@ -77,7 +77,7 @@ export interface CoordinatorDepsWithDispatch extends AdaptiveCoordinatorDeps {
    * `router.dispatch.bind(router)`. Until this is called, spawnSession() returns
    * a typed error rather than crashing.
    */
-  setDispatch(dispatch: (trigger: WorkflowTrigger) => void): void;
+  setDispatch(dispatch: (trigger: WorkflowTrigger, source?: SessionSource) => void): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -97,10 +97,10 @@ export function createCoordinatorDeps(
 
   // Mutable dispatch function. Null until setDispatch() is called.
   // WHY let (not const): assigned by setDispatch(), which is called after TriggerRouter construction.
-  let dispatch: ((trigger: WorkflowTrigger) => void) | null = null;
+  let dispatch: ((trigger: WorkflowTrigger, source?: SessionSource) => void) | null = null;
 
   return {
-    setDispatch(fn: (trigger: WorkflowTrigger) => void): void {
+    setDispatch(fn: (trigger: WorkflowTrigger, source?: SessionSource) => void): void {
       if (dispatch !== null) {
         process.stderr.write('[WARN coordinator-deps] setDispatch() called more than once -- ignoring reassignment\n');
         return;
@@ -121,15 +121,15 @@ export function createCoordinatorDeps(
       // is running correctly (the daemon already validated credentials at startup).
       // Calling executeStartWorkflow + router.dispatch() directly bypasses the
       // redundant credential check and eliminates the HTTP roundtrip.
-      // This mirrors the pattern used in console-routes.ts:810-863 (the HTTP handler
-      // uses this same flow: executeStartWorkflow -> _preAllocatedStartResponse -> dispatch).
+      // This mirrors the pattern used in console-routes.ts (the HTTP handler
+      // uses this same flow: executeStartWorkflow -> SessionSource -> dispatch).
       if (dispatch === null) {
         return { kind: 'err' as const, error: 'in-process router not initialized -- coordinator deps not ready' };
       }
 
       // Step 1: Allocate a session in the store synchronously.
-      // WHY _preAllocatedStartResponse: runWorkflow() skips its own executeStartWorkflow()
-      // call when this field is set, preventing double session creation.
+      // WHY SessionSource: runWorkflow() skips its own executeStartWorkflow() call when
+      // a pre_allocated SessionSource is passed, preventing double session creation.
       const startResult = await executeStartWorkflow(
         { workflowId, workspacePath: workspace, goal },
         ctx,
@@ -143,13 +143,13 @@ export function createCoordinatorDeps(
       const startContinueToken = startResult.value.response.continueToken;
       if (!startContinueToken) {
         // Workflow completed immediately (single-step); no agent loop session needed.
-        // Use workflowId as fallback handle (matches console-routes.ts:854-856 behavior).
+        // Use workflowId as fallback handle (matches console-routes.ts behavior).
         return { kind: 'ok' as const, value: workflowId };
       }
 
       // Step 2: Decode the session ID from the continueToken.
       // WHY parseContinueTokenOrFail: V2StartWorkflowOutputSchema does not expose sessionId
-      // directly (to avoid a breaking schema change). Same approach as console-routes.ts:837-851.
+      // directly (to avoid a breaking schema change). Same approach as console-routes.ts.
       const tokenResult = await parseContinueTokenOrFail(
         startContinueToken,
         ctx.v2.tokenCodecPorts,
@@ -164,18 +164,26 @@ export function createCoordinatorDeps(
       const sessionHandle = tokenResult.value.sessionId;
 
       // Step 3: Enqueue the agent loop via TriggerRouter's queue and semaphore.
-      // Pass _preAllocatedStartResponse so runWorkflow() skips executeStartWorkflow().
       // WHY agentConfig forwarded: coordinator sets per-phase timeouts (e.g. 55m for discovery)
       // that exceed DEFAULT_SESSION_TIMEOUT_MINUTES=30. Without forwarding, sessions die at 30m
       // and the coordinator's phase budget is never consumed (discovery-loop-fix, RC1).
-      dispatch({
+      const trigger: WorkflowTrigger = {
         workflowId,
         goal,
         workspacePath: workspace,
         context,
         ...(agentConfig !== undefined ? { agentConfig } : {}),
-        _preAllocatedStartResponse: startResult.value.response,
-      });
+      };
+      const r = startResult.value.response;
+      const allocatedSession: AllocatedSession = {
+        continueToken: r.continueToken ?? '',
+        checkpointToken: r.checkpointToken,
+        firstStepPrompt: r.pending?.prompt ?? '',
+        isComplete: r.isComplete,
+        triggerSource: 'daemon',
+      };
+      const source: SessionSource = { kind: 'pre_allocated', trigger, session: allocatedSession };
+      dispatch(trigger, source);
 
       return { kind: 'ok' as const, value: sessionHandle };
     },

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -25,7 +25,7 @@
 import * as crypto from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import type { WorkflowTrigger, WorkflowRunResult, WorkflowDeliveryFailed } from '../daemon/workflow-runner.js';
+import type { WorkflowTrigger, WorkflowRunResult, WorkflowDeliveryFailed, SessionSource } from '../daemon/workflow-runner.js';
 import type { ActiveSessionSet } from '../daemon/active-sessions.js';
 import { assertNever } from '../runtime/assert-never.js';
 import type { V2ToolContext } from '../mcp/types.js';
@@ -94,6 +94,9 @@ export type RunWorkflowFn = (
   daemonRegistry?: import('../v2/infra/in-memory/daemon-registry/index.js').DaemonRegistry,
   emitter?: DaemonEventEmitter,
   activeSessionSet?: ActiveSessionSet,
+  _statsDir?: string,
+  _sessionsDir?: string,
+  source?: SessionSource,
 ) => Promise<WorkflowRunResult>;
 
 // ---------------------------------------------------------------------------
@@ -811,12 +814,12 @@ export class TriggerRouter {
    *
    * @returns The workflowId that was dispatched.
    */
-  dispatch(workflowTrigger: WorkflowTrigger): string {
+  dispatch(workflowTrigger: WorkflowTrigger, source?: SessionSource): string {
     // Pre-allocated session: executeStartWorkflow already created the session in the store.
     // Deduplication must not apply here -- dropping this dispatch would zombie the session.
-    // The presence of _preAllocatedStartResponse is authoritative evidence that the caller
-    // explicitly intends to start this session. Skip the dedup block entirely.
-    if (workflowTrigger._preAllocatedStartResponse === undefined) {
+    // A pre_allocated SessionSource is authoritative evidence that the caller explicitly
+    // intends to start this session. Skip the dedup block entirely.
+    if (source?.kind !== 'pre_allocated') {
       // Deduplicate: if the same goal+workspace was dispatched within 30s, skip.
       // WHY shared deduplicator: prevents duplicate dispatches within the same 30s window.
       // Key format differs by path: route/dispatch use workflowId::goal::workspace;
@@ -844,7 +847,7 @@ export class TriggerRouter {
       await this.semaphore.acquire();
       let result: WorkflowRunResult;
       try {
-        result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey, undefined, this.emitter, this._activeSessionSet);
+        result = await this.runWorkflowFn(workflowTrigger, this.ctx, this.apiKey, undefined, this.emitter, this._activeSessionSet, undefined, undefined, source);
       } finally {
         this.semaphore.release();
       }

--- a/src/v2/usecases/console-routes.ts
+++ b/src/v2/usecases/console-routes.ts
@@ -24,6 +24,7 @@ import { isDevMode } from '../../mcp/dev-mode.js';
 import type { V2ToolContext } from '../../mcp/types.js';
 // TODO: runWorkflow is imported from src/daemon/ -- remaining coupling to address when browser dispatch is redesigned
 import { runWorkflow } from '../../daemon/workflow-runner.js';
+import type { SessionSource, AllocatedSession } from '../../daemon/workflow-runner.js';
 import { assertNever } from '../../runtime/assert-never.js';
 import { executeStartWorkflow } from '../../mcp/handlers/v2-execution/start.js';
 import { parseContinueTokenOrFail } from '../../mcp/handlers/v2-token-ops.js';
@@ -905,8 +906,8 @@ export function mountConsoleRoutes(
     //
     // WHY executeStartWorkflow() here instead of inside runWorkflow(): runWorkflow()
     // calls executeStartWorkflow() internally. To avoid double-session-creation,
-    // we pass the pre-allocated response via WorkflowTrigger._preAllocatedStartResponse.
-    // runWorkflow() skips its own executeStartWorkflow() call when this field is set.
+    // we pass the pre-allocated response as a SessionSource to runWorkflow().
+    // runWorkflow() skips its own executeStartWorkflow() call when source.kind === 'pre_allocated'.
     // ---------------------------------------------------------------------------
     const startResult = await executeStartWorkflow(
       { workflowId, workspacePath, goal },
@@ -957,7 +958,15 @@ export function mountConsoleRoutes(
     }
 
     // Direct fire-and-forget: no queue serialization in this path.
-    const trigger = { workflowId, goal, workspacePath, context, _preAllocatedStartResponse: startResponse };
+    const trigger = { workflowId, goal, workspacePath, context };
+    const allocatedSession: AllocatedSession = {
+      continueToken: startResponse.continueToken ?? '',
+      checkpointToken: startResponse.checkpointToken,
+      firstStepPrompt: startResponse.pending?.prompt ?? '',
+      isComplete: startResponse.isComplete,
+      triggerSource: 'mcp',
+    };
+    const source: SessionSource = { kind: 'pre_allocated', trigger, session: allocatedSession };
     void runWorkflow(
       trigger,
       v2ToolContext,
@@ -965,6 +974,9 @@ export function mountConsoleRoutes(
       undefined,   // daemonRegistry -- not available in this path
       undefined,   // emitter -- not available in this path
       undefined,   // activeSessionSet -- not applicable in standalone console
+      undefined,   // _statsDir -- use default
+      undefined,   // _sessionsDir -- use default
+      source,
     ).then((result) => {
       if (result._tag === 'success') {
         console.log(`[ConsoleRoutes] Auto dispatch completed: workflowId=${workflowId} stopReason=${result.stopReason}`);

--- a/tests/unit/session-source.test.ts
+++ b/tests/unit/session-source.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sessionSourceFromTrigger } from '../../src/daemon/workflow-runner.js';
-import type { WorkflowTrigger } from '../../src/daemon/workflow-runner.js';
+import type { SessionSource, AllocatedSession, WorkflowTrigger } from '../../src/daemon/workflow-runner.js';
 
 const BASE_TRIGGER: WorkflowTrigger = {
   workflowId: 'wr.coding-task',
@@ -8,36 +7,45 @@ const BASE_TRIGGER: WorkflowTrigger = {
   workspacePath: '/workspace',
 };
 
-/**
- * Tests for sessionSourceFromTrigger().
- *
- * WHY this function still exists (A9 migration):
- * After WorkflowTrigger._preAllocatedStartResponse was removed, sessionSourceFromTrigger()
- * was retained for backward compat. It now always returns kind: 'allocate'. Callers
- * that need pre_allocated should construct SessionSource directly.
- */
-describe('sessionSourceFromTrigger', () => {
-  it('always returns allocate (field removed in A9 migration)', () => {
-    const src = sessionSourceFromTrigger(BASE_TRIGGER);
+const ALLOCATED_SESSION: AllocatedSession = {
+  continueToken: 'ct_abc',
+  checkpointToken: 'ckpt_abc',
+  firstStepPrompt: 'step 1',
+  isComplete: false,
+  triggerSource: 'daemon',
+};
+
+describe('SessionSource discriminated union', () => {
+  it('allocate variant carries trigger', () => {
+    const src: SessionSource = { kind: 'allocate', trigger: BASE_TRIGGER };
     expect(src.kind).toBe('allocate');
     expect(src.trigger).toBe(BASE_TRIGGER);
   });
 
-  it('accepts optional triggerSource parameter for backward compat (ignored)', () => {
-    const src = sessionSourceFromTrigger(BASE_TRIGGER, 'mcp');
-    // triggerSource parameter is accepted but ignored -- always returns allocate
-    expect(src.kind).toBe('allocate');
-    expect(src.trigger).toBe(BASE_TRIGGER);
+  it('pre_allocated variant carries trigger and session', () => {
+    const src: SessionSource = { kind: 'pre_allocated', trigger: BASE_TRIGGER, session: ALLOCATED_SESSION };
+    expect(src.kind).toBe('pre_allocated');
+    if (src.kind !== 'pre_allocated') return;
+    expect(src.session.continueToken).toBe('ct_abc');
+    expect(src.session.triggerSource).toBe('daemon');
   });
 
-  it('always returns allocate regardless of trigger content', () => {
-    const trigger: WorkflowTrigger = {
-      ...BASE_TRIGGER,
-      context: { someField: 'value' },
-      branchStrategy: 'none',
-    };
-    const src = sessionSourceFromTrigger(trigger);
-    expect(src.kind).toBe('allocate');
-    expect(src.trigger).toBe(trigger);
+  it('TypeScript discriminant narrows correctly', () => {
+    const src: SessionSource = { kind: 'pre_allocated', trigger: BASE_TRIGGER, session: ALLOCATED_SESSION };
+    // This test documents that the union is exhaustive -- a switch on src.kind
+    // with both arms compiles without a default case.
+    let seen: string | undefined;
+    switch (src.kind) {
+      case 'allocate': seen = 'allocate'; break;
+      case 'pre_allocated': seen = 'pre_allocated'; break;
+    }
+    expect(seen).toBe('pre_allocated');
+  });
+
+  it('AllocatedSession triggerSource distinguishes daemon from mcp', () => {
+    const daemonSession: AllocatedSession = { ...ALLOCATED_SESSION, triggerSource: 'daemon' };
+    const mcpSession: AllocatedSession = { ...ALLOCATED_SESSION, triggerSource: 'mcp' };
+    expect(daemonSession.triggerSource).toBe('daemon');
+    expect(mcpSession.triggerSource).toBe('mcp');
   });
 });

--- a/tests/unit/session-source.test.ts
+++ b/tests/unit/session-source.test.ts
@@ -8,86 +8,36 @@ const BASE_TRIGGER: WorkflowTrigger = {
   workspacePath: '/workspace',
 };
 
+/**
+ * Tests for sessionSourceFromTrigger().
+ *
+ * WHY this function still exists (A9 migration):
+ * After WorkflowTrigger._preAllocatedStartResponse was removed, sessionSourceFromTrigger()
+ * was retained for backward compat. It now always returns kind: 'allocate'. Callers
+ * that need pre_allocated should construct SessionSource directly.
+ */
 describe('sessionSourceFromTrigger', () => {
-  it('returns allocate when _preAllocatedStartResponse is absent', () => {
+  it('always returns allocate (field removed in A9 migration)', () => {
     const src = sessionSourceFromTrigger(BASE_TRIGGER);
     expect(src.kind).toBe('allocate');
     expect(src.trigger).toBe(BASE_TRIGGER);
   });
 
-  it('returns pre_allocated when _preAllocatedStartResponse is set', () => {
-    const trigger: WorkflowTrigger = {
-      ...BASE_TRIGGER,
-      _preAllocatedStartResponse: {
-        continueToken: 'ct_abc',
-        checkpointToken: 'ckpt_abc',
-        isComplete: false,
-        pending: { prompt: 'step 1 prompt', stepId: 's1' },
-        preferences: undefined,
-        nextIntent: undefined,
-        nextCall: undefined,
-      },
-    };
-    const src = sessionSourceFromTrigger(trigger);
-    expect(src.kind).toBe('pre_allocated');
-    if (src.kind !== 'pre_allocated') return;
-    expect(src.session.continueToken).toBe('ct_abc');
-    expect(src.session.checkpointToken).toBe('ckpt_abc');
-    expect(src.session.firstStepPrompt).toBe('step 1 prompt');
-    expect(src.session.isComplete).toBe(false);
-    expect(src.session.triggerSource).toBe('daemon');
+  it('accepts optional triggerSource parameter for backward compat (ignored)', () => {
+    const src = sessionSourceFromTrigger(BASE_TRIGGER, 'mcp');
+    // triggerSource parameter is accepted but ignored -- always returns allocate
+    expect(src.kind).toBe('allocate');
+    expect(src.trigger).toBe(BASE_TRIGGER);
   });
 
-  it('defaults triggerSource to daemon', () => {
+  it('always returns allocate regardless of trigger content', () => {
     const trigger: WorkflowTrigger = {
       ...BASE_TRIGGER,
-      _preAllocatedStartResponse: {
-        continueToken: 'ct_x',
-        isComplete: false,
-        pending: { prompt: 'p', stepId: 's' },
-        preferences: undefined,
-        nextIntent: undefined,
-        nextCall: undefined,
-      },
+      context: { someField: 'value' },
+      branchStrategy: 'none',
     };
     const src = sessionSourceFromTrigger(trigger);
-    if (src.kind !== 'pre_allocated') throw new Error('expected pre_allocated');
-    expect(src.session.triggerSource).toBe('daemon');
-  });
-
-  it('respects explicit triggerSource mcp', () => {
-    const trigger: WorkflowTrigger = {
-      ...BASE_TRIGGER,
-      _preAllocatedStartResponse: {
-        continueToken: 'ct_y',
-        isComplete: false,
-        pending: { prompt: 'p', stepId: 's' },
-        preferences: undefined,
-        nextIntent: undefined,
-        nextCall: undefined,
-      },
-    };
-    const src = sessionSourceFromTrigger(trigger, 'mcp');
-    if (src.kind !== 'pre_allocated') throw new Error('expected pre_allocated');
-    expect(src.session.triggerSource).toBe('mcp');
-  });
-
-  it('handles absent continueToken with empty string fallback', () => {
-    const trigger: WorkflowTrigger = {
-      ...BASE_TRIGGER,
-      _preAllocatedStartResponse: {
-        continueToken: undefined,
-        isComplete: true,
-        pending: undefined,
-        preferences: undefined,
-        nextIntent: undefined,
-        nextCall: undefined,
-      },
-    };
-    const src = sessionSourceFromTrigger(trigger);
-    if (src.kind !== 'pre_allocated') throw new Error('expected pre_allocated');
-    expect(src.session.continueToken).toBe('');
-    expect(src.session.firstStepPrompt).toBe('');
-    expect(src.session.isComplete).toBe(true);
+    expect(src.kind).toBe('allocate');
+    expect(src.trigger).toBe(trigger);
   });
 });

--- a/tests/unit/trigger-router.test.ts
+++ b/tests/unit/trigger-router.test.ts
@@ -28,6 +28,7 @@ import type { TriggerDefinition, WebhookEvent } from '../../src/trigger/types.js
 import { asTriggerId } from '../../src/trigger/types.js';
 import type { V2ToolContext } from '../../src/mcp/types.js';
 import type { NotificationService } from '../../src/trigger/notification-service.js';
+import type { SessionSource, AllocatedSession } from '../../src/daemon/workflow-runner.js';
 import { tmpPath } from '../helpers/platform.js';
 
 // ---------------------------------------------------------------------------
@@ -1928,9 +1929,9 @@ describe('TriggerRouter.dispatchAdaptivePipeline deduplication', () => {
 });
 
 // ---------------------------------------------------------------------------
-// TriggerRouter.dispatch: _preAllocatedStartResponse dedup bypass
+// TriggerRouter.dispatch: pre_allocated SessionSource dedup bypass
 //
-// Verifies that dispatch() with _preAllocatedStartResponse set bypasses the
+// Verifies that dispatch() with a pre_allocated SessionSource bypasses the
 // 30s dedup window and calls runWorkflowFn, even when the same goal+workspace
 // was recently dispatched via dispatchAdaptivePipeline().
 //
@@ -1938,9 +1939,12 @@ describe('TriggerRouter.dispatchAdaptivePipeline deduplication', () => {
 // dispatchAdaptivePipeline() primes _recentAdaptiveDispatches with the same
 // goal::workspace key. Without the bypass, dispatch() returns early and the
 // pre-allocated session zombies in the store forever.
+//
+// A9 migration: source is now passed as second arg to dispatch() rather than
+// as WorkflowTrigger._preAllocatedStartResponse (field removed).
 // ---------------------------------------------------------------------------
 
-describe('TriggerRouter.dispatch _preAllocatedStartResponse bypass', () => {
+describe('TriggerRouter.dispatch pre_allocated SessionSource bypass', () => {
   /**
    * Minimal fake AdaptiveCoordinatorDeps for priming the dedup map via
    * dispatchAdaptivePipeline(). Only the fields called before executor dispatch
@@ -1973,15 +1977,15 @@ describe('TriggerRouter.dispatch _preAllocatedStartResponse bypass', () => {
     vi.useRealTimers();
   });
 
-  it('dispatch() with _preAllocatedStartResponse bypasses dedup and calls runWorkflowFn', async () => {
+  it('dispatch() with pre_allocated SessionSource bypasses dedup and calls runWorkflowFn', async () => {
     // WHY: proves the fix for the zombie-session bug. The dedup map contains goal::workspace
-    // from a prior dispatch. dispatch() with _preAllocatedStartResponse must bypass the dedup
+    // from a prior dispatch. dispatch() with a pre_allocated SessionSource must bypass the dedup
     // check and call runWorkflowFn. Without the fix, runWorkflowFn is never called (dedup fires)
     // and the pre-allocated session zombies in the store.
     //
     // Scenario:
-    // 1. First dispatch() (no preAlloc) -- primes _recentAdaptiveDispatches['goal::workspace']
-    // 2. Second dispatch() (with preAlloc) -- must bypass dedup and call runWorkflowFn
+    // 1. First dispatch() (no source) -- primes _recentAdaptiveDispatches['goal::workspace']
+    // 2. Second dispatch() (with pre_allocated source) -- must bypass dedup and call runWorkflowFn
     //
     // NOTE: We prime the dedup map via dispatch() rather than dispatchAdaptivePipeline()
     // to avoid async complexity with fake timers. The bug fires whenever the map has the key,
@@ -1993,31 +1997,34 @@ describe('TriggerRouter.dispatch _preAllocatedStartResponse bypass', () => {
     const goal = trigger.goal;
     const workspace = trigger.workspacePath;
 
-    // Step 1: First dispatch (no preAlloc) -- primes the dedup map AND calls runWorkflowFn (1st call)
+    // Step 1: First dispatch (no source) -- primes the dedup map AND calls runWorkflowFn (1st call)
     router.dispatch({ workflowId: trigger.workflowId, goal, workspacePath: workspace, context: {} });
 
-    // Step 2: Second dispatch WITH _preAllocatedStartResponse -- must bypass dedup (2nd call)
-    router.dispatch({
-      workflowId: trigger.workflowId,
-      goal,
-      workspacePath: workspace,
-      context: {},
-      _preAllocatedStartResponse: {} as Parameters<typeof router.dispatch>[0]['_preAllocatedStartResponse'],
-    });
+    // Step 2: Second dispatch WITH pre_allocated SessionSource -- must bypass dedup (2nd call)
+    const preAllocTrigger = { workflowId: trigger.workflowId, goal, workspacePath: workspace, context: {} };
+    const allocatedSession: AllocatedSession = {
+      continueToken: 'ct_test',
+      checkpointToken: undefined,
+      firstStepPrompt: '',
+      isComplete: false,
+      triggerSource: 'daemon',
+    };
+    const source: SessionSource = { kind: 'pre_allocated', trigger: preAllocTrigger, session: allocatedSession };
+    router.dispatch(preAllocTrigger, source);
 
     // Wait for the async queue to drain
     await new Promise<void>((r) => setTimeout(r, 20));
 
     // Both dispatches must have reached runWorkflowFn:
-    // - dispatch 1 (no preAlloc, first in window): primed map, called runWorkflowFn
-    // - dispatch 2 (with preAlloc): bypassed dedup map, called runWorkflowFn
+    // - dispatch 1 (no source, first in window): primed map, called runWorkflowFn
+    // - dispatch 2 (with pre_allocated source): bypassed dedup map, called runWorkflowFn
     // Total: exactly 2 calls
     expect(calls).toHaveLength(2);
     expect(calls[0]?.goal).toBe(goal);
     expect(calls[1]?.goal).toBe(goal);
   });
 
-  it('dispatch() WITHOUT _preAllocatedStartResponse is NOT suppressed by a prior dispatchAdaptivePipeline', async () => {
+  it('dispatch() without a pre_allocated source is NOT suppressed by a prior dispatchAdaptivePipeline', async () => {
     // WHY: since the dedup key for dispatch() now includes workflowId
     // (`${workflowId}::${goal}::${workspace}`) while dispatchAdaptivePipeline() uses
     // `${goal}::${workspace}`, the two paths no longer share dedup keys.
@@ -2053,7 +2060,7 @@ describe('TriggerRouter.dispatch _preAllocatedStartResponse bypass', () => {
     // Advance by 10s (within 30s TTL)
     vi.advanceTimersByTime(10_000);
 
-    // dispatch() WITHOUT _preAllocatedStartResponse -- must NOT be suppressed because
+    // dispatch() without pre_allocated source -- must NOT be suppressed because
     // dispatch() uses `${workflowId}::${goal}::${workspace}` as its dedup key
     router.dispatch({
       workflowId: trigger.workflowId,
@@ -2078,10 +2085,10 @@ describe('TriggerRouter.dispatch _preAllocatedStartResponse bypass', () => {
     logSpy.mockRestore();
   });
 
-  it('dispatch() WITHOUT _preAllocatedStartResponse deduplicates a repeat dispatch() within 30s', async () => {
+  it('dispatch() without pre_allocated source deduplicates a repeat dispatch() within 30s', async () => {
     // WHY: proves the dedup check still fires for normal dispatch() calls (without
-    // _preAllocatedStartResponse) when a prior dispatch() has the same workflowId+goal+workspace.
-    // This ensures the preAlloc bypass only applies to pre-allocated sessions, not all dispatch()s.
+    // a pre_allocated source) when a prior dispatch() has the same workflowId+goal+workspace.
+    // This ensures the bypass only applies to pre-allocated sessions, not all dispatch()s.
     vi.useFakeTimers();
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -2098,7 +2105,7 @@ describe('TriggerRouter.dispatch _preAllocatedStartResponse bypass', () => {
     // Advance by 10s (within 30s TTL)
     vi.advanceTimersByTime(10_000);
 
-    // Second dispatch() WITHOUT _preAllocatedStartResponse -- dedup must fire
+    // Second dispatch() without pre_allocated source -- dedup must fire
     router.dispatch({
       workflowId: trigger.workflowId,
       goal,

--- a/tests/unit/workflow-runner-crash-recovery.test.ts
+++ b/tests/unit/workflow-runner-crash-recovery.test.ts
@@ -543,9 +543,21 @@ describe('runStartupRecovery() with ctx -- resume and discard paths', () => {
 
     const runWorkflowTriggers: import('../../src/daemon/workflow-runner.js').WorkflowTrigger[] = [];
     const capturedApiKeys: string[] = [];
-    const fakeRunWorkflow = async (trigger: import('../../src/daemon/workflow-runner.js').WorkflowTrigger, _ctx: unknown, key: string) => {
+    const capturedSources: (import('../../src/daemon/workflow-runner.js').SessionSource | undefined)[] = [];
+    const fakeRunWorkflow = async (
+      trigger: import('../../src/daemon/workflow-runner.js').WorkflowTrigger,
+      _ctx: unknown,
+      key: string,
+      _daemonRegistry?: unknown,
+      _emitter?: unknown,
+      _activeSessionSet?: unknown,
+      _statsDir?: unknown,
+      _sessionsDir?: unknown,
+      source?: import('../../src/daemon/workflow-runner.js').SessionSource,
+    ) => {
       runWorkflowTriggers.push(trigger);
       capturedApiKeys.push(key);
+      capturedSources.push(source);
       return { _tag: 'success', workflowId: trigger.workflowId, stopReason: 'done' } as import('../../src/daemon/workflow-runner.js').WorkflowRunResult;
     };
 
@@ -565,8 +577,12 @@ describe('runStartupRecovery() with ctx -- resume and discard paths', () => {
     expect(runWorkflowTriggers[0]!.goal).toBe('Implement feature X');
     expect(runWorkflowTriggers[0]!.workspacePath).toBe('/some/workspace');
     expect(runWorkflowTriggers[0]!.branchStrategy).toBe('none');
-    expect(runWorkflowTriggers[0]!._preAllocatedStartResponse).toBeDefined();
-    expect(runWorkflowTriggers[0]!._preAllocatedStartResponse?.continueToken).toBe('ct_fake_rehydrated');
+    // SessionSource replaces the removed _preAllocatedStartResponse field (A9 migration)
+    expect(capturedSources[0]).toBeDefined();
+    expect(capturedSources[0]?.kind).toBe('pre_allocated');
+    if (capturedSources[0]?.kind === 'pre_allocated') {
+      expect(capturedSources[0].session.continueToken).toBe('ct_fake_rehydrated');
+    }
     // apiKey is forwarded to runWorkflow -- a regression here would pass all other assertions silently
     expect(capturedApiKeys[0]).toBe('test-api-key');
 

--- a/tests/unit/workflow-runner-outcome-invariants.test.ts
+++ b/tests/unit/workflow-runner-outcome-invariants.test.ts
@@ -84,7 +84,7 @@ vi.mock('../../src/v2/projections/node-outputs.js', () => ({
 
 // ── Import after mocks ────────────────────────────────────────────────────────
 
-import { runWorkflow, finalizeSession, type WorkflowTrigger, type FinalizationContext } from '../../src/daemon/workflow-runner.js';
+import { runWorkflow, finalizeSession, type WorkflowTrigger, type FinalizationContext, type SessionSource, type AllocatedSession } from '../../src/daemon/workflow-runner.js';
 import type { V2ToolContext } from '../../src/mcp/types.js';
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -132,6 +132,24 @@ function makeTrigger(overrides: Partial<WorkflowTrigger> = {}): WorkflowTrigger 
     workspacePath: tmpPath('test-workspace'),
     ...overrides,
   };
+}
+
+/**
+ * Build a pre_allocated SessionSource for instant-completion tests.
+ *
+ * WHY: replaces the removed WorkflowTrigger._preAllocatedStartResponse field.
+ * Callers that need to simulate "session already created" pass this as the
+ * last (source) parameter to runWorkflow().
+ */
+function makeInstantCompleteSource(trigger: WorkflowTrigger): SessionSource {
+  const session: AllocatedSession = {
+    continueToken: '',      // empty -> persistTokens() is skipped (if-guard)
+    checkpointToken: undefined,
+    firstStepPrompt: '',
+    isComplete: true,
+    triggerSource: 'daemon',
+  };
+  return { kind: 'pre_allocated', trigger, session };
 }
 
 // ── Test setup ────────────────────────────────────────────────────────────────
@@ -188,19 +206,10 @@ async function readStatsFile(statsDir: string): Promise<Array<{ outcome: string;
 
 describe('execution stats: _tag contract (input to tagToStatsOutcome)', () => {
   it('instant completion produces _tag=success → statsOutcome=success (file verified)', async () => {
-    const trigger = makeTrigger({
-      _preAllocatedStartResponse: {
-        isComplete: true,
-        continueToken: undefined as never,
-        checkpointToken: undefined,
-        pending: null,
-        preferences: { autonomy: 'full_auto_never_stop' as const, riskPolicy: 'balanced' as const },
-        nextIntent: 'complete' as const,
-        nextCall: null,
-      } as never,
-    });
+    const trigger = makeTrigger();
+    const source = makeInstantCompleteSource(trigger);
 
-    const result = await runWorkflow(trigger, FAKE_CTX, FAKE_API_KEY, undefined, undefined, undefined, tmpDir, tmpDir);
+    const result = await runWorkflow(trigger, FAKE_CTX, FAKE_API_KEY, undefined, undefined, undefined, tmpDir, tmpDir, source);
     expect(result._tag).toBe('success');
 
     // Wait for the entire fire-and-forget write chain to settle before reading.
@@ -248,19 +257,10 @@ describe('execution stats: _tag contract (input to tagToStatsOutcome)', () => {
 
 describe('result type invariants', () => {
   it('instant completion returns _tag=success', async () => {
-    const trigger = makeTrigger({
-      _preAllocatedStartResponse: {
-        isComplete: true,
-        continueToken: undefined as never,
-        checkpointToken: undefined,
-        pending: null,
-        preferences: { autonomy: 'full_auto_never_stop' as const, riskPolicy: 'balanced' as const },
-        nextIntent: 'complete' as const,
-        nextCall: null,
-      } as never,
-    });
+    const trigger = makeTrigger();
+    const source = makeInstantCompleteSource(trigger);
 
-    const result = await runWorkflow(trigger, FAKE_CTX, FAKE_API_KEY);
+    const result = await runWorkflow(trigger, FAKE_CTX, FAKE_API_KEY, undefined, undefined, undefined, undefined, undefined, source);
     expect(result._tag).toBe('success');
   });
 
@@ -305,19 +305,10 @@ describe('result type invariants', () => {
 
 describe('outcome completeness: no unknown for any defined exit path', () => {
   it('instant completion exit path does not produce outcome=unknown', async () => {
-    const trigger = makeTrigger({
-      _preAllocatedStartResponse: {
-        isComplete: true,
-        continueToken: undefined as never,
-        checkpointToken: undefined,
-        pending: null,
-        preferences: { autonomy: 'full_auto_never_stop' as const, riskPolicy: 'balanced' as const },
-        nextIntent: 'complete' as const,
-        nextCall: null,
-      } as never,
-    });
+    const trigger = makeTrigger();
+    const source = makeInstantCompleteSource(trigger);
 
-    const result = await runWorkflow(trigger, FAKE_CTX, FAKE_API_KEY);
+    const result = await runWorkflow(trigger, FAKE_CTX, FAKE_API_KEY, undefined, undefined, undefined, undefined, undefined, source);
     // The result _tag must be a defined outcome, not a fallback
     expect(['success', 'error', 'timeout', 'stuck']).toContain(result._tag);
     expect(result._tag).not.toBe('unknown' as never);
@@ -397,22 +388,13 @@ describe('_tag to stats outcome mapping (documented contract)', () => {
 
 describe('sidecar lifecycle invariants (documented for refactor)', () => {
   it('instant completion returns _tag=success (no sidecar write, no cleanup needed)', async () => {
-    // continueToken=undefined → persistTokens() is skipped → no sidecar to clean up
-    const trigger = makeTrigger({
-      _preAllocatedStartResponse: {
-        isComplete: true,
-        continueToken: undefined as never,
-        checkpointToken: undefined,
-        pending: null,
-        preferences: { autonomy: 'full_auto_never_stop' as const, riskPolicy: 'balanced' as const },
-        nextIntent: 'complete' as const,
-        nextCall: null,
-      } as never,
-    });
+    // continueToken='' → persistTokens() is skipped → no sidecar to clean up
+    const trigger = makeTrigger();
+    const source = makeInstantCompleteSource(trigger);
 
-    const result = await runWorkflow(trigger, FAKE_CTX, FAKE_API_KEY);
+    const result = await runWorkflow(trigger, FAKE_CTX, FAKE_API_KEY, undefined, undefined, undefined, undefined, undefined, source);
     expect(result._tag).toBe('success');
-    // Invariant: no sidecar was written because continueToken was undefined.
+    // Invariant: no sidecar was written because continueToken was empty.
     // The cleanup phase need not (and cannot) delete a file that was never created.
   });
 
@@ -461,19 +443,10 @@ describe('stepCount in stats', () => {
   it('instant completion records stepCount=0 (agent loop never ran)', async () => {
     // For pre-agent-loop exits, stepAdvanceCount is 0 since onAdvance() was never called
     // This is documented: stepCount=0 means "agent loop never ran; stepAdvanceCount tracks loop advances only"
-    const trigger = makeTrigger({
-      _preAllocatedStartResponse: {
-        isComplete: true,
-        continueToken: undefined as never,
-        checkpointToken: undefined,
-        pending: null,
-        preferences: { autonomy: 'full_auto_never_stop' as const, riskPolicy: 'balanced' as const },
-        nextIntent: 'complete' as const,
-        nextCall: null,
-      } as never,
-    });
+    const trigger = makeTrigger();
+    const source = makeInstantCompleteSource(trigger);
 
-    const result = await runWorkflow(trigger, FAKE_CTX, FAKE_API_KEY);
+    const result = await runWorkflow(trigger, FAKE_CTX, FAKE_API_KEY, undefined, undefined, undefined, undefined, undefined, source);
     expect(result._tag).toBe('success');
     // stepCount=0 is correct and intentional for instant completion
     // (the workflow was already done; no agent steps were needed)

--- a/tests/unit/workflow-runner-pre-allocated.test.ts
+++ b/tests/unit/workflow-runner-pre-allocated.test.ts
@@ -1,13 +1,13 @@
 /**
- * Unit tests for the _preAllocatedStartResponse branch in workflow-runner.ts.
+ * Unit tests for the SessionSource pre_allocated branch in workflow-runner.ts.
  *
- * INVARIANT tested: when WorkflowTrigger._preAllocatedStartResponse is set,
- * runWorkflow() MUST NOT call executeStartWorkflow(). The session is already
- * created -- calling it again would create a duplicate session.
+ * INVARIANT tested: when a pre_allocated SessionSource is passed to runWorkflow(),
+ * it MUST NOT call executeStartWorkflow(). The session is already created --
+ * calling it again would create a duplicate session.
  *
  * WHY vi.mock is used here (and not fakes):
  * runWorkflow() calls loadPiAi() (from pi-mono-loader.js) at the top of the
- * function to set up the model -- before the _preAllocatedStartResponse check.
+ * function to set up the model -- before the SessionSource check.
  * There are no injection points for loadPiAi or executeStartWorkflow in
  * runWorkflow()'s signature. vi.mock is the only way to stub these out in the
  * CJS test environment without refactoring production code.
@@ -42,12 +42,12 @@ vi.mock('../../src/daemon/pi-mono-loader.js', () => ({
 
 // Mock start.js so we can assert executeStartWorkflow is NOT called.
 // The mock never resolves since it must not be called on the
-// _preAllocatedStartResponse path.
+// pre_allocated SessionSource path.
 vi.mock('../../src/mcp/handlers/v2-execution/start.js', () => ({
   executeStartWorkflow: mockExecuteStartWorkflow,
 }));
 
-import { runWorkflow, type WorkflowTrigger } from '../../src/daemon/workflow-runner.js';
+import { runWorkflow, type WorkflowTrigger, type SessionSource, type AllocatedSession } from '../../src/daemon/workflow-runner.js';
 import type { V2ToolContext } from '../../src/mcp/types.js';
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
@@ -55,56 +55,55 @@ import type { V2ToolContext } from '../../src/mcp/types.js';
 /** Minimal fake V2ToolContext -- runWorkflow() passes it to tool constructors. */
 const FAKE_CTX = {} as V2ToolContext;
 
-/** Minimal fake API key -- not used on the _preAllocatedStartResponse path. */
+/** Minimal fake API key -- not used on the pre_allocated SessionSource path. */
 const FAKE_API_KEY = 'test-api-key';
 
 /**
- * Build a minimal _preAllocatedStartResponse that satisfies the shape read by
- * runWorkflow():
- *   - firstStep.isComplete -- read at line ~1172 to detect single-step completion
- *   - firstStep.continueToken -- read to persist tokens (guarded by `if (startContinueToken)`)
- *   - firstStep.checkpointToken -- read alongside continueToken
- *   - firstStep.pending -- only used after the isComplete check (never reached here)
+ * Build a minimal SessionSource with kind 'pre_allocated' that satisfies the
+ * shape read by runWorkflow() / buildPreAgentSession():
+ *   - session.isComplete -- read to detect single-step completion
+ *   - session.continueToken -- read to persist tokens (guarded by `if (startContinueToken)`)
+ *   - session.checkpointToken -- read alongside continueToken
+ *   - session.firstStepPrompt -- only used after the isComplete check (never reached here)
  *
  * With isComplete = true, runWorkflow() returns early before starting the agent
- * loop. continueToken is undefined so persistTokens() is skipped (if-guard).
- *
- * The shape is cast to the inferred Zod type to avoid importing and running
- * the Zod schema at test time (which would require all transitive imports).
+ * loop. continueToken is '' so persistTokens() is skipped (if-guard on empty string).
  */
-function makePreAllocatedResponse(overrides: { isComplete?: boolean } = {}) {
-  return {
-    isComplete: overrides.isComplete ?? true,
-    continueToken: undefined,
+function makePreAllocatedSource(
+  trigger: WorkflowTrigger,
+  overrides: { isComplete?: boolean } = {},
+): SessionSource {
+  const session: AllocatedSession = {
+    continueToken: '',
     checkpointToken: undefined,
-    pending: null,
-    preferences: { autonomy: 'full_auto_stop_on_user_deps' as const, riskPolicy: 'balanced' as const },
-    nextIntent: 'complete' as const,
-    nextCall: null,
+    firstStepPrompt: '',
+    isComplete: overrides.isComplete ?? true,
+    triggerSource: 'daemon',
   };
+  return { kind: 'pre_allocated', trigger, session };
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
-describe('runWorkflow() with _preAllocatedStartResponse', () => {
+describe('runWorkflow() with pre_allocated SessionSource', () => {
   beforeEach(() => {
     mockExecuteStartWorkflow.mockClear();
   });
 
-  it('skips executeStartWorkflow() and returns success when _preAllocatedStartResponse.isComplete is true', async () => {
+  it('skips executeStartWorkflow() and returns success when session.isComplete is true', async () => {
     const trigger: WorkflowTrigger = {
       workflowId: 'wr.coding-task',
       goal: 'test goal',
       workspacePath: tmpPath('test-workspace'),
-      _preAllocatedStartResponse: makePreAllocatedResponse({ isComplete: true }),
     };
+    const source = makePreAllocatedSource(trigger, { isComplete: true });
 
-    const result = await runWorkflow(trigger, FAKE_CTX, FAKE_API_KEY);
+    const result = await runWorkflow(trigger, FAKE_CTX, FAKE_API_KEY, undefined, undefined, undefined, undefined, undefined, source);
 
     // The pre-allocated path returns success immediately -- no agent loop needed.
     expect(result._tag).toBe('success');
 
-    // INVARIANT: executeStartWorkflow MUST NOT be called when _preAllocatedStartResponse is set.
+    // INVARIANT: executeStartWorkflow MUST NOT be called when source.kind === 'pre_allocated'.
     // Calling it again would create a duplicate session.
     expect(mockExecuteStartWorkflow).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Completes the A8 migration by removing `WorkflowTrigger._preAllocatedStartResponse` entirely. All call sites now construct `SessionSource` directly and pass it as a typed parameter.

**Removed:** `WorkflowTrigger._preAllocatedStartResponse` field

**Updated call sites (5 files):**
- `trigger-router.ts` -- `RunWorkflowFn` and `dispatch()` accept `source?: SessionSource`
- `coordinator-deps.ts` -- `spawnSession()` builds `AllocatedSession` + `SessionSource`
- `console-routes.ts` -- HTTP dispatch builds `SessionSource` with `triggerSource: 'mcp'`
- `tools/spawn-agent.ts` -- child sessions construct `SessionSource` before `runWorkflowFn`
- `workflow-runner.ts` -- crash recovery resume path and `runWorkflow()` thread `source` through `buildPreAgentSession()`

**Tests updated (5 files):** pre-allocated, outcome-invariants, crash-recovery, session-source, trigger-router.

369 test files, 5677 tests passing.

## Test plan
- [x] `npx vitest run` -- 5677 passing
- [x] `npm run build` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)