### PR TITLE
fix(engine): propagate AbortSignal to Bash tool so SIGTERM stops in-flight commands

### DIFF
--- a/src/daemon/tools/bash.ts
+++ b/src/daemon/tools/bash.ts
@@ -47,9 +47,9 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
           details: { stdout, stderr },
         };
       } catch (err: unknown) {
-        // ABORT_ERR is a string code -- it would fall through the numeric rawCode checks
-        // below and produce 'exit unknown'. Rethrow so _executeTools gets a clean error.
-        if ((err as { code?: unknown }).code === 'ABORT_ERR') throw err;
+        // AbortError falls through the numeric rawCode checks and produces 'exit unknown'.
+        // Rethrow so _executeTools gets a clean error.
+        if (err instanceof Error && err.name === 'AbortError') throw err;
 
         // Node's child_process.exec errors (ExecException) attach stdout, stderr,
         // code, and signal as own properties. Extract them so the agent can reason


### PR DESCRIPTION
## Summary

- Add `signal: AbortSignal` to `AgentTool.execute()` so execution context is explicit at the call boundary; `_executeTools()` passes the active controller signal on every tool call
- `makeBashTool` passes the signal to `execAsync` so in-flight bash commands are killed on abort instead of running for up to 5 minutes after SIGTERM
- Detect `ABORT_ERR` explicitly in the bash catch block before the numeric `rawCode` checks to avoid a confusing `exit unknown` log entry
- Rename shadowed `signal` local variable to `killSignal` in the error handler

## Test plan

- [ ] `npx vitest run` passes (388 files, 5986+ tests)
- [ ] New test: `makeBashTool() > abort signal > aborts a running command when signal is fired mid-execution` passes within 2s
- [ ] New test: `makeBashTool() > abort signal > rejects immediately when signal is already aborted before execute` passes
- [ ] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)