### PR TITLE
docs: add WorkTrain vision document and complete backlog updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,8 @@ The WorkRail Console is a browser-based dashboard for inspecting workflow sessio
 
 Do not duplicate information that already exists in a doc. Instead, point agents and readers to the right file. For the full documentation index, see `docs/README.md`.
 
+**Read this first:** `docs/vision.md` -- what WorkTrain is, what success looks like, and the principles every decision is held against. Every agent operating in this repo should read this before doing any work. It is short.
+
 ### Planning system
 
 The planning system follows a graduation path: ideas -> roadmap -> tickets -> execution.

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -3,6 +3,8 @@
 Workflow and feature ideas worth capturing but not yet planned or designed.
 For historical narrative and sprint journals, see `docs/history/worktrain-journal.md`.
 
+**Before reading this backlog, read the vision:** `docs/vision.md` -- what WorkTrain is, what success looks like, and the principles every decision is held against. Every item in this backlog should serve that vision. If it doesn't, it shouldn't be here.
+
 **To see a sorted priority view, run:**
 ```bash
 npm run backlog                                       # full list, grouped by blocked/unblocked

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -283,6 +283,38 @@ Five dimensions, each scored 1-3. Score = sum (max 15). Items marked **Blocked**
 
 ---
 
+### `delivery_failed` unreachable in `getChildSessionResult` -- type promises more than code delivers (Apr 30, 2026)
+
+**Status: bug** | Priority: medium
+
+**Score: 10** | Cor:3 Cap:1 Eff:2 Lev:2 Con:2 | Blocked: no
+
+`ChildSessionResult` has `reason: 'delivery_failed'` as a variant of `kind: 'failed'`. However `fetchChildSessionResult` in `coordinator-deps.ts` reads session status through `ConsoleService.getSessionDetail`, which returns statuses like `complete`/`blocked`/`in_progress` -- it never returns a `delivery_failed` status. `delivery_failed` is a `TriggerRouter`-level concept (callbackUrl POST failure) that is not stored as a session status in the event log. Child sessions spawned via `spawnSession`/`spawnAndAwait` have no `callbackUrl` and cannot produce it through this code path.
+
+The result: coordinators using `getChildSessionResult` can never observe `reason: 'delivery_failed'`, even though the type says they might. This violates the "make illegal states unrepresentable" principle -- the type union promises a variant the implementation cannot produce on this path.
+
+**Architectural fix (not a comment):** surface `delivery_failed` through session status. When `TriggerRouter` records a `delivery_failed` outcome, write a corresponding session event or status that `ConsoleService.getSessionDetail` returns. Then `fetchChildSessionResult` can map it correctly. This closes the gap between what the type promises and what the infrastructure delivers.
+
+Alternative: if `spawnSession`/`spawnAndAwait` child sessions genuinely cannot have `delivery_failed` outcomes by design, remove `reason: 'delivery_failed'` from `ChildSessionResult` entirely and document that it only exists in `spawn_agent`'s direct outcome mapping.
+
+**Things to hash out:**
+- Should `delivery_failed` be surfaced through ConsoleService (requires touching session status storage), or removed from `ChildSessionResult` since the `spawnSession` path provably cannot produce it?
+- If surfaced: what event or field in the session store carries this status, and how does ConsoleService project it?
+
+---
+
+### `spawnAndAwait` duplicates ~90 lines of polling logic from `awaitSessions` (Apr 30, 2026)
+
+**Status: tech debt** | Priority: low
+
+**Score: 8** | Cor:1 Cap:1 Eff:2 Lev:1 Con:3 | Blocked: no
+
+`spawnAndAwait` in `coordinator-deps.ts` contains an inline polling loop (~90 lines) that duplicates the logic in `awaitSessions`. The WHY comment explains a real construction-time constraint: object literals cannot reference sibling methods by name during construction. But this constraint applies to methods on the returned object -- it does not apply to closure-level functions, which are already used for `fetchAgentResult` and `fetchChildSessionResult`.
+
+**Fix:** extract a `pollUntilTerminal(handles: string[], timeoutMs: number): Promise<'completed' | 'timed_out' | 'degraded'>` closure-level function (before the `return {}` block). Have both `awaitSessions` and `spawnAndAwait` call it. This eliminates the duplication without violating the construction-time constraint.
+
+---
+
 ### Daemon architecture: remaining migrations (Apr 29, 2026)
 
 **Status: partial** | A9 shipped Apr 29, 2026.
@@ -1869,9 +1901,13 @@ A proof record contains: `prNumber`, `goal`, `verificationChain` (array of `{ ki
 
 ### Scripts-first coordinator: avoid the main agent wherever possible (Apr 15, 2026)
 
-**Status: idea** | Priority: high
+**Status: partial** | Foundation shipped PR #908 (Apr 30, 2026)
 
 **Score: 12** | Cor:1 Cap:3 Eff:2 Lev:3 Con:3 | Blocked: no
+
+**What shipped:** `ChildSessionResult` discriminated union, `getChildSessionResult()`, `spawnAndAwait()`, `parentSessionId` threading, `wr.coordinator_result` artifact schema. The typed coordinator primitives that enable in-process coordinator scripts are now available.
+
+**What's still needed:** the actual coordinator scripts (full development pipeline, bug-fix coordinator, grooming coordinator) and the `worktrain spawn`/`await` CLI commands that wrap these primitives for shell scripts.
 
 **The insight:** In a coordinator workflow, the main agent spends most of its time on mechanical work -- reading PR lists, checking CI status, deciding whether findings are blocking, sequencing merges. That's all deterministic logic. An LLM is expensive, slow, and inconsistent for deterministic work.
 
@@ -2038,7 +2074,7 @@ WorkTrain notices things without being asked. After a batch of work lands, it sc
 
 ### Native multi-agent orchestration: coordinator sessions + session DAG (Apr 15, 2026)
 
-**Status: idea** | Priority: high
+**Status: partial** | Typed primitives shipped PR #908 (Apr 30, 2026)
 
 **Score: 10** | Cor:1 Cap:3 Eff:1 Lev:3 Con:2 | Blocked: no
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,59 @@
+# WorkTrain Vision
+
+## What WorkTrain is
+
+WorkTrain is an autonomous software development daemon. It runs continuously in the background, picks up tasks from external systems (GitHub issues, GitLab MRs, Jira tickets, webhooks), and drives them through the full development lifecycle -- discovery, shaping, implementation, review, fix, merge -- without human intervention between phases.
+
+The operator's job is to configure what WorkTrain works on and what rules it follows. WorkTrain's job is to do the actual work, autonomously, reliably, and correctly.
+
+## What success looks like
+
+An operator assigns a ticket to WorkTrain in the morning. By the time they check in, there is a merged PR, a closed ticket, and a summary of what was done and why. They did not intervene between phases. Nothing surprising happened that required their attention.
+
+WorkTrain earns trust over time by doing this correctly, repeatedly, at scale -- not just for one-off tasks but as the default mode of software development.
+
+## What WorkTrain is not
+
+- **Not a chatbot or copilot.** WorkTrain does not assist humans doing development. It does development. The human is the operator, not the pair programmer.
+- **Not the WorkRail MCP server.** The WorkRail engine and MCP server are infrastructure WorkTrain uses. They are separate systems. Do not conflate them.
+- **Not a replacement for judgment.** WorkTrain surfaces decisions to humans when it hits genuine ambiguity. It does not pretend to understand things it does not, and it does not merge changes it is not confident in.
+
+## How WorkTrain thinks about work
+
+**Phases, not turns.** A task is a pipeline of phases: discovery, shaping, coding, review, fix, re-review, merge. Each phase is a session with a typed output contract. The coordinator decides what phase to run next based on the previous phase's structured result -- not on natural language reasoning.
+
+**Zero LLM turns for routing.** Coordinator decisions -- what workflow to run next, whether findings are blocking, when to merge -- are deterministic TypeScript code. LLM turns are used for cognitive work: understanding code, writing code, evaluating findings. Never for deciding "what do I do next?".
+
+**Structured outputs at every boundary.** Each phase produces a typed result. The next phase reads that result. Free-text scraping between phases is a design smell. `ChildSessionResult`, `wr.coordinator_result`, `wr.review_verdict` are the contracts that make phases composable without a main agent holding context.
+
+**Correctness over speed.** WorkTrain does not merge changes it is not confident in. Review findings are addressed. Tests pass. The right next step is not always the fastest one.
+
+## What makes WorkTrain different from other autonomous coding agents
+
+Most autonomous coding agents are single-session: they get a task, they work on it, they produce output. WorkTrain is a pipeline system: each phase is isolated, typed, and observable. The coordinator has no implicit memory -- it only knows what the typed outputs of previous phases told it. This makes pipelines:
+
+- **Reproducible**: the same task run twice takes the same path
+- **Observable**: every phase, every result, every decision is in the session store
+- **Recoverable**: a crashed phase is retried with the same inputs
+- **Auditable**: no black box; you can see exactly what each phase decided and why
+
+## Principles that guide every decision
+
+1. **Zero LLM turns for routing** -- coordinator logic is code, not reasoning
+2. **Typed contracts at phase boundaries** -- structured results, not free-text
+3. **The spec is the source of truth** -- every agent in a pipeline reads the same spec
+4. **Correctness over speed** -- do it right, not just done
+5. **Observable by default** -- every decision visible in the session store and console
+6. **Overnight-safe** -- the system must work while the operator is asleep
+
+## What is still being built
+
+WorkTrain is not finished. The vision above is where it is going, not where it is today. Key pieces still in progress:
+
+- **Living work context** -- shared knowledge document that accumulates across all phases so every agent starts informed (`docs/ideas/backlog.md`: "Living work context")
+- **Coordinator pipeline templates** -- actual coordinator scripts for full development pipeline, bug-fix, grooming (`docs/ideas/backlog.md`: "Scripts-first coordinator")
+- **`worktrain spawn`/`await` CLI** -- CLI surface for coordinator scripts
+- **Knowledge graph** -- per-workspace structural understanding so agents skip discovery on repeated tasks
+- **Spec as ground truth** -- wiring `wr.shaping` output into coordinator dispatch so coding/review agents work from the same spec
+
+For the current prioritized list, see `npm run backlog` or `docs/ideas/backlog.md`.


### PR DESCRIPTION
## Summary

- `docs/vision.md`: explicit statement of what WorkTrain is, what success looks like, the principles that guide every decision, and what is still being built
- Links from `docs/ideas/backlog.md` header and `AGENTS.md` so every agent reads it before starting work
- Backlog: mark Scripts-first coordinator and Native multi-agent orchestration as partial (typed primitives shipped PR #908)
- Backlog: add delivery_failed unreachability bug (issue #910), spawnAndAwait duplication tech debt, living work context entry, worktrain-meta repo entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)