### PR TITLE
docs: mark Living Work Context fully done in backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,6 +389,7 @@ These principles guide all code decisions in this project. When writing, reviewi
 - **Make illegal states unrepresentable** -- model domain states so invalid combinations cannot be constructed
 - **Prefer explicit domain types over primitives** -- avoid stringly/numberly typed APIs when domain-specific types or ADTs communicate intent
 - **Type safety as the first line of defense** -- prefer compile-time guarantees over runtime checks
+- **Types must constrain, not just label** -- a type that accepts everything its predecessor accepted is a rename, not an improvement. The test: can the compiler reject an invalid caller? If no, the type is documentation. An interface with an index signature (`[key: string]: unknown`) is structurally identical to `Record<string, unknown>` and provides no safety. Explicit fields with no escape hatch are the only way to make illegal states unrepresentable at compile time.
 - **Exhaustiveness everywhere** -- use discriminated unions so handling is complete and refactor-safe
 - **Errors are data** -- represent failure as values (Result/Either), not exceptions as control flow
 - **Validate at boundaries, trust inside** -- do input validation at system edges; keep core logic free of defensive checks

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -698,7 +698,7 @@ The autonomous workflow runner (`worktrain daemon`). Completely separate from th
 
 ### Living work context: shared knowledge document that accumulates across the full pipeline (Apr 30, 2026)
 
-**Status: partial** | Core infra shipped May 5, 2026 (PR #939). All three original gaps now addressed; one residual gap deferred to Phase 2.
+**Status: done** | Core infra shipped May 5, 2026 (PR #939). All three gaps fixed (PRs #948, #952). Residual: `github_prs_poll` direct dispatch path deferred to Phase 2 (MemoryStore).
 
 **Score: 13** | Cor:3 Cap:3 Eff:2 Lev:3 Con:2 | Blocked: no
 
@@ -706,7 +706,7 @@ The autonomous workflow runner (`worktrain daemon`). Completely separate from th
 
 **Gap #1 -- fixed (PR #948):** Contract test added: `tests/unit/context-chain-contract.test.ts` pins the seam between `buildContextSummary()` coordinator output and `buildSessionContext()` daemon input across all 4 phase transitions.
 
-**Gap #2 -- fixed (PR #952):** The actual gap was narrower than originally described: QUICK_REVIEW/REVIEW_ONLY do invoke `runPrReviewCoordinator` with a `contextAssembler` wired. The real issue was the **fix agent spawn** in `runFixAgentLoop()` was not forwarding `reviewSpawnContext` -- fixed with one line. Residual: the `github_prs_poll` direct dispatch path bypasses the coordinator entirely; fix agents from that path still start cold. Deferred to Phase 2 (MemoryStore pre-assembly).
+**Gap #2 -- fixed (PRs #952, #954):** The actual gap was narrower than originally described: QUICK_REVIEW/REVIEW_ONLY do invoke `runPrReviewCoordinator` with a `contextAssembler` wired. The real issue was the **fix agent spawn** in `runFixAgentLoop()` was not forwarding `reviewSpawnContext` -- fixed with one line. Also shipped: `CoordinatorSpawnContext` typed interface in `src/coordinators/types.ts` with explicit fields and no index signature, replacing `Readonly<Record<string,unknown>>` across all coordinator spawn sites (5 files). Passing unknown keys is now a compile error. Residual: the `github_prs_poll` direct dispatch path bypasses the coordinator entirely; fix agents from that path still start cold. Deferred to Phase 2 (MemoryStore pre-assembly).
 
 **Gap #3 -- fixed (PR #948):** Console session detail view now surfaces an **Injected Context** card when `assembledContextSummary` is present in the session's `context_set` event.
 

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -2048,27 +2048,20 @@ Each file is injected only into sessions running the matching pipeline phase. Re
 
 ### Coordinator architecture: separation of concerns
 
-**Status: idea** | Priority: medium
+**Status: done** | Shipped May 2026 (PRs #947, #954)
 
-**Score: 9** | Cor:1 Cap:2 Eff:2 Lev:2 Con:2 | Blocked: no (unblocked by Apr 30 discovery -- context assembly does not require the knowledge graph)
+**Score: 9** | Cor:1 Cap:2 Eff:2 Lev:2 Con:2 | Blocked: no
 
-**Problem:** `src/coordinators/pr-review.ts` is already ~500 LOC doing session dispatch, result aggregation, finding classification, merge routing, message queue drain, and outbox writes. Adding knowledge graph queries, context bundle assembly, and prior session lookups would create a god class.
-
-**Right layering:**
+The layering is implemented:
 ```
 Trigger layer         src/trigger/          receives events, validates, enqueues
-Dispatch layer        (TBD)                 decides which workflow + what goal
-Context assembly      src/daemon/           enriches trigger before runWorkflow() fires
-Orchestration layer   src/coordinators/     spawns, awaits, routes, retries, escalates
+Dispatch layer        adaptive-pipeline.ts  decides workflow + goal (queue-polled tasks)
+Context assembly      src/daemon/           WorkflowEnricher enriches before runWorkflow()
+Orchestration layer   src/coordinators/     CoordinatorSpawnContext typed interface (PR #954)
 Delivery layer        src/trigger/delivery  posts results back to origin systems
 ```
 
-**Resolution from Apr 30 discovery:** Context assembly does NOT require the knowledge graph as a prerequisite. The universal enricher (Phase 1 of the memory architecture) provides a structural context assembly layer via `WorkflowEnricher` injected into `runWorkflow()` -- this IS the missing layer. The orchestration scripts (coordinators) continue to add task-specific richer context on top (phase artifacts, git diff for PRs) via the existing `assembledContextSummary` mechanism. The two layers compose: universal enricher provides the floor, coordinators provide the ceiling.
-
-**The Dispatch layer question** is resolved by the adaptive pipeline coordinator (`src/coordinators/adaptive-pipeline.ts`) -- it IS the dispatch layer for queue-polled tasks. For webhook-triggered tasks, `TriggerRouter.route()` performs dispatch. The layering is already present; it just isn't documented as such.
-
-**Remaining open question:**
-- When a coordinator calls `spawnSession()` with an `assembledContextSummary`, should the universal enricher's prior-notes injection be suppressed (coordinator already covered it) or additive (both run)? The discovery recommends suppression -- enricher skips prior notes when `assembledContextSummary` is already set.
+Universal enricher provides the floor (prior workspace notes + git diff for all entry points). Coordinators provide the ceiling (phase artifacts, PR-specific context via `assembledContextSummary`). Enricher suppresses prior-notes when `assembledContextSummary` is already set -- resolved, not additive.
 
 ---
 
@@ -2935,26 +2928,20 @@ Human always required for: schema changes, dependency upgrades (major version), 
 
 ### Coordinator context injection standard: agents start informed, not discovering (Apr 18, 2026)
 
-**Status: idea** | Priority: high
+**Status: partial** | Priority: high
 
 **Score: 9** | Cor:1 Cap:2 Eff:2 Lev:2 Con:2 | Blocked: no
 
-Every coordinator-spawned agent gets a pre-packaged context bundle. The coordinator assembles it before calling `worktrain spawn`. The bundle includes:
-1. **Prior session findings** -- what relevant sessions discovered (from session store query)
-2. **Established patterns** -- the specific invariants and patterns the agent needs (from knowledge graph or AGENTS.md)
-3. **What NOT to discover** -- explicit list of things already known so the agent doesn't waste turns
-4. **Failure history** -- what's been tried and didn't work (prevents re-exploring dead ends)
+**What shipped (May 2026):**
+- `WorkflowEnricher` (PR #947) -- daemon injects prior workspace session notes + git diff stat for all root sessions. This is the floor layer.
+- `CoordinatorSpawnContext` typed interface (PR #954) in `src/coordinators/types.ts` -- explicit fields, no index signature. Coordinators inject typed context at dispatch time.
+- `buildContextSummary()` + `PipelineRunContext` (PR #939) -- inter-phase artifact threading for FULL pipeline (discovery/shaping/coding/review).
+- PR review coordinator assembles git diff + prior session notes via `ContextAssembler` before spawning review and fix sessions.
 
-~2000 tokens max, injected as a `<context>` block before the task description. Structured so the agent can skip Phase 0 context gathering entirely when the bundle is complete.
+**What remains:** "Prior session findings" and "failure history" require Phase 2 MemoryStore (indexed SQLite) before they're fast enough to use at dispatch time. The assembly architecture is correct; the indexed data source is still unbuilt.
 
-Without this: every agent spawned without proper context burns tokens on discovery that should have been provided upfront. At 10 concurrent agents, that's 10x the waste.
-
-**Things to hash out:**
-- Who assembles the context bundle -- the coordinator script, the daemon, or a dedicated context assembly service? Where does the assembly logic live?
-- The 2000-token budget is a guess. What is the actual optimal size -- enough to be useful, small enough not to crowd out the step prompt?
-- How does the context bundle stay fresh across a long coordinator run? Prior session findings from 2 hours ago may be stale if main advanced significantly.
-- If the knowledge graph is not yet built for a workspace, what is the fallback for context assembly? Does the coordinator skip bundling entirely, or manually assemble from known sources?
-- Should the `<context>` block format be standardized so all workflows know how to consume it, or is it opaque content the agent reads naturally?
+**Remaining thing to hash out:**
+- Should the context format be standardized across all workflows, or is unstructured text the agent reads naturally sufficient?
 
 ---
 

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -43,7 +43,7 @@ import {
   type Priority,
 } from './cli/commands/index.js';
 import { writeStatsSummary } from './daemon/stats-summary.js';
-import type { ChildSessionResult } from './coordinators/types.js';
+import type { ChildSessionResult, CoordinatorSpawnContext } from './coordinators/types.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -1294,8 +1294,7 @@ runCommand
         workflowId: string,
         goal: string,
         workspace: string,
-        context?: Readonly<Record<string, unknown>>,
-        // CLI path does not support agentConfig -- sessions use daemon default timeouts.
+        context?: CoordinatorSpawnContext,
         _agentConfig?: Readonly<{ readonly maxSessionMinutes?: number; readonly maxTurns?: number }>,
         parentSessionId?: string,
       ) => {

--- a/src/coordinators/modes/full-pipeline.ts
+++ b/src/coordinators/modes/full-pipeline.ts
@@ -48,7 +48,7 @@ import { buildContextSummary, extractPhaseArtifact } from '../context-assembly.j
 import { buildPhaseResult } from '../pipeline-run-context.js';
 import { runReviewAndVerdictCycle } from './implement-shared.js';
 import { touchesUI } from './implement.js';
-import type { CoordinatorSpawnContext } from '../pr-review.js';
+import type { CoordinatorSpawnContext } from '../types.js';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // CONSTANTS

--- a/src/coordinators/modes/implement-shared.ts
+++ b/src/coordinators/modes/implement-shared.ts
@@ -13,7 +13,7 @@
 import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts, PipelineOutcome } from '../adaptive-pipeline.js';
 import { CODING_TIMEOUT_MS, REVIEW_TIMEOUT_MS, checkSpawnCutoff } from '../adaptive-pipeline.js';
 import { readVerdictArtifact, parseFindingsFromNotes } from '../pr-review.js';
-import type { CoordinatorSpawnContext } from '../pr-review.js';
+import type { CoordinatorSpawnContext } from '../types.js';
 import type { ReviewVerdictArtifactV1 } from '../../v2/durable-core/schemas/artifacts/review-verdict.js';
 import { parseReviewVerdictArtifact } from '../../v2/durable-core/schemas/artifacts/review-verdict.js';
 import type { PhaseHandoffArtifact } from '../../v2/durable-core/schemas/artifacts/index.js';

--- a/src/coordinators/modes/implement.ts
+++ b/src/coordinators/modes/implement.ts
@@ -34,7 +34,7 @@ import {
 } from '../adaptive-pipeline.js';
 import { runReviewAndVerdictCycle, MAX_FIX_ITERATIONS } from './implement-shared.js';
 import { extractPhaseArtifact, buildContextSummary } from '../context-assembly.js';
-import type { CoordinatorSpawnContext } from '../pr-review.js';
+import type { CoordinatorSpawnContext } from '../types.js';
 import { buildPhaseResult } from '../pipeline-run-context.js';
 import type { PhaseHandoffArtifact } from '../../v2/durable-core/schemas/artifacts/index.js';
 import { isCodingHandoffArtifact, CodingHandoffArtifactV1Schema } from '../../v2/durable-core/schemas/artifacts/index.js';
@@ -155,9 +155,7 @@ async function runImplementCore(
     const cutoffCheck = checkSpawnCutoff(coordinatorStartMs, deps.now(), 'ux-gate');
     if (cutoffCheck) return cutoffCheck;
 
-    const uxSpawnResult = await deps.spawnSession('wr.ui-ux-design', opts.goal, opts.workspace, {
-      pitchPath,
-    });
+    const uxSpawnResult = await deps.spawnSession('wr.ui-ux-design', opts.goal, opts.workspace, { pitchPath });
 
     if (uxSpawnResult.kind === 'err') {
       deps.stderr(`[implement] UX gate spawn failed: ${uxSpawnResult.error}`);
@@ -201,15 +199,8 @@ async function runImplementCore(
 
   deps.stderr(`[implement] Spawning wr.coding-task`);
 
-  const codingSpawnResult = await deps.spawnSession(
-    'wr.coding-task',
-    opts.goal,
-    opts.workspace,
-    {
-      // Belt-and-suspenders: pass pitchPath explicitly (pitch invariant 13)
-      pitchPath,
-    },
-  );
+  // Belt-and-suspenders: pass pitchPath explicitly (pitch invariant 13)
+  const codingSpawnResult = await deps.spawnSession('wr.coding-task', opts.goal, opts.workspace, { pitchPath });
 
   if (codingSpawnResult.kind === 'err') {
     return {

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -36,30 +36,6 @@ import {
 import { renderContextBundle } from '../context-assembly/index.js';
 import type { ContextAssembler } from '../context-assembly/types.js';
 
-// ---------------------------------------------------------------------------
-// CoordinatorSpawnContext
-// ---------------------------------------------------------------------------
-
-/**
- * Typed context passed to spawned sessions by coordinators.
- *
- * WHY a named type (not Readonly<Record<string, unknown>>): makes the field surface
- * explicit and prevents callers from passing arbitrary untyped data. All fields are
- * passed through to the agent's trigger.context map.
- *
- * Invariant for assembledContextSummary: coordinators only set this when the rendered
- * context string is non-empty. The illegal state (set but empty) cannot arise at
- * construction sites that guard with `if (rendered.trim().length > 0)`.
- *
- * The index signature permits additional coordinator-specific fields (e.g. pitchPath,
- * prUrl, findings) without requiring a separate type per coordinator.
- */
-export interface CoordinatorSpawnContext {
-  /** Coordinator-assembled prior phase context injected as ## Prior Context in the system prompt. */
-  readonly assembledContextSummary?: string;
-  readonly [key: string]: unknown;
-}
-
 // ═══════════════════════════════════════════════════════════════════════════
 // DOMAIN TYPES
 // ═══════════════════════════════════════════════════════════════════════════
@@ -170,7 +146,7 @@ export interface CoordinatorDeps {
     workflowId: string,
     goal: string,
     workspace: string,
-    context?: CoordinatorSpawnContext,
+    context?: Readonly<Record<string, unknown>>,
     agentConfig?: Readonly<{ readonly maxSessionMinutes?: number; readonly maxTurns?: number }>,
     parentSessionId?: string,
   ) => Promise<Result<string, string>>;
@@ -1049,8 +1025,8 @@ export async function runPrReviewCoordinator(
   // Spawn review sessions in parallel
   const reviewHandles = new Map<number, string>(); // prNumber -> sessionHandle
   const spawnErrors = new Map<number, string>(); // prNumber -> error message
-  // Assembled context per PR -- forwarded to fix agent spawns and re-review spawns in runFixAgentLoop
-  const spawnContexts = new Map<number, CoordinatorSpawnContext>();
+  // Assembled context per PR -- forwarded to re-review spawns in runFixAgentLoop
+  const spawnContexts = new Map<number, Readonly<Record<string, unknown>>>();
 
   for (const pr of prs) {
     const goal = `Review PR #${pr.number} "${pr.title}" before merge`;
@@ -1060,7 +1036,7 @@ export async function runPrReviewCoordinator(
     }
 
     // Assemble context before spawning (optional -- skip if no assembler injected).
-    let spawnContext: CoordinatorSpawnContext | undefined;
+    let spawnContext: Readonly<Record<string, unknown>> | undefined;
     if (deps.contextAssembler) {
       const bundle = await deps.contextAssembler.assemble({
         kind: 'pr_review',
@@ -1296,7 +1272,7 @@ async function runFixAgentLoop(
   coordinatorStartMs: number,
   log: (line: string) => void,
   /** Assembled context from the initial review spawn. Forwarded to fix agent spawns and re-review spawns. */
-  reviewSpawnContext?: CoordinatorSpawnContext,
+  reviewSpawnContext?: Readonly<Record<string, unknown>>,
 ): Promise<PrOutcome> {
   let passCount = 0;
   let currentFindings = initialFindings;

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -28,7 +28,8 @@ import type { Result } from '../runtime/result.js';
 import { ok, err } from '../runtime/result.js';
 import { assertNever } from '../runtime/assert-never.js';
 import type { AwaitResult, SessionResult } from '../cli/commands/worktrain-await.js';
-import type { ChildSessionResult } from './types.js';
+import type { ChildSessionResult, CoordinatorSpawnContext } from './types.js';
+export type { CoordinatorSpawnContext } from './types.js';
 import {
   ReviewVerdictArtifactV1Schema,
   isReviewVerdictArtifact,
@@ -36,29 +37,6 @@ import {
 import { renderContextBundle } from '../context-assembly/index.js';
 import type { ContextAssembler } from '../context-assembly/types.js';
 
-// ---------------------------------------------------------------------------
-// CoordinatorSpawnContext
-// ---------------------------------------------------------------------------
-
-/**
- * Typed context passed to spawned sessions by coordinators.
- *
- * WHY a named type (not Readonly<Record<string, unknown>>): makes the field surface
- * explicit and prevents callers from passing arbitrary untyped data. All fields are
- * passed through to the agent's trigger.context map.
- *
- * Invariant for assembledContextSummary: coordinators only set this when the rendered
- * context string is non-empty. The illegal state (set but empty) cannot arise at
- * construction sites that guard with `if (rendered.trim().length > 0)`.
- *
- * The index signature permits additional coordinator-specific fields (e.g. pitchPath,
- * prUrl, findings) without requiring a separate type per coordinator.
- */
-export interface CoordinatorSpawnContext {
-  /** Coordinator-assembled prior phase context injected as ## Prior Context in the system prompt. */
-  readonly assembledContextSummary?: string;
-  readonly [key: string]: unknown;
-}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // DOMAIN TYPES

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -36,6 +36,30 @@ import {
 import { renderContextBundle } from '../context-assembly/index.js';
 import type { ContextAssembler } from '../context-assembly/types.js';
 
+// ---------------------------------------------------------------------------
+// CoordinatorSpawnContext
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed context passed to spawned sessions by coordinators.
+ *
+ * WHY a named type (not Readonly<Record<string, unknown>>): makes the field surface
+ * explicit and prevents callers from passing arbitrary untyped data. All fields are
+ * passed through to the agent's trigger.context map.
+ *
+ * Invariant for assembledContextSummary: coordinators only set this when the rendered
+ * context string is non-empty. The illegal state (set but empty) cannot arise at
+ * construction sites that guard with `if (rendered.trim().length > 0)`.
+ *
+ * The index signature permits additional coordinator-specific fields (e.g. pitchPath,
+ * prUrl, findings) without requiring a separate type per coordinator.
+ */
+export interface CoordinatorSpawnContext {
+  /** Coordinator-assembled prior phase context injected as ## Prior Context in the system prompt. */
+  readonly assembledContextSummary?: string;
+  readonly [key: string]: unknown;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // DOMAIN TYPES
 // ═══════════════════════════════════════════════════════════════════════════
@@ -146,7 +170,7 @@ export interface CoordinatorDeps {
     workflowId: string,
     goal: string,
     workspace: string,
-    context?: Readonly<Record<string, unknown>>,
+    context?: CoordinatorSpawnContext,
     agentConfig?: Readonly<{ readonly maxSessionMinutes?: number; readonly maxTurns?: number }>,
     parentSessionId?: string,
   ) => Promise<Result<string, string>>;
@@ -1025,8 +1049,8 @@ export async function runPrReviewCoordinator(
   // Spawn review sessions in parallel
   const reviewHandles = new Map<number, string>(); // prNumber -> sessionHandle
   const spawnErrors = new Map<number, string>(); // prNumber -> error message
-  // Assembled context per PR -- forwarded to re-review spawns in runFixAgentLoop
-  const spawnContexts = new Map<number, Readonly<Record<string, unknown>>>();
+  // Assembled context per PR -- forwarded to fix agent spawns and re-review spawns in runFixAgentLoop
+  const spawnContexts = new Map<number, CoordinatorSpawnContext>();
 
   for (const pr of prs) {
     const goal = `Review PR #${pr.number} "${pr.title}" before merge`;
@@ -1036,7 +1060,7 @@ export async function runPrReviewCoordinator(
     }
 
     // Assemble context before spawning (optional -- skip if no assembler injected).
-    let spawnContext: Readonly<Record<string, unknown>> | undefined;
+    let spawnContext: CoordinatorSpawnContext | undefined;
     if (deps.contextAssembler) {
       const bundle = await deps.contextAssembler.assemble({
         kind: 'pr_review',
@@ -1272,7 +1296,7 @@ async function runFixAgentLoop(
   coordinatorStartMs: number,
   log: (line: string) => void,
   /** Assembled context from the initial review spawn. Forwarded to fix agent spawns and re-review spawns. */
-  reviewSpawnContext?: Readonly<Record<string, unknown>>,
+  reviewSpawnContext?: CoordinatorSpawnContext,
 ): Promise<PrOutcome> {
   let passCount = 0;
   let currentFindings = initialFindings;

--- a/src/coordinators/types.ts
+++ b/src/coordinators/types.ts
@@ -1,5 +1,5 @@
 /**
- * Coordinator Session Chaining Types
+ * Coordinator Context and Session Chaining Types
  *
  * Typed result for child session execution in coordinator pipelines.
  *
@@ -20,6 +20,42 @@
  * spawn_agent uses ChildWorkflowRunResult (which also excludes delivery_failed) for the
  * same reason. The type says exactly what can happen; delivery_failed cannot happen here.
  */
+
+// ---------------------------------------------------------------------------
+// CoordinatorSpawnContext
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed context passed to spawned sessions by coordinators.
+ *
+ * WHY explicit fields (not Readonly<Record<string,unknown>> or index signature):
+ * Every field a coordinator can pass must be declared here. Unknown fields are
+ * rejected by TypeScript, preventing coordinators from silently injecting data
+ * that agents can't access via typed extraction. Adding a new field requires
+ * a deliberate type change, not an ad-hoc string key.
+ *
+ * Invariant: assembledContextSummary is only set when the rendered string is
+ * non-empty. Callers guard with `if (rendered.trim().length > 0)` before
+ * constructing -- the illegal state (set but empty) cannot arise.
+ */
+export interface CoordinatorSpawnContext {
+  /** Coordinator-assembled prior phase context injected as ## Prior Context. Non-empty when present. */
+  readonly assembledContextSummary?: string;
+  /** Absolute path to the pitch file for IMPLEMENT mode coding sessions. */
+  readonly pitchPath?: string;
+  /** PR URL passed to review, audit, and re-review sessions. */
+  readonly prUrl?: string;
+  /** Finding summaries forwarded to fix sessions so the agent knows what to fix. */
+  readonly findings?: readonly string[];
+  /** Severity from the review verdict, forwarded to audit sessions. */
+  readonly severity?: string;
+  /** Signals to the UX session that shaping completed (full-pipeline). */
+  readonly shapingComplete?: true;
+  /** Signals to the re-review session that the audit pass completed. */
+  readonly auditComplete?: true;
+}
+
+// ---------------------------------------------------------------------------
 
 /**
  * Typed result of a child session execution.

--- a/src/trigger/coordinator-deps.ts
+++ b/src/trigger/coordinator-deps.ts
@@ -23,7 +23,7 @@ import { randomUUID } from 'node:crypto';
 import { ok, err } from 'neverthrow';
 import type { V2ToolContext } from '../mcp/types.js';
 import type { AdaptiveCoordinatorDeps } from '../coordinators/adaptive-pipeline.js';
-import type { CoordinatorSpawnContext } from '../coordinators/pr-review.js';
+import type { CoordinatorSpawnContext } from '../coordinators/types.js';
 import type { ChildSessionResult } from '../coordinators/types.js';
 import { executeStartWorkflow } from '../mcp/handlers/v2-execution/start.js';
 import { parseContinueTokenOrFail } from '../mcp/handlers/v2-token-ops.js';
@@ -306,7 +306,8 @@ export function createCoordinatorDeps(
         workflowId,
         goal,
         workspacePath: workspace,
-        context,
+        // Widen coordinator-typed context to the daemon's generic map at this boundary.
+        context: context as Readonly<Record<string, unknown>> | undefined,
         ...(agentConfig !== undefined ? { agentConfig } : {}),
       };
       const r = startResult.value.response;


### PR DESCRIPTION
All three gaps shipped (PRs #948, #952, #954). Updates status and adds note about CoordinatorSpawnContext typing refactor.