### PR TITLE
fix(daemon): poll health endpoint on --start instead of fixed wait

### DIFF
--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -361,6 +361,22 @@ program
         },
         print: (line: string) => console.log(line),
         sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+        httpGet: async (url: string): Promise<number | null> => {
+          // WHY: the health check in runStart() needs to make an HTTP GET to the
+          // daemon's /health endpoint. We use Node's built-in http module here
+          // so there is no extra dependency. Errors (ECONNREFUSED, timeout, etc.)
+          // return null -- the caller handles null as "not yet up".
+          const { get } = await import('http');
+          return new Promise((resolve) => {
+            const req = get(url, { timeout: 1000 }, (res) => {
+              // Consume response body to free the socket.
+              res.resume();
+              resolve(res.statusCode ?? null);
+            });
+            req.on('error', () => resolve(null));
+            req.on('timeout', () => { req.destroy(); resolve(null); });
+          });
+        },
         startDaemon: async () => {
           // Load .env again as defense-in-depth: this callback may be invoked
           // from paths other than the daemon action handler in the future.

--- a/src/cli/commands/worktrain-daemon.ts
+++ b/src/cli/commands/worktrain-daemon.ts
@@ -136,6 +136,15 @@ export interface WorktrainDaemonCommandDeps {
   /** Sleep for the given number of milliseconds. */
   readonly sleep: (ms: number) => Promise<void>;
   /**
+   * Make an HTTP GET request and return the response status code, or null on
+   * any error (connection refused, network timeout, non-HTTP error, etc.).
+   *
+   * WHY this dep exists: the health check in runStart() must poll the daemon's
+   * /health endpoint to verify real liveness, not just launchctl PID presence.
+   * Injecting it keeps runStart() testable without a real HTTP server.
+   */
+  readonly httpGet: (url: string) => Promise<number | null>;
+  /**
    * Start the trigger listener daemon process. Called when `worktrain daemon`
    * is invoked with no flags -- the launchd entry point.
    *
@@ -328,6 +337,40 @@ function parseLaunchctlList(
   } catch {
     return { running: false, pid: null, loaded: false };
   }
+}
+
+/**
+ * Poll `url` until it responds with HTTP 200, or until `maxAttempts` is
+ * exhausted. Sleeps `intervalMs` before each attempt.
+ *
+ * WHY polling instead of a fixed wait: a fixed wait creates a false-positive
+ * when the daemon crashes immediately after launch -- launchctl briefly shows
+ * a PID for the exited process. Polling the actual health endpoint is the
+ * authoritative liveness check: if /health responds 200, the daemon is up.
+ *
+ * WHY exported: the polling logic is reusable for a future `--status` command
+ * that also needs to check whether the daemon is alive.
+ *
+ * Sleep happens BEFORE the httpGet call so the daemon has time to start
+ * binding its port on the first attempt.
+ */
+export async function pollHealthEndpoint(
+  url: string,
+  deps: Pick<WorktrainDaemonCommandDeps, 'httpGet' | 'sleep'>,
+  maxAttempts: number,
+  intervalMs: number,
+): Promise<{ readonly ok: true } | { readonly ok: false; readonly reason: string }> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    await deps.sleep(intervalMs);
+    const status = await deps.httpGet(url);
+    if (status === 200) {
+      return { ok: true };
+    }
+  }
+  return {
+    ok: false,
+    reason: `Health endpoint did not respond after ${maxAttempts} attempts (${(maxAttempts * intervalMs) / 1000}s).`,
+  };
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -608,20 +651,30 @@ async function runStart(deps: WorktrainDaemonCommandDeps): Promise<CliResult> {
     );
   }
 
-  // Brief wait then verify
-  await deps.sleep(1000);
-  const listResult = await deps.exec('launchctl', ['list', LAUNCHD_LABEL]);
-  const status = parseLaunchctlList(listResult.stdout, listResult.exitCode);
+  // Poll the daemon's health endpoint to verify liveness, not just PID presence.
+  // WHY: a fixed wait + launchctl PID check gives a false positive when the daemon
+  // crashes immediately -- the PID may be briefly visible after exit. Polling
+  // /health is the authoritative liveness signal.
+  const port = deps.env['WORKRAIL_TRIGGER_PORT']
+    ? parseInt(deps.env['WORKRAIL_TRIGGER_PORT'], 10)
+    : 3200;
+  const healthUrl = `http://127.0.0.1:${port}/health`;
+  const poll = await pollHealthEndpoint(healthUrl, deps, 10, 500);
 
-  if (status.running) {
-    deps.print(`WorkTrain daemon started (PID ${status.pid}).`);
+  if (poll.ok) {
+    deps.print('Daemon started successfully.');
     deps.print(`Logs: ${logDir}/daemon.stdout.log`);
-    return success({ message: `WorkTrain daemon started (PID ${status.pid})` });
+    return success({ message: 'Daemon started successfully' });
   }
 
   return failure(
-    'launchctl start returned 0 but daemon does not appear to be running.',
-    { suggestions: [`View logs: tail -f ${logDir}/daemon.stderr.log`] },
+    `Daemon did not respond to health check at ${healthUrl} within 5 seconds.`,
+    {
+      suggestions: [
+        `View logs: tail -f ${logDir}/daemon.stderr.log`,
+        `Check daemon status: worktrain daemon --status`,
+      ],
+    },
   );
 }
 

--- a/src/cli/commands/worktrain-daemon.ts
+++ b/src/cli/commands/worktrain-daemon.ts
@@ -84,6 +84,12 @@ const CAPTURED_ENV_VARS = [
   'USER',
   'PATH',
 
+  // Trigger webhook listener port (default 3200). Must be in plist so the
+  // daemon and the --start health check both use the same port. Without this,
+  // a user with WORKRAIL_TRIGGER_PORT set in their shell would poll the wrong
+  // port during --start and get a false "daemon did not respond" failure.
+  'WORKRAIL_TRIGGER_PORT',
+
   // WorkRail developer overrides (useful for local dev installs)
   'WORKRAIL_DEV',
   'WORKRAIL_LOG_LEVEL',

--- a/tests/unit/worktrain-daemon.test.ts
+++ b/tests/unit/worktrain-daemon.test.ts
@@ -98,6 +98,9 @@ function buildFakeDeps(overrides: Partial<WorktrainDaemonCommandDeps> = {}): Wor
     exec: defaultExec,
     print: (line) => printed.push(line),
     sleep: async () => undefined,
+    // Default: health endpoint responds 200 immediately.
+    // Override in specific tests to simulate timeout (return null) or custom port checks.
+    httpGet: async (_url: string): Promise<number | null> => 200,
 
     ...overrides,
   };
@@ -419,7 +422,7 @@ describe('worktrain daemon --start', () => {
     expect(startCall?.args[1]).toBe('io.worktrain.daemon');
   });
 
-  it('returns success with PID when daemon starts successfully', async () => {
+  it('returns success when health endpoint responds 200', async () => {
     const deps = buildFakeDeps();
     deps.files.set(PLIST_PATH, { content: '<plist />' });
 
@@ -427,7 +430,7 @@ describe('worktrain daemon --start', () => {
 
     expect(result.kind).toBe('success');
     if (result.kind === 'success') {
-      expect(result.output?.message).toContain('PID 42');
+      expect(result.output?.message).toContain('Daemon started successfully');
     }
   });
 
@@ -457,6 +460,46 @@ describe('worktrain daemon --start', () => {
     if (result.kind === 'failure') {
       expect(result.output.message).toContain('macOS');
     }
+  });
+
+  it('returns failure when health endpoint never responds (daemon crashed)', async () => {
+    // Simulate daemon crash: httpGet always returns null (connection refused).
+    const deps = buildFakeDeps({
+      httpGet: async (_url: string): Promise<number | null> => null,
+    });
+    deps.files.set(PLIST_PATH, { content: '<plist />' });
+
+    const result = await executeWorktrainDaemonCommand(deps, { start: true });
+
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      // Should mention the log path so operator knows where to look.
+      expect(result.output.message).toContain('5 seconds');
+    }
+  });
+
+  it('uses WORKRAIL_TRIGGER_PORT env var for health endpoint URL', async () => {
+    const capturedUrls: string[] = [];
+    const deps = buildFakeDeps({
+      env: {
+        ...{
+          AWS_PROFILE: 'test-profile',
+          WORKRAIL_TRIGGERS_ENABLED: 'true',
+          HOME: '/Users/test',
+          PATH: '/usr/local/bin:/usr/bin:/bin',
+        },
+        WORKRAIL_TRIGGER_PORT: '9999',
+      },
+      httpGet: async (url: string): Promise<number | null> => {
+        capturedUrls.push(url);
+        return 200;
+      },
+    });
+    deps.files.set(PLIST_PATH, { content: '<plist />' });
+
+    await executeWorktrainDaemonCommand(deps, { start: true });
+
+    expect(capturedUrls.some((url) => url.includes(':9999'))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replaces the 1-second fixed wait + `launchctl list` PID check in `worktrain daemon --start` with polling against the daemon's `/health` endpoint
- Polls every 500ms for up to 5 seconds; reports success only when HTTP 200 is received
- Port respects `WORKRAIL_TRIGGER_PORT` env var (default 3200)
- Extracts `pollHealthEndpoint()` as an exported module-level helper for future `--status` reuse (mirrors the existing `parseLaunchctlList()` pattern)
- Failure message includes log path so operators know where to look

Closes #896

## Test plan

- [ ] `npx vitest run tests/unit/worktrain-daemon.test.ts` passes (54 tests: 52 existing + 2 new)
- [ ] New test: `returns failure when health endpoint never responds (daemon crashed)` -- httpGet returns null, expect failure with '5 seconds' in message
- [ ] New test: `uses WORKRAIL_TRIGGER_PORT env var for health endpoint URL` -- captures URL, asserts port 9999
- [ ] `npx vitest run` passes with no new failures (pre-existing failures in smoke/bin-executable, cli-validate, cli-version unrelated -- require compiled binary)
- [ ] `npx tsc --noEmit` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)