### PR TITLE
fix(daemon): enforce workspace boundary in Read and Write tools

### DIFF
--- a/src/daemon/tools/file-tools.ts
+++ b/src/daemon/tools/file-tools.ts
@@ -12,6 +12,29 @@ import type { DaemonEventEmitter } from '../daemon-events.js';
 import type { ReadFileState } from '../workflow-runner.js';
 import { READ_SIZE_CAP_BYTES, findActualString, withWorkrailSession } from './_shared.js';
 
+/**
+ * Resolve a (possibly relative) file path against workspacePath and verify it
+ * stays within the workspace.
+ *
+ * WHY path.normalize + path.sep suffix:
+ * - path.normalize resolves '..' segments, defeating traversal attacks like
+ *   '/workspace/../../../etc/passwd' which would pass a naive startsWith check.
+ * - The trailing path.sep ensures prefix-sibling directories like '/workspace-evil'
+ *   don't pass the check for workspacePath '/workspace'.
+ *
+ * Returns the normalized absolute path on success, or throws with a clear message.
+ */
+function resolveWithinWorkspace(filePath: string, workspacePath: string, toolName: string): string {
+  const absolute = path.isAbsolute(filePath) ? filePath : path.join(workspacePath, filePath);
+  const normalizedWorkspace = path.normalize(workspacePath) + path.sep;
+  const normalizedTarget = path.normalize(absolute);
+  // Allow the workspace root itself (normalizedTarget === normalizedWorkspace without the sep)
+  if (normalizedTarget !== path.normalize(workspacePath) && !normalizedTarget.startsWith(normalizedWorkspace)) {
+    throw new Error(`${toolName} target is outside the workspace: ${filePath}`);
+  }
+  return normalizedTarget;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function makeReadTool(workspacePath: string, readFileState: Map<string, ReadFileState>, schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter, workrailSessionId?: string | null): AgentTool {
   return {
@@ -29,12 +52,7 @@ export function makeReadTool(workspacePath: string, readFileState: Map<string, R
       params: any,
     ): Promise<AgentToolResult<unknown>> => {
       if (typeof params.filePath !== 'string' || !params.filePath) throw new Error('Read: filePath must be a non-empty string');
-      const filePath: string = params.filePath;
-      // Enforce workspace boundary: prevent reads outside the workspace
-      const absoluteFilePath = path.isAbsolute(filePath) ? filePath : path.join(workspacePath, filePath);
-      if (!absoluteFilePath.startsWith(workspacePath)) {
-        throw new Error(`Read target is outside the workspace: ${filePath}`);
-      }
+      const filePath: string = resolveWithinWorkspace(params.filePath, workspacePath, 'Read');
       if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Read', summary: filePath.slice(0, 80), ...withWorkrailSession(workrailSessionId) });
 
       // Block device paths to prevent reads from infinite streams
@@ -91,12 +109,7 @@ export function makeWriteTool(workspacePath: string, readFileState: Map<string, 
     ): Promise<AgentToolResult<unknown>> => {
       if (typeof params.filePath !== 'string' || !params.filePath) throw new Error('Write: filePath must be a non-empty string');
       if (typeof params.content !== 'string') throw new Error('Write: content must be a string');
-      const filePath: string = params.filePath;
-      // Enforce workspace boundary: prevent writes outside the workspace
-      const absoluteFilePath = path.isAbsolute(filePath) ? filePath : path.join(workspacePath, filePath);
-      if (!absoluteFilePath.startsWith(workspacePath)) {
-        throw new Error(`Write target is outside the workspace: ${filePath}`);
-      }
+      const filePath: string = resolveWithinWorkspace(params.filePath, workspacePath, 'Write');
       if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Write', summary: filePath.slice(0, 80), ...withWorkrailSession(workrailSessionId) });
 
       // Staleness guard: only for existing files. New files bypass the check entirely.
@@ -159,15 +172,7 @@ export function makeEditTool(workspacePath: string, readFileState: Map<string, R
       if (typeof params.file_path !== 'string' || !params.file_path) throw new Error('Edit: file_path must be a non-empty string');
       if (typeof params.old_string !== 'string') throw new Error('Edit: old_string must be a string');
       if (typeof params.new_string !== 'string') throw new Error('Edit: new_string must be a string');
-      const rawFilePath: string = params.file_path;
-      const absoluteFilePath = path.isAbsolute(rawFilePath)
-        ? rawFilePath
-        : path.join(workspacePath, rawFilePath);
-      // Enforce workspace boundary: prevent edits outside the workspace
-      if (!absoluteFilePath.startsWith(workspacePath)) {
-        throw new Error(`Edit target is outside the workspace: ${rawFilePath}`);
-      }
-      const filePath: string = absoluteFilePath;
+      const filePath: string = resolveWithinWorkspace(params.file_path, workspacePath, 'Edit');
       const oldString: string = params.old_string;
       const newString: string = params.new_string;
       const replaceAll: boolean = params.replace_all ?? false;

--- a/src/daemon/tools/file-tools.ts
+++ b/src/daemon/tools/file-tools.ts
@@ -13,7 +13,7 @@ import type { ReadFileState } from '../workflow-runner.js';
 import { READ_SIZE_CAP_BYTES, findActualString, withWorkrailSession } from './_shared.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function makeReadTool(readFileState: Map<string, ReadFileState>, schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter, workrailSessionId?: string | null): AgentTool {
+export function makeReadTool(workspacePath: string, readFileState: Map<string, ReadFileState>, schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter, workrailSessionId?: string | null): AgentTool {
   return {
     name: 'Read',
     description:
@@ -30,6 +30,11 @@ export function makeReadTool(readFileState: Map<string, ReadFileState>, schemas:
     ): Promise<AgentToolResult<unknown>> => {
       if (typeof params.filePath !== 'string' || !params.filePath) throw new Error('Read: filePath must be a non-empty string');
       const filePath: string = params.filePath;
+      // Enforce workspace boundary: prevent reads outside the workspace
+      const absoluteFilePath = path.isAbsolute(filePath) ? filePath : path.join(workspacePath, filePath);
+      if (!absoluteFilePath.startsWith(workspacePath)) {
+        throw new Error(`Read target is outside the workspace: ${filePath}`);
+      }
       if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Read', summary: filePath.slice(0, 80), ...withWorkrailSession(workrailSessionId) });
 
       // Block device paths to prevent reads from infinite streams
@@ -69,7 +74,7 @@ export function makeReadTool(readFileState: Map<string, ReadFileState>, schemas:
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function makeWriteTool(readFileState: Map<string, ReadFileState>, schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter, workrailSessionId?: string | null): AgentTool {
+export function makeWriteTool(workspacePath: string, readFileState: Map<string, ReadFileState>, schemas: Record<string, any>, sessionId?: string, emitter?: DaemonEventEmitter, workrailSessionId?: string | null): AgentTool {
   return {
     name: 'Write',
     description:
@@ -87,6 +92,11 @@ export function makeWriteTool(readFileState: Map<string, ReadFileState>, schemas
       if (typeof params.filePath !== 'string' || !params.filePath) throw new Error('Write: filePath must be a non-empty string');
       if (typeof params.content !== 'string') throw new Error('Write: content must be a string');
       const filePath: string = params.filePath;
+      // Enforce workspace boundary: prevent writes outside the workspace
+      const absoluteFilePath = path.isAbsolute(filePath) ? filePath : path.join(workspacePath, filePath);
+      if (!absoluteFilePath.startsWith(workspacePath)) {
+        throw new Error(`Write target is outside the workspace: ${filePath}`);
+      }
       if (sessionId) emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'Write', summary: filePath.slice(0, 80), ...withWorkrailSession(workrailSessionId) });
 
       // Staleness guard: only for existing files. New files bypass the check entirely.

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -3091,8 +3091,8 @@ function constructTools(
     // WHY sessionWorkspacePath: when branchStrategy === 'worktree', all agent file operations
     // must target the isolated worktree, not the main checkout.
     makeBashTool(sessionWorkspacePath, schemas, sid, emitter, workrailSid),
-    makeReadTool(readFileStateMap, schemas, sid, emitter, workrailSid),
-    makeWriteTool(readFileStateMap, schemas, sid, emitter, workrailSid),
+    makeReadTool(sessionWorkspacePath, readFileStateMap, schemas, sid, emitter, workrailSid),
+    makeWriteTool(sessionWorkspacePath, readFileStateMap, schemas, sid, emitter, workrailSid),
     makeGlobTool(sessionWorkspacePath, schemas, sid, emitter, workrailSid),
     makeGrepTool(sessionWorkspacePath, schemas, sid, emitter, workrailSid),
     makeEditTool(sessionWorkspacePath, readFileStateMap, schemas, sid, emitter, workrailSid),

--- a/tests/unit/workflow-runner-file-tools.test.ts
+++ b/tests/unit/workflow-runner-file-tools.test.ts
@@ -152,6 +152,28 @@ describe('makeReadTool()', () => {
       tool.execute('test-id', { filePath: outsidePath }),
     ).rejects.toThrow(/outside the workspace/i);
   });
+
+  it('rejects dotdot traversal that escapes the workspace', async () => {
+    // /workspace/../../../etc/passwd passes a naive startsWith check
+    const traversalPath = path.join(testDir, '..', '..', 'etc', 'passwd');
+
+    const readFileState = new Map<string, ReadFileState>();
+    const tool = makeReadTool(testDir, readFileState, stubSchemas);
+    await expect(
+      tool.execute('test-id', { filePath: traversalPath }),
+    ).rejects.toThrow(/outside the workspace/i);
+  });
+
+  it('rejects prefix-sibling directories', async () => {
+    // /workspace-evil passes a naive startsWith('/workspace') check
+    const siblingPath = testDir + '-evil' + path.sep + 'secret.txt';
+
+    const readFileState = new Map<string, ReadFileState>();
+    const tool = makeReadTool(testDir, readFileState, stubSchemas);
+    await expect(
+      tool.execute('test-id', { filePath: siblingPath }),
+    ).rejects.toThrow(/outside the workspace/i);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -209,6 +231,26 @@ describe('makeWriteTool()', () => {
 
     // Verify the file was never created
     await expect(fs.access(outsidePath)).rejects.toThrow();
+  });
+
+  it('rejects dotdot traversal that escapes the workspace', async () => {
+    const traversalPath = path.join(testDir, '..', '..', 'etc', 'passwd');
+
+    const readFileState = new Map<string, ReadFileState>();
+    const tool = makeWriteTool(testDir, readFileState, stubSchemas);
+    await expect(
+      tool.execute('test-id', { filePath: traversalPath, content: 'pwned' }),
+    ).rejects.toThrow(/outside the workspace/i);
+  });
+
+  it('rejects prefix-sibling directories', async () => {
+    const siblingPath = testDir + '-evil' + path.sep + 'file.txt';
+
+    const readFileState = new Map<string, ReadFileState>();
+    const tool = makeWriteTool(testDir, readFileState, stubSchemas);
+    await expect(
+      tool.execute('test-id', { filePath: siblingPath, content: 'should not write' }),
+    ).rejects.toThrow(/outside the workspace/i);
   });
 });
 

--- a/tests/unit/workflow-runner-file-tools.test.ts
+++ b/tests/unit/workflow-runner-file-tools.test.ts
@@ -73,7 +73,7 @@ describe('makeReadTool()', () => {
     await fs.writeFile(filePath, 'line one\nline two\nline three', 'utf8');
 
     const readFileState = new Map<string, ReadFileState>();
-    const tool = makeReadTool(readFileState, stubSchemas);
+    const tool = makeReadTool(testDir, readFileState, stubSchemas);
     const result = await tool.execute('test-id', { filePath });
 
     const text = (result.content[0] as { type: string; text: string }).text;
@@ -87,7 +87,7 @@ describe('makeReadTool()', () => {
     await fs.writeFile(filePath, 'a\nb\nc\nd\ne', 'utf8');
 
     const readFileState = new Map<string, ReadFileState>();
-    const tool = makeReadTool(readFileState, stubSchemas);
+    const tool = makeReadTool(testDir, readFileState, stubSchemas);
     // Read lines 2-3 (offset=1 means start at line 2, limit=2 means 2 lines)
     const result = await tool.execute('test-id', { filePath, offset: 1, limit: 2 });
 
@@ -106,7 +106,7 @@ describe('makeReadTool()', () => {
     await fs.writeFile(filePath, lines, 'utf8');
 
     const readFileState = new Map<string, ReadFileState>();
-    const tool = makeReadTool(readFileState, stubSchemas);
+    const tool = makeReadTool(testDir, readFileState, stubSchemas);
     await expect(tool.execute('test-id', { filePath })).rejects.toThrow(/too large/i);
   });
 
@@ -118,7 +118,7 @@ describe('makeReadTool()', () => {
     await fs.writeFile(filePath, lines, 'utf8');
 
     const readFileState = new Map<string, ReadFileState>();
-    const tool = makeReadTool(readFileState, stubSchemas);
+    const tool = makeReadTool(testDir, readFileState, stubSchemas);
     // offset and limit are provided -- size cap must be skipped
     const result = await tool.execute('test-id', { filePath, offset: 0, limit: 5 });
 
@@ -134,13 +134,23 @@ describe('makeReadTool()', () => {
     await fs.writeFile(filePath, 'hello\nworld', 'utf8');
 
     const readFileState = new Map<string, ReadFileState>();
-    const tool = makeReadTool(readFileState, stubSchemas);
+    const tool = makeReadTool(testDir, readFileState, stubSchemas);
     await tool.execute('test-id', { filePath });
 
     expect(readFileState.has(filePath)).toBe(true);
     const state = readFileState.get(filePath)!;
     expect(state.content).toBe('hello\nworld');
     expect(state.timestamp).toBeGreaterThan(0);
+  });
+
+  it('rejects paths outside the workspace', async () => {
+    const outsidePath = path.join(os.tmpdir(), `wr-outside-${randomUUID()}`, 'secret.txt');
+
+    const readFileState = new Map<string, ReadFileState>();
+    const tool = makeReadTool(testDir, readFileState, stubSchemas);
+    await expect(
+      tool.execute('test-id', { filePath: outsidePath }),
+    ).rejects.toThrow(/outside the workspace/i);
   });
 });
 
@@ -153,7 +163,7 @@ describe('makeWriteTool()', () => {
     const filePath = path.join(testDir, 'new-file.txt');
 
     const readFileState = new Map<string, ReadFileState>();
-    const tool = makeWriteTool(readFileState, stubSchemas);
+    const tool = makeWriteTool(testDir, readFileState, stubSchemas);
     const result = await tool.execute('test-id', { filePath, content: 'hello world' });
 
     const text = (result.content[0] as { type: string; text: string }).text;
@@ -167,7 +177,7 @@ describe('makeWriteTool()', () => {
     await fs.writeFile(filePath, 'original content', 'utf8');
 
     const readFileState = new Map<string, ReadFileState>();
-    const tool = makeWriteTool(readFileState, stubSchemas);
+    const tool = makeWriteTool(testDir, readFileState, stubSchemas);
     await expect(
       tool.execute('test-id', { filePath, content: 'new content' }),
     ).rejects.toThrow(/has not been read/i);
@@ -181,10 +191,24 @@ describe('makeWriteTool()', () => {
     const readFileState = new Map<string, ReadFileState>();
     readFileState.set(filePath, { content: 'original content', timestamp: 1000, isPartialView: false });
 
-    const tool = makeWriteTool(readFileState, stubSchemas);
+    const tool = makeWriteTool(testDir, readFileState, stubSchemas);
     await expect(
       tool.execute('test-id', { filePath, content: 'new content' }),
     ).rejects.toThrow(/modified since/i);
+  });
+
+  it('rejects paths outside the workspace', async () => {
+    const outsideDir = path.join(os.tmpdir(), `wr-outside-${randomUUID()}`);
+    const outsidePath = path.join(outsideDir, 'secret.txt');
+
+    const readFileState = new Map<string, ReadFileState>();
+    const tool = makeWriteTool(testDir, readFileState, stubSchemas);
+    await expect(
+      tool.execute('test-id', { filePath: outsidePath, content: 'should not be written' }),
+    ).rejects.toThrow(/outside the workspace/i);
+
+    // Verify the file was never created
+    await expect(fs.access(outsidePath)).rejects.toThrow();
   });
 });
 

--- a/tests/unit/workflow-runner-tool-validation.test.ts
+++ b/tests/unit/workflow-runner-tool-validation.test.ts
@@ -70,7 +70,7 @@ describe('Bash tool validation', () => {
 });
 
 describe('Read tool validation', () => {
-  const tool = makeReadTool(readFileState, fakeSchemas);
+  const tool = makeReadTool(workspacePath, readFileState, fakeSchemas);
 
   it('throws when filePath is missing', async () => {
     await expectThrows(tool.execute.bind(tool), {}, 'Read: filePath');
@@ -82,7 +82,7 @@ describe('Read tool validation', () => {
 });
 
 describe('Write tool validation', () => {
-  const tool = makeWriteTool(readFileState, fakeSchemas);
+  const tool = makeWriteTool(workspacePath, readFileState, fakeSchemas);
 
   it('throws when filePath is missing', async () => {
     await expectThrows(tool.execute.bind(tool), { content: 'x' }, 'Write: filePath');


### PR DESCRIPTION
## Problem

In worktree sessions, \`Read\` and \`Write\` tools accepted any absolute path. \`Edit\`, \`Bash\`, \`Glob\`, and \`Grep\` already enforced the workspace boundary via \`workspacePath\` -- \`Read\` and \`Write\` were the gap.

Closes #884.

## Change

Added \`workspacePath: string\` as the first parameter to \`makeReadTool\` and \`makeWriteTool\`, following the exact same pattern as \`makeEditTool\`. Paths outside the workspace throw an error tool result before any I/O.

Updated both callsites in \`workflow-runner.ts\` to pass \`sessionWorkspacePath\` (same as the other tools already receive).

## Tests

Added path rejection tests for Read and Write. All 369 test files pass.