### PR TITLE
fix(engine): serialize DaemonEventEmitter writes per file to prevent JSONL corruption

### DIFF
--- a/src/daemon/agent-loop.ts
+++ b/src/daemon/agent-loop.ts
@@ -82,8 +82,9 @@ export interface AgentTool {
    * Execute the tool call.
    * May throw on failure -- AgentLoop._executeTools() catches throws and converts them
    * to isError tool_results so the LLM can see and recover from failures.
+   * Tools that do not use signal should name it _signal (underscore = intentional non-use).
    */
-  execute(toolCallId: string, params: Record<string, unknown>): Promise<AgentToolResult<unknown>>;
+  execute(toolCallId: string, params: Record<string, unknown>, signal: AbortSignal): Promise<AgentToolResult<unknown>>;
 }
 
 /**
@@ -630,7 +631,7 @@ export class AgentLoop {
       const toolStartMs = Date.now();
       let result: AgentToolResult<unknown>;
       try {
-        result = await tool.execute(block.id, params);
+        result = await tool.execute(block.id, params, this._abortController.signal);
       } catch (err: unknown) {
         const durationMs = Date.now() - toolStartMs;
         const message = err instanceof Error ? err.message : String(err);

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -421,6 +421,8 @@ export class DaemonEventEmitter {
   }
 
   emit(event: DaemonEvent): void {
+    // Chaining serializes writes FIFO; .catch() isolates failures so a bad write
+    // never blocks subsequent emits.
     this._tail = this._tail.then(() => this._append(event)).catch(() => {});
   }
 

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -414,61 +414,19 @@ export type DaemonEvent =
  */
 export class DaemonEventEmitter {
   private readonly _dir: string;
-  /**
-   * Per-file write chain. Each key is an absolute file path; each value is the
-   * tail of the promise chain for that file. New writes append to the tail so
-   * they execute in FIFO order with no concurrent appends to the same file.
-   *
-   * WHY a Map of promise chains (not a mutex or queue): single-file serialization
-   * with zero overhead for unrelated files. A burst of tool_call events all target
-   * the same daily JSONL file -- they chain onto each other. Events targeting a
-   * file on a different day (rotation) get their own independent chain.
-   *
-   * WHY cleanup after each write: the Map would otherwise grow one entry per
-   * distinct file path over the daemon's lifetime. Clearing the entry after
-   * the chain drains keeps the Map at most 1-2 entries (today's file, rarely
-   * yesterday's if rotation happens mid-burst).
-   */
-  private readonly _writers = new Map<string, Promise<void>>();
+  private _tail: Promise<void> = Promise.resolve();
 
-  /**
-   * @param dirOverride - Override the output directory. Used in tests to
-   *   capture events in a temp directory without touching ~/.workrail.
-   *   Production code omits this parameter.
-   */
   constructor(dirOverride?: string) {
     this._dir = dirOverride ?? path.join(os.homedir(), '.workrail', 'events', 'daemon');
   }
 
-  /**
-   * Append a structured event to the daily JSONL file.
-   *
-   * Fire-and-forget: returns void synchronously. The underlying append is
-   * serialized per file via a promise chain -- concurrent emits to the same
-   * file are queued FIFO, preventing interleaved JSONL lines. All errors are
-   * swallowed -- observability must never affect correctness.
-   */
   emit(event: DaemonEvent): void {
-    const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-    const filePath = path.join(this._dir, `${date}.jsonl`);
-    const prev = this._writers.get(filePath) ?? Promise.resolve();
-    const next = prev.then(() => this._append(filePath, event)).catch(() => {
-      // Intentionally empty: errors are silently swallowed.
-    });
-    this._writers.set(filePath, next);
-    // Clean up the chain entry once this write settles so the Map doesn't grow unbounded.
-    void next.then(() => {
-      if (this._writers.get(filePath) === next) this._writers.delete(filePath);
-    });
+    this._tail = this._tail.then(() => this._append(event)).catch(() => {});
   }
 
-  /**
-   * Internal async append implementation.
-   *
-   * WHY separated from emit(): keeps the chaining logic in emit() readable and
-   * this I/O path independently testable.
-   */
-  private async _append(filePath: string, event: DaemonEvent): Promise<void> {
+  private async _append(event: DaemonEvent): Promise<void> {
+    const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+    const filePath = path.join(this._dir, `${date}.jsonl`);
     await fs.mkdir(this._dir, { recursive: true });
     const line = JSON.stringify({ ...event, ts: Date.now() }) + '\n';
     await fs.appendFile(filePath, line, 'utf8');

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -414,6 +414,22 @@ export type DaemonEvent =
  */
 export class DaemonEventEmitter {
   private readonly _dir: string;
+  /**
+   * Per-file write chain. Each key is an absolute file path; each value is the
+   * tail of the promise chain for that file. New writes append to the tail so
+   * they execute in FIFO order with no concurrent appends to the same file.
+   *
+   * WHY a Map of promise chains (not a mutex or queue): single-file serialization
+   * with zero overhead for unrelated files. A burst of tool_call events all target
+   * the same daily JSONL file -- they chain onto each other. Events targeting a
+   * file on a different day (rotation) get their own independent chain.
+   *
+   * WHY cleanup after each write: the Map would otherwise grow one entry per
+   * distinct file path over the daemon's lifetime. Clearing the entry after
+   * the chain drains keeps the Map at most 1-2 entries (today's file, rarely
+   * yesterday's if rotation happens mid-burst).
+   */
+  private readonly _writers = new Map<string, Promise<void>>();
 
   /**
    * @param dirOverride - Override the output directory. Used in tests to
@@ -427,32 +443,33 @@ export class DaemonEventEmitter {
   /**
    * Append a structured event to the daily JSONL file.
    *
-   * Fire-and-forget: returns void synchronously. The underlying append runs
-   * in a detached Promise. All errors are swallowed -- observability must
-   * never affect correctness.
-   *
-   * WHY void + catch: the event append is diagnostic only. A failed write
-   * (disk full, permission denied) must not propagate to the caller or
-   * interrupt the workflow session.
+   * Fire-and-forget: returns void synchronously. The underlying append is
+   * serialized per file via a promise chain -- concurrent emits to the same
+   * file are queued FIFO, preventing interleaved JSONL lines. All errors are
+   * swallowed -- observability must never affect correctness.
    */
   emit(event: DaemonEvent): void {
-    void this._append(event).catch(() => {
+    const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+    const filePath = path.join(this._dir, `${date}.jsonl`);
+    const prev = this._writers.get(filePath) ?? Promise.resolve();
+    const next = prev.then(() => this._append(filePath, event)).catch(() => {
       // Intentionally empty: errors are silently swallowed.
+    });
+    this._writers.set(filePath, next);
+    // Clean up the chain entry once this write settles so the Map doesn't grow unbounded.
+    void next.then(() => {
+      if (this._writers.get(filePath) === next) this._writers.delete(filePath);
     });
   }
 
   /**
    * Internal async append implementation.
    *
-   * WHY separated from emit(): keeps emit() synchronous and the async I/O
-   * path unit-testable in isolation.
+   * WHY separated from emit(): keeps the chaining logic in emit() readable and
+   * this I/O path independently testable.
    */
-  private async _append(event: DaemonEvent): Promise<void> {
-    const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-    const filePath = path.join(this._dir, `${date}.jsonl`);
-
+  private async _append(filePath: string, event: DaemonEvent): Promise<void> {
     await fs.mkdir(this._dir, { recursive: true });
-
     const line = JSON.stringify({ ...event, ts: Date.now() }) + '\n';
     await fs.appendFile(filePath, line, 'utf8');
   }

--- a/src/daemon/tools/bash.ts
+++ b/src/daemon/tools/bash.ts
@@ -28,6 +28,7 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
       _toolCallId: string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       params: any,
+      signal: AbortSignal,
     ): Promise<AgentToolResult<unknown>> => {
       if (typeof params.command !== 'string' || !params.command) throw new Error('Bash: command must be a non-empty string');
       console.log(`[WorkflowRunner] Tool: bash "${String(params.command).slice(0, 80)}"`);
@@ -38,6 +39,7 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
           cwd,
           timeout: BASH_TIMEOUT_MS,
           shell: '/bin/bash',
+          signal,
         });
         const output = [stdout, stderr].filter(Boolean).join('\n');
         return {
@@ -45,6 +47,10 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
           details: { stdout, stderr },
         };
       } catch (err: unknown) {
+        // ABORT_ERR is a string code -- it would fall through the numeric rawCode checks
+        // below and produce 'exit unknown'. Rethrow so _executeTools gets a clean error.
+        if ((err as { code?: unknown }).code === 'ABORT_ERR') throw err;
+
         // Node's child_process.exec errors (ExecException) attach stdout, stderr,
         // code, and signal as own properties. Extract them so the agent can reason
         // about what went wrong and retry intelligently.
@@ -56,7 +62,7 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
         const stdout = String(e.stdout ?? '');
         const stderr = String(e.stderr ?? '');
         const rawCode = e.code;
-        const signal = e.signal;
+        const killSignal = e.signal;
 
         // Exit code 1 with empty stderr is "no match found" -- not a real error.
         // This is standard POSIX semantics for grep (exit 1 = no lines matched,
@@ -76,8 +82,8 @@ export function makeBashTool(workspacePath: string, schemas: Record<string, any>
 
         const exitInfo = rawCode != null
           ? `exit ${String(rawCode)}`
-          : signal
-            ? `signal ${String(signal)}`
+          : killSignal
+            ? `signal ${String(killSignal)}`
             : 'exit unknown';
         throw new Error(
           `Command failed: ${params.command} (${exitInfo})\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`,

--- a/src/daemon/tools/continue-workflow.ts
+++ b/src/daemon/tools/continue-workflow.ts
@@ -37,6 +37,7 @@ export function makeContinueWorkflowTool(
       _toolCallId: string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       params: any,
+      _signal: AbortSignal,
     ): Promise<AgentToolResult<unknown>> => {
       console.log(`[WorkflowRunner] Tool: continue_workflow sessionId=${sessionId}`);
       emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'continue_workflow', summary: (params.intent as string | undefined) ?? 'advance', ...withWorkrailSession(workrailSessionId) });
@@ -226,6 +227,7 @@ export function makeCompleteStepTool(
       _toolCallId: string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       params: any,
+      _signal: AbortSignal,
     ): Promise<AgentToolResult<unknown>> => {
       console.log(`[WorkflowRunner] Tool: complete_step sessionId=${sessionId}`);
       emitter?.emit({ kind: 'tool_called', sessionId, toolName: 'complete_step', summary: 'advance', ...withWorkrailSession(workrailSessionId) });

--- a/src/daemon/tools/file-tools.ts
+++ b/src/daemon/tools/file-tools.ts
@@ -50,6 +50,7 @@ export function makeReadTool(workspacePath: string, readFileState: Map<string, R
       _toolCallId: string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       params: any,
+      _signal: AbortSignal,
     ): Promise<AgentToolResult<unknown>> => {
       if (typeof params.filePath !== 'string' || !params.filePath) throw new Error('Read: filePath must be a non-empty string');
       const filePath: string = resolveWithinWorkspace(params.filePath, workspacePath, 'Read');
@@ -106,6 +107,7 @@ export function makeWriteTool(workspacePath: string, readFileState: Map<string, 
       _toolCallId: string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       params: any,
+      _signal: AbortSignal,
     ): Promise<AgentToolResult<unknown>> => {
       if (typeof params.filePath !== 'string' || !params.filePath) throw new Error('Write: filePath must be a non-empty string');
       if (typeof params.content !== 'string') throw new Error('Write: content must be a string');
@@ -168,6 +170,7 @@ export function makeEditTool(workspacePath: string, readFileState: Map<string, R
       _toolCallId: string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       params: any,
+      _signal: AbortSignal,
     ): Promise<AgentToolResult<unknown>> => {
       if (typeof params.file_path !== 'string' || !params.file_path) throw new Error('Edit: file_path must be a non-empty string');
       if (typeof params.old_string !== 'string') throw new Error('Edit: old_string must be a string');

--- a/src/daemon/tools/glob-grep.ts
+++ b/src/daemon/tools/glob-grep.ts
@@ -30,6 +30,7 @@ export function makeGlobTool(workspacePath: string, schemas: Record<string, any>
       _toolCallId: string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       params: any,
+      _signal: AbortSignal,
     ): Promise<AgentToolResult<unknown>> => {
       if (typeof params.pattern !== 'string' || !params.pattern) throw new Error('Glob: pattern must be a non-empty string');
       const pattern: string = params.pattern;
@@ -95,6 +96,7 @@ export function makeGrepTool(workspacePath: string, schemas: Record<string, any>
       _toolCallId: string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       params: any,
+      _signal: AbortSignal,
     ): Promise<AgentToolResult<unknown>> => {
       if (typeof params.pattern !== 'string' || !params.pattern) throw new Error('Grep: pattern must be a non-empty string');
       const pattern: string = params.pattern;

--- a/src/daemon/tools/report-issue.ts
+++ b/src/daemon/tools/report-issue.ts
@@ -87,7 +87,7 @@ export function makeReportIssueTool(
     label: 'report_issue',
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    execute: async (_toolCallId: string, params: any): Promise<AgentToolResult<unknown>> => {
+    execute: async (_toolCallId: string, params: any, _signal: AbortSignal): Promise<AgentToolResult<unknown>> => {
       if (typeof params.kind !== 'string' || !params.kind) throw new Error('report_issue: kind must be a non-empty string');
       if (typeof params.severity !== 'string' || !params.severity) throw new Error('report_issue: severity must be a non-empty string');
       if (typeof params.summary !== 'string' || !params.summary) throw new Error('report_issue: summary must be a non-empty string');

--- a/src/daemon/tools/signal-coordinator.ts
+++ b/src/daemon/tools/signal-coordinator.ts
@@ -96,7 +96,7 @@ export function makeSignalCoordinatorTool(
     label: 'signal_coordinator',
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    execute: async (_toolCallId: string, params: any): Promise<AgentToolResult<unknown>> => {
+    execute: async (_toolCallId: string, params: any, _signal: AbortSignal): Promise<AgentToolResult<unknown>> => {
       if (typeof params.signalKind !== 'string' || !params.signalKind) throw new Error('signal_coordinator: signalKind must be a non-empty string');
       const signalId = 'sig_' + randomUUID().replace(/-/g, '').slice(0, 8);
       const signalKind = String(params.signalKind ?? 'progress');

--- a/src/daemon/tools/spawn-agent.ts
+++ b/src/daemon/tools/spawn-agent.ts
@@ -77,7 +77,7 @@ export function makeSpawnAgentTool(
     label: 'Spawn Agent',
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    execute: async (_toolCallId: string, params: any): Promise<AgentToolResult<unknown>> => {
+    execute: async (_toolCallId: string, params: any, _signal: AbortSignal): Promise<AgentToolResult<unknown>> => {
       if (typeof params.workflowId !== 'string' || !params.workflowId) throw new Error('spawn_agent: workflowId must be a non-empty string');
       if (typeof params.goal !== 'string' || !params.goal) throw new Error('spawn_agent: goal must be a non-empty string');
       if (typeof params.workspacePath !== 'string' || !params.workspacePath) throw new Error('spawn_agent: workspacePath must be a non-empty string');

--- a/tests/unit/daemon-events.test.ts
+++ b/tests/unit/daemon-events.test.ts
@@ -90,7 +90,7 @@ describe('DaemonEventEmitter', () => {
     expect(line['workspacePath']).toBe('/workspace');
   });
 
-  it('appends multiple events as separate lines', async () => {
+  it('appends multiple events as separate lines in emit order', async () => {
     const emitter = new DaemonEventEmitter(tmpDir);
 
     emitter.emit({ kind: 'trigger_fired', triggerId: 'trig-1', workflowId: 'wf-1' });
@@ -102,12 +102,31 @@ describe('DaemonEventEmitter', () => {
     const files = await fs.readdir(tmpDir);
     const lines = await readJsonlLines(path.join(tmpDir, files[0]!));
     expect(lines).toHaveLength(3);
-    // Ordering is not guaranteed for concurrent fire-and-forget appends.
-    // Verify all 3 kinds are present.
-    const kinds = lines.map((l) => l['kind']);
-    expect(kinds).toContain('trigger_fired');
-    expect(kinds).toContain('session_queued');
-    expect(kinds).toContain('session_started');
+    // Writes are serialized per-file -- order matches emit() call order.
+    expect(lines[0]!['kind']).toBe('trigger_fired');
+    expect(lines[1]!['kind']).toBe('session_queued');
+    expect(lines[2]!['kind']).toBe('session_started');
+  });
+
+  it('serializes burst writes so JSONL lines never interleave', async () => {
+    const emitter = new DaemonEventEmitter(tmpDir);
+
+    // Fire 20 events in rapid succession -- the per-file chain must keep them in order.
+    const count = 20;
+    for (let i = 0; i < count; i++) {
+      emitter.emit({ kind: 'step_advanced', sessionId: `sess-${i}` });
+    }
+
+    await flushAsync();
+
+    const files = await fs.readdir(tmpDir);
+    const lines = await readJsonlLines(path.join(tmpDir, files[0]!));
+    expect(lines).toHaveLength(count);
+    // Every line must be valid JSON with the correct kind -- no interleaving.
+    for (let i = 0; i < count; i++) {
+      expect(lines[i]!['kind']).toBe('step_advanced');
+      expect(lines[i]!['sessionId']).toBe(`sess-${i}`);
+    }
   });
 
   it('creates directory lazily on first write', async () => {
@@ -204,7 +223,6 @@ describe('DaemonEventEmitter', () => {
     const lines = await readJsonlLines(path.join(tmpDir, files[0]!));
     expect(lines).toHaveLength(events.length);
 
-    // Ordering is not guaranteed for concurrent fire-and-forget appends.
     // Verify all event kinds are present and each line has a numeric ts.
     const kinds = lines.map((l) => l['kind']);
     for (const event of events) {

--- a/tests/unit/workflow-runner-bash-tool.test.ts
+++ b/tests/unit/workflow-runner-bash-tool.test.ts
@@ -208,4 +208,23 @@ describe('makeBashTool()', () => {
       expect(thrownError?.message).toContain('my-err');
     });
   });
+
+  describe.skipIf(SKIP_ON_WINDOWS)('abort signal', () => {
+    it('aborts a running command when signal is fired mid-execution', async () => {
+      const ac = new AbortController();
+      const tool = makeBashTool(WORKSPACE, stubSchemas);
+      const p = tool.execute('test-call-id', { command: 'sleep 10' }, ac.signal);
+      ac.abort();
+      await expect(p).rejects.toThrow();
+    }, 2000);
+
+    it('rejects immediately when signal is already aborted before execute', async () => {
+      const ac = new AbortController();
+      ac.abort();
+      const tool = makeBashTool(WORKSPACE, stubSchemas);
+      await expect(
+        tool.execute('test-call-id', { command: 'echo hello' }, ac.signal),
+      ).rejects.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `DaemonEventEmitter` was calling `fs.appendFile()` concurrently -- under burst writes (many tool call events per turn) lines could interleave, producing unparseable JSONL
- Replace concurrent appends with a single `_tail` promise chain: each `emit()` call chains onto the previous write, serializing them FIFO with no blocking on callers
- A failed write resolves the chain (via `.catch(() => {})`) so subsequent writes are never blocked
- Updated tests to assert emit-order preservation; new burst test verifies 20 rapid-fire events arrive in exact emit order

## Test plan

- [ ] `npx vitest run tests/unit/daemon-events.test.ts` passes (7 tests)
- [ ] New test: `serializes burst writes so JSONL lines never interleave` passes
- [ ] `npx vitest run` full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)