### PR TITLE
fix(daemon): rotate queue-poll.jsonl at 10 MB to prevent unbounded growth

### DIFF
--- a/src/trigger/polling-scheduler.ts
+++ b/src/trigger/polling-scheduler.ts
@@ -858,24 +858,71 @@ async function countActiveSessions(sessionsDir: string): Promise<number> {
  */
 const MAX_QUEUE_POLL_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
-// NOTE: rotation path not covered by unit tests -- mocking os.homedir() requires
-// test infrastructure changes not currently in place.
-async function appendQueuePollLog(entry: Record<string, unknown>): Promise<void> {
-  const logPath = path.join(os.homedir(), '.workrail', 'queue-poll.jsonl');
+/**
+ * Rotate a log file when it exceeds maxBytes.
+ *
+ * Rotation scheme (2-file cap):
+ *   logPath.2 -- deleted if it exists (oldest backup)
+ *   logPath.1 -- renamed to logPath.2
+ *   logPath   -- renamed to logPath.1 (caller then creates a fresh logPath)
+ *
+ * WHY 2-file cap: balances history retention against unbounded growth. A single
+ * .1 backup keeps ~5 weeks of data before rotation; two backups give ~10 weeks.
+ * More than 2 files would require numbered-suffix logic that adds complexity with
+ * little operational value for a diagnostic log.
+ *
+ * Best-effort: errors are swallowed and logged as warnings so the caller can
+ * always proceed to append even if rotation fails.
+ *
+ * Exported so other append helpers (outbox.jsonl, signals/<id>.jsonl, etc.)
+ * can reuse this logic without duplicating it.
+ */
+export async function rotateLogFile(logPath: string, maxBytes: number): Promise<void> {
   try {
+    const stat = await fs.stat(logPath);
+    if (stat.size < maxBytes) return; // below threshold -- nothing to do
+
+    // Delete .2 to enforce 2-file cap before shifting files down
+    const backup2 = logPath + '.2';
     try {
-      const stat = await fs.stat(logPath);
-      if (stat.size >= MAX_QUEUE_POLL_FILE_SIZE) {
-        // Rotate: rename current log to .1 (overwrites any existing backup),
-        // then let the appendFile below create a fresh log file.
-        await fs.rename(logPath, logPath + '.1');
-      }
+      await fs.unlink(backup2);
     } catch {
-      // File does not exist yet or stat/rename failed -- proceed to append.
-      // On ENOENT: appendFile will create the file. On other errors: log entry
-      // will still be written to the existing (potentially oversized) file,
-      // and console.warn is emitted by the outer catch if appendFile itself fails.
+      // ENOENT is expected when no .2 exists -- silently skip
     }
+
+    // Shift .1 -> .2, then current -> .1
+    // WHY rename not copy: atomic on same filesystem, no partial-write risk
+    const backup1 = logPath + '.1';
+    try {
+      await fs.rename(backup1, backup2);
+    } catch {
+      // ENOENT if no .1 yet -- silently skip (first rotation)
+    }
+
+    await fs.rename(logPath, backup1);
+  } catch (e) {
+    // stat() failed (ENOENT: file does not exist yet) or final rename failed.
+    // Either way, log a warning and let the caller proceed with append.
+    // On ENOENT the file will be created fresh by appendFile -- no rotation needed.
+    const isEnoent = e instanceof Error && 'code' in e && (e as NodeJS.ErrnoException).code === 'ENOENT';
+    if (!isEnoent) {
+      console.warn(`[rotateLogFile] Failed to rotate ${logPath}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+}
+
+/**
+ * Append a JSON-line entry to the queue-poll log, rotating if the file exceeds
+ * MAX_QUEUE_POLL_FILE_SIZE.
+ *
+ * logPath is injectable for testing; defaults to ~/.workrail/queue-poll.jsonl.
+ */
+async function appendQueuePollLog(
+  entry: Record<string, unknown>,
+  logPath: string = path.join(os.homedir(), '.workrail', 'queue-poll.jsonl'),
+): Promise<void> {
+  try {
+    await rotateLogFile(logPath, MAX_QUEUE_POLL_FILE_SIZE);
     await fs.appendFile(logPath, JSON.stringify(entry) + '\n', 'utf8');
   } catch (e) {
     console.warn(`[QueuePoll] Failed to write queue-poll.jsonl: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/trigger/polling-scheduler.ts
+++ b/src/trigger/polling-scheduler.ts
@@ -852,9 +852,10 @@ async function countActiveSessions(sessionsDir: string): Promise<number> {
 
 /**
  * Maximum size of queue-poll.jsonl before rotation.
- * When the file reaches this size, it is renamed to queue-poll.jsonl.1
- * (overwriting any existing backup) and a fresh log file is started.
+ * When the file reaches this size, the .1 backup shifts to .2 (oldest deleted),
+ * the current file renames to .1, and a fresh log file is started.
  * WHY 10 MB: conservative cap holding ~5 weeks of history at 5-minute polling intervals.
+ * Two backup files gives ~10 weeks total retention.
  */
 const MAX_QUEUE_POLL_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 

--- a/tests/unit/polling-scheduler.test.ts
+++ b/tests/unit/polling-scheduler.test.ts
@@ -16,13 +16,18 @@
  * - forcePoll: returns wrong_provider for non-queue triggers
  * - forcePoll: runs one cycle and returns cycleRan=true when no poll in flight
  * - forcePoll: returns cycleRan=false when skip-cycle guard fires
+ * - rotateLogFile: does nothing when file is below threshold
+ * - rotateLogFile: rotates when file reaches threshold (rename to .1)
+ * - rotateLogFile: enforces 2-file cap (deletes .2 before shifting .1 -> .2)
+ * - rotateLogFile: does not throw when file does not exist (ENOENT)
+ * - rotateLogFile: logs warning on unexpected rotation failure (not ENOENT)
  */
 
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
-import { PollingScheduler } from '../../src/trigger/polling-scheduler.js';
+import { PollingScheduler, rotateLogFile } from '../../src/trigger/polling-scheduler.js';
 import { PolledEventStore } from '../../src/trigger/polled-event-store.js';
 import type { TriggerDefinition } from '../../src/trigger/types.js';
 import { asTriggerId } from '../../src/trigger/types.js';
@@ -936,5 +941,120 @@ describe('doPollGitHubQueue dispatch loop protection', () => {
     // attemptCount=2 < maxDispatchAttempts=3, so dispatch should proceed
     expect(adaptiveDispatched).toHaveLength(1);
     expect(adaptiveDispatched[0]?.goal).toBe('Implement login flow');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotateLogFile helper
+// ---------------------------------------------------------------------------
+
+describe('rotateLogFile', () => {
+  it('does nothing when the file is below the size threshold', async () => {
+    const tmpDir = await makeTmpDir();
+    const logPath = path.join(tmpDir, 'test.jsonl');
+
+    // Write content well below the 10 MB threshold
+    await fs.writeFile(logPath, 'entry\n'.repeat(10), 'utf8');
+
+    await rotateLogFile(logPath, 10 * 1024 * 1024);
+
+    // Original file still exists and unchanged; no .1 created
+    const exists = await fs.stat(logPath).then(() => true).catch(() => false);
+    expect(exists).toBe(true);
+    const backup1Exists = await fs.stat(logPath + '.1').then(() => true).catch(() => false);
+    expect(backup1Exists).toBe(false);
+  });
+
+  it('rotates when the file reaches the threshold (renames current to .1)', async () => {
+    const tmpDir = await makeTmpDir();
+    const logPath = path.join(tmpDir, 'test.jsonl');
+    const originalContent = 'a'.repeat(100);
+
+    await fs.writeFile(logPath, originalContent, 'utf8');
+
+    // Threshold of 50 bytes -- file is 100 bytes, should rotate
+    await rotateLogFile(logPath, 50);
+
+    // Original file is gone (renamed to .1)
+    const originalExists = await fs.stat(logPath).then(() => true).catch(() => false);
+    expect(originalExists).toBe(false);
+
+    // .1 exists with the original content
+    const backup1Content = await fs.readFile(logPath + '.1', 'utf8');
+    expect(backup1Content).toBe(originalContent);
+  });
+
+  it('enforces 2-file cap: deletes .2 before shifting .1 to .2 and current to .1', async () => {
+    const tmpDir = await makeTmpDir();
+    const logPath = path.join(tmpDir, 'test.jsonl');
+
+    // Set up: current file (oversized), .1 (first backup), .2 (second backup -- must be deleted)
+    await fs.writeFile(logPath, 'current'.repeat(20), 'utf8');
+    await fs.writeFile(logPath + '.1', 'backup1', 'utf8');
+    await fs.writeFile(logPath + '.2', 'backup2_to_be_deleted', 'utf8');
+
+    await rotateLogFile(logPath, 10); // threshold of 10 bytes -- triggers rotation
+
+    // .2 was deleted and replaced by old .1 content
+    const backup2Content = await fs.readFile(logPath + '.2', 'utf8');
+    expect(backup2Content).toBe('backup1');
+
+    // .1 now holds what was the current file
+    const backup1Content = await fs.readFile(logPath + '.1', 'utf8');
+    expect(backup1Content).toBe('current'.repeat(20));
+
+    // Original file is gone
+    const originalExists = await fs.stat(logPath).then(() => true).catch(() => false);
+    expect(originalExists).toBe(false);
+  });
+
+  it('does not throw when the file does not exist (ENOENT -- fresh start)', async () => {
+    const tmpDir = await makeTmpDir();
+    const logPath = path.join(tmpDir, 'nonexistent.jsonl');
+
+    // Should resolve without throwing -- ENOENT is silently swallowed
+    await expect(rotateLogFile(logPath, 100)).resolves.toBeUndefined();
+  });
+
+  it('logs a warning on unexpected rotation failure (not ENOENT)', async () => {
+    // WHY real filesystem instead of vi.spyOn(fs, 'rename'):
+    // node:fs/promises is an ESM module with non-configurable exports.
+    // vi.spyOn() cannot patch it at runtime -- only vi.mock() (module-level) can,
+    // but that would affect all tests in this file which rely on real I/O.
+    //
+    // Instead, we trigger EISDIR naturally: if backup1 (.1) exists as a non-empty
+    // directory, rename(current_file, .1) fails with EISDIR, which is caught by
+    // the outer try/catch and logged as a warning (not silently swallowed like ENOENT).
+    const tmpDir = await makeTmpDir();
+    const logPath = path.join(tmpDir, 'test.jsonl');
+
+    // Write an oversized file (above threshold of 10 bytes)
+    await fs.writeFile(logPath, 'x'.repeat(200), 'utf8');
+
+    // Trigger EISDIR on the final rename(logPath, .1) by making both .1 and .2
+    // non-empty directories.
+    //
+    // rotateLogFile's rotation sequence:
+    //   1. unlink(.2)         -- inner try/catch -- fails EISDIR, silently swallowed
+    //   2. rename(.1, .2)     -- inner try/catch -- fails ENOTEMPTY (.2 non-empty dir), swallowed
+    //   3. rename(logPath, .1) -- outer try/catch -- fails EISDIR (.1 still non-empty dir)
+    //
+    // Step 3 is caught by the outer catch, which logs the warning because EISDIR != ENOENT.
+    const backup1 = logPath + '.1';
+    await fs.mkdir(path.join(backup1, 'subdir'), { recursive: true });
+    await fs.writeFile(path.join(backup1, 'marker'), 'marker', 'utf8');
+    const backup2 = logPath + '.2';
+    await fs.mkdir(path.join(backup2, 'subdir'), { recursive: true });
+    await fs.writeFile(path.join(backup2, 'marker'), 'marker2', 'utf8');
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await rotateLogFile(logPath, 10);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[rotateLogFile] Failed to rotate'),
+    );
+
+    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- Adds size-based rotation to `queue-poll.jsonl` -- at 10 MB the current file is renamed to `.1`, keeping at most 2 files
- Extracts `rotateLogFile(logPath, maxBytes)` as a reusable exported helper so future callers (`outbox.jsonl`, `signals/<id>.jsonl`) can adopt the same scheme without duplication
- Best-effort: rotation failure logs a warning but never blocks the append

## Test plan

- [ ] All 33 tests pass in `tests/unit/polling-scheduler.test.ts`
- [ ] `rotateLogFile` tests cover: below-threshold no-op, rotation trigger, 2-file cap enforcement, ENOENT handling, warning on unexpected failure
- [ ] Pre-existing failures in `cli-validate.test.ts` / `bin-executable.smoke.test.ts` are unrelated (require built `dist/`, absent in fresh worktrees)

## Notes

The warning-path test (`logs a warning on unexpected rotation failure`) cannot use `vi.spyOn(fs, 'rename')` because ESM modules have non-configurable exports. The test instead uses a real filesystem scenario: creating `.1` and `.2` as non-empty directories causes `rename(current, .1)` to fail with EISDIR, which is caught by the outer catch and logged as a warning. The test comment documents this technique.

Closes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)