### PR TITLE
refactor(engine): CoordinatorSpawnContext with explicit fields, no index signature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,6 +389,7 @@ These principles guide all code decisions in this project. When writing, reviewi
 - **Make illegal states unrepresentable** -- model domain states so invalid combinations cannot be constructed
 - **Prefer explicit domain types over primitives** -- avoid stringly/numberly typed APIs when domain-specific types or ADTs communicate intent
 - **Type safety as the first line of defense** -- prefer compile-time guarantees over runtime checks
+- **Types must constrain, not just label** -- a type that accepts everything its predecessor accepted is a rename, not an improvement. The test: can the compiler reject an invalid caller? If no, the type is documentation. An interface with an index signature (`[key: string]: unknown`) is structurally identical to `Record<string, unknown>` and provides no safety. Explicit fields with no escape hatch are the only way to make illegal states unrepresentable at compile time.
 - **Exhaustiveness everywhere** -- use discriminated unions so handling is complete and refactor-safe
 - **Errors are data** -- represent failure as values (Result/Either), not exceptions as control flow
 - **Validate at boundaries, trust inside** -- do input validation at system edges; keep core logic free of defensive checks

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -43,7 +43,7 @@ import {
   type Priority,
 } from './cli/commands/index.js';
 import { writeStatsSummary } from './daemon/stats-summary.js';
-import type { ChildSessionResult } from './coordinators/types.js';
+import type { ChildSessionResult, CoordinatorSpawnContext } from './coordinators/types.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -1294,8 +1294,7 @@ runCommand
         workflowId: string,
         goal: string,
         workspace: string,
-        context?: Readonly<Record<string, unknown>>,
-        // CLI path does not support agentConfig -- sessions use daemon default timeouts.
+        context?: CoordinatorSpawnContext,
         _agentConfig?: Readonly<{ readonly maxSessionMinutes?: number; readonly maxTurns?: number }>,
         parentSessionId?: string,
       ) => {

--- a/src/coordinators/modes/full-pipeline.ts
+++ b/src/coordinators/modes/full-pipeline.ts
@@ -48,7 +48,7 @@ import { buildContextSummary, extractPhaseArtifact } from '../context-assembly.j
 import { buildPhaseResult } from '../pipeline-run-context.js';
 import { runReviewAndVerdictCycle } from './implement-shared.js';
 import { touchesUI } from './implement.js';
-import type { CoordinatorSpawnContext } from '../pr-review.js';
+import type { CoordinatorSpawnContext } from '../types.js';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // CONSTANTS

--- a/src/coordinators/modes/implement-shared.ts
+++ b/src/coordinators/modes/implement-shared.ts
@@ -13,7 +13,7 @@
 import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts, PipelineOutcome } from '../adaptive-pipeline.js';
 import { CODING_TIMEOUT_MS, REVIEW_TIMEOUT_MS, checkSpawnCutoff } from '../adaptive-pipeline.js';
 import { readVerdictArtifact, parseFindingsFromNotes } from '../pr-review.js';
-import type { CoordinatorSpawnContext } from '../pr-review.js';
+import type { CoordinatorSpawnContext } from '../types.js';
 import type { ReviewVerdictArtifactV1 } from '../../v2/durable-core/schemas/artifacts/review-verdict.js';
 import { parseReviewVerdictArtifact } from '../../v2/durable-core/schemas/artifacts/review-verdict.js';
 import type { PhaseHandoffArtifact } from '../../v2/durable-core/schemas/artifacts/index.js';

--- a/src/coordinators/modes/implement.ts
+++ b/src/coordinators/modes/implement.ts
@@ -34,7 +34,7 @@ import {
 } from '../adaptive-pipeline.js';
 import { runReviewAndVerdictCycle, MAX_FIX_ITERATIONS } from './implement-shared.js';
 import { extractPhaseArtifact, buildContextSummary } from '../context-assembly.js';
-import type { CoordinatorSpawnContext } from '../pr-review.js';
+import type { CoordinatorSpawnContext } from '../types.js';
 import { buildPhaseResult } from '../pipeline-run-context.js';
 import type { PhaseHandoffArtifact } from '../../v2/durable-core/schemas/artifacts/index.js';
 import { isCodingHandoffArtifact, CodingHandoffArtifactV1Schema } from '../../v2/durable-core/schemas/artifacts/index.js';
@@ -155,9 +155,7 @@ async function runImplementCore(
     const cutoffCheck = checkSpawnCutoff(coordinatorStartMs, deps.now(), 'ux-gate');
     if (cutoffCheck) return cutoffCheck;
 
-    const uxSpawnResult = await deps.spawnSession('wr.ui-ux-design', opts.goal, opts.workspace, {
-      pitchPath,
-    });
+    const uxSpawnResult = await deps.spawnSession('wr.ui-ux-design', opts.goal, opts.workspace, { pitchPath });
 
     if (uxSpawnResult.kind === 'err') {
       deps.stderr(`[implement] UX gate spawn failed: ${uxSpawnResult.error}`);
@@ -201,15 +199,8 @@ async function runImplementCore(
 
   deps.stderr(`[implement] Spawning wr.coding-task`);
 
-  const codingSpawnResult = await deps.spawnSession(
-    'wr.coding-task',
-    opts.goal,
-    opts.workspace,
-    {
-      // Belt-and-suspenders: pass pitchPath explicitly (pitch invariant 13)
-      pitchPath,
-    },
-  );
+  // Belt-and-suspenders: pass pitchPath explicitly (pitch invariant 13)
+  const codingSpawnResult = await deps.spawnSession('wr.coding-task', opts.goal, opts.workspace, { pitchPath });
 
   if (codingSpawnResult.kind === 'err') {
     return {

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -36,30 +36,6 @@ import {
 import { renderContextBundle } from '../context-assembly/index.js';
 import type { ContextAssembler } from '../context-assembly/types.js';
 
-// ---------------------------------------------------------------------------
-// CoordinatorSpawnContext
-// ---------------------------------------------------------------------------
-
-/**
- * Typed context passed to spawned sessions by coordinators.
- *
- * WHY a named type (not Readonly<Record<string, unknown>>): makes the field surface
- * explicit and prevents callers from passing arbitrary untyped data. All fields are
- * passed through to the agent's trigger.context map.
- *
- * Invariant for assembledContextSummary: coordinators only set this when the rendered
- * context string is non-empty. The illegal state (set but empty) cannot arise at
- * construction sites that guard with `if (rendered.trim().length > 0)`.
- *
- * The index signature permits additional coordinator-specific fields (e.g. pitchPath,
- * prUrl, findings) without requiring a separate type per coordinator.
- */
-export interface CoordinatorSpawnContext {
-  /** Coordinator-assembled prior phase context injected as ## Prior Context in the system prompt. */
-  readonly assembledContextSummary?: string;
-  readonly [key: string]: unknown;
-}
-
 // ═══════════════════════════════════════════════════════════════════════════
 // DOMAIN TYPES
 // ═══════════════════════════════════════════════════════════════════════════
@@ -170,7 +146,7 @@ export interface CoordinatorDeps {
     workflowId: string,
     goal: string,
     workspace: string,
-    context?: CoordinatorSpawnContext,
+    context?: Readonly<Record<string, unknown>>,
     agentConfig?: Readonly<{ readonly maxSessionMinutes?: number; readonly maxTurns?: number }>,
     parentSessionId?: string,
   ) => Promise<Result<string, string>>;
@@ -1049,8 +1025,8 @@ export async function runPrReviewCoordinator(
   // Spawn review sessions in parallel
   const reviewHandles = new Map<number, string>(); // prNumber -> sessionHandle
   const spawnErrors = new Map<number, string>(); // prNumber -> error message
-  // Assembled context per PR -- forwarded to fix agent spawns and re-review spawns in runFixAgentLoop
-  const spawnContexts = new Map<number, CoordinatorSpawnContext>();
+  // Assembled context per PR -- forwarded to re-review spawns in runFixAgentLoop
+  const spawnContexts = new Map<number, Readonly<Record<string, unknown>>>();
 
   for (const pr of prs) {
     const goal = `Review PR #${pr.number} "${pr.title}" before merge`;
@@ -1060,7 +1036,7 @@ export async function runPrReviewCoordinator(
     }
 
     // Assemble context before spawning (optional -- skip if no assembler injected).
-    let spawnContext: CoordinatorSpawnContext | undefined;
+    let spawnContext: Readonly<Record<string, unknown>> | undefined;
     if (deps.contextAssembler) {
       const bundle = await deps.contextAssembler.assemble({
         kind: 'pr_review',
@@ -1296,7 +1272,7 @@ async function runFixAgentLoop(
   coordinatorStartMs: number,
   log: (line: string) => void,
   /** Assembled context from the initial review spawn. Forwarded to fix agent spawns and re-review spawns. */
-  reviewSpawnContext?: CoordinatorSpawnContext,
+  reviewSpawnContext?: Readonly<Record<string, unknown>>,
 ): Promise<PrOutcome> {
   let passCount = 0;
   let currentFindings = initialFindings;

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -28,7 +28,8 @@ import type { Result } from '../runtime/result.js';
 import { ok, err } from '../runtime/result.js';
 import { assertNever } from '../runtime/assert-never.js';
 import type { AwaitResult, SessionResult } from '../cli/commands/worktrain-await.js';
-import type { ChildSessionResult } from './types.js';
+import type { ChildSessionResult, CoordinatorSpawnContext } from './types.js';
+export type { CoordinatorSpawnContext } from './types.js';
 import {
   ReviewVerdictArtifactV1Schema,
   isReviewVerdictArtifact,
@@ -36,29 +37,6 @@ import {
 import { renderContextBundle } from '../context-assembly/index.js';
 import type { ContextAssembler } from '../context-assembly/types.js';
 
-// ---------------------------------------------------------------------------
-// CoordinatorSpawnContext
-// ---------------------------------------------------------------------------
-
-/**
- * Typed context passed to spawned sessions by coordinators.
- *
- * WHY a named type (not Readonly<Record<string, unknown>>): makes the field surface
- * explicit and prevents callers from passing arbitrary untyped data. All fields are
- * passed through to the agent's trigger.context map.
- *
- * Invariant for assembledContextSummary: coordinators only set this when the rendered
- * context string is non-empty. The illegal state (set but empty) cannot arise at
- * construction sites that guard with `if (rendered.trim().length > 0)`.
- *
- * The index signature permits additional coordinator-specific fields (e.g. pitchPath,
- * prUrl, findings) without requiring a separate type per coordinator.
- */
-export interface CoordinatorSpawnContext {
-  /** Coordinator-assembled prior phase context injected as ## Prior Context in the system prompt. */
-  readonly assembledContextSummary?: string;
-  readonly [key: string]: unknown;
-}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // DOMAIN TYPES

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -36,6 +36,30 @@ import {
 import { renderContextBundle } from '../context-assembly/index.js';
 import type { ContextAssembler } from '../context-assembly/types.js';
 
+// ---------------------------------------------------------------------------
+// CoordinatorSpawnContext
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed context passed to spawned sessions by coordinators.
+ *
+ * WHY a named type (not Readonly<Record<string, unknown>>): makes the field surface
+ * explicit and prevents callers from passing arbitrary untyped data. All fields are
+ * passed through to the agent's trigger.context map.
+ *
+ * Invariant for assembledContextSummary: coordinators only set this when the rendered
+ * context string is non-empty. The illegal state (set but empty) cannot arise at
+ * construction sites that guard with `if (rendered.trim().length > 0)`.
+ *
+ * The index signature permits additional coordinator-specific fields (e.g. pitchPath,
+ * prUrl, findings) without requiring a separate type per coordinator.
+ */
+export interface CoordinatorSpawnContext {
+  /** Coordinator-assembled prior phase context injected as ## Prior Context in the system prompt. */
+  readonly assembledContextSummary?: string;
+  readonly [key: string]: unknown;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // DOMAIN TYPES
 // ═══════════════════════════════════════════════════════════════════════════
@@ -146,7 +170,7 @@ export interface CoordinatorDeps {
     workflowId: string,
     goal: string,
     workspace: string,
-    context?: Readonly<Record<string, unknown>>,
+    context?: CoordinatorSpawnContext,
     agentConfig?: Readonly<{ readonly maxSessionMinutes?: number; readonly maxTurns?: number }>,
     parentSessionId?: string,
   ) => Promise<Result<string, string>>;
@@ -1025,8 +1049,8 @@ export async function runPrReviewCoordinator(
   // Spawn review sessions in parallel
   const reviewHandles = new Map<number, string>(); // prNumber -> sessionHandle
   const spawnErrors = new Map<number, string>(); // prNumber -> error message
-  // Assembled context per PR -- forwarded to re-review spawns in runFixAgentLoop
-  const spawnContexts = new Map<number, Readonly<Record<string, unknown>>>();
+  // Assembled context per PR -- forwarded to fix agent spawns and re-review spawns in runFixAgentLoop
+  const spawnContexts = new Map<number, CoordinatorSpawnContext>();
 
   for (const pr of prs) {
     const goal = `Review PR #${pr.number} "${pr.title}" before merge`;
@@ -1036,7 +1060,7 @@ export async function runPrReviewCoordinator(
     }
 
     // Assemble context before spawning (optional -- skip if no assembler injected).
-    let spawnContext: Readonly<Record<string, unknown>> | undefined;
+    let spawnContext: CoordinatorSpawnContext | undefined;
     if (deps.contextAssembler) {
       const bundle = await deps.contextAssembler.assemble({
         kind: 'pr_review',
@@ -1272,7 +1296,7 @@ async function runFixAgentLoop(
   coordinatorStartMs: number,
   log: (line: string) => void,
   /** Assembled context from the initial review spawn. Forwarded to fix agent spawns and re-review spawns. */
-  reviewSpawnContext?: Readonly<Record<string, unknown>>,
+  reviewSpawnContext?: CoordinatorSpawnContext,
 ): Promise<PrOutcome> {
   let passCount = 0;
   let currentFindings = initialFindings;

--- a/src/coordinators/types.ts
+++ b/src/coordinators/types.ts
@@ -1,5 +1,5 @@
 /**
- * Coordinator Session Chaining Types
+ * Coordinator Context and Session Chaining Types
  *
  * Typed result for child session execution in coordinator pipelines.
  *
@@ -20,6 +20,42 @@
  * spawn_agent uses ChildWorkflowRunResult (which also excludes delivery_failed) for the
  * same reason. The type says exactly what can happen; delivery_failed cannot happen here.
  */
+
+// ---------------------------------------------------------------------------
+// CoordinatorSpawnContext
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed context passed to spawned sessions by coordinators.
+ *
+ * WHY explicit fields (not Readonly<Record<string,unknown>> or index signature):
+ * Every field a coordinator can pass must be declared here. Unknown fields are
+ * rejected by TypeScript, preventing coordinators from silently injecting data
+ * that agents can't access via typed extraction. Adding a new field requires
+ * a deliberate type change, not an ad-hoc string key.
+ *
+ * Invariant: assembledContextSummary is only set when the rendered string is
+ * non-empty. Callers guard with `if (rendered.trim().length > 0)` before
+ * constructing -- the illegal state (set but empty) cannot arise.
+ */
+export interface CoordinatorSpawnContext {
+  /** Coordinator-assembled prior phase context injected as ## Prior Context. Non-empty when present. */
+  readonly assembledContextSummary?: string;
+  /** Absolute path to the pitch file for IMPLEMENT mode coding sessions. */
+  readonly pitchPath?: string;
+  /** PR URL passed to review, audit, and re-review sessions. */
+  readonly prUrl?: string;
+  /** Finding summaries forwarded to fix sessions so the agent knows what to fix. */
+  readonly findings?: readonly string[];
+  /** Severity from the review verdict, forwarded to audit sessions. */
+  readonly severity?: string;
+  /** Signals to the UX session that shaping completed (full-pipeline). */
+  readonly shapingComplete?: true;
+  /** Signals to the re-review session that the audit pass completed. */
+  readonly auditComplete?: true;
+}
+
+// ---------------------------------------------------------------------------
 
 /**
  * Typed result of a child session execution.

--- a/src/trigger/coordinator-deps.ts
+++ b/src/trigger/coordinator-deps.ts
@@ -23,7 +23,7 @@ import { randomUUID } from 'node:crypto';
 import { ok, err } from 'neverthrow';
 import type { V2ToolContext } from '../mcp/types.js';
 import type { AdaptiveCoordinatorDeps } from '../coordinators/adaptive-pipeline.js';
-import type { CoordinatorSpawnContext } from '../coordinators/pr-review.js';
+import type { CoordinatorSpawnContext } from '../coordinators/types.js';
 import type { ChildSessionResult } from '../coordinators/types.js';
 import { executeStartWorkflow } from '../mcp/handlers/v2-execution/start.js';
 import { parseContinueTokenOrFail } from '../mcp/handlers/v2-token-ops.js';
@@ -306,7 +306,8 @@ export function createCoordinatorDeps(
         workflowId,
         goal,
         workspacePath: workspace,
-        context,
+        // Widen coordinator-typed context to the daemon's generic map at this boundary.
+        context: context as Readonly<Record<string, unknown>> | undefined,
         ...(agentConfig !== undefined ? { agentConfig } : {}),
       };
       const r = startResult.value.response;


### PR DESCRIPTION
## Summary

Follow-up to PR #952. `CoordinatorSpawnContext` previously had an index signature (`readonly [key: string]: unknown`) making it structurally identical to `Readonly<Record<string,unknown>>` -- passing arbitrary unknown keys was still a compile-time no-op.

This PR:
- Moves `CoordinatorSpawnContext` to `src/coordinators/types.ts` alongside `ChildSessionResult`
- Removes the index signature -- all coordinator-passable fields are now explicit (`assembledContextSummary`, `pitchPath`, `prUrl`, `findings`, `severity`, `shapingComplete`, `auditComplete`)
- Passing unknown keys is now a compile error
- Single widening cast in `coordinator-deps.ts` at the boundary where typed coordinator context enters the daemon's generic `WorkflowTrigger.context` map
- Re-exports `CoordinatorSpawnContext` from `pr-review.ts` for backward compatibility

## Test plan
- [x] `npm run build` -- clean
- [x] `npx vitest run tests/unit/coordinator-pr-review.test.ts` -- 83/83 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)