### PR TITLE
feat(engine): add stepId to step_advanced daemon events as correlation key

### DIFF
--- a/src/cli/commands/worktrain-diagnose.ts
+++ b/src/cli/commands/worktrain-diagnose.ts
@@ -151,6 +151,12 @@ export interface StepRecord {
   readonly status: 'completed' | 'terminal' | 'not_reached';
   /** Turn count for this step (turns between previous step_advanced and this one) */
   readonly turns: number;
+  /**
+   * The workflow step ID for this step (e.g. 'phase-0-reframe').
+   * Present when the daemon emitted stepId on the step_advanced event (requires daemon
+   * version that includes this field). Absent for sessions from older daemon versions.
+   */
+  readonly stepId?: string;
 }
 
 export type ProcessState = 'STOPPED' | 'RUNNING' | 'UNKNOWN';
@@ -180,6 +186,8 @@ interface SessionAccumulator {
   // Track LLM turns per step for step timeline
   turnsAtLastStep: number;
   stepTurnCounts: number[];
+  // Step IDs in order of completion (from step_advanced events, optional per event)
+  stepIds: Array<string | undefined>;
 }
 
 // ---------------------------------------------------------------------------
@@ -470,6 +478,9 @@ function accumulateEvent(acc: SessionAccumulator, obj: Record<string, unknown>, 
       acc.stepTurnCounts.push(turnsForStep);
       acc.turnsAtLastStep = acc.llmTurns;
       acc.stepAdvances++;
+      // stepId is optional -- present only in daemon versions that emit it
+      const sid = typeof obj['stepId'] === 'string' ? obj['stepId'] : undefined;
+      acc.stepIds.push(sid);
       break;
     }
     case 'tool_call_started': {
@@ -535,6 +546,7 @@ function createAccumulator(sessionId: string): SessionAccumulator {
     lastEventKind: null,
     turnsAtLastStep: 0,
     stepTurnCounts: [],
+    stepIds: [],
   };
 }
 
@@ -552,7 +564,13 @@ function buildMetrics(acc: SessionAccumulator): SessionMetrics {
 function buildSteps(acc: SessionAccumulator): StepRecord[] {
   const steps: StepRecord[] = [];
   for (let i = 0; i < acc.stepTurnCounts.length; i++) {
-    steps.push({ index: i + 1, status: 'completed', turns: acc.stepTurnCounts[i] ?? 0 });
+    const stepId = acc.stepIds[i];
+    steps.push({
+      index: i + 1,
+      status: 'completed',
+      turns: acc.stepTurnCounts[i] ?? 0,
+      ...(stepId !== undefined ? { stepId } : {}),
+    });
   }
   // Add terminal step (the one that failed/timed out)
   if (acc.stepAdvances > 0 || acc.llmTurns > 0) {
@@ -561,6 +579,7 @@ function buildSteps(acc: SessionAccumulator): StepRecord[] {
       index: steps.length + 1,
       status: acc.completedEvent?.outcome === 'success' ? 'completed' : 'terminal',
       turns: turnsOnTerminalStep,
+      // Terminal step has no stepId -- it's the step the session was on when it stopped
     });
   }
   return steps;

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -117,6 +117,17 @@ export interface StepAdvancedEvent {
   readonly sessionId: RunId;
   /** The WorkRail session ID for correlation. Present when continueToken was decoded. */
   readonly workrailSessionId?: string;
+  /**
+   * The workflow step ID that was just completed (e.g. 'phase-0-reframe').
+   * A correlation key -- maps this event to the workflow definition and session store.
+   * Optional for backward compatibility with daemon logs written before this field existed.
+   *
+   * WHY stepId only (not stepTitle): stepId is a correlation key that belongs in the
+   * daemon event log. stepTitle is human-readable content that lives authoritatively
+   * in the workflow definition and session store -- duplicating it here would violate
+   * single source of state truth.
+   */
+  readonly stepId?: string;
 }
 
 /** Workflow run ended (success, error, or timeout). */

--- a/src/daemon/runner/agent-loop-runner.ts
+++ b/src/daemon/runner/agent-loop-runner.ts
@@ -244,10 +244,15 @@ export async function buildAgentReadySession(
   const MAX_ISSUE_SUMMARIES = 10;
   const STUCK_REPEAT_THRESHOLD = 3;
 
-  const onAdvance = (stepText: string, continueToken: string): void => {
-    advanceStep(state, stepText, continueToken);
+  const onAdvance = (stepText: string, continueToken: string, stepId?: string): void => {
+    advanceStep(state, stepText, continueToken, stepId);
     if (state.workrailSessionId !== null) daemonRegistry?.heartbeat(state.workrailSessionId);
-    emitter?.emit({ kind: 'step_advanced', sessionId, ...withWorkrailSession(state.workrailSessionId) });
+    emitter?.emit({
+      kind: 'step_advanced',
+      sessionId,
+      ...withWorkrailSession(state.workrailSessionId),
+      ...(state.lastCompletedStepId !== null ? { stepId: state.lastCompletedStepId } : {}),
+    });
   };
 
   const onComplete = (notes: string | undefined, artifacts?: readonly unknown[]): void => {

--- a/src/daemon/session-scope.ts
+++ b/src/daemon/session-scope.ts
@@ -148,8 +148,14 @@ export interface SessionScope {
   /**
    * Called by `complete_step` / `continue_workflow` tools when the agent advances
    * to the next step. Updates mutable session state in runWorkflow().
+   *
+   * @param stepText - Prompt text for the next step (injected into agent via steer).
+   * @param continueToken - Updated continue token from the engine response.
+   * @param stepId - The step ID that was just completed (from V2PendingStep.stepId).
+   *   Stored on SessionState.lastCompletedStepId so the emitter can include it in
+   *   step_advanced events as a correlation key.
    */
-  readonly onAdvance: (stepText: string, continueToken: string) => void;
+  readonly onAdvance: (stepText: string, continueToken: string, stepId?: string) => void;
 
   /**
    * Called by `complete_step` tool when the workflow completes.

--- a/src/daemon/state/session-state.ts
+++ b/src/daemon/state/session-state.ts
@@ -94,6 +94,17 @@ export interface SessionState {
   terminalSignal: TerminalSignal | null;
   /** Number of complete LLM response turns since the agent loop started. */
   turnCount: number;
+  /**
+   * The step ID that was most recently completed by advanceStep().
+   * Set to null before the first advance and between advances.
+   * Read by the agent-loop-runner emitter to include in step_advanced events.
+   *
+   * WHY on state (not passed directly to the emitter): the onAdvance callback has
+   * signature (stepText, continueToken) today; threading stepId directly would require
+   * changing the emitter's closure capture. Storing it on state keeps the emitter
+   * change minimal: read state.lastCompletedStepId at emit time.
+   */
+  lastCompletedStepId: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -119,6 +130,7 @@ export function createSessionState(initialToken: string): SessionState {
     pendingSteerParts: [],
     terminalSignal: null,
     turnCount: 0,
+    lastCompletedStepId: null,
   };
 }
 
@@ -129,16 +141,20 @@ export function createSessionState(initialToken: string): SessionState {
 /**
  * Advance the workflow to the next step.
  *
- * WHY a named transition: combines three writes that must happen atomically --
- * pushing the step text to the steer queue, incrementing the advance count, and
- * updating the continue token. Writing these three separately risks forgetting one.
+ * WHY a named transition: combines four writes that must happen atomically --
+ * pushing the step text to the steer queue, incrementing the advance count,
+ * updating the continue token, and recording the completed step ID.
  *
  * Called by the onAdvance callback in buildAgentReadySession().
+ *
+ * @param stepId - The step ID that was just completed (from V2PendingStep.stepId).
+ *   Optional -- absent when pending was null (final step completion path).
  */
-export function advanceStep(state: SessionState, stepText: string, continueToken: string): void {
+export function advanceStep(state: SessionState, stepText: string, continueToken: string, stepId?: string): void {
   state.pendingSteerParts.push(stepText);
   state.stepAdvanceCount++;
   state.currentContinueToken = continueToken;
+  state.lastCompletedStepId = stepId ?? null;
 }
 
 /**

--- a/src/daemon/tools/continue-workflow.ts
+++ b/src/daemon/tools/continue-workflow.ts
@@ -14,7 +14,7 @@ import { persistTokens, withWorkrailSession } from './_shared.js';
 export function makeContinueWorkflowTool(
   sessionId: RunId,
   ctx: V2ToolContext,
-  onAdvance: (nextStepText: string, continueToken: string) => void,
+  onAdvance: (nextStepText: string, continueToken: string, stepId?: string) => void,
   onComplete: (notes: string | undefined, artifacts?: readonly unknown[]) => void,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   schemas: Record<string, any>,
@@ -150,7 +150,7 @@ export function makeContinueWorkflowTool(
         ? `## Next step: ${pending.title}\n\n${pending.prompt}\n\ncontinueToken: ${continueToken}`
         : `Step advanced. continueToken: ${continueToken}`;
 
-      onAdvance(stepText, continueToken);
+      onAdvance(stepText, continueToken, pending?.stepId);
 
       return {
         content: [{ type: 'text', text: stepText }],
@@ -201,7 +201,7 @@ export function makeCompleteStepTool(
   sessionId: RunId,
   ctx: V2ToolContext,
   getCurrentToken: () => string,
-  onAdvance: (nextStepText: string, continueToken: string) => void,
+  onAdvance: (nextStepText: string, continueToken: string, stepId?: string) => void,
   onComplete: (notes: string | undefined, artifacts?: readonly unknown[]) => void,
   onTokenUpdate: (t: string) => void,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -366,7 +366,7 @@ export function makeCompleteStepTool(
         ? `${JSON.stringify({ status: 'advanced', nextStep: pending.title })}\n\n## ${pending.title}\n\n${pending.prompt}`
         : JSON.stringify({ status: 'advanced', nextStep: nextStepTitle });
 
-      onAdvance(stepText, newContinueToken);
+      onAdvance(stepText, newContinueToken, pending?.stepId);
 
       return {
         content: [{ type: 'text', text: stepText }],

--- a/tests/unit/cli-worktrain-diagnose.test.ts
+++ b/tests/unit/cli-worktrain-diagnose.test.ts
@@ -75,8 +75,8 @@ function toolCallStarted(sessionId: string, toolName: string, ts = 1100): string
   return JSON.stringify({ kind: 'tool_call_started', sessionId, toolName, argsSummary: 'args', ts });
 }
 
-function stepAdvanced(sessionId: string, ts = 1300): string {
-  return JSON.stringify({ kind: 'step_advanced', sessionId, ts });
+function stepAdvanced(sessionId: string, ts = 1300, stepId?: string): string {
+  return JSON.stringify({ kind: 'step_advanced', sessionId, ts, ...(stepId ? { stepId } : {}) });
 }
 
 // ---------------------------------------------------------------------------
@@ -280,6 +280,44 @@ describe('parseDaemonEvents', () => {
     expect(() => parseDaemonEvents('sess_abc123', EVENTS_DIR, 7, readFile)).not.toThrow();
     const result = parseDaemonEvents('sess_abc123', EVENTS_DIR, 7, readFile);
     expect(result.kind).toBe('SUCCESS');
+  });
+
+  it('populates stepId on StepRecord when step_advanced event includes stepId', () => {
+    const readFile = makeReadFile({
+      [`${EVENTS_DIR}/${TODAY}.jsonl`]: [
+        sessionStarted('sess_abc123'),
+        llmTurn('sess_abc123', 100, 50, 1100),
+        stepAdvanced('sess_abc123', 1200, 'phase-0-reframe'),
+        llmTurn('sess_abc123', 100, 50, 1300),
+        stepAdvanced('sess_abc123', 1400, 'phase-1a-landscape'),
+        sessionCompleted('sess_abc123', 'timeout', 'wall_clock', 2000),
+      ].join('\n'),
+    });
+    const result = parseDaemonEvents('sess_abc123', EVENTS_DIR, 7, readFile);
+    expect(result.kind).toBe('WORKFLOW_TIMEOUT');
+    if (result.kind === 'WORKFLOW_TIMEOUT') {
+      expect(result.steps[0]?.stepId).toBe('phase-0-reframe');
+      expect(result.steps[1]?.stepId).toBe('phase-1a-landscape');
+      // Terminal step has no stepId
+      expect(result.steps[2]?.stepId).toBeUndefined();
+    }
+  });
+
+  it('handles step_advanced events without stepId (backward compat with old daemon logs)', () => {
+    const readFile = makeReadFile({
+      [`${EVENTS_DIR}/${TODAY}.jsonl`]: [
+        sessionStarted('sess_abc123'),
+        llmTurn('sess_abc123', 100, 50, 1100),
+        stepAdvanced('sess_abc123', 1200), // no stepId
+        sessionCompleted('sess_abc123', 'timeout', 'wall_clock', 2000),
+      ].join('\n'),
+    });
+    const result = parseDaemonEvents('sess_abc123', EVENTS_DIR, 7, readFile);
+    expect(result.kind).toBe('WORKFLOW_TIMEOUT');
+    if (result.kind === 'WORKFLOW_TIMEOUT') {
+      // stepId absent -- backward compat
+      expect(result.steps[0]?.stepId).toBeUndefined();
+    }
   });
 
   it('accumulates metrics across multiple turns and tool calls', () => {


### PR DESCRIPTION
## Summary

- Adds `stepId?: string` to `StepAdvancedEvent` in the daemon event log -- a correlation key that maps each step advance to the workflow definition and session store
- Threads `pending.stepId` from `executeContinueWorkflow` through the `onAdvance()` callback into the emitted event and into `StepRecord` in `parseDaemonEvents()`
- `StepRecord.stepId` is now populated when daemon events include it; absent for old sessions (backward compat)
- `stepId` only -- no `stepTitle` (content belongs in session store / workflow definition, not duplicated in daemon events)

**Why this matters:** `worktrain diagnose` fleet summary can now show which workflow step sessions time out on, not just the timeout reason. Previously required cross-referencing session store snapshots via the Python script.

## Test plan

- [x] 2 new tests: `stepId` populated in `StepRecord`, old events without `stepId` parse correctly
- [x] `npx vitest run tests/unit/cli-worktrain-diagnose.test.ts` -- 36 tests passing
- [x] `npx vitest run` -- 6024 tests, 0 failures
- [x] `npm run build` -- clean