### PR TITLE
docs: add worktree and branch lifecycle management to backlog

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -1188,3 +1188,14 @@ The agent is expensive, inconsistent, and slow. Scripts are free, deterministic,
 
 ---
 
+### Worktree and branch lifecycle management
+
+WorkTrain has no tooling to surface the state of worktrees and branches relative to main. Doing this manually today requires running git commands across every registered worktree, cross-referencing merged PR lists, and inspecting each branch's unique commits to determine if the work landed. Pain points observed in practice:
+
+- Worktrees persist after their branch's PR is squash-merged -- no signal that they are safe to delete
+- No inventory of which branches have genuinely unmerged work vs. fully superseded content
+- Abandoned in-progress branches have no attached context about why they were abandoned or what state they were in
+- Daemon-spawned worktrees under `~/.workrail/worktrees/` are opaque -- no indication of which session created them or whether cleanup is safe
+
+---
+


### PR DESCRIPTION
## Summary

- Adds a new backlog entry capturing the pain points around worktree and branch lifecycle management observed during manual cleanup session on Apr 29, 2026
- Four specific pain points recorded: no post-merge signal, no unmerged-work inventory, no context on abandoned branches, opaque daemon worktrees

## Test plan

- [ ] Verify backlog entry appears at end of file with correct formatting
- [ ] No other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)