### PR TITLE
chore: use corepack to enforce npm@11.11.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
+
       - name: Install dependencies (no lifecycle scripts)
         run: npm install --ignore-scripts
 
@@ -78,14 +81,13 @@ jobs:
         run: node scripts/ci-policy-check.js
 
   # ============================================================================
-  # REQUIRED: Lockfile is stable under npm ci
+  # REQUIRED: Lockfile is stable under npm install
   # ============================================================================
   lockfile:
     name: Lockfile Stable
     runs-on: ubuntu-latest
-    # Advisory only -- lockfile drift (e.g. from npm version differences across
-    # platforms) should not block PRs. The check still runs and uploads a
-    # regenerated lockfile artifact when drift is detected.
+    # Advisory only -- lockfile drift should not block PRs. The check still runs
+    # and uploads a regenerated lockfile artifact when drift is detected.
     continue-on-error: true
 
     steps:
@@ -98,8 +100,8 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
-      - name: Upgrade npm (fix lockfile cpu-filter bug present in npm <11.3.0)
-        run: npm install -g npm@^11.11.1 --ignore-scripts
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
 
       - name: Regenerate lockfile (no lifecycle scripts)
         run: npm install --ignore-scripts
@@ -137,6 +139,9 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
+
       - name: Install dependencies (no lifecycle scripts)
         run: npm install --ignore-scripts
 
@@ -161,6 +166,9 @@ jobs:
         with:
           node-version: 22.14.0
           cache: 'npm'
+
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
 
       - name: Install dependencies (no lifecycle scripts)
         run: npm install --ignore-scripts
@@ -215,6 +223,9 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
+
       - name: Install dependencies
         run: npm install --ignore-scripts
 
@@ -238,6 +249,9 @@ jobs:
         with:
           node-version: 22.14.0
           cache: 'npm'
+
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
 
       - name: Install dependencies
         run: npm install --ignore-scripts
@@ -270,6 +284,9 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
+
       - name: Install dependencies (no lifecycle scripts)
         run: npm install --ignore-scripts
 
@@ -294,6 +311,9 @@ jobs:
         with:
           node-version: 22.14.0
           cache: 'npm'
+
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
 
       - name: Install dependencies
         run: npm install --ignore-scripts
@@ -372,6 +392,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
+
       - name: Install dependencies
         run: npm install --ignore-scripts
 
@@ -421,6 +444,9 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
+
       - name: Install dependencies
         run: npm install --ignore-scripts
 
@@ -459,7 +485,7 @@ jobs:
         # Slim matrix on PRs (Node 22 only), full matrix on main
         node-version: ${{ github.event_name == 'pull_request' && fromJSON('["22.14.0"]') || fromJSON('["20", "22.14.0"]') }}
       fail-fast: false
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -469,6 +495,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
 
       - name: Install dependencies
         run: npm install --ignore-scripts

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -24,15 +24,14 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
-      # npm Trusted Publishing (OIDC) requires npm >= 11.5.1
-      - name: Upgrade npm (Trusted Publishing)
-        run: |
-          npm --version
-          npm install -g npm@11.6.2
-          npm --version
+      # npm Trusted Publishing (OIDC) requires npm >= 11.5.1.
+      # corepack reads the packageManager field from package.json and activates
+      # the correct npm version, reliably shadowing the bundled npm in PATH.
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
 
       - name: Install dependencies (no lifecycle scripts)
-        run: npm ci --ignore-scripts
+        run: npm install --ignore-scripts
 
       - name: semantic-release dry-run
         env:
@@ -41,7 +40,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Mirror the real release job: use the upgraded global npm and avoid
+          # Mirror the real release job: use the corepack-activated npm and avoid
           # PATH shadowing from ./node_modules/.bin when invoking semantic-release.
           export PATH="$(echo "$PATH" | tr ':' '\n' | awk '!/\/node_modules\/\.bin/' | paste -sd ':' -)"
           hash -r

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,15 +82,14 @@ jobs:
           # Align with npm trusted publishing reference setup
           registry-url: https://registry.npmjs.org
 
-      # npm Trusted Publishing (OIDC) requires npm >= 11.5.1
-      - name: Upgrade npm (Trusted Publishing)
-        run: |
-          npm --version
-          npm install -g npm@11.6.2
-          npm --version
+      # npm Trusted Publishing (OIDC) requires npm >= 11.5.1.
+      # corepack reads the packageManager field from package.json and activates
+      # the correct npm version, reliably shadowing the bundled npm in PATH.
+      - name: Activate npm (corepack reads packageManager from package.json)
+        run: corepack enable npm && corepack prepare --activate
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm install --ignore-scripts
 
       - name: Download build artifact (dist/)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -133,9 +132,9 @@ jobs:
           # the app token (which has bypass permission) is used, not GITHUB_TOKEN.
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
 
-          # Ensure we use the upgraded global npm (OIDC requires npm >= 11.5.1).
-          # npx prepends ./node_modules/.bin to PATH, which can shadow the global npm
-          # with a bundled npm package version that does not support trusted publishing.
+          # Ensure we use the corepack-activated npm (OIDC requires npm >= 11.5.1).
+          # npx prepends ./node_modules/.bin to PATH, which can shadow the corepack
+          # shim with a bundled npm package version that does not support trusted publishing.
           export PATH="$(echo "$PATH" | tr ':' '\n' | awk '!/\/node_modules\/\.bin/' | paste -sd ':' -)"
           hash -r
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1704,7 +1704,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1753,7 +1752,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1866,6 +1864,29 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -2461,7 +2482,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4779,7 +4799,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -5031,7 +5052,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -5219,6 +5239,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -6113,6 +6134,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6145,7 +6167,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -6473,7 +6496,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6617,7 +6639,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7219,7 +7240,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8271,6 +8291,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8309,7 +8330,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10566,7 +10586,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11171,6 +11190,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11186,6 +11206,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11196,6 +11217,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11365,7 +11387,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/read-package-up": {
       "version": "11.0.0",
@@ -11638,7 +11661,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semantic-release": {
       "version": "25.0.3",
@@ -11646,7 +11670,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -12765,7 +12788,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13002,7 +13024,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13276,7 +13297,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13378,7 +13398,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -13497,7 +13516,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13511,7 +13529,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13871,7 +13888,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "vite": "^8.0.10",
     "vitest": "^3.2.4"
   },
+  "packageManager": "npm@11.11.1",
   "engines": {
     "node": ">=20",
     "npm": ">=11.11.1"


### PR DESCRIPTION
## Summary

- Node 22.14.0 ships npm@10.9.2, which rejects lockfiles generated by npm@11.x due to a cpu-filter bug fixed in npm@11.3.0
- Previous workaround (`npm install -g npm@^11.11.1`) did not work because `actions/setup-node` controls the PATH and the global install does not shadow it
- Adds `packageManager: npm@11.11.1` to `package.json` and uses `corepack enable npm && corepack prepare --activate` in every CI job before running npm
- Corepack creates PATH shims that reliably intercept npm calls and route them through the declared version, eliminating the version mismatch at the source
- Also replaces remaining `npm ci` calls in `release.yml` and `release-dry-run.yml` with `npm install --ignore-scripts` for consistency

## Test plan

- [ ] CI passes on this PR (pull_request event) with cold cache
- [ ] Lockfile Stable job passes (no drift between what dev machines generate and what CI generates)
- [ ] Build and test jobs pass on all matrix combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)