### PR TITLE
feat(engine): inject prior workspace notes and git diff for all session entry points

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4739,19 +4739,16 @@ WorkTrain has no tooling to surface the state of worktrees and branches relative
 
 **Score: 9** | Cor:1 Cap:3 Eff:1 Lev:2 Con:2 | Blocked: no
 
-There is no reproducible way to compare WorkTrain against other AI coding systems (Cursor, Copilot, raw Claude Code, competing agent frameworks) or to compare model families within WorkTrain on the same real tasks. Without this, claims about WorkTrain's quality are anecdotal. A structured blind benchmark would produce empirical evidence about where WorkTrain adds value and where it falls short.
-
-The core idea: run the same coding task on N selected tools/models simultaneously, grade all outputs using a shared reusable rubric, and do the grading blind (an agent or series of parallel agents evaluates each submission without knowing which system produced it). Token usage is tracked per system so cost-adjusted comparisons are possible.
+There is no reproducible way to compare WorkTrain against other AI coding systems (Cursor, Copilot, raw Claude Code, competing agent frameworks) or to compare model families within WorkTrain on the same real tasks. Without this, claims about WorkTrain's quality are anecdotal and there is no principled way to understand where WorkTrain adds value versus where it falls short.
 
 **Things to hash out:**
-- What constitutes a valid "task" for comparison? Real GitHub issues from a well-understood repo are better than synthetic benchmarks, but they may not reproduce cleanly across different tool setups. What's the minimum reproducibility requirement?
-- How does the blind grading work in practice? The grading agent can't see the submission metadata, but it will see code style and comments that may reveal the model/tool. How blind is "blind" enough to be meaningful? Should we normalize submissions before grading (strip comments, rename vars)?
-- Should the rubric be global (same for all task types) or per-task-type (refactor vs feature vs bug fix)? A feature task and a debugging task have different quality signals.
-- Token usage comparison requires accurate accounting. WorkTrain sessions already record input/output tokens. Other tools may not expose this. How do we handle tools where token cost is opaque?
-- Is this a one-time study or a continuous regression benchmark? The demo-repo benchmark idea (existing backlog entry) covers regression -- this entry is specifically about cross-system comparative evaluation.
-- What is the right number of tasks to be statistically meaningful? 5 is too few; 100 is too many for a first pass. 15-20 tasks across 3 task types is probably the right starting point.
+- What constitutes a valid "task" for comparison? Real GitHub issues from a well-understood repo are higher quality than synthetic benchmarks, but may not reproduce cleanly across different tool setups. What is the minimum reproducibility requirement?
+- How do you grade fairly? A grader that can see code style, comments, or formatting may infer which system produced the output. What does true blind evaluation look like here, and how blind is "blind enough"?
+- Should the rubric be global (same for all task types) or per-task-type (refactor vs feature vs bug fix)?
+- Token usage comparison requires accurate per-system accounting. Not all tools expose this. Is a cost-adjusted comparison feasible, or does this reduce to a quality-only benchmark?
+- Is this a one-time study or a continuous regression benchmark? The demo-repo benchmark entry covers regression -- this is specifically about cross-system comparative evaluation.
 
-**Relationship to existing entries:** the demo-repo benchmark (existing entry) runs the same tasks after each WorkRail release to track regression. This entry is orthogonal -- it compares WorkTrain vs other systems, not WorkTrain past vs present.
+**Relationship to existing entries:** the demo-repo benchmark (existing entry) runs the same tasks after each WorkRail release to track regression. This entry is about comparing WorkTrain vs other systems, not WorkTrain past vs present.
 
 ---
 
@@ -4761,37 +4758,20 @@ The core idea: run the same coding task on N selected tools/models simultaneousl
 
 **Score: 13** | Cor:2 Cap:3 Eff:1 Lev:3 Con:2 | Blocked: no
 
-The current vision defines WorkTrain as an autonomous *software development* system. But the work that ships software is not just coding -- it's product management, design, data science, operations, release engineering, and the feedback loop from production back into ideas. WorkTrain should eventually be capable of covering every role that contributes to shipping software, not just the coding role.
+The current vision defines WorkTrain as an autonomous *software development* system. But shipping software requires more than coding -- product management, design, data science, operations, release engineering, and the feedback loop from production back into ideas are all necessary to deliver something that works and keeps working. WorkTrain currently handles only the coding-and-review slice of this. Everything before "write the code" (discovery what to build, analyzing what users actually need) and everything after "merge the PR" (instrumentation, metrics analysis, idea generation, rollout management, incident response) is done manually.
 
-**What this means concretely:**
+The result is that the value loop -- PR → metrics → insight → idea → spec → PR -- is only partially automated. Humans still have to bridge analysis → idea and metrics → iteration gaps. An autonomous system that stops at "ship a PR" requires continuous human intervention to keep it pointed at the right work.
 
-- **PM work:** Analyze a product area from usage metrics, session logs, user feedback, and issue patterns. Surface improvement opportunities backed by data, not intuition. Prioritize a backlog using real signal. Write specs grounded in evidence of what users need. Identify features whose value hypothesis can be tested quickly.
+The constraint on idea generation specifically: ideas grounded in vague intuition are not useful. The gap is not that WorkTrain can't generate suggestions -- it can. The gap is that those suggestions are not grounded in specific, verifiable facts about the actual system and its users. An idea like "23% of users who reach step 3 abandon, and the median time on that step is 47 seconds, and here is what the error logs show" is categorically different from "users might want X."
 
-- **Design work:** Produce interaction designs and design decisions grounded in the existing system's patterns, constraints, and user behavior data -- not pixel pushing, but the decisions about what to build, what to optimize for, what tradeoffs to accept. Review proposed designs against established patterns and flag inconsistencies or regressions.
-
-- **Data science / analytics:** Instrument features correctly, write and validate tracking, query event logs and metrics stores, identify anomalies, attribute causality from metrics changes, and produce the data-backed analysis that should precede any significant product decision.
-
-- **Fact-based idea generation:** WorkTrain should originate good ideas -- not generic LLM suggestions like "add a dark mode," but ideas grounded in specific evidence from production data, user behavior, competitive positioning, and system constraints. "Your p95 load time for this flow is 4.2s and 23% of users who reach step 3 abandon -- here is a data-backed hypothesis about why and a proposal for addressing it" is the kind of output this needs to produce. Every claim must be traceable to a specific data source, and the hypothesis stated in falsifiable form.
-
-- **Iterating on ideas with metrics:** Once a feature ships, WorkTrain closes the loop -- instruments it, collects data, compares against the hypothesis, and proposes iterations or reversals based on what the data shows.
-
-- **Release engineering and feature flags:** Manage the full rollout lifecycle -- create and configure feature flags, implement gradual rollouts, monitor metrics during rollout, automate rollback if a threshold is crossed, and clean up flags after full rollout.
-
-- **Operational excellence:** Monitor production health, respond to anomalies, investigate root cause with access to logs and traces, implement mitigations, and report on incidents with full context. This goes beyond anomaly detection to proactive operational improvement.
-
-**Why this matters:** The current vision stops at "ship a PR." But the value loop for software is PR → metrics → insight → idea → spec → PR → repeat. If WorkTrain only covers the middle of that loop and not the edges, humans have to manually bridge the analysis → idea and the metrics → iteration gaps. That defeats the purpose of having an autonomous system.
-
-**What distinguishes this from "crappy LLM ideas":** The constraint is that every claim must be traceable to a specific, verifiable data source. "Users might want X" is not a WorkTrain-quality idea. "23% of users who reach step 3 abandon at the form validation; the median time on that step is 47 seconds; the top 3 errors are Y, Z, W; here is what fixing those errors is projected to recover" is. The difference is specificity and falsifiability.
-
-**Relationship to existing entries:** This is the north star that many existing backlog entries are partial implementations of -- monitoring loops, analytics integration, feature flag management, opex, the blind benchmark / comparative study, subagent context packages. This entry captures the full frame so those individual entries can be understood as steps toward it rather than isolated features.
+**Relationship to existing entries:** Many existing backlog entries are partial implementations of this broader capability -- monitoring loops, analytics integration, feature flag management, opex, the blind benchmark entry. This entry captures the full frame so those entries can be understood as steps toward it rather than isolated features.
 
 **Things to hash out:**
-- The vision.md defines WorkTrain as "autonomous software development." Does expanding to design, PM, and data science require a vision revision, or is this a natural extension of "everything that ships software"?
-- Design work requires access to design systems, component libraries, and interaction patterns. What is WorkTrain's interface to design tooling (Figma, Storybook, etc.) and how does it learn the constraints of an existing system?
-- Data science work requires access to event logs, metrics stores, and potentially sensitive user data. What is the authorization model, and what is the minimum data needed to produce useful insights?
-- "Fact-based idea generation" requires WorkTrain to know what a good idea looks like in context -- product domain knowledge, not just technical knowledge. How does it acquire and maintain this? Workspace context (like AGENTS.md today) or accumulated from prior analysis sessions?
-- Release management requires write access to feature flag systems (LaunchDarkly, Statsig, homegrown). What safeguards prevent accidental wrong-pace rollouts or incorrect rollbacks?
-- How does opex (incident response, SLO management) interact with the current coding-focused pipeline? Separate workflow type, or extension of the existing one?
+- The vision.md defines WorkTrain as "autonomous software development." Does this require a vision revision, or is design/PM/data science/opex a natural extension of "everything that ships software"?
+- Design and PM work requires product domain knowledge -- not just technical knowledge. There is no obvious equivalent of AGENTS.md for product context. What is the right mechanism for WorkTrain to acquire and maintain that context?
+- Data science work requires access to event logs, metrics stores, and potentially sensitive user data. What is the authorization model? What is the minimum access needed to produce useful insights without exposing sensitive data?
+- Release management requires write access to production systems (feature flag platforms, deployment infrastructure). What safeguards are necessary before WorkTrain can act autonomously there?
+- Opex (incident response, SLO management) has a different urgency profile than coding work. How does it fit into the existing pipeline model, which is designed for hours-to-days timescales?
 
 ---
 
@@ -4801,21 +4781,12 @@ The current vision defines WorkTrain as an autonomous *software development* sys
 
 **Score: 12** | Cor:3 Cap:2 Eff:2 Lev:2 Con:2 | Blocked: no
 
-Agents routinely defer work within tasks rather than completing it. Common patterns: "I'll file a ticket for this later," "this is out of scope, leaving for a follow-up," "TODO: handle this edge case," "I noticed X but didn't address it to stay focused." These deferral patterns are individually plausible but collectively mean tasks are never actually finished -- they just transition from "in progress" to "apparently done" while work accumulates in a long tail of unfiled tickets and unresolved TODOs.
+Agents routinely defer work within tasks rather than completing it. Common patterns: "I'll file a ticket for this later," "this is out of scope, leaving for a follow-up," "TODO: handle this edge case," "I noticed X but didn't address it to stay focused." These deferral patterns are individually plausible but collectively mean tasks are never actually finished -- they transition from "in progress" to "apparently done" while work accumulates in a long tail of unfiled tickets and unresolved TODOs.
 
-The problem is not that agents identify things they can't do in a single session -- some deferral is legitimate. The problem is that there is no mechanism to distinguish "this genuinely needs a separate session with different scope" from "I could have done this but chose not to," and there is no enforcement that deferred items are actually tracked and eventually completed. A task that spawns three follow-up tickets without completing the core work is not done. A task that leaves TODOs in the code is not done.
-
-**What correct behavior looks like:** A completed task has no unresolved work that was in scope at the time of dispatch. If the agent determined that work was genuinely out of scope, that determination is documented and the coordinator decides whether to accept it or spawn a follow-up agent immediately. The agent cannot unilaterally declare something out of scope and move on -- it must surface the decision to the coordinator.
-
-**Mechanisms to explore:**
-- Completion proof requirement: before a session advances past its final step, it must produce a structured `CompletionProofArtifact` that itemizes what was done, what was explicitly deferred (with rationale), and what TODOs remain in the code. The coordinator inspects this before accepting the session as complete.
-- Deferred work detection: static analysis of the session output for TODO/FIXME/HACK markers, "I'll..." patterns in notes, open questions that weren't resolved. Any detection triggers either forced continuation or a follow-up spawn.
-- Scope boundary enforcement: agents declare scope at the start of a session (via the shaping artifact or trigger context). Anything discovered in-session that is in scope must either be handled or explicitly escalated, not silently deferred.
-- Parallel spawning: when an agent identifies legitimate deferred work, the coordinator can immediately spawn a parallel agent for that work rather than relying on a future human to file and prioritize a ticket.
+There is no mechanism to distinguish "this genuinely needs a separate session with different scope" from "I could have done this but chose not to." There is no enforcement that deferred items are tracked and eventually completed. There is no way to prove a task is actually done versus claimed done. A task that leaves TODOs in the code, or that defers 3 of its 5 acceptance criteria, is not done -- but the system currently has no way to detect or prevent this.
 
 **Things to hash out:**
-- What is the right place to enforce this -- in the workflow step definitions (each step has completion criteria), in the coordinator (inspects session output before accepting), or in the agent loop itself (turn-end subscriber checks for deferral patterns)?
-- How do you distinguish legitimate scope decisions from laziness? A session on a performance bug that identifies an unrelated security issue is right to defer the security issue. A session that fixes only 2 of 3 acceptance criteria and defers the third is not right to defer it. The distinction is whether the deferred work is in scope for the task or genuinely separate.
-- TODO comments in code are not always deferred work -- some are architectural notes, some are pre-existing. How does the completion proof system avoid false positives from pre-existing TODOs that the agent inherited?
-- If the agent is forced to continue when it wants to stop, what is the token budget and time limit for continuation? There needs to be a ceiling to prevent a stuck continuation loop.
-- How does this interact with the existing stuck detection system? An agent that keeps spinning on the same step because it can't complete it is already detected. This is different -- an agent that *could* complete but *chooses not to*.
+- What does "done" mean in a provable sense? What evidence would allow a coordinator to conclude that a task is complete rather than merely that an agent has stopped working on it?
+- How do you distinguish legitimate scope decisions from avoidance? A session on a performance bug that surfaces an unrelated security issue is right to defer the security issue. A session that addresses only 2 of 3 acceptance criteria is not. What is the principled distinction?
+- TODO comments in code are not always deferred work -- some are architectural notes, some are pre-existing. How do you identify TODOs that represent deferred task-scope work versus incidental notes?
+- How does this interact with the existing stuck detection system? A stuck agent and a "done-claiming but not actually done" agent are different failure modes. How does the system tell them apart?

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -192,6 +192,87 @@ The delivery pipeline was extracted into `delivery-pipeline.ts` with explicit st
 
 ## WorkTrain Daemon
 
+### Context injection bugs: double-injection, byte-slice truncation, workspaceRules[0] drop (Apr 30, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 13** | Cor:3 Cap:1 Eff:3 Lev:3 Con:3 | Blocked: no
+
+Three active bugs in the context injection pipeline that waste tokens, produce incorrect truncation, and silently discard workspace context. Confirmed by codebase audit (Apr 30, 2026).
+
+1. **Double-injection (`session-context.ts:117-119`):** `trigger.context` is JSON-serialized in full into the initial user message. Since coordinators write `assembledContextSummary` *into* `trigger.context`, the assembled context appears twice -- once in the system prompt (8KB cap applied) and once in the initial user message (uncapped). These diverge when the content exceeds 8KB.
+
+2. **Byte-slice truncation (`system-prompt.ts:200-202`):** `assembledContextSummary` is truncated by raw byte index (`ctxStr.slice(0, 8192)`), which splits mid-sentence, mid-section, and can produce malformed UTF-8. The section-aware `buildBudgetedOutput()` pattern already exists in `src/coordinators/context-assembly.ts` and handles this correctly.
+
+3. **`workspaceRules[0]` silent drop (`session-context.ts:106`):** `ContextBundle.workspaceRules` is typed as `ContextRule[]` but only `[0]` is consumed. All additional workspace context rules are silently dropped. The type implies per-file rules are supported; the consumer silently ignores them.
+
+**Also in scope:** introduce `WorkflowContextSlots` typed fields on `WorkflowTrigger` (or a companion type) for system-managed context fields (`assembledContextSummary`, `priorSessionNotes`, `gitDiffStat`). This eliminates the stringly-typed `trigger.context['assembledContextSummary']` access pattern and is a prerequisite for the universal enricher (see next item). Scope Phase 0 changes to consumption sites only (`buildSystemPrompt`, `buildSessionContext`); coordinator write sites migrate in Phase 1.
+
+**Done looks like:** no `trigger.context` JSON dump in `initialPrompt`; `assembledContextSummary` truncated at section boundaries; all `workspaceRules` entries injected; `WorkflowContextSlots` typed fields replace stringly-typed access in consumption sites.
+
+---
+
+### Universal context enricher for all session entry points (Apr 30, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 11** | Cor:1 Cap:3 Eff:2 Lev:3 Con:2 | Blocked: yes (needs context injection bugs fixed first)
+
+Today 4 of 6 session entry points receive zero assembled context: raw webhook triggers, direct dispatch, `spawn_agent` children, and crash-recovered sessions never get cross-session notes or git diff state. Only coordinator-spawned sessions (via `pr-review.ts` or the adaptive pipeline) get assembled context -- and even then only through opt-in coordinator logic, not structural injection.
+
+There is no single layer that all dispatch paths share where assembly can run universally. Coordinators that care must call assembly explicitly; everything else gets nothing. This means every new entry point or coordinator is another opportunity to forget assembly.
+
+**Design (from Apr 30 discovery):** A `WorkflowEnricher` service injected into `runWorkflow()` that fires for root sessions only (`spawnDepth === 0`). Provides prior workspace session notes (max 3, newest-first, workspace-scoped) and `git diff HEAD~1 --stat` to all entry points. Injected via `WorkflowContextSlots` typed fields (see context injection bugs item). When a coordinator has already set `assembledContextSummary`, the enricher skips prior-notes injection (coordinator's richer context takes precedence) but still provides git diff stat if absent.
+
+**Critical gate:** before this ships, run a pilot test -- one session with `assembledContextSummary` injected, inspect turn-1 reasoning for citation. If agents don't reference pre-loaded context, the investment in universal enrichment adds tokens without improving outcomes.
+
+**Things to hash out:**
+- Where exactly does the enricher inject: inside `runWorkflow()` before `buildPreAgentSession()`, or inside `buildPreAgentSession()` itself? The latter is cleaner but changes the pre-agent phase boundary.
+- `listRecentSessions` must have a 1s wall-clock timeout with partial-result fallback. Without it, large session stores silently slow all session startups. This is a spec requirement, not optional.
+- `spawn_agent` children don't get enriched (they'd trigger redundant assembly for deeply nested trees). Is there a case where children should optionally enrich? Candidate: an `inheritParentContext: boolean` flag in the `spawn_agent` tool schema.
+
+---
+
+### MemoryStore: indexed session history and mid-session query_memory tool (Apr 30, 2026)
+
+**Status: idea** | Priority: medium
+
+**Score: 10** | Cor:1 Cap:3 Eff:1 Lev:3 Con:2 | Blocked: yes (needs universal enricher first)
+
+The session event log is rich -- it records goals, step notes, artifacts, delivered commits, git state, and phase handoffs. But querying it requires a full directory scan and per-session event projection on every call. `LocalSessionSummaryProviderV2` does this today and is used in exactly one place (the PR-review coordinator). Every other consumer either skips it or re-implements a slower version.
+
+There is no mid-session memory query capability at all. An agent mid-session cannot ask "what did we decide about this module last week" and get an answer from persistent memory -- it can only use what was pre-loaded at session start.
+
+**Design (from Apr 30 discovery):** A `MemoryStore` port backed by `~/.workrail/memory.db` (SQLite, WAL mode) indexed by `finalizeSession()` as fire-and-forget after each session completes. Query kinds v1: `recent_sessions` (by workspace path hash), `sessions_by_goal_keywords`. A `query_memory` tool added to the daemon tool set. Replaces the slow `listRecentSessions` scan in the universal enricher.
+
+Phase 2b (separate): index phase artifacts via a new `phase_artifact_appended` session event kind -- bridges the current PipelineRunContext silo into the session event log so phase artifacts are queryable alongside session notes. Requires engine schema review before implementation.
+
+**Things to hash out:**
+- SQLite native compilation may fail in some deployment environments (Docker, Alpine Linux). Mitigation: use `@sqlite.org/sqlite-wasm` (pure WASM) or make `MemoryStore` fully optional -- daemon works without it, just no indexed queries.
+- `phase_artifact_appended` event schema change is the highest-risk part of Phase 2b. Should it reuse the existing artifact channel with a new content type, or be a new event kind? Each has different backward-compatibility implications.
+- Should `query_memory` be a general-purpose tool or typed with specific query kinds? A typed discriminated union prevents agents from inventing unsupported query shapes.
+
+---
+
+### worktrain session analyze: verify agents actually use pre-loaded context (Apr 30, 2026)
+
+**Status: idea** | Priority: medium
+
+**Score: 8** | Cor:1 Cap:2 Eff:2 Lev:2 Con:2 | Blocked: no
+
+There is no way to verify whether agents actually use pre-loaded context (soul, workspace context, `assembledContextSummary`, session notes) in their reasoning. The entire memory architecture investment (universal enricher, MemoryStore, knowledge graph) assumes agents reference pre-loaded context at turn 1 -- but this assumption is unvalidated. If agents receive 32KB of workspace context and `assembledContextSummary` but don't cite them in their reasoning before acting, richer pre-loading adds token cost without improving outcomes.
+
+Today, validating this requires manually reading raw session transcripts, which is impractical at scale. A `worktrain session analyze <sessionId>` command that reads the agent turn events and reports whether any pre-loaded context fields were cited in turn-1 reasoning would make this automatable and support data-driven decisions about context loading investment.
+
+**Done looks like:** `worktrain session analyze <sessionId>` reads the session event log, extracts turn-1 assistant message content, checks for citations of injected fields (workspace context file names, goal text, prior step note content), and reports a structured summary: fields injected, fields cited, fields ignored.
+
+**Things to hash out:**
+- "Citation" is hard to define precisely -- the agent might paraphrase rather than quote. Does substring matching suffice, or does this need an LLM similarity check?
+- Should this be a CLI command or a console feature? The console already reads session data; this could be a "context audit" view.
+- The primary use case is a one-time validation gate (before shipping the universal enricher). Does this justify a permanent command, or is it a one-off script?
+
+---
+
 ### Per-run retrospective: structured learning from pipeline outcomes (Apr 30, 2026)
 
 **Status: idea** | Priority: medium
@@ -1939,7 +2020,7 @@ Each file is injected only into sessions running the matching pipeline phase. Re
 
 **Status: idea** | Priority: medium
 
-**Score: 9** | Cor:1 Cap:2 Eff:2 Lev:2 Con:2 | Blocked: yes (needs knowledge graph for context assembly)
+**Score: 9** | Cor:1 Cap:2 Eff:2 Lev:2 Con:2 | Blocked: no (unblocked by Apr 30 discovery -- context assembly does not require the knowledge graph)
 
 **Problem:** `src/coordinators/pr-review.ts` is already ~500 LOC doing session dispatch, result aggregation, finding classification, merge routing, message queue drain, and outbox writes. Adding knowledge graph queries, context bundle assembly, and prior session lookups would create a god class.
 
@@ -1947,18 +2028,17 @@ Each file is injected only into sessions running the matching pipeline phase. Re
 ```
 Trigger layer         src/trigger/          receives events, validates, enqueues
 Dispatch layer        (TBD)                 decides which workflow + what goal
-Context assembly      (TBD)                 gathers and packages context before spawning
+Context assembly      src/daemon/           enriches trigger before runWorkflow() fires
 Orchestration layer   src/coordinators/     spawns, awaits, routes, retries, escalates
 Delivery layer        src/trigger/delivery  posts results back to origin systems
 ```
 
-**Context assembly** is the missing layer. Before dispatching a coding session, `assembleContext(task, workspace)` runs: knowledge graph query, upstream pitch/PRD fetch, relevant prior session notes, returns a structured context bundle. The orchestration script should call this, not own it.
+**Resolution from Apr 30 discovery:** Context assembly does NOT require the knowledge graph as a prerequisite. The universal enricher (Phase 1 of the memory architecture) provides a structural context assembly layer via `WorkflowEnricher` injected into `runWorkflow()` -- this IS the missing layer. The orchestration scripts (coordinators) continue to add task-specific richer context on top (phase artifacts, git diff for PRs) via the existing `assembledContextSummary` mechanism. The two layers compose: universal enricher provides the floor, coordinators provide the ceiling.
 
-**Things to hash out:**
-- The right layering puts "Dispatch layer (TBD)" between Trigger and Orchestration. What exactly does the dispatch layer decide, and how does it relate to the adaptive pipeline coordinator concept elsewhere in the backlog?
-- Context assembly requires the knowledge graph. What is the fallback when the KG is not yet built for a workspace -- does context assembly simply return empty, or does it fall back to a slower manual search?
-- Should context assembly run synchronously before dispatch (blocking the trigger listener) or asynchronously (session starts with partial context while assembly continues)?
-- Who owns the context assembly API contract -- the engine (as a new primitive), the daemon (as an infrastructure capability), or user-authored scripts?
+**The Dispatch layer question** is resolved by the adaptive pipeline coordinator (`src/coordinators/adaptive-pipeline.ts`) -- it IS the dispatch layer for queue-polled tasks. For webhook-triggered tasks, `TriggerRouter.route()` performs dispatch. The layering is already present; it just isn't documented as such.
+
+**Remaining open question:**
+- When a coordinator calls `spawnSession()` with an `assembledContextSummary`, should the universal enricher's prior-notes injection be suppressed (coordinator already covered it) or additive (both run)? The discovery recommends suppression -- enricher skips prior notes when `assembledContextSummary` is already set.
 
 ---
 
@@ -2384,6 +2464,42 @@ When an MR review session (run by a WorkTrain agent) finds issues in a coding se
 - How do you distinguish "the workflow is fine but this was a genuinely hard edge case" from "the workflow has a systematic gap"? A single miss doesn't prove a gap; multiple misses of the same kind do.
 - Should the analysis result feed directly into `workflow-effectiveness-assessment`, or is it a separate concern?
 - For the "coding agent missed it" case: is the right fix to change the coding workflow, or to make the review workflow more adversarial?
+
+---
+
+### wr.discovery lacks domain-specific ideation guidance (May 6, 2026)
+
+**Status: idea** | Priority: medium
+
+**Score: 9** | Cor:1 Cap:2 Eff:2 Lev:2 Con:2 | Blocked: no
+
+`wr.discovery` classifies `problemDomain` (software / product / ux / personal / general) and uses it for a few things -- philosophy source lookup, vision doc location, and `decisionCriteria` examples. But candidate generation, challenge framing, and resolution path guidance do not adapt to domain at all. A personal career decision, a product strategy question, and a software architecture problem have meaningfully different ideation patterns, different failure modes in candidate generation, different challenge rubrics, and different resolution artifacts. The workflow currently treats them all identically after `problemDomain` is set.
+
+The result is that `problemDomain` is a classification that carries almost no behavioral weight past phase-0 and phase-2. It reads well but does not change the actual work.
+
+**Things to hash out:**
+- Where is domain-specific guidance most needed? Candidate generation (different ideation patterns per domain) and challenge framing (different adversarial angles) are the clearest gaps. Are there others -- resolution mode selection, confidence dimensions, handoff format?
+- What is the right mechanism -- `promptFragments` conditioned on `problemDomain`, a domain-specific routine injected via `templateCall`, or richer domain context blocks injected at workflow start? The answer probably varies by where in the workflow the guidance applies.
+- How much domain specificity is enough? Software vs non-software is the biggest gap. Within non-software, personal vs product vs ux are also meaningfully different. Is a two-level split (software / general) sufficient for now, or is the full five-way split worth tackling immediately?
+- Are there domain-specific output formats worth considering? A personal decision probably ends with a different handoff shape than a software architecture decision -- different fields, different confidence dimensions, different "next actions" structure.
+
+---
+
+### wr.discovery anchors candidates to existing infrastructure instead of the ideal solution (Apr 30, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 11** | Cor:1 Cap:3 Eff:2 Lev:3 Con:2 | Blocked: no
+
+`wr.discovery` produces candidates bounded by what already exists. The landscape step grounds the agent in the current codebase, which anchors candidate generation to what is buildable today rather than what would be best. On a discovery run for context-passing, for example, candidates are shaped by the current pre-load architecture instead of questioning whether pre-load is the right model at all. Decisions that should be challenged by the discovery process are instead silently inherited from it.
+
+The result is that discovery optimizes within the current design space rather than finding the edge of it. Problems that require restructuring existing code -- not just adding to it -- tend to produce timid candidates that paper over the root cause instead of addressing it. Discovery is supposed to find the best answer; it is currently finding the best answer that doesn't require changing much.
+
+**Things to hash out:**
+- Should the ideal-first reasoning happen before or after the landscape pass? Before risks ignoring hard constraints; after risks being anchored by them. What is the right sequencing, and is it always the same or does it depend on the problem type?
+- How do non-negotiable constraints (e.g. "must not change the engine API", "must work without a running daemon") get introduced without becoming the excuse for avoiding the best answer? There's a real difference between a hard constraint and an inherited assumption that could be challenged.
+- Is "what would the ideal look like, and what's the migration path from here?" a step inside discovery, or does it belong in `wr.shaping`? Shaping already produces an appetite and scope cut -- is ideal-first reasoning a discovery concern or a shaping concern, or does each need it independently?
+- When the ideal requires multi-sprint groundwork (e.g. "first build the KG, then build context assembly on top of it"), how should discovery represent that? As a sequenced multi-phase candidate? As a separate "phase 1" item that gets its own discovery?
 
 ---
 
@@ -3218,33 +3334,33 @@ openclaw is worth studying deeply before building out the platform layer. Draw i
 
 **Status: idea** | Priority: medium
 
-**Score: 10** | Cor:1 Cap:3 Eff:1 Lev:3 Con:2 | Blocked: no
+**Score: 10** | Cor:1 Cap:3 Eff:1 Lev:3 Con:2 | Blocked: yes (needs MemoryStore first as Phase 2 prerequisite)
 
-**Problem:** Every session starts with a full repo sweep. Context gathering subagents re-read the same files, re-trace the same call chains, re-identify the same invariants.
+**Problem:** Every session starts with a full repo sweep. Context gathering subagents re-read the same files, re-trace the same call chains, re-identify the same invariants. And cross-session semantic queries ("what did we find about this module last week") cannot be answered without a vector index.
+
+**Position in the phased memory architecture (from Apr 30 discovery):** This is Phase 3 in a four-phase sequence. Phase 0 (bug fixes) → Phase 1 (universal enricher) → Phase 2 (MemoryStore SQLite) → Phase 3 (knowledge graph). The MemoryStore SQLite from Phase 2 answers 6 of 8 memory queries without a vector model. The knowledge graph adds the remaining two: code-structure traversal (Q8) and semantic similarity ("what is related to X"). Phase 3a (structural layer) extends the existing spike; Phase 3b (vector layer) is a feature flag.
 
 **Design -- two-layer hybrid:**
 
-**Layer 1: Structural graph (hard edges, deterministic)**
-Built by `ts-morph` (TypeScript Compiler API) + DuckDB. Captures: `imports`, `calls`, `exports`, `implements`, `extends`, `registers_in`, `tested_by`. Answers precise questions with certainty: "what imports trigger-router.ts?", "what CLI commands are registered?"
+**Layer 1: Structural graph (hard edges, deterministic) -- Phase 3a**
+Extends existing `src/knowledge-graph/` spike (DuckDB + ts-morph, already in `dependencies`). New node kinds: `session`, `pipeline_run`, `workspace_convention`. New edge kinds: `produced_by` (session → file), `applies_to_workspace`. Current spike only tracks import edges and CLI commands; session data from Phase 2 MemoryStore migrates here. Answers: "what imports trigger-router.ts?", "what files did session X touch?", "what sessions ran in this workspace?"
 
-**Layer 2: Vector similarity (soft weights, semantic)**
-Every node gets an embedding. Answers fuzzy questions: "what is conceptually related to this?", "what past sessions are relevant to this bug?" Built with LanceDB (embedded, TypeScript-native, local-first).
+**Layer 2: Vector similarity (soft weights, semantic) -- Phase 3b (feature flag)**
+LanceDB (embedded, TypeScript-native, local-first). Embeddings over session recaps and workspace conventions. Off by default (`WORKRAIL_VECTOR_SEARCH=1` to enable). Answers: "what sessions are semantically related to this bug?", "what workspace conventions mention authentication?"
 
 **Technology:**
-- Structural: `ts-morph` + DuckDB
-- Vector: LanceDB + local embedding model (Ollama or `@xenova/transformers`)
-- Unified query: `query_knowledge_graph(intent)` returns merged structural + semantic results
-
-**Build order:** Structural layer spike first (1-day). Vector layer after spike proves the foundation. Incremental update: re-index only files in `filesChanged` after each session.
+- Structural: `ts-morph` + DuckDB (existing spike, already in dependencies)
+- Vector: LanceDB + local embedding model -- `@xenova/transformers` (in-process, no external dep) preferred over Ollama (better quality but requires external process)
+- Unified query: `query_knowledge(intent, workspacePath)` replaces `query_memory` tool when Phase 3a lands
 
 **Build decision (from Apr 15 research):** ts-morph + DuckDB wins. Cognee: Python-only. GraphRAG/LightRAG: use LLMs to build graph (violates scripts-over-agent). Mem0/Zep: conversational memory, not code graphs. Sourcegraph: enterprise weight, overkill.
 
 **Things to hash out:**
-- How large does a typical workspace KG get? For a medium-sized TypeScript monorepo, what are the expected node and edge counts for the structural layer?
-- The incremental update strategy (re-index only `filesChanged`) requires accurate change tracking. What is the fallback when `filesChanged` is unavailable (e.g. for manually triggered sessions)?
-- The embedding model (Ollama or `@xenova/transformers`) needs to be running locally. What is the setup story for a new workspace -- is it expected to already have an embedding model, or does WorkTrain set one up?
-- DuckDB is in-process -- what is the concurrency story when multiple daemon sessions try to query or update it simultaneously?
-- Is the KG per-workspace or global? If per-workspace, cross-workspace queries (multi-project WorkTrain) require a federation layer.
+- Phase 3a scope: should the structural layer replace the Phase 2 SQLite MemoryStore (same data, different engine) or exist alongside it? Replacing is cleaner; coexisting avoids a migration.
+- `@xenova/transformers` vs Ollama for Phase 3b: @xenova runs in-process (no setup friction) but has lower embedding quality. Ollama is better quality but adds an external process dependency. Which matters more for the target user base?
+- The incremental update strategy (re-index only `filesChanged` after each session) requires accurate change tracking. What is the fallback when `filesChanged` is unavailable?
+- DuckDB is in-process -- WAL mode handles read concurrency but writes are serialized. Is the concurrency story acceptable when 3 sessions complete simultaneously?
+- Is the KG per-workspace or global? Per-workspace is simpler; global enables cross-workspace queries but adds federation complexity.
 
 ---
 

--- a/src/daemon/core/session-context.ts
+++ b/src/daemon/core/session-context.ts
@@ -15,6 +15,7 @@
 
 import type { WorkflowTrigger } from '../types.js';
 import type { ContextBundle } from '../context-loader.js';
+import type { EnricherResult } from '../workflow-enricher.js';
 import { buildSystemPrompt, buildSessionRecap } from './system-prompt.js';
 
 // ---------------------------------------------------------------------------
@@ -98,6 +99,7 @@ export function buildSessionContext(
   context: ContextBundle,
   firstStepPrompt: string,
   effectiveWorkspacePath: string,
+  enricherResult?: EnricherResult,
 ): SessionContext {
   // ---- Flatten ContextBundle to the primitives buildSystemPrompt expects ----
   // WHY flatten here (not in DefaultContextLoader): buildSystemPrompt() is a stable
@@ -108,7 +110,7 @@ export function buildSessionContext(
 
   // ---- System prompt ----
   const sessionState = buildSessionRecap(sessionNotes);
-  const systemPrompt = buildSystemPrompt(trigger, sessionState, context.soulContent, workspaceContext, effectiveWorkspacePath);
+  const systemPrompt = buildSystemPrompt(trigger, sessionState, context.soulContent, workspaceContext, effectiveWorkspacePath, enricherResult);
 
   // ---- Initial prompt ----
   // WHY no continueToken in the initial prompt: the daemon uses complete_step which

--- a/src/daemon/core/system-prompt.ts
+++ b/src/daemon/core/system-prompt.ts
@@ -1,17 +1,4 @@
-/**
- * System prompt construction for daemon agent sessions.
- *
- * WHY this module: buildSystemPrompt, buildSessionRecap, and BASE_SYSTEM_PROMPT
- * are pure functions/values -- no I/O, no node: imports, no SDK deps. They belong
- * in the functional core, not in the 3,900-line orchestration file.
- *
- * WHY no node: or @anthropic-ai/* imports: this module is part of the functional
- * core. It must be importable in any test context without I/O stubs.
- *
- * DAEMON_SOUL_DEFAULT is re-exported from soul-template.ts (which has zero deps
- * and exists specifically to avoid loading heavy deps in CLI init). Tests that
- * need DAEMON_SOUL_DEFAULT can import from here or from soul-template.ts directly.
- */
+// Pure functions only. No node:/SDK imports -- must be importable in any test context.
 
 import type { WorkflowTrigger } from '../types.js';
 import { extractContextSlots } from '../types.js';
@@ -22,30 +9,12 @@ export { DAEMON_SOUL_DEFAULT } from '../soul-template.js';
 // Constants
 // ---------------------------------------------------------------------------
 
-/**
- * Maximum combined byte size of assembled coordinator context injected via
- * trigger.context['assembledContextSummary'].
- * WHY: caps the coordinator-assembled context to protect LLM token budget.
- */
 const MAX_ASSEMBLED_CONTEXT_BYTES = 8192;
 
 // ---------------------------------------------------------------------------
 // BASE_SYSTEM_PROMPT
 // ---------------------------------------------------------------------------
 
-/**
- * Static preamble for the daemon agent system prompt.
- *
- * WHY a named constant: extracting the preamble makes it readable as a document,
- * gives it a stable identity for tests, and follows the soul-template.ts precedent
- * of separating stable content from dynamic assembly. The dynamic parts (session
- * state, soul, workspace context) are injected by buildSystemPrompt() below.
- *
- * WHY these sections: daemon sessions run unattended. The agent has no user to ask.
- * The preamble replaces that missing human with: an oracle hierarchy, a reasoning
- * protocol, and explicit contracts for the two failure modes that matter most --
- * skipping steps and silent failure.
- */
 export const BASE_SYSTEM_PROMPT = `\
 You are WorkRail Auto, an autonomous agent that executes workflows step by step. You are running unattended -- there is no user watching. Your entire job is to faithfully complete the current workflow.
 
@@ -119,23 +88,8 @@ function truncateToByteLimit(s: string, maxBytes: number, marker: string): strin
 // buildSessionRecap
 // ---------------------------------------------------------------------------
 
-/**
- * Format prior step notes into a concise session state recap string.
- *
- * Pure function -- all I/O (note loading, truncation decisions) is handled
- * by the caller. WHY pure: unit-testable without mocking the session store
- * or token codec.
- *
- * Returns an empty string when `notes` is empty so the caller can guard on
- * `recap !== ''` before injecting it into the system prompt.
- *
- * WHY `<workrail_session_state>` tag: `buildSystemPrompt()` already reserves
- * this XML slot in the system prompt. Using the existing tag ensures the agent
- * parses it consistently with the documented schema.
- *
- * @param notes - Prior step notes (already limited to MAX_SESSION_RECAP_NOTES
- *   entries and bounded in size by the caller).
- */
+// <workrail_session_state> tag is reserved in BASE_SYSTEM_PROMPT; using the same tag
+// ensures the agent parses it consistently with the documented schema.
 export function buildSessionRecap(notes: readonly string[]): string {
   if (notes.length === 0) return '';
 

--- a/src/daemon/core/system-prompt.ts
+++ b/src/daemon/core/system-prompt.ts
@@ -14,6 +14,7 @@
  */
 
 import type { WorkflowTrigger } from '../types.js';
+import type { EnricherResult } from '../workflow-enricher.js';
 export { DAEMON_SOUL_DEFAULT } from '../soul-template.js';
 
 // ---------------------------------------------------------------------------
@@ -154,12 +155,20 @@ export function buildSessionRecap(notes: readonly string[]): string {
  *   the main checkout. The worktree path is only known after worktree creation in
  *   buildPreAgentSession(). Passing it explicitly keeps this function pure and testable.
  */
+/**
+ * Maximum byte size of git diff stat injected from WorkflowEnricher.
+ * WHY 2KB: diff stat is orientation context (file names + change counts), not the
+ * full diff. 2KB covers typical PRs without bloating the system prompt.
+ */
+const MAX_GIT_DIFF_STAT_BYTES = 2048;
+
 export function buildSystemPrompt(
   trigger: WorkflowTrigger,
   sessionState: string,
   soulContent: string,
   workspaceContext: string | null,
   effectiveWorkspacePath: string,
+  enricherResult?: EnricherResult,
 ): string {
   const isWorktreeSession = effectiveWorkspacePath !== trigger.workspacePath;
 
@@ -203,6 +212,43 @@ export function buildSystemPrompt(
     lines.push('');
     lines.push('## Prior Context');
     lines.push(ctxStr.trim());
+  }
+
+  // Inject prior workspace session notes from WorkflowEnricher.
+  // WHY after ## Prior Context: coordinator-assembled phase artifacts (discovery/shaping/coding
+  // handoffs) are higher-signal than raw session recaps. Enricher notes follow to supplement.
+  // WHY skip when assembledContextSummary present: the coordinator already provided richer
+  // structured context; raw notes would be redundant and lower-signal.
+  if (
+    enricherResult !== undefined &&
+    enricherResult.priorSessionNotes.length > 0 &&
+    !(typeof trigger.context?.['assembledContextSummary'] === 'string' &&
+      (trigger.context['assembledContextSummary'] as string).trim().length > 0)
+  ) {
+    lines.push('');
+    lines.push('## Prior Workspace Notes');
+    for (const note of enricherResult.priorSessionNotes) {
+      const title = note.sessionTitle ?? note.sessionId.slice(0, 12);
+      const branch = note.gitBranch ? ` (${note.gitBranch})` : '';
+      const recap = note.recapSnippet ?? '(no recap)';
+      lines.push(`**${title}**${branch}: ${recap}`);
+    }
+  }
+
+  // Inject git diff stat from WorkflowEnricher.
+  // WHY always inject (even when assembledContextSummary present): coordinators don't always
+  // include changed-files lists, and the diff stat is cheap orientation context that never
+  // conflicts with phase artifacts.
+  if (enricherResult !== undefined && enricherResult.gitDiffStat !== null) {
+    let diffStat = enricherResult.gitDiffStat;
+    if (Buffer.byteLength(diffStat, 'utf8') > MAX_GIT_DIFF_STAT_BYTES) {
+      diffStat = diffStat.slice(0, MAX_GIT_DIFF_STAT_BYTES) + '\n[diff stat truncated]';
+    }
+    lines.push('');
+    lines.push('## Changed files');
+    lines.push('```');
+    lines.push(diffStat);
+    lines.push('```');
   }
 
   // Append reference URLs section when provided.

--- a/src/daemon/core/system-prompt.ts
+++ b/src/daemon/core/system-prompt.ts
@@ -117,7 +117,7 @@ complete_step is your advancement tool. It does not require a continueToken. Do 
  * parses it consistently with the documented schema.
  *
  * @param notes - Prior step notes (already limited to MAX_SESSION_RECAP_NOTES
- *   entries and truncated to MAX_SESSION_NOTE_CHARS each by the caller).
+ *   entries and bounded in size by the caller).
  */
 export function buildSessionRecap(notes: readonly string[]): string {
   if (notes.length === 0) return '';
@@ -242,7 +242,9 @@ export function buildSystemPrompt(
   if (enricherResult !== undefined && enricherResult.gitDiffStat !== null) {
     let diffStat = enricherResult.gitDiffStat;
     if (Buffer.byteLength(diffStat, 'utf8') > MAX_GIT_DIFF_STAT_BYTES) {
-      diffStat = diffStat.slice(0, MAX_GIT_DIFF_STAT_BYTES) + '\n[diff stat truncated]';
+      // WHY Buffer subarray + TextDecoder: avoids the char-based slice pitfall where
+      // a 2048-char slice of non-ASCII content exceeds 2048 bytes.
+      diffStat = new TextDecoder().decode(Buffer.from(diffStat, 'utf8').subarray(0, MAX_GIT_DIFF_STAT_BYTES)) + '\n[diff stat truncated]';
     }
     lines.push('');
     lines.push('## Changed files');

--- a/src/daemon/core/system-prompt.ts
+++ b/src/daemon/core/system-prompt.ts
@@ -123,17 +123,14 @@ function sectionWorkspaceContext(workspaceContext: string | null): string[] {
   return ['', '## Workspace Context (from AGENTS.md / CLAUDE.md)', workspaceContext];
 }
 
-function sectionAssembledContext(trigger: WorkflowTrigger): string[] {
-  const { assembledContextSummary } = extractContextSlots(trigger.context);
+function sectionAssembledContext(assembledContextSummary: string | undefined): string[] {
   if (!assembledContextSummary || assembledContextSummary.trim().length === 0) return [];
   const ctxStr = truncateToByteLimit(assembledContextSummary, MAX_ASSEMBLED_CONTEXT_BYTES, '[Prior context truncated at 8KB]');
   return ['', '## Prior Context', ctxStr.trim()];
 }
 
-function sectionPriorWorkspaceNotes(trigger: WorkflowTrigger, enricherResult: EnricherResult | undefined): string[] {
+function sectionPriorWorkspaceNotes(assembledContextSummary: string | undefined, enricherResult: EnricherResult | undefined): string[] {
   if (!enricherResult || enricherResult.priorSessionNotes.length === 0) return [];
-  // Skip when coordinator already provided richer assembled context.
-  const { assembledContextSummary } = extractContextSlots(trigger.context);
   if (assembledContextSummary && assembledContextSummary.trim().length > 0) return [];
   const noteLines = enricherResult.priorSessionNotes.map((note) => {
     const title = note.sessionTitle ?? note.sessionId.slice(0, 12);
@@ -170,12 +167,13 @@ export function buildSystemPrompt(
   effectiveWorkspacePath: string,
   enricherResult?: EnricherResult,
 ): string {
+  const { assembledContextSummary } = extractContextSlots(trigger.context);
   const sections: string[][] = [
     [BASE_SYSTEM_PROMPT, '', `<workrail_session_state>${sessionState}</workrail_session_state>`, '', '## Agent Rules and Philosophy', soulContent, '', `## Workspace: ${effectiveWorkspacePath}`],
     sectionWorktreeScope(trigger, effectiveWorkspacePath),
     sectionWorkspaceContext(workspaceContext),
-    sectionAssembledContext(trigger),
-    sectionPriorWorkspaceNotes(trigger, enricherResult),
+    sectionAssembledContext(assembledContextSummary),
+    sectionPriorWorkspaceNotes(assembledContextSummary, enricherResult),
     sectionChangedFiles(enricherResult),
     sectionReferenceUrls(trigger),
   ];

--- a/src/daemon/core/system-prompt.ts
+++ b/src/daemon/core/system-prompt.ts
@@ -14,6 +14,7 @@
  */
 
 import type { WorkflowTrigger } from '../types.js';
+import { extractContextSlots } from '../types.js';
 import type { EnricherResult } from '../workflow-enricher.js';
 export { DAEMON_SOUL_DEFAULT } from '../soul-template.js';
 
@@ -99,6 +100,22 @@ complete_step is your advancement tool. It does not require a continueToken. Do 
 `;
 
 // ---------------------------------------------------------------------------
+// truncateToByteLimit
+// ---------------------------------------------------------------------------
+
+function truncateToByteLimit(s: string, maxBytes: number, marker: string): string {
+  if (Buffer.byteLength(s, 'utf8') <= maxBytes) return s;
+  let end = maxBytes;
+  while (end > 0 && Buffer.byteLength(s.slice(0, end), 'utf8') > maxBytes) end--;
+  while (end > 0) {
+    const code = s.charCodeAt(end - 1);
+    if (code >= 0xD800 && code <= 0xDFFF) { end--; } else { break; }
+  }
+  const newlineIdx = s.lastIndexOf('\n', end);
+  return (newlineIdx > 0 ? s.slice(0, newlineIdx) : s.slice(0, end)) + '\n' + marker;
+}
+
+// ---------------------------------------------------------------------------
 // buildSessionRecap
 // ---------------------------------------------------------------------------
 
@@ -130,37 +147,66 @@ export function buildSessionRecap(notes: readonly string[]): string {
 }
 
 // ---------------------------------------------------------------------------
-// buildSystemPrompt
+// buildSystemPrompt -- pipeline of pure section functions
 // ---------------------------------------------------------------------------
 
-/**
- * Build the system prompt for the daemon agent.
- *
- * Intentionally synchronous and pure -- all I/O (soul file, workspace context)
- * is resolved by the caller before invoking this function. WHY: keeps the
- * function unit-testable by passing pre-loaded strings directly, without
- * requiring fs mocking or real disk access in tests.
- *
- * @param trigger - The workflow trigger containing workspacePath and referenceUrls.
- * @param sessionState - Serialized WorkRail session state (may be empty string).
- * @param soulContent - Loaded content of daemon-soul.md (always a string; caller
- *   provides the hardcoded default if the file was absent).
- * @param workspaceContext - Combined workspace context from CLAUDE.md / AGENTS.md,
- *   or null if no workspace context files were found.
- * @param effectiveWorkspacePath - The workspace path the agent must work in.
- *   Callers compute this as: sessionWorkspacePath ?? trigger.workspacePath.
- *   Required (not optional) so the type system enforces the caller makes an explicit
- *   decision -- there is no silent fallback to trigger.workspacePath inside this function.
- *   WHY a separate parameter (not derived from trigger): trigger.workspacePath is always
- *   the main checkout. The worktree path is only known after worktree creation in
- *   buildPreAgentSession(). Passing it explicitly keeps this function pure and testable.
- */
-/**
- * Maximum byte size of git diff stat injected from WorkflowEnricher.
- * WHY 2KB: diff stat is orientation context (file names + change counts), not the
- * full diff. 2KB covers typical PRs without bloating the system prompt.
- */
+// Each section function returns string[] (lines to append) or [] to omit.
+// buildSystemPrompt composes them in order. Adding a new section = adding one
+// function and one entry in the pipeline array.
+
 const MAX_GIT_DIFF_STAT_BYTES = 2048;
+
+function sectionWorktreeScope(trigger: WorkflowTrigger, effectiveWorkspacePath: string): string[] {
+  if (effectiveWorkspacePath === trigger.workspacePath) return [];
+  return [
+    '',
+    `**Worktree session scope:** Your workspace is the isolated git worktree at \`${effectiveWorkspacePath}\`. Do not access, read, or modify the main checkout at \`${trigger.workspacePath}\`. Do not read planning docs, roadmap files, or backlog files. All Bash commands, file reads, and file writes must stay within your worktree path.`,
+  ];
+}
+
+function sectionWorkspaceContext(workspaceContext: string | null): string[] {
+  if (workspaceContext === null) return [];
+  return ['', '## Workspace Context (from AGENTS.md / CLAUDE.md)', workspaceContext];
+}
+
+function sectionAssembledContext(trigger: WorkflowTrigger): string[] {
+  const { assembledContextSummary } = extractContextSlots(trigger.context);
+  if (!assembledContextSummary || assembledContextSummary.trim().length === 0) return [];
+  const ctxStr = truncateToByteLimit(assembledContextSummary, MAX_ASSEMBLED_CONTEXT_BYTES, '[Prior context truncated at 8KB]');
+  return ['', '## Prior Context', ctxStr.trim()];
+}
+
+function sectionPriorWorkspaceNotes(trigger: WorkflowTrigger, enricherResult: EnricherResult | undefined): string[] {
+  if (!enricherResult || enricherResult.priorSessionNotes.length === 0) return [];
+  // Skip when coordinator already provided richer assembled context.
+  const { assembledContextSummary } = extractContextSlots(trigger.context);
+  if (assembledContextSummary && assembledContextSummary.trim().length > 0) return [];
+  const noteLines = enricherResult.priorSessionNotes.map((note) => {
+    const title = note.sessionTitle ?? note.sessionId.slice(0, 12);
+    const branch = note.gitBranch ? ` (${note.gitBranch})` : '';
+    const recap = note.recapSnippet ?? '(no recap)';
+    return `**${title}**${branch}: ${recap}`;
+  });
+  return ['', '## Prior Workspace Notes', ...noteLines];
+}
+
+function sectionChangedFiles(enricherResult: EnricherResult | undefined): string[] {
+  if (!enricherResult || enricherResult.gitDiffStat === null) return [];
+  const diffStat = Buffer.byteLength(enricherResult.gitDiffStat, 'utf8') > MAX_GIT_DIFF_STAT_BYTES
+    ? new TextDecoder().decode(Buffer.from(enricherResult.gitDiffStat, 'utf8').subarray(0, MAX_GIT_DIFF_STAT_BYTES)) + '\n[diff stat truncated]'
+    : enricherResult.gitDiffStat;
+  return ['', '## Changed files', '```', diffStat, '```'];
+}
+
+function sectionReferenceUrls(trigger: WorkflowTrigger): string[] {
+  if (!trigger.referenceUrls || trigger.referenceUrls.length === 0) return [];
+  return [
+    '',
+    '## Reference documents',
+    'Before starting, fetch and read these reference documents: ' + trigger.referenceUrls.join(' '),
+    'If you cannot fetch any of these documents, note their unavailability and proceed.',
+  ];
+}
 
 export function buildSystemPrompt(
   trigger: WorkflowTrigger,
@@ -170,101 +216,14 @@ export function buildSystemPrompt(
   effectiveWorkspacePath: string,
   enricherResult?: EnricherResult,
 ): string {
-  const isWorktreeSession = effectiveWorkspacePath !== trigger.workspacePath;
-
-  const lines = [
-    BASE_SYSTEM_PROMPT,
-    '',
-    `<workrail_session_state>${sessionState}</workrail_session_state>`,
-    '',
-    '## Agent Rules and Philosophy',
-    soulContent,
-    '',
-    `## Workspace: ${effectiveWorkspacePath}`,
+  const sections: string[][] = [
+    [BASE_SYSTEM_PROMPT, '', `<workrail_session_state>${sessionState}</workrail_session_state>`, '', '## Agent Rules and Philosophy', soulContent, '', `## Workspace: ${effectiveWorkspacePath}`],
+    sectionWorktreeScope(trigger, effectiveWorkspacePath),
+    sectionWorkspaceContext(workspaceContext),
+    sectionAssembledContext(trigger),
+    sectionPriorWorkspaceNotes(trigger, enricherResult),
+    sectionChangedFiles(enricherResult),
+    sectionReferenceUrls(trigger),
   ];
-
-  // When running in a worktree, add an explicit scope boundary so the agent never
-  // accidentally reads roadmap docs, runs git log on main, or modifies the main checkout.
-  // WHY: without this, the agent may drift to the main checkout for "context" (git log,
-  // planning docs, roadmap) which (1) pollutes the session with coordinator work and
-  // (2) can mutate the main checkout. This note is a hard constraint, not guidance.
-  if (isWorktreeSession) {
-    lines.push('');
-    lines.push(`**Worktree session scope:** Your workspace is the isolated git worktree at \`${effectiveWorkspacePath}\`. Do not access, read, or modify the main checkout at \`${trigger.workspacePath}\`. Do not read planning docs, roadmap files, or backlog files. All Bash commands, file reads, and file writes must stay within your worktree path.`);
-  }
-
-  // Inject workspace context (CLAUDE.md / AGENTS.md) when available.
-  if (workspaceContext !== null) {
-    lines.push('');
-    lines.push('## Workspace Context (from AGENTS.md / CLAUDE.md)');
-    lines.push(workspaceContext);
-  }
-
-  // Inject assembled task context (prior session notes + git diff stat) when provided.
-  // WHY before referenceUrls: task-specific runtime context should be visible before
-  // static reference documents. Earlier position improves agent attention.
-  const assembledContextSummary = trigger.context?.['assembledContextSummary'];
-  if (typeof assembledContextSummary === 'string' && assembledContextSummary.trim().length > 0) {
-    let ctxStr = assembledContextSummary as string;
-    if (Buffer.byteLength(ctxStr, 'utf8') > MAX_ASSEMBLED_CONTEXT_BYTES) {
-      ctxStr = ctxStr.slice(0, MAX_ASSEMBLED_CONTEXT_BYTES) + '\n[Prior context truncated at 8KB]';
-    }
-    lines.push('');
-    lines.push('## Prior Context');
-    lines.push(ctxStr.trim());
-  }
-
-  // Inject prior workspace session notes from WorkflowEnricher.
-  // WHY after ## Prior Context: coordinator-assembled phase artifacts (discovery/shaping/coding
-  // handoffs) are higher-signal than raw session recaps. Enricher notes follow to supplement.
-  // WHY skip when assembledContextSummary present: the coordinator already provided richer
-  // structured context; raw notes would be redundant and lower-signal.
-  if (
-    enricherResult !== undefined &&
-    enricherResult.priorSessionNotes.length > 0 &&
-    !(typeof trigger.context?.['assembledContextSummary'] === 'string' &&
-      (trigger.context['assembledContextSummary'] as string).trim().length > 0)
-  ) {
-    lines.push('');
-    lines.push('## Prior Workspace Notes');
-    for (const note of enricherResult.priorSessionNotes) {
-      const title = note.sessionTitle ?? note.sessionId.slice(0, 12);
-      const branch = note.gitBranch ? ` (${note.gitBranch})` : '';
-      const recap = note.recapSnippet ?? '(no recap)';
-      lines.push(`**${title}**${branch}: ${recap}`);
-    }
-  }
-
-  // Inject git diff stat from WorkflowEnricher.
-  // WHY always inject (even when assembledContextSummary present): coordinators don't always
-  // include changed-files lists, and the diff stat is cheap orientation context that never
-  // conflicts with phase artifacts.
-  if (enricherResult !== undefined && enricherResult.gitDiffStat !== null) {
-    let diffStat = enricherResult.gitDiffStat;
-    if (Buffer.byteLength(diffStat, 'utf8') > MAX_GIT_DIFF_STAT_BYTES) {
-      // WHY Buffer subarray + TextDecoder: avoids the char-based slice pitfall where
-      // a 2048-char slice of non-ASCII content exceeds 2048 bytes.
-      diffStat = new TextDecoder().decode(Buffer.from(diffStat, 'utf8').subarray(0, MAX_GIT_DIFF_STAT_BYTES)) + '\n[diff stat truncated]';
-    }
-    lines.push('');
-    lines.push('## Changed files');
-    lines.push('```');
-    lines.push(diffStat);
-    lines.push('```');
-  }
-
-  // Append reference URLs section when provided.
-  if (trigger.referenceUrls && trigger.referenceUrls.length > 0) {
-    lines.push('');
-    lines.push('## Reference documents');
-    lines.push(
-      'Before starting, fetch and read these reference documents: ' +
-      trigger.referenceUrls.join(' '),
-    );
-    lines.push(
-      'If you cannot fetch any of these documents, note their unavailability and proceed.',
-    );
-  }
-
-  return lines.join('\n');
+  return sections.flat().join('\n');
 }

--- a/src/daemon/runner/agent-loop-runner.ts
+++ b/src/daemon/runner/agent-loop-runner.ts
@@ -43,6 +43,7 @@ import type { PreAgentSession, AgentReadySession, SessionOutcome } from './runne
 import { getSchemas } from './tool-schemas.js';
 import { constructTools } from './construct-tools.js';
 import type { runWorkflow } from '../workflow-runner.js';
+import type { EnricherResult } from '../workflow-enricher.js';
 
 // ---------------------------------------------------------------------------
 // TurnEndSubscriberContext
@@ -234,6 +235,7 @@ export async function buildAgentReadySession(
   daemonRegistry: DaemonRegistry | undefined,
   activeSessionSet: ActiveSessionSet | undefined,
   runWorkflowFn: typeof runWorkflow,
+  enricherResult?: EnricherResult,
 ): Promise<AgentReadySession> {
   const { state, firstStepPrompt, sessionWorkspacePath, sessionWorktreePath, agentClient, modelId } = preAgentSession;
   const startContinueToken = preAgentSession.continueToken;
@@ -289,6 +291,7 @@ export async function buildAgentReadySession(
     contextBundle,
     firstStepPrompt || 'No step content available',
     effectiveWorkspacePath,
+    enricherResult,
   );
 
   // ---- Observability callbacks for AgentLoop ----

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -465,3 +465,21 @@ export interface OrphanedSession {
    */
   readonly workspacePath?: string;
 }
+
+// ---------------------------------------------------------------------------
+// WorkflowContextSlots
+// ---------------------------------------------------------------------------
+
+export interface WorkflowContextSlots {
+  /** Coordinator-assembled prior phase context (discovery/shaping/coding handoffs). */
+  readonly assembledContextSummary?: string;
+}
+
+export function extractContextSlots(context: Readonly<Record<string, unknown>> | undefined): WorkflowContextSlots {
+  if (!context) return {};
+  const assembledContextSummary = typeof context['assembledContextSummary'] === 'string'
+    ? context['assembledContextSummary']
+    : undefined;
+  return { assembledContextSummary };
+}
+

--- a/src/daemon/workflow-enricher.ts
+++ b/src/daemon/workflow-enricher.ts
@@ -131,15 +131,24 @@ export async function enrichTriggerContext(
   const [notesResult, gitResult] = await Promise.all([
     skipPriorNotes
       ? Promise.resolve<Result<readonly SessionNote[], string>>({ kind: 'ok', value: [] })
-      : Promise.race<Result<readonly SessionNote[], string>>([
-          deps.listRecentSessions(trigger.workspacePath, MAX_PRIOR_NOTES),
-          new Promise<Result<readonly SessionNote[], string>>((resolve) =>
-            setTimeout(
+      : (() => {
+          // WHY clearTimeout on normal path: without it the timeout timer keeps
+          // running after listRecentSessions resolves, leaking a handle.
+          let timeoutHandle: ReturnType<typeof setTimeout>;
+          const timeoutPromise = new Promise<Result<readonly SessionNote[], string>>((resolve) => {
+            timeoutHandle = setTimeout(
               () => resolve({ kind: 'err', error: 'listRecentSessions timeout (1s)' }),
               LIST_SESSIONS_TIMEOUT_MS,
-            ),
-          ),
-        ]),
+            );
+          });
+          return Promise.race([
+            deps.listRecentSessions(trigger.workspacePath, MAX_PRIOR_NOTES).then((r) => {
+              clearTimeout(timeoutHandle);
+              return r;
+            }),
+            timeoutPromise,
+          ]);
+        })(),
     deps.execGit(['diff', 'HEAD~1', '--stat'], trigger.workspacePath),
   ]);
 

--- a/src/daemon/workflow-enricher.ts
+++ b/src/daemon/workflow-enricher.ts
@@ -1,0 +1,170 @@
+/**
+ * WorkflowEnricher: inject cross-session context for all session entry points.
+ *
+ * WHY this module: runWorkflow() is the single point through which all 6 session
+ * entry points pass. Placing enrichment here -- for root sessions only -- gives
+ * every entry point prior workspace session notes and git diff stat without
+ * requiring each coordinator or trigger to opt in.
+ *
+ * WHY root sessions only (spawnDepth === 0): spawn_agent children should
+ * inherit context from their parent's params.context, not re-assemble
+ * independently. Enriching children would trigger redundant I/O for every
+ * nested call and could produce context that conflicts with the parent's
+ * richer coordinator-assembled context.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { Result } from '../runtime/result.js';
+import type { SessionNote } from '../context-assembly/types.js';
+import type { WorkflowTrigger } from './types.js';
+import { createListRecentSessions } from '../context-assembly/infra.js';
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// EnricherResult
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed output of enrichTriggerContext().
+ *
+ * WHY a named type (not Partial<Record<string,unknown>>): makes the valid
+ * payload explicit, gives buildSystemPrompt typed parameters rather than
+ * runtime guards, and prevents accidental shadowing of WorkflowTrigger fields.
+ */
+export interface EnricherResult {
+  /** Prior workspace session notes (max 3, newest-first, workspace-scoped). */
+  readonly priorSessionNotes: readonly SessionNote[];
+  /**
+   * Output of `git diff HEAD~1 --stat` for the workspace.
+   * Null when git is unavailable, the workspace has no commits, or the
+   * command fails for any reason.
+   */
+  readonly gitDiffStat: string | null;
+}
+
+/** Empty result returned on timeout or total failure. */
+const EMPTY_RESULT: EnricherResult = {
+  priorSessionNotes: [],
+  gitDiffStat: null,
+};
+
+// ---------------------------------------------------------------------------
+// WorkflowEnricherDeps
+// ---------------------------------------------------------------------------
+
+/**
+ * Injectable I/O dependencies for the enricher.
+ *
+ * Follows the ContextAssemblerDeps DI pattern exactly: all I/O behind this
+ * interface; tests inject fakes.
+ */
+export interface WorkflowEnricherDeps {
+  /**
+   * Run a git command in the given working directory.
+   * Args passed as an array -- no shell interpolation.
+   */
+  readonly execGit: (
+    args: readonly string[],
+    cwd: string,
+  ) => Promise<Result<string, string>>;
+
+  /**
+   * List recent sessions for a workspace, ordered newest-first.
+   * Returns at most `limit` sessions.
+   */
+  readonly listRecentSessions: (
+    workspacePath: string,
+    limit: number,
+  ) => Promise<Result<readonly SessionNote[], string>>;
+}
+
+// ---------------------------------------------------------------------------
+// Production deps factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create production WorkflowEnricherDeps.
+ */
+export function createWorkflowEnricherDeps(): WorkflowEnricherDeps {
+  return {
+    execGit: async (args, cwd) => {
+      try {
+        const { stdout } = await execFileAsync('git', [...args], { cwd });
+        return { kind: 'ok', value: stdout };
+      } catch (e) {
+        return { kind: 'err', error: e instanceof Error ? e.message : String(e) };
+      }
+    },
+    listRecentSessions: createListRecentSessions(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// enrichTriggerContext
+// ---------------------------------------------------------------------------
+
+/** Maximum prior session notes to inject. */
+const MAX_PRIOR_NOTES = 3;
+
+/** Wall-clock timeout for listRecentSessions (ms). */
+const LIST_SESSIONS_TIMEOUT_MS = 1000;
+
+/**
+ * Assemble cross-session context for a root session.
+ *
+ * Never throws. On any failure, returns the best partial result available.
+ *
+ * @param trigger - The WorkflowTrigger for this session.
+ * @param deps - Injectable I/O dependencies.
+ * @param skipPriorNotes - When true, skip prior notes assembly (coordinator
+ *   already provided richer context via assembledContextSummary). gitDiffStat
+ *   is always attempted regardless.
+ */
+export async function enrichTriggerContext(
+  trigger: WorkflowTrigger,
+  deps: WorkflowEnricherDeps,
+  skipPriorNotes: boolean,
+): Promise<EnricherResult> {
+  // Run prior notes and git diff concurrently.
+  const [notesResult, gitResult] = await Promise.all([
+    skipPriorNotes
+      ? Promise.resolve<Result<readonly SessionNote[], string>>({ kind: 'ok', value: [] })
+      : Promise.race<Result<readonly SessionNote[], string>>([
+          deps.listRecentSessions(trigger.workspacePath, MAX_PRIOR_NOTES),
+          new Promise<Result<readonly SessionNote[], string>>((resolve) =>
+            setTimeout(
+              () => resolve({ kind: 'err', error: 'listRecentSessions timeout (1s)' }),
+              LIST_SESSIONS_TIMEOUT_MS,
+            ),
+          ),
+        ]),
+    deps.execGit(['diff', 'HEAD~1', '--stat'], trigger.workspacePath),
+  ]);
+
+  const priorSessionNotes =
+    notesResult.kind === 'ok' ? notesResult.value : [];
+
+  const gitDiffStat =
+    gitResult.kind === 'ok' && gitResult.value.trim().length > 0
+      ? gitResult.value.trim()
+      : null;
+
+  return { priorSessionNotes, gitDiffStat };
+}
+
+/**
+ * Decide whether to run the enricher for this trigger.
+ *
+ * WHY a separate pure function: keeps the guard logic testable without
+ * setting up a full WorkflowTrigger with all fields.
+ *
+ * Returns false for:
+ * - spawn_agent children (spawnDepth > 0) -- children use parent's context
+ */
+export function shouldEnrich(trigger: WorkflowTrigger): boolean {
+  return (trigger.spawnDepth ?? 0) === 0;
+}
+
+export { EMPTY_RESULT };

--- a/src/daemon/workflow-enricher.ts
+++ b/src/daemon/workflow-enricher.ts
@@ -67,12 +67,7 @@ export function createWorkflowEnricherDeps(): WorkflowEnricherDeps {
 
 const LIST_SESSIONS_TIMEOUT_MS = 1000;
 
-/**
- * Race a promise against a timeout. Clears the timer if the promise resolves
- * first to avoid handle leaks.
- *
- * Returns err('timeout') when the timer fires before the promise resolves.
- */
+// Clears the timer on the normal path to avoid handle leaks.
 function raceWithTimeout<T>(
   promise: Promise<Result<T, string>>,
   timeoutMs: number,

--- a/src/daemon/workflow-enricher.ts
+++ b/src/daemon/workflow-enricher.ts
@@ -25,13 +25,8 @@ export const EMPTY_RESULT: EnricherResult = {
 // PriorNotesPolicy
 // ---------------------------------------------------------------------------
 
-/**
- * Controls whether prior workspace session notes are assembled.
- *
- * 'inject': assemble and inject notes (standard path for all root sessions).
- * 'skip_coordinator_provided': coordinator already wrote assembledContextSummary;
- *   prior notes would be redundant and lower-signal. gitDiffStat still assembled.
- */
+// skip_coordinator_provided: coordinator already wrote assembledContextSummary, so prior
+// notes would be lower-signal redundancy. gitDiffStat is still assembled either way.
 export type PriorNotesPolicy = 'inject' | 'skip_coordinator_provided';
 
 // ---------------------------------------------------------------------------

--- a/src/daemon/workflow-enricher.ts
+++ b/src/daemon/workflow-enricher.ts
@@ -1,18 +1,3 @@
-/**
- * WorkflowEnricher: inject cross-session context for all session entry points.
- *
- * WHY this module: runWorkflow() is the single point through which all 6 session
- * entry points pass. Placing enrichment here -- for root sessions only -- gives
- * every entry point prior workspace session notes and git diff stat without
- * requiring each coordinator or trigger to opt in.
- *
- * WHY root sessions only (spawnDepth === 0): spawn_agent children should
- * inherit context from their parent's params.context, not re-assemble
- * independently. Enriching children would trigger redundant I/O for every
- * nested call and could produce context that conflicts with the parent's
- * richer coordinator-assembled context.
- */
-
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { Result } from '../runtime/result.js';
@@ -26,67 +11,42 @@ const execFileAsync = promisify(execFile);
 // EnricherResult
 // ---------------------------------------------------------------------------
 
-/**
- * Typed output of enrichTriggerContext().
- *
- * WHY a named type (not Partial<Record<string,unknown>>): makes the valid
- * payload explicit, gives buildSystemPrompt typed parameters rather than
- * runtime guards, and prevents accidental shadowing of WorkflowTrigger fields.
- */
 export interface EnricherResult {
-  /** Prior workspace session notes (max 3, newest-first, workspace-scoped). */
   readonly priorSessionNotes: readonly SessionNote[];
-  /**
-   * Output of `git diff HEAD~1 --stat` for the workspace.
-   * Null when git is unavailable, the workspace has no commits, or the
-   * command fails for any reason.
-   */
   readonly gitDiffStat: string | null;
 }
 
-/** Empty result returned on timeout or total failure. */
-const EMPTY_RESULT: EnricherResult = {
+export const EMPTY_RESULT: EnricherResult = {
   priorSessionNotes: [],
   gitDiffStat: null,
 };
 
 // ---------------------------------------------------------------------------
-// WorkflowEnricherDeps
+// PriorNotesPolicy
 // ---------------------------------------------------------------------------
 
 /**
- * Injectable I/O dependencies for the enricher.
+ * Controls whether prior workspace session notes are assembled.
  *
- * Follows the ContextAssemblerDeps DI pattern exactly: all I/O behind this
- * interface; tests inject fakes.
+ * 'inject': assemble and inject notes (standard path for all root sessions).
+ * 'skip_coordinator_provided': coordinator already wrote assembledContextSummary;
+ *   prior notes would be redundant and lower-signal. gitDiffStat still assembled.
  */
-export interface WorkflowEnricherDeps {
-  /**
-   * Run a git command in the given working directory.
-   * Args passed as an array -- no shell interpolation.
-   */
-  readonly execGit: (
-    args: readonly string[],
-    cwd: string,
-  ) => Promise<Result<string, string>>;
+export type PriorNotesPolicy = 'inject' | 'skip_coordinator_provided';
 
-  /**
-   * List recent sessions for a workspace, ordered newest-first.
-   * Returns at most `limit` sessions.
-   */
-  readonly listRecentSessions: (
-    workspacePath: string,
-    limit: number,
-  ) => Promise<Result<readonly SessionNote[], string>>;
+// ---------------------------------------------------------------------------
+// WorkflowEnricherDeps
+// ---------------------------------------------------------------------------
+
+export interface WorkflowEnricherDeps {
+  readonly execGit: (args: readonly string[], cwd: string) => Promise<Result<string, string>>;
+  readonly listRecentSessions: (workspacePath: string, limit: number) => Promise<Result<readonly SessionNote[], string>>;
 }
 
 // ---------------------------------------------------------------------------
 // Production deps factory
 // ---------------------------------------------------------------------------
 
-/**
- * Create production WorkflowEnricherDeps.
- */
 export function createWorkflowEnricherDeps(): WorkflowEnricherDeps {
   return {
     execGit: async (args, cwd) => {
@@ -102,78 +62,68 @@ export function createWorkflowEnricherDeps(): WorkflowEnricherDeps {
 }
 
 // ---------------------------------------------------------------------------
-// enrichTriggerContext
+// raceWithTimeout
 // ---------------------------------------------------------------------------
 
-/** Maximum prior session notes to inject. */
-const MAX_PRIOR_NOTES = 3;
-
-/** Wall-clock timeout for listRecentSessions (ms). */
 const LIST_SESSIONS_TIMEOUT_MS = 1000;
 
 /**
- * Assemble cross-session context for a root session.
+ * Race a promise against a timeout. Clears the timer if the promise resolves
+ * first to avoid handle leaks.
  *
- * Never throws. On any failure, returns the best partial result available.
- *
- * @param trigger - The WorkflowTrigger for this session.
- * @param deps - Injectable I/O dependencies.
- * @param skipPriorNotes - When true, skip prior notes assembly (coordinator
- *   already provided richer context via assembledContextSummary). gitDiffStat
- *   is always attempted regardless.
+ * Returns err('timeout') when the timer fires before the promise resolves.
  */
+function raceWithTimeout<T>(
+  promise: Promise<Result<T, string>>,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<Result<T, string>> {
+  let handle: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<Result<T, string>>((resolve) => {
+    handle = setTimeout(() => resolve({ kind: 'err', error: timeoutMessage }), timeoutMs);
+  });
+  return Promise.race([
+    promise.then((r) => { clearTimeout(handle); return r; }),
+    timeout,
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// enrichTriggerContext
+// ---------------------------------------------------------------------------
+
+const MAX_PRIOR_NOTES = 3;
+
 export async function enrichTriggerContext(
   trigger: WorkflowTrigger,
   deps: WorkflowEnricherDeps,
-  skipPriorNotes: boolean,
+  policy: PriorNotesPolicy,
 ): Promise<EnricherResult> {
-  // Run prior notes and git diff concurrently.
+  const notesPromise = policy === 'skip_coordinator_provided'
+    ? Promise.resolve<Result<readonly SessionNote[], string>>({ kind: 'ok', value: [] })
+    : raceWithTimeout(
+        deps.listRecentSessions(trigger.workspacePath, MAX_PRIOR_NOTES),
+        LIST_SESSIONS_TIMEOUT_MS,
+        'listRecentSessions timeout (1s)',
+      );
+
   const [notesResult, gitResult] = await Promise.all([
-    skipPriorNotes
-      ? Promise.resolve<Result<readonly SessionNote[], string>>({ kind: 'ok', value: [] })
-      : (() => {
-          // WHY clearTimeout on normal path: without it the timeout timer keeps
-          // running after listRecentSessions resolves, leaking a handle.
-          let timeoutHandle: ReturnType<typeof setTimeout>;
-          const timeoutPromise = new Promise<Result<readonly SessionNote[], string>>((resolve) => {
-            timeoutHandle = setTimeout(
-              () => resolve({ kind: 'err', error: 'listRecentSessions timeout (1s)' }),
-              LIST_SESSIONS_TIMEOUT_MS,
-            );
-          });
-          return Promise.race([
-            deps.listRecentSessions(trigger.workspacePath, MAX_PRIOR_NOTES).then((r) => {
-              clearTimeout(timeoutHandle);
-              return r;
-            }),
-            timeoutPromise,
-          ]);
-        })(),
+    notesPromise,
     deps.execGit(['diff', 'HEAD~1', '--stat'], trigger.workspacePath),
   ]);
 
-  const priorSessionNotes =
-    notesResult.kind === 'ok' ? notesResult.value : [];
-
-  const gitDiffStat =
-    gitResult.kind === 'ok' && gitResult.value.trim().length > 0
+  return {
+    priorSessionNotes: notesResult.kind === 'ok' ? notesResult.value : [],
+    gitDiffStat: gitResult.kind === 'ok' && gitResult.value.trim().length > 0
       ? gitResult.value.trim()
-      : null;
-
-  return { priorSessionNotes, gitDiffStat };
+      : null,
+  };
 }
 
-/**
- * Decide whether to run the enricher for this trigger.
- *
- * WHY a separate pure function: keeps the guard logic testable without
- * setting up a full WorkflowTrigger with all fields.
- *
- * Returns false for:
- * - spawn_agent children (spawnDepth > 0) -- children use parent's context
- */
+// ---------------------------------------------------------------------------
+// shouldEnrich
+// ---------------------------------------------------------------------------
+
 export function shouldEnrich(trigger: WorkflowTrigger): boolean {
   return (trigger.spawnDepth ?? 0) === 0;
 }
-
-export { EMPTY_RESULT };

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -74,12 +74,15 @@ import type {
   ChildWorkflowRunResult,
   OrphanedSession,
 } from './types.js';
+import { extractContextSlots } from './types.js';
 import {
   enrichTriggerContext,
   shouldEnrich,
   EMPTY_RESULT,
+  type WorkflowEnricherDeps,
+  type EnricherResult,
+  type PriorNotesPolicy,
 } from './workflow-enricher.js';
-import type { WorkflowEnricherDeps, EnricherResult } from './workflow-enricher.js';
 import type { SessionState, TerminalSignal, StuckConfig, StuckSignal } from './state/index.js';
 import {
   createSessionState,
@@ -366,10 +369,11 @@ export async function runWorkflow(
   // created. spawn_agent children bypass this via the spawnDepth guard.
   let enricherResult: EnricherResult = EMPTY_RESULT;
   if (enricherDeps !== undefined && shouldEnrich(trigger)) {
-    const skipPriorNotes =
-      typeof trigger.context?.['assembledContextSummary'] === 'string' &&
-      (trigger.context['assembledContextSummary'] as string).trim().length > 0;
-    enricherResult = await enrichTriggerContext(trigger, enricherDeps, skipPriorNotes);
+    const { assembledContextSummary } = extractContextSlots(trigger.context);
+    const policy: PriorNotesPolicy = assembledContextSummary !== undefined && assembledContextSummary.trim().length > 0
+      ? 'skip_coordinator_provided'
+      : 'inject';
+    enricherResult = await enrichTriggerContext(trigger, enricherDeps, policy);
   }
 
   // ---- Pre-agent I/O phase ----

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -74,6 +74,12 @@ import type {
   ChildWorkflowRunResult,
   OrphanedSession,
 } from './types.js';
+import {
+  enrichTriggerContext,
+  shouldEnrich,
+  EMPTY_RESULT,
+} from './workflow-enricher.js';
+import type { WorkflowEnricherDeps, EnricherResult } from './workflow-enricher.js';
 import type { SessionState, TerminalSignal, StuckConfig, StuckSignal } from './state/index.js';
 import {
   createSessionState,
@@ -314,6 +320,15 @@ export async function runWorkflow(
    * (allocate internally) pass kind: 'allocate' or omit this parameter entirely.
    */
   source?: SessionSource,
+  /**
+   * Optional WorkflowEnricher deps for cross-session context injection.
+   *
+   * WHY optional: callers that don't provide this (e.g. spawn_agent children,
+   * old call sites) get the original behaviour unchanged. Only root sessions
+   * (spawnDepth === 0) with this param injected will receive prior workspace
+   * notes and git diff stat in their system prompt.
+   */
+  enricherDeps?: WorkflowEnricherDeps,
 ): Promise<WorkflowRunResult> {
   // ---- Resolved dirs (injectable for tests) ----
   const statsDir = _statsDir ?? DAEMON_STATS_DIR;
@@ -343,6 +358,19 @@ export async function runWorkflow(
     workflowId: trigger.workflowId,
     workspacePath: trigger.workspacePath,
   });
+
+  // ---- Context enrichment (root sessions only) ----
+  // WHY before buildPreAgentSession: enrichment is I/O-bound (session scan +
+  // git), not session-bound. Running it here ensures all entry points that
+  // reach runWorkflow() get enrichment, regardless of how the session is
+  // created. spawn_agent children bypass this via the spawnDepth guard.
+  let enricherResult: EnricherResult = EMPTY_RESULT;
+  if (enricherDeps !== undefined && shouldEnrich(trigger)) {
+    const skipPriorNotes =
+      typeof trigger.context?.['assembledContextSummary'] === 'string' &&
+      (trigger.context['assembledContextSummary'] as string).trim().length > 0;
+    enricherResult = await enrichTriggerContext(trigger, enricherDeps, skipPriorNotes);
+  }
 
   // ---- Pre-agent I/O phase ----
   // All setup (model validation, start_workflow, token decode, persistTokens,
@@ -383,6 +411,7 @@ export async function runWorkflow(
   const readySession = await buildAgentReadySession(
     preResult.session, trigger, ctx, apiKey, sessionId,
     emitter, daemonRegistry, activeSessionSet, runWorkflow,
+    enricherResult,
   );
 
   // ---- Agent loop phase: run prompt loop to completion ----

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -484,7 +484,9 @@ export async function startTriggerListener(
   // throws from the function's own error-handling path.
   // WHY pass ctx: enables resume-path logic (decode token, count step advances,
   // call executeContinueWorkflow with intent: 'rehydrate' for sessions with progress).
-  await runStartupRecovery(undefined, undefined, ctx, undefined, undefined, undefined, apiKey).catch((err: unknown) => {
+  // WHY pass runWorkflowFn: crash-recovered sessions resume via runWorkflow; passing the
+  // enricher-wrapped fn ensures recovered root sessions also receive context enrichment.
+  await runStartupRecovery(undefined, undefined, ctx, undefined, undefined, runWorkflowFn, apiKey).catch((err: unknown) => {
     console.warn(
       '[TriggerListener] Startup recovery encountered an unexpected error:',
       err instanceof Error ? err.message : String(err),

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -30,6 +30,7 @@ import { ActiveSessionSet } from '../daemon/active-sessions.js';
 import { loadWorkrailConfigFile, loadWorkspacesFromConfigFile } from '../config/config-file.js';
 import { NotificationService } from './notification-service.js';
 import { runWorkflow } from '../daemon/workflow-runner.js';
+import { createWorkflowEnricherDeps } from '../daemon/workflow-enricher.js';
 import { runStartupRecovery } from '../daemon/startup-recovery.js';
 import type { WebhookEvent, WorkspaceConfig } from './types.js';
 import { asTriggerId } from './types.js';
@@ -440,7 +441,14 @@ export async function startTriggerListener(
   };
 
   // Create router and Express app
-  const runWorkflowFn: RunWorkflowFn = options.runWorkflowFn ?? runWorkflow;
+  // WHY enricherDeps bound here: trigger-listener.ts is the composition root for the
+  // production daemon. Binding the enricher here (not inside runWorkflow) keeps the
+  // production wiring explicit and testable -- tests that pass a fake runWorkflowFn
+  // bypass this wiring entirely and are unaffected.
+  const enricherDeps = createWorkflowEnricherDeps();
+  const baseRunWorkflow = options.runWorkflowFn ?? runWorkflow;
+  const runWorkflowFn: RunWorkflowFn = (trigger, ctx, apiKey, daemonRegistry, emitter, activeSessionSet, _statsDir, _sessionsDir, source) =>
+    baseRunWorkflow(trigger, ctx, apiKey, daemonRegistry, emitter, activeSessionSet, _statsDir, _sessionsDir, source, enricherDeps);
   const router = new TriggerRouter(triggerIndex, ctx, apiKey, runWorkflowFn, undefined, maxConcurrentSessions, options.emitter, notificationService, activeSessionSet, coordinatorDeps, modeExecutors);
   // Bind the router's dispatch function so spawnSession can dispatch in-process.
   // WHY after construction: coordinatorDeps must be created before TriggerRouter (it's

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -97,6 +97,7 @@ export type RunWorkflowFn = (
   _statsDir?: string,
   _sessionsDir?: string,
   source?: SessionSource,
+  enricherDeps?: import('../daemon/workflow-enricher.js').WorkflowEnricherDeps,
 ) => Promise<WorkflowRunResult>;
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/workflow-enricher.test.ts
+++ b/tests/unit/workflow-enricher.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for workflow-enricher.ts.
+ *
+ * Strategy: inject fake deps for all I/O. Tests are synchronous-ish (vitest
+ * handles async). No fs access, no git subprocess, no session store.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  enrichTriggerContext,
+  shouldEnrich,
+  type WorkflowEnricherDeps,
+} from '../../src/daemon/workflow-enricher.js';
+import type { WorkflowTrigger } from '../../src/daemon/types.js';
+import type { SessionNote } from '../../src/context-assembly/types.js';
+
+const baseTrigger: WorkflowTrigger = {
+  workflowId: 'wr.coding-task',
+  goal: 'implement feature',
+  workspacePath: '/workspace',
+};
+
+const sampleNotes: readonly SessionNote[] = [
+  {
+    sessionId: 'sess_abc',
+    sessionTitle: 'Prior review session',
+    recapSnippet: 'Reviewed PR and found 2 issues',
+    gitBranch: 'main',
+    lastModifiedMs: Date.now() - 3600_000,
+  },
+];
+
+function makeFakeDeps(overrides: Partial<WorkflowEnricherDeps> = {}): WorkflowEnricherDeps {
+  return {
+    execGit: vi.fn().mockResolvedValue({ kind: 'ok', value: 'src/foo.ts | 5 ++\n1 file changed' }),
+    listRecentSessions: vi.fn().mockResolvedValue({ kind: 'ok', value: sampleNotes }),
+    ...overrides,
+  };
+}
+
+describe('shouldEnrich()', () => {
+  it('returns true for root sessions (no spawnDepth)', () => {
+    expect(shouldEnrich(baseTrigger)).toBe(true);
+  });
+
+  it('returns true for spawnDepth === 0', () => {
+    expect(shouldEnrich({ ...baseTrigger, spawnDepth: 0 })).toBe(true);
+  });
+
+  it('returns false for spawn_agent children (spawnDepth > 0)', () => {
+    expect(shouldEnrich({ ...baseTrigger, spawnDepth: 1 })).toBe(false);
+    expect(shouldEnrich({ ...baseTrigger, spawnDepth: 3 })).toBe(false);
+  });
+});
+
+describe('enrichTriggerContext()', () => {
+  it('returns prior notes and gitDiffStat for a root session', async () => {
+    const deps = makeFakeDeps();
+    const result = await enrichTriggerContext(baseTrigger, deps, false);
+
+    expect(result.priorSessionNotes).toHaveLength(1);
+    expect(result.priorSessionNotes[0]?.sessionTitle).toBe('Prior review session');
+    expect(result.gitDiffStat).toContain('src/foo.ts');
+  });
+
+  it('skips prior notes when skipPriorNotes is true (assembledContextSummary present)', async () => {
+    const deps = makeFakeDeps();
+    const result = await enrichTriggerContext(baseTrigger, deps, true);
+
+    expect(result.priorSessionNotes).toHaveLength(0);
+    expect(deps.listRecentSessions).not.toHaveBeenCalled();
+    // gitDiffStat is still injected
+    expect(result.gitDiffStat).toBeTruthy();
+  });
+
+  it('still injects gitDiffStat when assembledContextSummary present (skipPriorNotes=true)', async () => {
+    const triggerWithCtx: WorkflowTrigger = {
+      ...baseTrigger,
+      context: { assembledContextSummary: 'Coordinator assembled context' },
+    };
+    const deps = makeFakeDeps();
+    const result = await enrichTriggerContext(triggerWithCtx, deps, true);
+
+    expect(result.priorSessionNotes).toHaveLength(0);
+    expect(result.gitDiffStat).toBeTruthy();
+  });
+
+  it('returns empty priorSessionNotes when listRecentSessions times out', async () => {
+    const slowListSessions: WorkflowEnricherDeps['listRecentSessions'] = () =>
+      new Promise((resolve) => setTimeout(() => resolve({ kind: 'ok', value: sampleNotes }), 5000));
+    const deps = makeFakeDeps({ listRecentSessions: slowListSessions });
+
+    const result = await enrichTriggerContext(baseTrigger, deps, false);
+
+    // Timeout fires before the slow promise resolves
+    expect(result.priorSessionNotes).toHaveLength(0);
+    // gitDiffStat is independent and should still resolve
+    expect(result.gitDiffStat).toBeTruthy();
+  }, 3000); // 3s timeout -- enricher times out at 1s
+
+  it('returns null gitDiffStat when git command fails', async () => {
+    const deps = makeFakeDeps({
+      execGit: vi.fn().mockResolvedValue({ kind: 'err', error: 'not a git repository' }),
+    });
+    const result = await enrichTriggerContext(baseTrigger, deps, false);
+
+    expect(result.gitDiffStat).toBeNull();
+    expect(result.priorSessionNotes).toHaveLength(1);
+  });
+
+  it('returns empty result when listRecentSessions fails', async () => {
+    const deps = makeFakeDeps({
+      listRecentSessions: vi.fn().mockResolvedValue({ kind: 'err', error: 'store unavailable' }),
+    });
+    const result = await enrichTriggerContext(baseTrigger, deps, false);
+
+    expect(result.priorSessionNotes).toHaveLength(0);
+    expect(result.gitDiffStat).toBeTruthy(); // git still ran
+  });
+});

--- a/tests/unit/workflow-enricher.test.ts
+++ b/tests/unit/workflow-enricher.test.ts
@@ -10,6 +10,7 @@ import {
   enrichTriggerContext,
   shouldEnrich,
   type WorkflowEnricherDeps,
+  type PriorNotesPolicy,
 } from '../../src/daemon/workflow-enricher.js';
 import type { WorkflowTrigger } from '../../src/daemon/types.js';
 import type { SessionNote } from '../../src/context-assembly/types.js';
@@ -56,30 +57,29 @@ describe('shouldEnrich()', () => {
 describe('enrichTriggerContext()', () => {
   it('returns prior notes and gitDiffStat for a root session', async () => {
     const deps = makeFakeDeps();
-    const result = await enrichTriggerContext(baseTrigger, deps, false);
+    const result = await enrichTriggerContext(baseTrigger, deps, 'inject');
 
     expect(result.priorSessionNotes).toHaveLength(1);
     expect(result.priorSessionNotes[0]?.sessionTitle).toBe('Prior review session');
     expect(result.gitDiffStat).toContain('src/foo.ts');
   });
 
-  it('skips prior notes when skipPriorNotes is true (assembledContextSummary present)', async () => {
+  it('skips prior notes when policy is skip_coordinator_provided', async () => {
     const deps = makeFakeDeps();
-    const result = await enrichTriggerContext(baseTrigger, deps, true);
+    const result = await enrichTriggerContext(baseTrigger, deps, 'skip_coordinator_provided');
 
     expect(result.priorSessionNotes).toHaveLength(0);
     expect(deps.listRecentSessions).not.toHaveBeenCalled();
-    // gitDiffStat is still injected
     expect(result.gitDiffStat).toBeTruthy();
   });
 
-  it('still injects gitDiffStat when assembledContextSummary present (skipPriorNotes=true)', async () => {
+  it('still injects gitDiffStat when policy is skip_coordinator_provided', async () => {
     const triggerWithCtx: WorkflowTrigger = {
       ...baseTrigger,
       context: { assembledContextSummary: 'Coordinator assembled context' },
     };
     const deps = makeFakeDeps();
-    const result = await enrichTriggerContext(triggerWithCtx, deps, true);
+    const result = await enrichTriggerContext(triggerWithCtx, deps, 'skip_coordinator_provided');
 
     expect(result.priorSessionNotes).toHaveLength(0);
     expect(result.gitDiffStat).toBeTruthy();
@@ -90,7 +90,7 @@ describe('enrichTriggerContext()', () => {
       new Promise((resolve) => setTimeout(() => resolve({ kind: 'ok', value: sampleNotes }), 5000));
     const deps = makeFakeDeps({ listRecentSessions: slowListSessions });
 
-    const result = await enrichTriggerContext(baseTrigger, deps, false);
+    const result = await enrichTriggerContext(baseTrigger, deps, 'inject');
 
     // Timeout fires before the slow promise resolves
     expect(result.priorSessionNotes).toHaveLength(0);
@@ -102,7 +102,7 @@ describe('enrichTriggerContext()', () => {
     const deps = makeFakeDeps({
       execGit: vi.fn().mockResolvedValue({ kind: 'err', error: 'not a git repository' }),
     });
-    const result = await enrichTriggerContext(baseTrigger, deps, false);
+    const result = await enrichTriggerContext(baseTrigger, deps, 'inject');
 
     expect(result.gitDiffStat).toBeNull();
     expect(result.priorSessionNotes).toHaveLength(1);
@@ -112,7 +112,7 @@ describe('enrichTriggerContext()', () => {
     const deps = makeFakeDeps({
       listRecentSessions: vi.fn().mockResolvedValue({ kind: 'err', error: 'store unavailable' }),
     });
-    const result = await enrichTriggerContext(baseTrigger, deps, false);
+    const result = await enrichTriggerContext(baseTrigger, deps, 'inject');
 
     expect(result.priorSessionNotes).toHaveLength(0);
     expect(result.gitDiffStat).toBeTruthy(); // git still ran

--- a/tests/unit/workflow-runner-system-prompt.test.ts
+++ b/tests/unit/workflow-runner-system-prompt.test.ts
@@ -314,4 +314,82 @@ describe('buildSystemPrompt()', () => {
       expect(prompt).not.toContain('## Prior Context');
     });
   });
+
+  describe('enricherResult injection', () => {
+    const sampleEnricher = {
+      priorSessionNotes: [
+        {
+          sessionId: 'sess_abc',
+          sessionTitle: 'Prior review',
+          recapSnippet: 'Found 2 issues in auth module',
+          gitBranch: 'main',
+          lastModifiedMs: Date.now(),
+        },
+      ],
+      gitDiffStat: 'src/auth.ts | 12 +++\n1 file changed',
+    };
+
+    it('injects ## Prior Workspace Notes when enricherResult has notes and no assembledContextSummary', () => {
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath, sampleEnricher);
+
+      expect(prompt).toContain('## Prior Workspace Notes');
+      expect(prompt).toContain('Prior review');
+      expect(prompt).toContain('Found 2 issues in auth module');
+    });
+
+    it('injects ## Changed files section', () => {
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath, sampleEnricher);
+
+      expect(prompt).toContain('## Changed files');
+      expect(prompt).toContain('src/auth.ts');
+    });
+
+    it('skips ## Prior Workspace Notes when assembledContextSummary is present', () => {
+      const triggerWithCtx: WorkflowTrigger = {
+        ...baseTrigger,
+        context: { assembledContextSummary: 'Coordinator context here' },
+      };
+      const prompt = buildSystemPrompt(triggerWithCtx, '', DAEMON_SOUL_DEFAULT, null, triggerWithCtx.workspacePath, sampleEnricher);
+
+      expect(prompt).not.toContain('## Prior Workspace Notes');
+      // But Changed files is still injected
+      expect(prompt).toContain('## Changed files');
+    });
+
+    it('omits ## Prior Workspace Notes when enricherResult has empty notes', () => {
+      const emptyNotes = { priorSessionNotes: [], gitDiffStat: null };
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath, emptyNotes);
+
+      expect(prompt).not.toContain('## Prior Workspace Notes');
+      expect(prompt).not.toContain('## Changed files');
+    });
+
+    it('omits enricher sections when enricherResult is undefined', () => {
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath);
+
+      expect(prompt).not.toContain('## Prior Workspace Notes');
+      expect(prompt).not.toContain('## Changed files');
+    });
+
+    it('injects ## Changed files even when notes are empty', () => {
+      const onlyDiff = { priorSessionNotes: [], gitDiffStat: 'src/foo.ts | 1 +' };
+      const prompt = buildSystemPrompt(baseTrigger, '', DAEMON_SOUL_DEFAULT, null, baseTrigger.workspacePath, onlyDiff);
+
+      expect(prompt).toContain('## Changed files');
+      expect(prompt).not.toContain('## Prior Workspace Notes');
+    });
+
+    it('## Changed files appears after ## Prior Context', () => {
+      const trigger: WorkflowTrigger = {
+        ...baseTrigger,
+        context: { assembledContextSummary: 'coordinator context' },
+      };
+      const prompt = buildSystemPrompt(trigger, '', DAEMON_SOUL_DEFAULT, null, trigger.workspacePath, sampleEnricher);
+
+      const priorCtxIdx = prompt.indexOf('## Prior Context');
+      const changedFilesIdx = prompt.indexOf('## Changed files');
+      expect(priorCtxIdx).toBeGreaterThan(-1);
+      expect(changedFilesIdx).toBeGreaterThan(priorCtxIdx);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `WorkflowEnricher` service (`src/daemon/workflow-enricher.ts`) that runs for root sessions (`spawnDepth === 0`) before the agent loop starts
- Injects prior workspace session notes (max 3, newest-first) and `git diff HEAD~1 --stat` into all 6 session entry points -- raw triggers, direct dispatch, crash recovery, CLI dispatch all now get cross-session context automatically
- `EnricherResult` is a typed value threaded through the call chain rather than merged into `trigger.context`, keeping the trigger immutable
- Double-injection guard: prior notes are skipped when `assembledContextSummary` is already present (coordinator context takes precedence); git diff stat is always injected
- 1s wall-clock timeout on `listRecentSessions` with graceful partial-result fallback
- Production wiring in `trigger-listener.ts`; all existing callers unaffected (enricher is last optional param)

## Design notes

Phase 1 of the WorkTrain memory system architecture (see `.workrail/discovery-worktrain-memory-ideal.md`). Phase 0 (bug fixes + WorkflowContextSlots) is PR #946.

**Pilot test gate:** before declaring Phase 1 successful, run one session with prior notes injected and verify the agent references them in turn-1 reasoning.

## Test plan
- [x] `npx vitest run` -- 385 files, 5951 tests pass
- [x] `npm run build` -- clean
- [x] `workflow-enricher.test.ts` -- 9 unit tests covering spawnDepth guard, double-injection skip, 1s timeout, git failure, and listRecentSessions failure modes
- [x] `workflow-runner-system-prompt.test.ts` -- 8 new tests for Prior Workspace Notes and Changed files sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)