### PR TITLE
feat(mcp): merge worktrain analyze into diagnose; add fleet summary view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,19 +265,21 @@ If you are working in a fresh worktree and `node_modules` or other required depe
 
 ## Debugging daemon sessions
 
-When a daemon session fails or stops making progress, use `worktrain diagnose` to get a failure card -- category, evidence, and a suggested fix -- without reading raw JSONL files.
+`worktrain diagnose` is the single entry point for session observability.
 
 ```bash
-worktrain diagnose <sessionId>          # failure card (last 7 days)
-worktrain diagnose <sessionId> --json   # machine-readable JSON
-worktrain diagnose <sessionId> --ascii  # plain-terminal / pipe-safe output
+worktrain diagnose                        # fleet summary: outcome breakdown, per-workflow stats, token burn
+worktrain diagnose --workflow wr.discovery  # fleet filtered by workflow
+worktrain diagnose <sessionId>            # per-session failure card (last 7 days)
+worktrain diagnose <sessionId> --json     # machine-readable JSON
+worktrain diagnose <sessionId> --ascii    # plain-terminal / pipe-safe output
 ```
 
-`worktrain health <sessionId>` now also delegates to this for completed sessions from prior days (previously returned "No events today").
+`worktrain health <sessionId>` also delegates to diagnose for completed sessions from prior days.
 
 Failure categories: `CONFIG` (bad model ID), `WORKFLOW` (stuck loop or timeout), `INFRA` (daemon stopped/crashed), `ORPHANED` (no terminal event), `SUCCESS`, `DEFAULT` (unrecognized).
 
-Source: `src/cli/commands/worktrain-diagnose.ts`. Design: `docs/design/worktrain-diagnose-ux-spec.md`.
+Source: `src/cli/commands/worktrain-diagnose.ts`.
 
 ---
 

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -44,7 +44,13 @@ import {
 } from './cli/commands/index.js';
 import { writeStatsSummary } from './daemon/stats-summary.js';
 import type { ChildSessionResult, CoordinatorSpawnContext } from './coordinators/types.js';
-import { parseDaemonEvents, formatDiagnosticCard, formatDiagnosticJson } from './cli/commands/worktrain-diagnose.js';
+import {
+  parseDaemonEvents,
+  analyzeFleet,
+  formatDiagnosticCard,
+  formatDiagnosticJson,
+  formatFleetSummary,
+} from './cli/commands/worktrain-diagnose.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -995,28 +1001,36 @@ program
 // ═══════════════════════════════════════════════════════════════════════════
 
 program
-  .command('diagnose <sessionId>')
+  .command('diagnose [sessionId]')
   .description(
-    'Print a failure card for a daemon session. Searches the last 7 days of daemon event logs. ' +
-    'Works without the daemon running. Accepts sessionId (UUID prefix) or workrailSessionId (sess_xxx).',
+    'Session diagnostics. No args: fleet summary with step bottleneck analysis and token burn. ' +
+    'Pass a sessionId for a per-session failure card with evidence and suggested fix. ' +
+    'Searches the last 7 days of daemon event logs. Works without the daemon running.',
   )
-  .option('--json', 'Output machine-readable JSON (full untruncated fields)')
+  .option('--workflow <id>', 'Filter fleet view by workflow ID (e.g. wr.discovery)')
+  .option('--json', 'Output machine-readable JSON (per-session only)')
   .option('--ascii', 'Use ASCII-only output (no Unicode glyphs)')
-  .action((sessionId: string, options: { json?: boolean; ascii?: boolean }) => {
+  .action((sessionId: string | undefined, options: { workflow?: string; json?: boolean; ascii?: boolean }) => {
     const eventsDir = path.join(os.homedir(), '.workrail', 'events', 'daemon');
     const readFile = (filePath: string): string | null => {
-      try {
-        return fs.readFileSync(filePath, 'utf8');
-      } catch {
-        return null;
-      }
+      try { return fs.readFileSync(filePath, 'utf8'); } catch { return null; }
     };
-    const result = parseDaemonEvents(sessionId, eventsDir, 7, readFile);
-    if (options.json) {
-      process.stdout.write(formatDiagnosticJson(result) + '\n');
+
+    if (sessionId !== undefined) {
+      // Per-session failure card
+      const result = parseDaemonEvents(sessionId, eventsDir, 7, readFile);
+      if (options.json) {
+        process.stdout.write(formatDiagnosticJson(result) + '\n');
+      } else {
+        process.stdout.write(formatDiagnosticCard(result, { ascii: options.ascii ?? false }) + '\n');
+      }
     } else {
-      const card = formatDiagnosticCard(result, { ascii: options.ascii ?? false });
-      process.stdout.write(card + '\n');
+      // Fleet summary
+      const readDir = (dir: string): readonly string[] | null => {
+        try { return fs.readdirSync(dir); } catch { return null; }
+      };
+      const analysis = analyzeFleet(readDir, readFile, eventsDir, options.workflow);
+      process.stdout.write(formatFleetSummary(analysis, { ascii: options.ascii ?? false }) + '\n');
     }
   });
 

--- a/src/cli/commands/worktrain-diagnose.ts
+++ b/src/cli/commands/worktrain-diagnose.ts
@@ -950,3 +950,284 @@ function formatRelativeTime(ts: number): string {
 export function formatDiagnosticJson(result: DiagnosticResult): string {
   return JSON.stringify(result, null, 2);
 }
+
+// ---------------------------------------------------------------------------
+// Fleet analysis types
+// ---------------------------------------------------------------------------
+
+export interface WorkflowStat {
+  readonly workflowId: string;
+  readonly total: number;
+  readonly successCount: number;
+  readonly avgDurationMs: number;
+  readonly avgTurns: number;
+  readonly categoryBreakdown: ReadonlyMap<string, number>;
+}
+
+export interface FleetAnalysis {
+  /** Total sessions analysed (3+ LLM turns). */
+  readonly sessionCount: number;
+  /** Failure category -> count, sorted by count desc. */
+  readonly categoryBreakdown: ReadonlyArray<readonly [string, number]>;
+  /** Per-workflow stats. */
+  readonly workflowStats: ReadonlyArray<WorkflowStat>;
+  /**
+   * Which step sessions timed out on (from DiagnosticResult.pendingStep), sorted by frequency.
+   * WHY no per-step durations here: step names and durations require reading the WorkRail
+   * session store (snapshots), which is outside the daemon event log scope of this module.
+   * Per-step timing is available via the Python analysis script for now.
+   */
+  readonly timeoutStepCounts: ReadonlyArray<readonly [string, number]>;
+  /** Total tokens consumed. */
+  readonly totalTokens: number;
+  /** Tokens burned on sessions that timed out. */
+  readonly timeoutTokens: number;
+}
+
+// ---------------------------------------------------------------------------
+// analyzeFleet -- pure, injected I/O
+// ---------------------------------------------------------------------------
+
+/**
+ * Load all daemon event sessions from the events directory and derive fleet-level statistics.
+ *
+ * @param readDir  - Injected: list file names in a directory. Returns null on error.
+ * @param readFile - Injected: read a file. Returns null on error.
+ * @param eventsDir - Absolute path to ~/.workrail/events/daemon/
+ * @param workflowFilter - Optional: only include sessions for this workflowId.
+ */
+export function analyzeFleet(
+  readDir: (dir: string) => readonly string[] | null,
+  readFile: (path: string) => string | null,
+  eventsDir: string,
+  workflowFilter?: string,
+): FleetAnalysis {
+  // Collect all event lines keyed by sessionId across all daily files.
+  // WHY collect across all files first: parseDaemonEvents() already does per-session
+  // cross-file assembly; we just need to discover the full set of session IDs.
+  const sessionIds = new Set<string>();
+  const fileNames = readDir(eventsDir) ?? [];
+
+  for (const fileName of fileNames) {
+    if (!fileName.endsWith('.jsonl')) continue;
+    const content = readFile(`${eventsDir}/${fileName}`);
+    if (!content) continue;
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const obj = JSON.parse(trimmed) as Record<string, unknown>;
+        const sid = (typeof obj['sessionId'] === 'string' ? obj['sessionId'] : null)
+          ?? (typeof obj['workrailSessionId'] === 'string' ? obj['workrailSessionId'] : null);
+        if (sid) sessionIds.add(sid);
+      } catch {
+        // malformed line -- skip
+      }
+    }
+  }
+
+  // Analyse each unique session.
+  const results: Array<{ result: DiagnosticResult; turns: number }> = [];
+
+  for (const sid of sessionIds) {
+    const result = parseDaemonEvents(sid, eventsDir, 14, readFile);
+    // Skip NOT_FOUND (shouldn't happen -- we found the ID in the files)
+    // and AMBIGUOUS (shouldn't happen -- we're using exact IDs from the logs)
+    if (result.kind === 'NOT_FOUND' || result.kind === 'AMBIGUOUS') continue;
+
+    const turns = 'metrics' in result ? result.metrics.llmTurns : 0;
+    if (turns < 3) continue; // skip trivial sessions
+
+    // Apply workflow filter
+    if (workflowFilter) {
+      const wf = 'workflowId' in result ? result.workflowId : '';
+      if (!wf.includes(workflowFilter)) continue;
+    }
+
+    results.push({ result, turns });
+  }
+
+  // Derive category breakdown
+  const catCounts = new Map<string, number>();
+  for (const { result } of results) {
+    const cat = _resultCategory(result);
+    catCounts.set(cat, (catCounts.get(cat) ?? 0) + 1);
+  }
+  const categoryBreakdown = [...catCounts.entries()].sort((a, b) => b[1] - a[1]);
+
+  // Derive per-workflow stats
+  const wfGroups = new Map<string, Array<DiagnosticResult>>();
+  for (const { result } of results) {
+    const wf = 'workflowId' in result ? result.workflowId : 'unknown';
+    const group = wfGroups.get(wf) ?? [];
+    group.push(result);
+    wfGroups.set(wf, group);
+  }
+  const workflowStats: WorkflowStat[] = [];
+  for (const [wfId, wfResults] of wfGroups) {
+    const total = wfResults.length;
+    const successCount = wfResults.filter(r => r.kind === 'SUCCESS').length;
+    const durs = wfResults.map(r => 'durationMs' in r ? r.durationMs : 0);
+    const turnsArr = wfResults.map(r => 'metrics' in r ? r.metrics.llmTurns : 0);
+    const catMap = new Map<string, number>();
+    for (const r of wfResults) {
+      const c = _resultCategory(r);
+      catMap.set(c, (catMap.get(c) ?? 0) + 1);
+    }
+    workflowStats.push({
+      workflowId: wfId,
+      total,
+      successCount,
+      avgDurationMs: durs.reduce((a, b) => a + b, 0) / Math.max(total, 1),
+      avgTurns: turnsArr.reduce((a, b) => a + b, 0) / Math.max(total, 1),
+      categoryBreakdown: catMap,
+    });
+  }
+  workflowStats.sort((a, b) => b.total - a.total);
+
+  // Step bottleneck analysis for timeout sessions
+  const timeoutResults = results
+    .filter(({ result }) => _resultCategory(result).startsWith('timeout'))
+    .map(({ result }) => result);
+
+  const timeoutOnStep = new Map<string, number>();
+  for (const result of timeoutResults) {
+    const pending = _pendingStep(result);
+    if (pending) timeoutOnStep.set(pending, (timeoutOnStep.get(pending) ?? 0) + 1);
+  }
+  const timeoutStepCounts = [...timeoutOnStep.entries()].sort((a, b) => b[1] - a[1]);
+
+  // Token stats
+  let totalTokens = 0;
+  let timeoutTokens = 0;
+  for (const { result } of results) {
+    const tok = 'metrics' in result
+      ? result.metrics.inputTokens + result.metrics.outputTokens
+      : 0;
+    totalTokens += tok;
+    if (_resultCategory(result).startsWith('timeout')) timeoutTokens += tok;
+  }
+
+  return {
+    sessionCount: results.length,
+    categoryBreakdown,
+    workflowStats,
+    timeoutStepCounts,
+    totalTokens,
+    timeoutTokens,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fleet analysis helpers (pure)
+// ---------------------------------------------------------------------------
+
+function _resultCategory(result: DiagnosticResult): string {
+  switch (result.kind) {
+    case 'SUCCESS': return 'success';
+    case 'NOT_FOUND': return 'not_found';
+    case 'AMBIGUOUS': return 'ambiguous';
+    case 'CONFIG_ERROR': return 'config/bad_model';
+    case 'WORKFLOW_STUCK': return `stuck/${result.stuckReason}/${result.toolName ?? '?'}`;
+    case 'WORKFLOW_TIMEOUT': return `timeout/${result.timeoutReason}`;
+    case 'INFRA_ERROR': return `infra/${result.infraReason}`;
+    case 'ORPHANED': return 'orphaned';
+    case 'DEFAULT': return `other/${result.outcome}`;
+    default: {
+      const _exhaustive: never = result;
+      return `unknown/${(_exhaustive as DiagnosticResult).kind}`;
+    }
+  }
+}
+
+function _pendingStep(result: DiagnosticResult): string | null {
+  if (result.kind === 'WORKFLOW_TIMEOUT') return result.timeoutReason ?? null;
+  if (result.kind === 'WORKFLOW_STUCK') return result.stuckReason ?? null;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// formatFleetSummary -- pure renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a FleetAnalysis to a human-readable string for terminal output.
+ * Pure function -- no I/O.
+ */
+export function formatFleetSummary(analysis: FleetAnalysis, opts: FormatOptions = {}): string {
+  const lines: string[] = [];
+  const { sessionCount, categoryBreakdown, workflowStats, timeoutStepCounts, totalTokens, timeoutTokens } = analysis;
+
+  if (sessionCount === 0) {
+    return 'No sessions with 3+ LLM turns found in the last 14 days.';
+  }
+
+  lines.push(applyChalk(`Fleet summary  (${sessionCount} sessions with 3+ turns)`, chalk.bold, opts));
+  lines.push('');
+
+  // Category breakdown with bar chart
+  lines.push('Failure categories:');
+  for (const [cat, count] of categoryBreakdown) {
+    const pct = count / sessionCount * 100;
+    const bar = _bar(pct, 25, opts);
+    const label = cat === 'success' ? applyChalk(cat, chalk.green, opts) : cat;
+    lines.push(`  ${bar}  ${pct.toFixed(0).padStart(3)}%  ${String(count).padStart(3)}  ${label}`);
+  }
+
+  // Per-workflow breakdown
+  lines.push('');
+  lines.push('Per-workflow:');
+  for (const wf of workflowStats) {
+    const successPct = Math.round(wf.successCount / wf.total * 100);
+    lines.push('');
+    lines.push(`  ${applyChalk(wf.workflowId, chalk.bold, opts)}  `
+      + `(${wf.total} sessions, ${wf.successCount}/${wf.total} success, `
+      + `avg ${_fmtDur(wf.avgDurationMs)}, avg ${Math.round(wf.avgTurns)} turns)`);
+    for (const [cat, count] of [...wf.categoryBreakdown.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5)) {
+      lines.push(`    ${String(count).padStart(3)}  ${cat}`);
+    }
+  }
+
+  // Step bottleneck analysis
+  if (timeoutStepCounts.length > 0) {
+    const timeoutCount = categoryBreakdown.filter(([c]) => c.startsWith('timeout')).reduce((a, [, n]) => a + n, 0);
+    lines.push('');
+    lines.push(`Timeout breakdown  (${timeoutCount} timeout sessions):`);
+    lines.push('');
+    lines.push('  Timeout reason:');
+    for (const [reason, count] of timeoutStepCounts.slice(0, 10)) {
+      lines.push(`    ${String(count).padStart(3)}  ${reason}`);
+    }
+  }
+
+  // Token burn
+  const wastePct = totalTokens > 0 ? Math.round(timeoutTokens / totalTokens * 100) : 0;
+  const avgPerSession = sessionCount > 0 ? Math.round(totalTokens / sessionCount) : 0;
+  lines.push('');
+  lines.push('Token burn:');
+  lines.push(`  Total:            ${_fmtTokens(totalTokens).padStart(18)}`);
+  lines.push(`  Burned on timeout: ${_fmtTokens(timeoutTokens).padStart(17)}  (${wastePct}% waste)`);
+  lines.push(`  Avg per session:   ${_fmtTokens(avgPerSession).padStart(17)}`);
+
+  return lines.join('\n');
+}
+
+function _bar(pct: number, width: number, opts: FormatOptions): string {
+  const filled = Math.round(pct / 100 * width);
+  const bar = '█'.repeat(filled) + '░'.repeat(width - filled);
+  return opts.noColor ? bar : bar;
+}
+
+function _fmtDur(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  if (m === 0) return `${s}s`;
+  return `${m}m ${String(s).padStart(2, '0')}s`;
+}
+
+function _fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+  return String(n);
+}


### PR DESCRIPTION
## Summary

- `worktrain diagnose` with no args now shows a fleet summary: outcome breakdown, per-workflow stats, timeout reason breakdown, and token burn analysis
- `worktrain diagnose --workflow wr.discovery` filters the fleet view to one workflow
- A session ID still gives the per-session failure card
- Drops the separate `worktrain analyze` command (was a Python subprocess shim -- violates coding philosophy)
- Fleet analysis is now pure TypeScript with injected I/O deps, exported from `src/cli/commands/worktrain-diagnose.ts` alongside `parseDaemonEvents()`
- `analyzeFleet(readDir, readFile, eventsDir, workflowFilter?)` and `formatFleetSummary()` follow the same pure-function / injected-deps pattern as the rest of the module
- Also drops `scripts/session-analysis.py` from the CLI path (kept as a dev convenience for deep session-store analysis that requires cross-referencing snapshots)

## Test plan

- [x] `npx vitest run tests/unit/cli-worktrain-diagnose.test.ts` -- 22 tests passing
- [x] `npm run build` -- clean
- [x] `worktrain diagnose` -- fleet summary output
- [x] `worktrain diagnose --workflow wr.discovery` -- filtered fleet
- [x] `worktrain diagnose fa706671` -- per-session failure card unchanged
- [x] `worktrain diagnose fa706671 --json` -- JSON output unchanged