### PR TITLE
chore: fix CI npm cpu-filter bug via composite setup-npm action

### DIFF
--- a/.github/actions/setup-npm/action.yml
+++ b/.github/actions/setup-npm/action.yml
@@ -1,0 +1,30 @@
+name: Setup Node.js with npm>=11
+description: >
+  Wraps actions/setup-node and upgrades npm to >=11.11.1.
+  Required because Node 22.14.0 ships npm@10.9.2 which has a cpu-filter
+  bug (fixed in npm@11.3.0) that rejects lockfiles with optional packages
+  filtered by cpu/os (e.g. @rolldown/binding-wasm32-wasi used by vite).
+inputs:
+  node-version:
+    description: Node.js version to install
+    required: false
+    default: '22.14.0'
+  cache:
+    description: Package manager cache ('npm', 'yarn', 'pnpm', or '')
+    required: false
+    default: 'npm'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js ${{ inputs.node-version }}
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.cache }}
+
+    - name: Upgrade npm (fix cpu-filter bug present in npm <11.3.0)
+      shell: bash
+      run: |
+        npm install -g npm@^11.11.1
+        npm --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup Node.js (toolchain)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup Node.js with npm>=11
+        uses: ./.github/actions/setup-npm
         with:
           node-version: 22.14.0
-          cache: 'npm'
 
       - name: Install dependencies (no lifecycle scripts)
         run: npm install --ignore-scripts
@@ -92,14 +91,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup Node.js (toolchain)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup Node.js with npm>=11
+        uses: ./.github/actions/setup-npm
         with:
           node-version: 22.14.0
-          cache: 'npm'
-
-      - name: Upgrade npm (fix lockfile cpu-filter bug present in npm <11.3.0)
-        run: npm install -g npm@^11.11.1 --ignore-scripts
 
       - name: Regenerate lockfile (no lifecycle scripts)
         run: npm install --ignore-scripts
@@ -131,11 +126,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js (toolchain)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup Node.js with npm>=11
+        uses: ./.github/actions/setup-npm
         with:
           node-version: 22.14.0
-          cache: 'npm'
 
       - name: Install dependencies (no lifecycle scripts)
         run: npm install --ignore-scripts
@@ -156,11 +150,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup Node.js (toolchain)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup Node.js with npm>=11
+        uses: ./.github/actions/setup-npm
         with:
           node-version: 22.14.0
-          cache: 'npm'
 
       - name: Install dependencies (no lifecycle scripts)
         run: npm install --ignore-scripts
@@ -209,11 +202,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup Node.js with npm>=11
+        uses: ./.github/actions/setup-npm
         with:
           node-version: 22.14.0
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm install --ignore-scripts
@@ -233,11 +225,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup Node.js with npm>=11
+        uses: ./.github/actions/setup-npm
         with:
           node-version: 22.14.0
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm install --ignore-scripts
@@ -264,11 +255,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup Node.js with npm>=11
+        uses: ./.github/actions/setup-npm
         with:
           node-version: 22.14.0
-          cache: 'npm'
 
       - name: Install dependencies (no lifecycle scripts)
         run: npm install --ignore-scripts
@@ -289,11 +279,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup Node.js with npm>=11
+        uses: ./.github/actions/setup-npm
         with:
           node-version: 22.14.0
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm install --ignore-scripts
@@ -366,11 +355,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup Node.js with npm>=11
+        uses: ./.github/actions/setup-npm
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm install --ignore-scripts
@@ -415,11 +403,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup Node.js with npm>=11
+        uses: ./.github/actions/setup-npm
         with:
           node-version: 22.14.0
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm install --ignore-scripts
@@ -464,11 +451,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup Node.js with npm>=11
+        uses: ./.github/actions/setup-npm
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm install --ignore-scripts


### PR DESCRIPTION
## Summary

- Node 22.14.0 ships npm@10.9.2, which has a cpu-filter bug (fixed in npm@11.3.0) that rejects lockfiles with optional packages filtered by cpu/os (the `@rolldown/binding-wasm32-wasi` package pulled in by vite triggers this)
- The previous fix only upgraded npm in the `lockfile` job, which has `continue-on-error: true` - every other job still used the broken npm@10.9.2
- Extract a composite action `.github/actions/setup-npm` that wraps `actions/setup-node` and upgrades npm to `^11.11.1` atomically, so the fix is defined once and applied everywhere

## What changed

- New: `.github/actions/setup-npm/action.yml` - composite action that does `setup-node` + `npm install -g npm@^11.11.1`
- Updated: `.github/workflows/ci.yml` - replace all 11 bare `actions/setup-node` calls with `uses: ./.github/actions/setup-npm`, removing the now-redundant inline upgrade step from the lockfile job

## Test plan

- [ ] CI passes on this PR (the pull_request event trigger) with no `@emnapi/core` missing-from-lockfile error
- [ ] All jobs install with npm>=11.11.1 (visible in the "Upgrade npm" step output within the composite action)
- [ ] Lockfile job still detects drift and uploads artifact on mismatch
- [ ] Matrix jobs (Node 20 and Node 22, ubuntu/macos/windows) all succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)