### PR TITLE
fix(mcp): add delimiter after continue token to prevent concatenation

### DIFF
--- a/src/mcp/v2-response-formatter.ts
+++ b/src/mcp/v2-response-formatter.ts
@@ -458,6 +458,7 @@ function formatCleanBlocked(data: V2Blocked): string {
   const token = data.retryContinueToken ?? data.nextCall?.params.continueToken ?? data.continueToken;
   if (token) {
     lines.push(`WorkRail: retry with corrected output. Token: ${token}`);
+    lines.push('---');
   }
 
   return lines.join('\n');
@@ -476,6 +477,7 @@ function formatCleanRehydrate(data: V2ExecutionResponse): string {
   if (token) {
     const footer = pickFooter(CLEAN_REHYDRATE_FOOTERS, data.pending?.stepId);
     lines.push(`${footer} ${token}`);
+    lines.push('---');
   }
 
   const driftBlock = formatBindingDriftWarnings(data);
@@ -499,6 +501,7 @@ function formatCleanSuccess(data: V2ExecutionResponse): string {
   if (token) {
     const footer = pickFooter(CLEAN_ADVANCE_FOOTERS, data.pending?.stepId);
     lines.push(`${footer} ${token}`);
+    lines.push('---');
   }
 
   const driftBlock = formatBindingDriftWarnings(data);


### PR DESCRIPTION
## Summary

- Claude Code renders multiple MCP content items from a single tool call result without visual separation between them
- The continue token at the end of the primary content item ran directly into the supplement text (`WorkRail is a separate live system...`), making the token boundary unreadable
- Result: agents couldn't extract a valid continue token from the rendered output, breaking `continue_workflow` calls

## Fix

Add a `---` delimiter line after the token line in `formatCleanSuccess`, `formatCleanRehydrate`, and `formatCleanBlocked` formatters. The token is now visually bounded:

```
---
WorkRail: advance with continue_workflow when ready. Include your notes. Token: ct_xyz...
---
WorkRail is a separate live system...
```

## Test plan

- [x] `npx vitest run tests/unit/v2/v2-response-formatter*` -- 86/86 pass
- [x] `npx vitest run tests/unit/mcp/` -- 240/240 pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)