### PR TITLE
feat(engine): add triggerSource attribution to run_started events

### DIFF
--- a/src/daemon/tools/spawn-agent.ts
+++ b/src/daemon/tools/spawn-agent.ts
@@ -119,7 +119,7 @@ export function makeSpawnAgentTool(
         // stays unchanged. parentSessionId is extracted in buildInitialEvents() to populate
         // session_created.data (typed, durable, DAG-queryable).
         // is_autonomous: 'true' marks the child as a daemon-owned session.
-        { is_autonomous: 'true', workspacePath: String(params.workspacePath), parentSessionId: thisWorkrailSessionId },
+        { is_autonomous: 'true', workspacePath: String(params.workspacePath), parentSessionId: thisWorkrailSessionId, triggerSource: 'daemon' },
       );
 
       if (startResult.isErr()) {

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -2856,7 +2856,7 @@ export async function buildPreAgentSession(
     const startResult = await executeStartWorkflow(
       { workflowId: trigger.workflowId, workspacePath: trigger.workspacePath, goal: trigger.goal },
       ctx,
-      { is_autonomous: 'true', workspacePath: trigger.workspacePath },
+      { is_autonomous: 'true', workspacePath: trigger.workspacePath, triggerSource: 'daemon' },
     );
     if (startResult.isErr()) {
       writeExecutionStats(statsDir, sessionId, trigger.workflowId, startMs, 'error', 0);

--- a/src/mcp/handlers/v2-execution/index.ts
+++ b/src/mcp/handlers/v2-execution/index.ts
@@ -84,7 +84,7 @@ export async function handleV2StartWorkflow(
   const rememberedRootFailure = await rememberExplicitWorkspaceRoot(input.workspacePath, guard.ctx.v2.rememberedRootsStore);
   if (rememberedRootFailure) return rememberedRootFailure;
 
-  return executeStartWorkflow(input, guard.ctx).match(
+  return executeStartWorkflow(input, guard.ctx, { triggerSource: 'mcp' }).match(
     (result) => success(attachV2ExecutionRenderMetadata({
       response: result.response,
       lifecycle: 'start',

--- a/src/mcp/handlers/v2-execution/start.ts
+++ b/src/mcp/handlers/v2-execution/start.ts
@@ -255,11 +255,13 @@ export function buildInitialEvents(args: {
         workflowHash,
         workflowSourceKind,
         workflowSourceRef,
-        // WHY extracted from internalContext (not a public input field): the public
+        // WHY extracted from extraContext (not a public input field): the public
         // V2StartWorkflowInput schema stays unchanged. The daemon passes 'daemon' via
-        // internalContext; MCP sessions omit it and the field is undefined (backward compat).
-        ...(internalContext?.['triggerSource'] === 'daemon' || internalContext?.['triggerSource'] === 'mcp'
-          ? { triggerSource: internalContext['triggerSource'] as 'daemon' | 'mcp' }
+        // extraContext; MCP sessions pass 'mcp'. extraContext is the parameter name
+        // in buildInitialEvents -- internalContext is the name in executeStartWorkflow
+        // which forwards it as extraContext when calling buildInitialEvents.
+        ...(extraContext?.['triggerSource'] === 'daemon' || extraContext?.['triggerSource'] === 'mcp'
+          ? { triggerSource: extraContext['triggerSource'] as 'daemon' | 'mcp' }
           : {}),
       },
     },

--- a/src/mcp/handlers/v2-execution/start.ts
+++ b/src/mcp/handlers/v2-execution/start.ts
@@ -255,6 +255,12 @@ export function buildInitialEvents(args: {
         workflowHash,
         workflowSourceKind,
         workflowSourceRef,
+        // WHY extracted from internalContext (not a public input field): the public
+        // V2StartWorkflowInput schema stays unchanged. The daemon passes 'daemon' via
+        // internalContext; MCP sessions omit it and the field is undefined (backward compat).
+        ...(internalContext?.['triggerSource'] === 'daemon' || internalContext?.['triggerSource'] === 'mcp'
+          ? { triggerSource: internalContext['triggerSource'] as 'daemon' | 'mcp' }
+          : {}),
       },
     },
     {

--- a/src/trigger/coordinator-deps.ts
+++ b/src/trigger/coordinator-deps.ts
@@ -133,7 +133,7 @@ export function createCoordinatorDeps(
       const startResult = await executeStartWorkflow(
         { workflowId, workspacePath: workspace, goal },
         ctx,
-        { is_autonomous: 'true', workspacePath: workspace },
+        { is_autonomous: 'true', workspacePath: workspace, triggerSource: 'daemon' },
       );
       if (startResult.isErr()) {
         const detail = `${startResult.error.kind}${'message' in startResult.error ? ': ' + (startResult.error as { message: string }).message : ''}`;

--- a/src/v2/durable-core/schemas/session/events.ts
+++ b/src/v2/durable-core/schemas/session/events.ts
@@ -68,6 +68,14 @@ const RunStartedDataV1Schema = z.object({
   workflowHash: workflowHashSchema,
   workflowSourceKind: WorkflowSourceKindSchema,
   workflowSourceRef: z.string().min(1),
+  /**
+   * Whether this session was started by the WorkTrain daemon or a human via MCP.
+   * Optional for backward compatibility with sessions created before this field existed.
+   * WHY: the only reliable way to distinguish daemon-initiated sessions from human-initiated
+   * ones is at start time. Every session-level metric (ROI, cost attribution, success rate
+   * by source) is ambiguous without this. Durable in the event log and queryable forever.
+   */
+  triggerSource: z.enum(['daemon', 'mcp']).optional(),
 });
 
 /**

--- a/src/v2/usecases/console-routes.ts
+++ b/src/v2/usecases/console-routes.ts
@@ -915,7 +915,7 @@ export function mountConsoleRoutes(
       // Mark as autonomous so isAutonomous is derivable from the event log.
       // workspacePath is written into the context_set event so the console can group sessions
       // by workspace even when workspace anchor resolution produces empty observations.
-      { is_autonomous: 'true', workspacePath },
+      { is_autonomous: 'true', workspacePath, triggerSource: 'daemon' },
     );
 
     if (startResult.isErr()) {

--- a/src/v2/usecases/console-service.ts
+++ b/src/v2/usecases/console-service.ts
@@ -1042,6 +1042,20 @@ function projectSessionSummary(
     );
   })();
 
+  // Derive triggerSource from run_started events. Always non-optional at this layer:
+  // old sessions without the field are backfilled using isAutonomous as a proxy.
+  const triggerSource = ((): 'daemon' | 'mcp' => {
+    if (sortedEventsRes.isOk()) {
+      for (const e of sortedEventsRes.value) {
+        if (e.kind === 'run_started' && e.data.triggerSource !== undefined) {
+          return e.data.triggerSource;
+        }
+      }
+    }
+    // Backfill: sessions predating this field -- daemon sessions had is_autonomous: 'true'.
+    return isAutonomous ? 'daemon' : 'mcp';
+  })();
+
   const metrics = projectSessionMetricsV2(events);
 
   const runs = Object.values(dag.runsById);
@@ -1067,6 +1081,7 @@ function projectSessionSummary(
       repoRoot,
       lastModifiedMs,
       isAutonomous,
+      triggerSource,
       isLive,
       parentSessionId,
       metrics,
@@ -1124,6 +1139,7 @@ function projectSessionSummary(
     repoRoot,
     lastModifiedMs,
     isAutonomous,
+    triggerSource,
     isLive,
     parentSessionId,
     metrics,

--- a/src/v2/usecases/console-service.ts
+++ b/src/v2/usecases/console-service.ts
@@ -1164,11 +1164,27 @@ function projectSessionDetail(
   const sortedEventsRes = asSortedEventLog(events);
   const sessionTitle = sortedEventsRes.isOk() ? deriveSessionTitle(sortedEventsRes.value) : null;
 
+  // Derive triggerSource from run_started events (same backfill logic as projectSessionSummary).
+  const detailTriggerSource = ((): 'daemon' | 'mcp' => {
+    if (sortedEventsRes.isOk()) {
+      for (const e of sortedEventsRes.value) {
+        if (e.kind === 'run_started' && e.data.triggerSource !== undefined) {
+          return e.data.triggerSource;
+        }
+      }
+    }
+    const contextRes = sortedEventsRes.isOk() ? projectRunContextV2(sortedEventsRes.value) : err(sortedEventsRes.error as never);
+    const isAutonomous = contextRes.isOk() && Object.values(contextRes.value.byRunId).some(
+      (runCtx) => runCtx.context['is_autonomous'] === 'true',
+    );
+    return isAutonomous ? 'daemon' : 'mcp';
+  })();
+
   const dagRes = projectRunDagV2(events);
   if (dagRes.isErr()) {
     // metrics and repoRoot are null here as placeholders; the caller (getSessionDetail)
     // always overrides these with the actual computed values via spread.
-    return { sessionId, sessionTitle, health: sessionHealth, runs: [], metrics: null, repoRoot: null };
+    return { sessionId, sessionTitle, health: sessionHealth, runs: [], metrics: null, repoRoot: null, triggerSource: detailTriggerSource };
   }
 
   const statusRes = sortedEventsRes.isOk() ? projectRunStatusSignalsV2(sortedEventsRes.value) : err(sortedEventsRes.error);
@@ -1257,7 +1273,7 @@ function projectSessionDetail(
 
   // metrics and repoRoot are null here as placeholders; the caller (getSessionDetail)
   // always overrides these with the actual computed values via spread.
-  return { sessionId, sessionTitle, health: sessionHealth, runs, metrics: null, repoRoot: null };
+  return { sessionId, sessionTitle, health: sessionHealth, runs, metrics: null, repoRoot: null, triggerSource: detailTriggerSource };
 }
 
 /**

--- a/src/v2/usecases/console-types.ts
+++ b/src/v2/usecases/console-types.ts
@@ -189,6 +189,10 @@ export interface ConsoleSessionDetail {
    * Used by the diff-summary endpoint to run git diff in the correct directory.
    */
   readonly repoRoot: string | null;
+  /** Whether this session was started by the WorkTrain daemon or a human via MCP.
+   * Same backfill logic as ConsoleSessionSummary: old sessions without the field
+   * default to 'daemon' when isAutonomous is true, 'mcp' otherwise. */
+  readonly triggerSource: 'daemon' | 'mcp';
 }
 
 // ---------------------------------------------------------------------------

--- a/src/v2/usecases/console-types.ts
+++ b/src/v2/usecases/console-types.ts
@@ -48,6 +48,12 @@ export interface ConsoleSessionSummary {
   /** True when the session was started by the WorkRail autonomous daemon.
    * Durable: derived from context_set event with is_autonomous: 'true'. */
   readonly isAutonomous: boolean;
+  /**
+   * Whether this session was started by the WorkTrain daemon or a human via MCP.
+   * Always non-optional at this layer. Old sessions without the field in their
+   * run_started event are backfilled: 'daemon' when isAutonomous is true, 'mcp' otherwise.
+   */
+  readonly triggerSource: 'daemon' | 'mcp';
   /** True when the daemon event log for today contains a session_started event for this
    * session but no session_completed event. Derived from disk -- survives console restarts.
    * False on any read error (safe default). */


### PR DESCRIPTION
## Problem

No reliable way to determine whether a session was started by the WorkTrain daemon or a human via the MCP server. Every session-level metric (ROI, cost, success rate by source) is ambiguous.

## Design

Three layers, each with the right invariant:

- **Schema** (\`events.ts\`): \`triggerSource\` is \`.optional()\` in Zod -- old session logs without the field still validate cleanly
- **Write layer**: every \`executeStartWorkflow\` callsite now passes \`'daemon'\` or \`'mcp'\` via \`internalContext\`, so no new session is ever written without it
- **Projected view** (\`ConsoleSessionSummary\`): \`triggerSource: 'daemon' | 'mcp'\` is required -- old sessions are backfilled using \`isAutonomous\` as proxy (daemon sessions had \`is_autonomous: 'true'\`)

## Changes

- \`src/v2/durable-core/schemas/session/events.ts\` -- optional field on \`RunStartedDataV1Schema\`
- \`src/mcp/handlers/v2-execution/start.ts\` -- extracts from \`internalContext\` at emit time
- \`src/mcp/handlers/v2-execution/index.ts\` -- MCP callsite passes \`'mcp'\`
- \`src/daemon/workflow-runner.ts\`, \`spawn-agent.ts\`, \`coordinator-deps.ts\`, \`console-routes.ts\` -- daemon callsites pass \`'daemon'\`
- \`src/v2/usecases/console-types.ts\` -- \`ConsoleSessionSummary.triggerSource\` required
- \`src/v2/usecases/console-service.ts\` -- projection with backfill logic