### PR TITLE
fix(daemon): inject worktree path into system prompt when branchStrategy=worktree

### DIFF
--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -481,6 +481,23 @@ export interface AllocatedSession {
    * place so the wire-up is a one-liner when that work is done.
    */
   readonly triggerSource: 'daemon' | 'mcp';
+  /**
+   * Effective workspace path for this session -- the directory the agent should work in.
+   *
+   * WHY here (not on WorkflowTrigger): the recovery path sets branchStrategy:'none' to
+   * suppress worktree re-creation, but the agent still needs to work in the existing
+   * worktree. If we set trigger.workspacePath = worktreePath, then buildSystemPrompt()'s
+   * isWorktreeSession check (effectiveWorkspacePath !== trigger.workspacePath) always
+   * evaluates false and the scope boundary paragraph is never injected.
+   *
+   * Carrying the effective path here lets buildPreAgentSession() override sessionWorkspacePath
+   * without changing trigger.workspacePath, so the comparison in buildSystemPrompt() stays
+   * correct for both fresh and recovered worktree sessions.
+   *
+   * Only set by the crash recovery path. Normal allocations leave this undefined and
+   * buildPreAgentSession() derives sessionWorkspacePath from trigger as usual.
+   */
+  readonly sessionWorkspacePath?: string;
 }
 
 /**
@@ -1163,18 +1180,30 @@ export async function runStartupRecovery(
             firstStepPrompt: rehydrated.pending.prompt ?? '',
             isComplete: rehydrated.isComplete,
             triggerSource: 'daemon',
+            // Pass the effective workspace path so buildPreAgentSession() can override
+            // sessionWorkspacePath for recovered worktree sessions. Without this, the
+            // recovery trigger has workspacePath=worktreePath (so the agent uses the
+            // correct directory) but isWorktreeSession evaluates false (no scope boundary).
+            // See AllocatedSession.sessionWorkspacePath for the full rationale.
+            ...(session.worktreePath !== undefined
+              ? { sessionWorkspacePath: session.worktreePath }
+              : {}),
           };
 
-          // Determine effective workspace: use the worktree path if the session had one
-          // (already verified to exist above), otherwise use the original workspacePath.
-          const effectiveWorkspacePath = session.worktreePath ?? session.workspacePath!;
           // Suppress worktree re-creation: the worktree already exists (or was never created).
           const branchStrategy: 'none' = 'none';
 
+          // WHY workspacePath = session.workspacePath (main checkout), not session.worktreePath:
+          // buildSystemPrompt() determines isWorktreeSession by comparing effectiveWorkspacePath
+          // against trigger.workspacePath. If both are set to the worktree path, isWorktreeSession
+          // is always false and the scope boundary paragraph is never injected. Setting
+          // trigger.workspacePath to the original main checkout preserves the comparison,
+          // and sessionWorkspacePath (from session.worktreePath) flows through buildPreAgentSession
+          // as the actual workspace the agent uses.
           const recoveredTrigger: WorkflowTrigger = {
             workflowId: session.workflowId!,
             goal: session.goal ?? 'Resumed session (crash recovery)',
-            workspacePath: effectiveWorkspacePath,
+            workspacePath: session.workspacePath!,
             branchStrategy,
           };
           const recoverySource: SessionSource = {
@@ -2885,6 +2914,17 @@ export async function buildPreAgentSession(
   // ---- Worktree isolation ----
   let sessionWorkspacePath = trigger.workspacePath;
   let sessionWorktreePath: string | undefined;
+
+  // Override sessionWorkspacePath for crash-recovered worktree sessions.
+  // WHY: the recovery path sets branchStrategy:'none' (suppress re-creation) but the
+  // agent still needs to work in the existing worktree. AllocatedSession.sessionWorkspacePath
+  // carries the worktree path; trigger.workspacePath stays as the main checkout so that
+  // buildSystemPrompt()'s isWorktreeSession check (effectiveWorkspacePath !== trigger.workspacePath)
+  // evaluates correctly and the scope boundary paragraph is injected.
+  if (effectiveSource.kind === 'pre_allocated' && effectiveSource.session.sessionWorkspacePath !== undefined) {
+    sessionWorkspacePath = effectiveSource.session.sessionWorkspacePath;
+    sessionWorktreePath = effectiveSource.session.sessionWorkspacePath;
+  }
 
   if (trigger.branchStrategy === 'worktree') {
     const branchPrefix = trigger.branchPrefix ?? 'worktrain/';

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -1975,13 +1975,23 @@ export function buildSessionRecap(notes: readonly string[]): string {
  *   provides the hardcoded default if the file was absent).
  * @param workspaceContext - Combined workspace context from CLAUDE.md / AGENTS.md,
  *   or null if no workspace context files were found.
+ * @param effectiveWorkspacePath - The workspace path the agent must work in.
+ *   Callers compute this as: sessionWorkspacePath ?? trigger.workspacePath.
+ *   Required (not optional) so the type system enforces the caller makes an explicit
+ *   decision -- there is no silent fallback to trigger.workspacePath inside this function.
+ *   WHY a separate parameter (not derived from trigger): trigger.workspacePath is always
+ *   the main checkout. The worktree path is only known after worktree creation in
+ *   buildPreAgentSession(). Passing it explicitly keeps this function pure and testable.
  */
 export function buildSystemPrompt(
   trigger: WorkflowTrigger,
   sessionState: string,
   soulContent: string,
   workspaceContext: string | null,
+  effectiveWorkspacePath: string,
 ): string {
+  const isWorktreeSession = effectiveWorkspacePath !== trigger.workspacePath;
+
   const lines = [
     BASE_SYSTEM_PROMPT,
     '',
@@ -1990,8 +2000,18 @@ export function buildSystemPrompt(
     '## Agent Rules and Philosophy',
     soulContent,
     '',
-    `## Workspace: ${trigger.workspacePath}`,
+    `## Workspace: ${effectiveWorkspacePath}`,
   ];
+
+  // When running in a worktree, add an explicit scope boundary so the agent never
+  // accidentally reads roadmap docs, runs git log on main, or modifies the main checkout.
+  // WHY: without this, the agent may drift to the main checkout for "context" (git log,
+  // planning docs, roadmap) which (1) pollutes the session with coordinator work and
+  // (2) can mutate the main checkout. This note is a hard constraint, not guidance.
+  if (isWorktreeSession) {
+    lines.push('');
+    lines.push(`**Worktree session scope:** Your workspace is the isolated git worktree at \`${effectiveWorkspacePath}\`. Do not access, read, or modify the main checkout at \`${trigger.workspacePath}\`. Do not read planning docs, roadmap files, or backlog files. All Bash commands, file reads, and file writes must stay within your worktree path.`);
+  }
 
   // Inject workspace context (CLAUDE.md / AGENTS.md) when available.
   // WHY: these files define repo-specific coding conventions, commit style, and
@@ -2664,12 +2684,17 @@ export interface SessionContext {
  * @param context - The ContextBundle from DefaultContextLoader.loadSession().
  * @param firstStepPrompt - The first step's pending prompt from executeStartWorkflow
  *   or the pre-allocated AllocatedSession.
+ * @param effectiveWorkspacePath - The workspace path the agent must work in.
+ *   Callers compute this as: sessionWorkspacePath ?? trigger.workspacePath.
+ *   Required so the type system forces callers to make an explicit decision.
+ *   Passed through to buildSystemPrompt() -- see that function's docs for details.
  * @returns SessionContext containing systemPrompt, initialPrompt, and session limits.
  */
 export function buildSessionContext(
   trigger: WorkflowTrigger,
   context: import('./context-loader.js').ContextBundle,
   firstStepPrompt: string,
+  effectiveWorkspacePath: string,
 ): SessionContext {
   // ---- Flatten ContextBundle to the primitives buildSystemPrompt expects ----
   // WHY flatten here (not in DefaultContextLoader): buildSystemPrompt() is a stable
@@ -2688,7 +2713,7 @@ export function buildSessionContext(
   // and referenceUrls from trigger.context and trigger.referenceUrls directly;
   // the authoritative values flow through trigger.
   const sessionState = buildSessionRecap(sessionNotes);
-  const systemPrompt = buildSystemPrompt(trigger, sessionState, context.soulContent, workspaceContext);
+  const systemPrompt = buildSystemPrompt(trigger, sessionState, context.soulContent, workspaceContext, effectiveWorkspacePath);
 
   // ---- Initial prompt ----
   // WHY no continueToken in the initial prompt: the daemon uses complete_step which
@@ -3379,10 +3404,17 @@ async function buildAgentReadySession(
   // buildSessionContext() is synchronous and pure -- it assembles the system
   // prompt, initial prompt, and session limits from the loaded data and trigger config.
   // WHY separated from I/O: makes prompt assembly testable without any fs or LLM mocking.
+  // WHY effectiveWorkspacePath (not sessionWorkspacePath directly): buildSessionContext
+  // requires a string, not string|undefined. The caller resolves the value here so the
+  // type system enforces an explicit decision -- there is no silent fallback inside the
+  // function. For worktree sessions, effectiveWorkspacePath is the isolated worktree;
+  // for branchStrategy:'none', it equals trigger.workspacePath.
+  const effectiveWorkspacePath = sessionWorkspacePath ?? trigger.workspacePath;
   const sessionCtx = buildSessionContext(
     trigger,
     contextBundle,
     firstStepPrompt || 'No step content available',
+    effectiveWorkspacePath,
   );
 
   // ---- Observability callbacks for AgentLoop ----

--- a/tests/unit/workflow-runner-crash-recovery.test.ts
+++ b/tests/unit/workflow-runner-crash-recovery.test.ts
@@ -672,9 +672,17 @@ describe('runStartupRecovery() with ctx -- resume and discard paths', () => {
 
     const runWorkflowTriggers: import('../../src/daemon/workflow-runner.js').WorkflowTrigger[] = [];
     const capturedApiKeys: string[] = [];
-    const fakeRunWorkflow = async (trigger: import('../../src/daemon/workflow-runner.js').WorkflowTrigger, _ctx: unknown, key: string) => {
+    const capturedSources: import('../../src/daemon/workflow-runner.js').SessionSource[] = [];
+    const fakeRunWorkflow = async (
+      trigger: import('../../src/daemon/workflow-runner.js').WorkflowTrigger,
+      _ctx: unknown,
+      key: string,
+      _d?: unknown, _e?: unknown, _f?: unknown, _g?: unknown, _h?: unknown,
+      source?: import('../../src/daemon/workflow-runner.js').SessionSource,
+    ) => {
       runWorkflowTriggers.push(trigger);
       capturedApiKeys.push(key);
+      if (source !== undefined) capturedSources.push(source);
       return { _tag: 'success', workflowId: trigger.workflowId, stopReason: 'done' } as import('../../src/daemon/workflow-runner.js').WorkflowRunResult;
     };
 
@@ -690,9 +698,16 @@ describe('runStartupRecovery() with ctx -- resume and discard paths', () => {
 
     // Worktree exists -> _runWorkflowFn IS called
     expect(runWorkflowTriggers).toHaveLength(1);
-    // effectiveWorkspacePath should be the worktree path, not the original workspacePath
-    expect(runWorkflowTriggers[0]!.workspacePath).toBe(fakeWorktreePath);
+    // trigger.workspacePath is the original main checkout (not the worktree).
+    // The worktree path flows through AllocatedSession.sessionWorkspacePath so
+    // buildSystemPrompt() can correctly identify this as a worktree session.
+    expect(runWorkflowTriggers[0]!.workspacePath).toBe('/some/workspace');
     expect(runWorkflowTriggers[0]!.branchStrategy).toBe('none');
+    // AllocatedSession.sessionWorkspacePath carries the worktree path so the
+    // agent is scoped to the worktree and gets the scope boundary paragraph.
+    expect(capturedSources).toHaveLength(1);
+    const allocatedSession = capturedSources[0]!.kind === 'pre_allocated' ? capturedSources[0]!.session : null;
+    expect(allocatedSession?.sessionWorkspacePath).toBe(fakeWorktreePath);
     expect(capturedApiKeys[0]).toBe('test-api-key');
 
     // Sidecar is NOT deleted (runWorkflow manages its own lifecycle)

--- a/tests/unit/workflow-runner-pure-functions.test.ts
+++ b/tests/unit/workflow-runner-pure-functions.test.ts
@@ -410,6 +410,21 @@ function makeSessionTrigger(overrides: Partial<WorkflowTrigger> = {}): WorkflowT
 }
 
 /**
+ * Thin wrapper around buildSessionContext that passes trigger.workspacePath as
+ * effectiveWorkspacePath, representing branchStrategy:'none' (no worktree) sessions.
+ * WHY a wrapper: avoids threading trigger.workspacePath through every single test call
+ * while keeping the required-parameter enforcement on the real function.
+ */
+function callBuildSessionContext(
+  trigger: WorkflowTrigger,
+  context: ContextBundle,
+  firstStepPrompt: string,
+  effectiveWorkspacePath?: string,
+): ReturnType<typeof buildSessionContext> {
+  return buildSessionContext(trigger, context, firstStepPrompt, effectiveWorkspacePath ?? trigger.workspacePath);
+}
+
+/**
  * Helper to build a minimal ContextBundle for buildSessionContext tests.
  *
  * WHY a helper (not inline construction): mirrors the old makeInputs() pattern
@@ -438,14 +453,14 @@ describe('buildSessionContext', () => {
   // ---- System prompt ----
 
   it('system prompt contains the soul content', () => {
-    const { systemPrompt } = buildSessionContext(makeSessionTrigger(), makeContextBundle({
+    const { systemPrompt } = callBuildSessionContext(makeSessionTrigger(), makeContextBundle({
       soulContent: 'custom-soul-content-marker',
     }), 'Step 1: Do the work.');
     expect(systemPrompt).toContain('custom-soul-content-marker');
   });
 
   it('system prompt contains workspace context when present', () => {
-    const { systemPrompt } = buildSessionContext(makeSessionTrigger(), makeContextBundle({
+    const { systemPrompt } = callBuildSessionContext(makeSessionTrigger(), makeContextBundle({
       workspaceContext: '## Agent Rules\n- Use TypeScript strict mode',
     }), 'Step 1: Do the work.');
     expect(systemPrompt).toContain('## Workspace Context (from AGENTS.md / CLAUDE.md)');
@@ -454,7 +469,7 @@ describe('buildSessionContext', () => {
   });
 
   it('system prompt omits workspace context section when workspaceContext is null', () => {
-    const { systemPrompt } = buildSessionContext(makeSessionTrigger(), makeContextBundle({
+    const { systemPrompt } = callBuildSessionContext(makeSessionTrigger(), makeContextBundle({
       workspaceContext: null,
     }), 'Step 1: Do the work.');
     expect(systemPrompt).not.toContain('## Workspace Context');
@@ -463,7 +478,7 @@ describe('buildSessionContext', () => {
   // ---- Initial prompt ----
 
   it('initial prompt contains the first step prompt', () => {
-    const { initialPrompt } = buildSessionContext(makeSessionTrigger(), makeContextBundle(),
+    const { initialPrompt } = callBuildSessionContext(makeSessionTrigger(), makeContextBundle(),
       'unique-first-step-marker-12345',
     );
     expect(initialPrompt).toContain('unique-first-step-marker-12345');
@@ -473,7 +488,7 @@ describe('buildSessionContext', () => {
     const trigger = makeSessionTrigger({
       context: { task: 'implement-oauth', priority: 'high' },
     });
-    const { initialPrompt } = buildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
+    const { initialPrompt } = callBuildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
     expect(initialPrompt).toContain('Trigger context:');
     expect(initialPrompt).toContain('"task"');
     expect(initialPrompt).toContain('"implement-oauth"');
@@ -483,12 +498,12 @@ describe('buildSessionContext', () => {
 
   it('initial prompt omits context JSON block when trigger.context is absent', () => {
     const trigger = makeSessionTrigger(); // no context field
-    const { initialPrompt } = buildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
+    const { initialPrompt } = callBuildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
     expect(initialPrompt).not.toContain('Trigger context:');
   });
 
   it('initial prompt contains the closing directive to call complete_step', () => {
-    const { initialPrompt } = buildSessionContext(makeSessionTrigger(), makeContextBundle(), 'Step 1: Do the work.');
+    const { initialPrompt } = callBuildSessionContext(makeSessionTrigger(), makeContextBundle(), 'Step 1: Do the work.');
     expect(initialPrompt).toContain(
       'Complete all step work, then call complete_step with your notes to advance.',
     );
@@ -500,7 +515,7 @@ describe('buildSessionContext', () => {
     });
     // referenceUrls appear in the system prompt, not the initial prompt
     // (they are injected by buildSystemPrompt via trigger.referenceUrls)
-    const { systemPrompt } = buildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
+    const { systemPrompt } = callBuildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
     expect(systemPrompt).toContain('## Reference documents');
     expect(systemPrompt).toContain('https://example.com/spec.md');
     expect(systemPrompt).toContain('https://example.com/design.md');
@@ -512,13 +527,13 @@ describe('buildSessionContext', () => {
     const trigger = makeSessionTrigger({
       agentConfig: { maxSessionMinutes: 45 },
     });
-    const { sessionTimeoutMs } = buildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
+    const { sessionTimeoutMs } = callBuildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
     expect(sessionTimeoutMs).toBe(45 * 60 * 1000);
   });
 
   it('sessionTimeoutMs = DEFAULT_SESSION_TIMEOUT_MINUTES * 60 * 1000 when agentConfig absent', () => {
     const trigger = makeSessionTrigger(); // no agentConfig
-    const { sessionTimeoutMs } = buildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
+    const { sessionTimeoutMs } = callBuildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
     expect(sessionTimeoutMs).toBe(DEFAULT_SESSION_TIMEOUT_MINUTES * 60 * 1000);
   });
 
@@ -526,20 +541,20 @@ describe('buildSessionContext', () => {
     const trigger = makeSessionTrigger({
       agentConfig: { maxTurns: 50 },
     });
-    const { maxTurns } = buildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
+    const { maxTurns } = callBuildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
     expect(maxTurns).toBe(50);
   });
 
   it('maxTurns = DEFAULT_MAX_TURNS when agentConfig.maxTurns is absent', () => {
     const trigger = makeSessionTrigger(); // no agentConfig
-    const { maxTurns } = buildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
+    const { maxTurns } = callBuildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
     expect(maxTurns).toBe(DEFAULT_MAX_TURNS);
   });
 
   // ---- Session recap in system prompt ----
 
   it('session recap appears in system prompt when sessionNotes is non-empty', () => {
-    const { systemPrompt } = buildSessionContext(makeSessionTrigger(), makeContextBundle({
+    const { systemPrompt } = callBuildSessionContext(makeSessionTrigger(), makeContextBundle({
       sessionNotes: ['Prior step note: found 3 bugs.', 'Step 2: fixed all 3.'],
     }), 'Step 1: Do the work.');
     // buildSessionRecap wraps notes in <workrail_session_state>
@@ -552,9 +567,40 @@ describe('buildSessionContext', () => {
     const trigger = makeSessionTrigger({
       context: { assembledContextSummary: 'prior-session-diff-summary' },
     });
-    const { systemPrompt } = buildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
+    const { systemPrompt } = callBuildSessionContext(trigger, makeContextBundle(), 'Step 1: Do the work.');
     expect(systemPrompt).toContain('## Prior Context');
     expect(systemPrompt).toContain('prior-session-diff-summary');
+  });
+
+  // ---- Worktree workspace path injection (Issue #880) ----
+
+  it('system prompt names trigger.workspacePath when sessionWorkspacePath is absent', () => {
+    const trigger = makeSessionTrigger();
+    const { systemPrompt } = callBuildSessionContext(trigger, makeContextBundle(), 'Step 1.');
+    expect(systemPrompt).toContain(`## Workspace: ${trigger.workspacePath}`);
+    expect(systemPrompt).not.toContain('Worktree session scope');
+  });
+
+  it('system prompt names the worktree path when sessionWorkspacePath differs from trigger.workspacePath', () => {
+    const trigger = makeSessionTrigger();
+    const worktreePath = '/Users/test/.workrail/worktrees/session-abc123';
+    const { systemPrompt } = buildSessionContext(trigger, makeContextBundle(), 'Step 1.', worktreePath);
+    expect(systemPrompt).toContain(`## Workspace: ${worktreePath}`);
+    expect(systemPrompt).not.toContain(`## Workspace: ${trigger.workspacePath}`);
+  });
+
+  it('system prompt adds worktree scope boundary when sessionWorkspacePath differs from trigger.workspacePath', () => {
+    const trigger = makeSessionTrigger();
+    const worktreePath = '/Users/test/.workrail/worktrees/session-abc123';
+    const { systemPrompt } = buildSessionContext(trigger, makeContextBundle(), 'Step 1.', worktreePath);
+    expect(systemPrompt).toContain('Worktree session scope');
+    expect(systemPrompt).toContain(`Do not access, read, or modify the main checkout at \`${trigger.workspacePath}\``);
+  });
+
+  it('does not add worktree scope boundary when sessionWorkspacePath equals trigger.workspacePath', () => {
+    const trigger = makeSessionTrigger();
+    const { systemPrompt } = callBuildSessionContext(trigger, makeContextBundle(), 'Step 1.');
+    expect(systemPrompt).not.toContain('Worktree session scope');
   });
 
   // ---- Purity guarantee ----
@@ -572,8 +618,8 @@ describe('buildSessionContext', () => {
     });
     const firstStepPrompt = 'Do the work';
 
-    const result1 = buildSessionContext(trigger, bundle, firstStepPrompt);
-    const result2 = buildSessionContext(trigger, bundle, firstStepPrompt);
+    const result1 = callBuildSessionContext(trigger, bundle, firstStepPrompt);
+    const result2 = callBuildSessionContext(trigger, bundle, firstStepPrompt);
 
     expect(result1.systemPrompt).toBe(result2.systemPrompt);
     expect(result1.initialPrompt).toBe(result2.initialPrompt);

--- a/tests/unit/workflow-runner-system-prompt.test.ts
+++ b/tests/unit/workflow-runner-system-prompt.test.ts
@@ -24,7 +24,7 @@ const baseTrigger: WorkflowTrigger = {
 describe('buildSystemPrompt()', () => {
   describe('base structure', () => {
     it('always contains the agent identity, tools, and execution contract', () => {
-      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null);
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath);
 
       expect(prompt).toContain('You are WorkRail Auto');
       expect(prompt).toContain('## Your tools');
@@ -32,7 +32,7 @@ describe('buildSystemPrompt()', () => {
     });
 
     it('always contains the workspace path', () => {
-      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null);
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath);
 
       expect(prompt).toContain('## Workspace: /Users/test/my-project');
     });
@@ -44,7 +44,7 @@ describe('buildSystemPrompt()', () => {
     });
 
     it('injects empty session state tag when session state is empty', () => {
-      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null);
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath);
 
       expect(prompt).toContain('<workrail_session_state></workrail_session_state>');
     });
@@ -52,20 +52,20 @@ describe('buildSystemPrompt()', () => {
 
   describe('soul content injection (Feature 1)', () => {
     it('always includes ## Agent Rules and Philosophy section', () => {
-      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null);
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath);
 
       expect(prompt).toContain('## Agent Rules and Philosophy');
     });
 
     it('injects the default soul content when provided', () => {
-      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null);
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath);
 
       expect(prompt).toContain(DAEMON_SOUL_DEFAULT);
     });
 
     it('injects custom soul content when provided', () => {
       const customSoul = 'Always write TypeScript. Never use any.';
-      const prompt = buildSystemPrompt(baseTrigger, '', customSoul, null);
+      const prompt = buildSystemPrompt(baseTrigger, '', customSoul, null, baseTrigger.workspacePath);
 
       expect(prompt).toContain('## Agent Rules and Philosophy');
       expect(prompt).toContain(customSoul);
@@ -74,7 +74,7 @@ describe('buildSystemPrompt()', () => {
 
     it('soul section appears before the workspace line', () => {
       const customSoul = 'custom-soul-marker';
-      const prompt = buildSystemPrompt(baseTrigger, '', customSoul, null);
+      const prompt = buildSystemPrompt(baseTrigger, '', customSoul, null, baseTrigger.workspacePath);
 
       const soulIdx = prompt.indexOf('## Agent Rules and Philosophy');
       const workspaceIdx = prompt.indexOf('## Workspace:');
@@ -87,7 +87,7 @@ describe('buildSystemPrompt()', () => {
 
   describe('workspace context injection (Feature 2)', () => {
     it('omits workspace context section when workspaceContext is null', () => {
-      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null);
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath);
 
       expect(prompt).not.toContain('## Workspace Context');
     });
@@ -125,7 +125,7 @@ describe('buildSystemPrompt()', () => {
 
   describe('reference URLs section', () => {
     it('omits reference documents section when no URLs provided', () => {
-      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null);
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath);
 
       expect(prompt).not.toContain('## Reference documents');
     });
@@ -135,7 +135,7 @@ describe('buildSystemPrompt()', () => {
         ...baseTrigger,
         referenceUrls: ['https://example.com/spec.md', 'https://example.com/design.md'],
       };
-      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, null);
+      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, null, trigger.workspacePath);
 
       expect(prompt).toContain('## Reference documents');
       expect(prompt).toContain('https://example.com/spec.md');
@@ -148,7 +148,7 @@ describe('buildSystemPrompt()', () => {
         referenceUrls: ['https://example.com/spec.md'],
       };
       const context = 'workspace-context-marker';
-      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, context);
+      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, context, trigger.workspacePath);
 
       const contextIdx = prompt.indexOf('## Workspace Context');
       const refsIdx = prompt.indexOf('## Reference documents');
@@ -167,7 +167,7 @@ describe('buildSystemPrompt()', () => {
       };
       const customSoul = 'Follow TDD strictly.';
       const context = '### CLAUDE.md\nUse TypeScript strict mode.';
-      const prompt = buildSystemPrompt(trigger, 'state-abc', customSoul, context);
+      const prompt = buildSystemPrompt(trigger, 'state-abc', customSoul, context, trigger.workspacePath);
 
       // All sections present
       expect(prompt).toContain('## Agent Rules and Philosophy');
@@ -190,13 +190,93 @@ describe('buildSystemPrompt()', () => {
     });
   });
 
+  describe('worktree session scoping (Issue #880)', () => {
+    const mainCheckoutPath = '/Users/test/my-project';
+    const worktreePath = '/Users/test/.workrail/worktrees/session-abc123';
+
+    it('uses the provided path in the workspace heading (branchStrategy:none -- same path as trigger)', () => {
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, mainCheckoutPath);
+
+      expect(prompt).toContain(`## Workspace: ${mainCheckoutPath}`);
+    });
+
+    it('does NOT add scope boundary when effectiveWorkspacePath equals trigger.workspacePath', () => {
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, mainCheckoutPath);
+
+      expect(prompt).toContain(`## Workspace: ${mainCheckoutPath}`);
+      expect(prompt).not.toContain('Worktree session scope');
+    });
+
+    it('uses worktree path in the workspace heading for a worktree session', () => {
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, worktreePath);
+
+      expect(prompt).toContain(`## Workspace: ${worktreePath}`);
+      expect(prompt).not.toContain(`## Workspace: ${mainCheckoutPath}`);
+    });
+
+    it('adds the worktree scope boundary note for a worktree session', () => {
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, worktreePath);
+
+      expect(prompt).toContain('Worktree session scope');
+      expect(prompt).toContain(worktreePath);
+      expect(prompt).toContain(mainCheckoutPath);
+    });
+
+    it('scope boundary note explicitly forbids accessing the main checkout', () => {
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, worktreePath);
+
+      expect(prompt).toContain(`Do not access, read, or modify the main checkout at \`${mainCheckoutPath}\``);
+    });
+
+    it('scope boundary note explicitly forbids reading planning/roadmap/backlog docs', () => {
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, worktreePath);
+
+      expect(prompt).toContain('Do not read planning docs, roadmap files, or backlog files');
+    });
+
+    it('does NOT add scope boundary note when effectiveWorkspacePath equals trigger.workspacePath (none strategy)', () => {
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, mainCheckoutPath);
+
+      expect(prompt).not.toContain('Worktree session scope');
+    });
+
+    it('scope boundary note appears immediately after the workspace heading', () => {
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, worktreePath);
+
+      const workspaceIdx = prompt.indexOf(`## Workspace: ${worktreePath}`);
+      const scopeIdx = prompt.indexOf('Worktree session scope');
+      const workspaceContextIdx = prompt.indexOf('## Workspace Context');
+
+      expect(workspaceIdx).toBeGreaterThan(-1);
+      expect(scopeIdx).toBeGreaterThan(-1);
+      // scope note comes after the workspace heading
+      expect(scopeIdx).toBeGreaterThan(workspaceIdx);
+      // if workspace context is present, scope note comes before it
+      if (workspaceContextIdx !== -1) {
+        expect(scopeIdx).toBeLessThan(workspaceContextIdx);
+      }
+    });
+
+    it('workspace context is still injected after the scope boundary for worktree sessions', () => {
+      const context = 'workspace-context-marker';
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, context, worktreePath);
+
+      const scopeIdx = prompt.indexOf('Worktree session scope');
+      const contextIdx = prompt.indexOf('## Workspace Context');
+
+      expect(scopeIdx).toBeGreaterThan(-1);
+      expect(contextIdx).toBeGreaterThan(-1);
+      expect(contextIdx).toBeGreaterThan(scopeIdx);
+    });
+  });
+
   describe('prior context injection (F1)', () => {
     it('injects ## Prior Context section when assembledContextSummary is a non-empty string', () => {
       const trigger: WorkflowTrigger = {
         ...baseTrigger,
         context: { assembledContextSummary: 'prior-context-marker' },
       };
-      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, null);
+      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, null, trigger.workspacePath);
 
       expect(prompt).toContain('## Prior Context');
       expect(prompt).toContain('prior-context-marker');
@@ -208,7 +288,7 @@ describe('buildSystemPrompt()', () => {
         context: { assembledContextSummary: 'prior-context-marker' },
         referenceUrls: ['https://example.com/spec.md'],
       };
-      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, null);
+      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, null, trigger.workspacePath);
 
       const priorCtxIdx = prompt.indexOf('## Prior Context');
       const refsIdx = prompt.indexOf('## Reference documents');
@@ -219,7 +299,7 @@ describe('buildSystemPrompt()', () => {
     });
 
     it('omits ## Prior Context when assembledContextSummary is absent', () => {
-      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null);
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath);
 
       expect(prompt).not.toContain('## Prior Context');
     });
@@ -229,7 +309,7 @@ describe('buildSystemPrompt()', () => {
         ...baseTrigger,
         context: { assembledContextSummary: 42 },
       };
-      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, null);
+      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, null, trigger.workspacePath);
 
       expect(prompt).not.toContain('## Prior Context');
     });


### PR DESCRIPTION
## Problem

When \`branchStrategy: 'worktree'\` is configured, the daemon creates an isolated git worktree per session. The system prompt previously named \`trigger.workspacePath\` (the main checkout) as the agent's workspace, causing:

1. All Bash commands ran against the main checkout. Code changes went nowhere. Delivery found nothing to commit.
2. The agent read planning docs, ran \`git log\` on main, called \`gh issue view\` -- coordinator work it should never do.

Closes #880.

## Change

\`buildSystemPrompt()\` and \`buildSessionContext()\` now take \`effectiveWorkspacePath: string\` as a **required** parameter. The fallback \`sessionWorkspacePath ?? trigger.workspacePath\` is computed at the single callsite in \`buildAgentReadySession()\`. No silent fallback inside the functions -- the type system enforces that every caller makes an explicit decision.

For worktree sessions, the system prompt injects a scope boundary paragraph explicitly forbidding access to the main checkout and planning docs.

**Crash recovery:** also fixed. The recovery path previously set \`trigger.workspacePath = worktreePath\`, making \`isWorktreeSession\` always false. Fix: \`trigger.workspacePath\` stays as the original main checkout; the worktree path is carried in \`AllocatedSession.sessionWorkspacePath\` and applied in \`buildPreAgentSession()\`.

**Note on CLAUDE.md loading:** workspace context files load from \`trigger.workspacePath\` (the main checkout). This is correct -- the worktree is a fresh checkout without a separate CLAUDE.md.

**Follow-up:** \`Read\` and \`Write\` tools have no path restriction -- tracked in #884.

## Tests

101 passing tests across \`workflow-runner-system-prompt.test.ts\` and \`workflow-runner-pure-functions.test.ts\`.