### PR TITLE
chore: pin npm via corepack to eliminate lockfile drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
+      - name: Enable corepack (pins npm to version declared in packageManager)
+        run: corepack enable npm
+
       - name: Install dependencies (no lifecycle scripts)
         run: npm install --ignore-scripts
 
@@ -83,10 +86,6 @@ jobs:
   lockfile:
     name: Lockfile Stable
     runs-on: ubuntu-latest
-    # Advisory only -- lockfile drift (e.g. from npm version differences across
-    # platforms) should not block PRs. The check still runs and uploads a
-    # regenerated lockfile artifact when drift is detected.
-    continue-on-error: true
 
     steps:
       - name: Checkout code
@@ -98,8 +97,8 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
-      - name: Upgrade npm (fix lockfile cpu-filter bug present in npm <11.3.0)
-        run: npm install -g npm@^11.11.1 --ignore-scripts
+      - name: Enable corepack (pins npm to version declared in packageManager)
+        run: corepack enable npm
 
       - name: Regenerate lockfile (no lifecycle scripts)
         run: npm install --ignore-scripts
@@ -137,6 +136,9 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
+      - name: Enable corepack (pins npm to version declared in packageManager)
+        run: corepack enable npm
+
       - name: Install dependencies (no lifecycle scripts)
         run: npm install --ignore-scripts
 
@@ -161,6 +163,9 @@ jobs:
         with:
           node-version: 22.14.0
           cache: 'npm'
+
+      - name: Enable corepack (pins npm to version declared in packageManager)
+        run: corepack enable npm
 
       - name: Install dependencies (no lifecycle scripts)
         run: npm install --ignore-scripts
@@ -215,6 +220,9 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
+      - name: Enable corepack (pins npm to version declared in packageManager)
+        run: corepack enable npm
+
       - name: Install dependencies
         run: npm install --ignore-scripts
 
@@ -238,6 +246,9 @@ jobs:
         with:
           node-version: 22.14.0
           cache: 'npm'
+
+      - name: Enable corepack (pins npm to version declared in packageManager)
+        run: corepack enable npm
 
       - name: Install dependencies
         run: npm install --ignore-scripts
@@ -270,6 +281,9 @@ jobs:
           node-version: 22.14.0
           cache: 'npm'
 
+      - name: Enable corepack (pins npm to version declared in packageManager)
+        run: corepack enable npm
+
       - name: Install dependencies (no lifecycle scripts)
         run: npm install --ignore-scripts
 
@@ -294,6 +308,9 @@ jobs:
         with:
           node-version: 22.14.0
           cache: 'npm'
+
+      - name: Enable corepack (pins npm to version declared in packageManager)
+        run: corepack enable npm
 
       - name: Install dependencies
         run: npm install --ignore-scripts
@@ -372,6 +389,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
+      - name: Enable corepack (pins npm to version declared in packageManager)
+        run: corepack enable npm
+
       - name: Install dependencies
         run: npm install --ignore-scripts
 
@@ -420,6 +440,9 @@ jobs:
         with:
           node-version: 22.14.0
           cache: 'npm'
+
+      - name: Enable corepack (pins npm to version declared in packageManager)
+        run: corepack enable npm
 
       - name: Install dependencies
         run: npm install --ignore-scripts
@@ -470,6 +493,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
+      - name: Enable corepack (pins npm to version declared in packageManager)
+        run: corepack enable npm
+
       - name: Install dependencies
         run: npm install --ignore-scripts
 
@@ -514,12 +540,13 @@ jobs:
           echo "## CI Success Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Lockfile: advisory only (continue-on-error -- does not block merge)
-          if [[ "${{ needs.lockfile.result }}" == "success" ]]; then
-            echo "- Lockfile Stable: PASSED" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "- Lockfile Stable: ADVISORY (drift detected -- see artifact)" >> $GITHUB_STEP_SUMMARY
+          # Check lockfile (hard gate -- corepack guarantees same npm version everywhere)
+          if [[ "${{ needs.lockfile.result }}" != "success" ]]; then
+            echo "- Lockfile Stable: FAILED" >> $GITHUB_STEP_SUMMARY
+            echo "Lockfile is not stable -- run 'npm install' locally and commit package-lock.json"
+            exit 1
           fi
+          echo "- Lockfile Stable: PASSED" >> $GITHUB_STEP_SUMMARY
 
           # Check build-artifact
           if [[ "${{ needs.build-artifact.result }}" != "success" ]]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1704,7 +1704,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1753,7 +1752,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1866,6 +1864,29 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -2461,7 +2482,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4779,7 +4799,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -5031,7 +5052,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -5219,6 +5239,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -6113,6 +6134,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6145,7 +6167,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -6473,7 +6496,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6617,7 +6639,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7219,7 +7240,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8271,6 +8291,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8309,7 +8330,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10566,7 +10586,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11171,6 +11190,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11186,6 +11206,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11196,6 +11217,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11365,7 +11387,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/read-package-up": {
       "version": "11.0.0",
@@ -11638,7 +11661,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semantic-release": {
       "version": "25.0.3",
@@ -11646,7 +11670,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -12765,7 +12788,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13002,7 +13024,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13276,7 +13297,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13378,7 +13398,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -13497,7 +13516,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13511,7 +13529,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13871,7 +13888,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "vite": "^8.0.10",
     "vitest": "^3.2.4"
   },
+  "packageManager": "npm@11.11.1+sha512.6ac6b30a876415dcf545e433ba4cb34bf0c3efbb86088a9415e446de0b5a4fc6fd511d277b59bd40e06e3204fbda28f5aeded346b3a8c780355b39ed31622e12",
   "engines": {
     "node": ">=20",
     "npm": ">=11.11.1"


### PR DESCRIPTION
## Summary

- Adds `packageManager: npm@11.11.1` to `package.json` to pin the exact npm version via corepack
- Adds `corepack enable npm` before every install step in CI so the pinned version is used regardless of what Node ships (Node 22.14.0 bundles npm@10.9.2 which has the cpu-filter bug)
- Updates `package-lock.json` with the canonical npm@11.11.1 output: adds `@emnapi/core@1.10.0` and `@emnapi/runtime@1.10.0` as explicit optional entries, and normalizes `peer` field placement across several entries
- Promotes `Lockfile Stable` from advisory (`continue-on-error: true`) to a hard gate -- with corepack, lockfile drift is now a real error rather than expected noise

## Why this works

The root cause was npm version skew: `setup-node` gives Node 22.14.0 which bundles npm@10.9.2, but the lockfile was generated with npm@11.11.1. npm@10.9.2 has a cpu-filter bug (fixed in npm@11.3.0) where it rejects lockfiles that don't have explicit entries for transitive deps of cpu-filtered optional packages (`@rolldown/binding-wasm32-wasi` -> `@emnapi/core@1.10.0`).

Previous attempts:
- `npm install -g npm@^11.11.1 && npm ci` -- global install doesn't shadow setup-node's PATH npm
- `npx --yes npm@^11.11.1 ci` -- also failed due to lockfile drift from a release bump
- `npm install` (no `ci`) -- works but produces different lockfile metadata across npm versions, causing the lockfile stability check to always show drift

With corepack, `npm` is a shim that downloads and runs exactly `npm@11.11.1`. Every environment (local, CI ubuntu, CI macos, CI windows) runs the same binary and produces byte-identical lockfile output.

## Test plan

- [ ] CI passes on this PR (lockfile stable, no emnapi errors, no drift)
- [ ] Cold cache run produces same result (corepack downloads npm@11.11.1 and installs cleanly)
- [ ] `npm install` locally with corepack active produces no lockfile diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)