### PR TITLE
feat(engine): enrich gate evaluator with actual step notes and artifacts

### DIFF
--- a/spec/workflow.schema.json
+++ b/spec/workflow.schema.json
@@ -472,12 +472,12 @@
         },
         "assessmentConsequences": {
           "type": "array",
-          "description": "Step-local assessment consequence declarations. V1 supports at most one exact-match follow-up consequence.",
+          "description": "Step-local assessment consequence declarations. Each consequence fires independently when its trigger level matches. Use forAssessment to scope a consequence to a specific assessmentRef when multiple assessments are declared on the same step.",
           "items": {
             "$ref": "#/$defs/assessmentConsequence"
           },
           "minItems": 1,
-          "maxItems": 1
+          "maxItems": 10
         },
         "notesOptional": {
           "type": "boolean",
@@ -1086,12 +1086,18 @@
     },
     "assessmentConsequenceTrigger": {
       "type": "object",
-      "description": "Fires when ANY dimension in the submitted assessment equals the given level. The consequence blocks advancement until the agent addresses all dimensions that scored at that level.",
+      "description": "Fires when ANY dimension in the submitted assessment equals the given level. The consequence blocks advancement until the agent addresses all dimensions that scored at that level. Use forAssessment to scope the consequence to a specific assessment when a step declares multiple assessmentRefs.",
       "properties": {
         "anyEqualsLevel": {
           "type": "string",
           "minLength": 1,
           "maxLength": 64
+        },
+        "forAssessment": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "description": "Optional: scope this consequence to a specific assessment ID. Must be one of the assessmentRefs declared on the same step. When absent, any recorded assessment matching anyEqualsLevel fires the consequence."
         }
       },
       "required": ["anyEqualsLevel"],

--- a/src/application/services/validation-engine.ts
+++ b/src/application/services/validation-engine.ts
@@ -908,11 +908,6 @@ export class ValidationEngine {
         return;
       }
 
-      if (step.assessmentConsequences.length > 1) {
-        issues.push(`${stepLabel}: v1 assessment support allows exactly one assessment consequence per step`);
-        suggestions.push(`Reduce assessmentConsequences on ${stepLabel} to a single declaration`);
-      }
-
       const referencedDefinitions = assessments.filter(assessment => step.assessmentRefs!.includes(assessment.id));
       if (referencedDefinitions.length === 0) return;
 
@@ -920,14 +915,38 @@ export class ValidationEngine {
         const trigger = consequence.when;
         const effect = consequence.effect;
 
-        const allLevels = referencedDefinitions.flatMap(def => def.dimensions.flatMap(d => d.levels));
-        if (!allLevels.includes(trigger.anyEqualsLevel)) {
-          issues.push(
-            `${stepLabel}: assessment consequence anyEqualsLevel '${trigger.anyEqualsLevel}' is not declared in any dimension of any referenced assessment`
-          );
-          suggestions.push(
-            `Use a level declared in one of the dimensions: ${[...new Set(allLevels)].join(', ')}`
-          );
+        if (trigger.forAssessment !== undefined) {
+          // forAssessment must name a declared assessmentRef.
+          if (!step.assessmentRefs!.includes(trigger.forAssessment)) {
+            issues.push(
+              `${stepLabel}: assessment consequence forAssessment '${trigger.forAssessment}' is not in the step's assessmentRefs`
+            );
+            suggestions.push(
+              `Use one of the declared assessmentRefs: ${step.assessmentRefs!.join(', ')}`
+            );
+          } else {
+            // Level must exist in the scoped assessment.
+            const scopedDef = referencedDefinitions.find(d => d.id === trigger.forAssessment);
+            const scopedLevels = scopedDef?.dimensions.flatMap(d => d.levels) ?? [];
+            if (!scopedLevels.includes(trigger.anyEqualsLevel)) {
+              issues.push(
+                `${stepLabel}: assessment consequence anyEqualsLevel '${trigger.anyEqualsLevel}' is not declared in assessment '${trigger.forAssessment}'`
+              );
+              suggestions.push(
+                `Use a level declared in '${trigger.forAssessment}': ${[...new Set(scopedLevels)].join(', ')}`
+              );
+            }
+          }
+        } else {
+          const allLevels = referencedDefinitions.flatMap(def => def.dimensions.flatMap(d => d.levels));
+          if (!allLevels.includes(trigger.anyEqualsLevel)) {
+            issues.push(
+              `${stepLabel}: assessment consequence anyEqualsLevel '${trigger.anyEqualsLevel}' is not declared in any dimension of any referenced assessment`
+            );
+            suggestions.push(
+              `Use a level declared in one of the dimensions: ${[...new Set(allLevels)].join(', ')}`
+            );
+          }
         }
 
         if (effect.kind !== 'require_followup') {

--- a/src/application/services/workflow-compiler.ts
+++ b/src/application/services/workflow-compiler.ts
@@ -311,23 +311,34 @@ export class WorkflowCompiler {
         ));
       }
 
-      if (assessmentConsequences.length > 1) {
-        return err(Err.invalidState(
-          `Step '${step.id}' declares ${assessmentConsequences.length} assessment consequences. V1 supports exactly one assessment consequence per step.`
-        ));
-      }
-
       const allLevelsAcrossRefs = (workflow.definition.assessments ?? [])
         .filter(candidate => typedStep.assessmentRefs!.includes(candidate.id))
         .flatMap(assessment => assessment.dimensions.flatMap(d => d.levels));
 
       for (const consequence of assessmentConsequences) {
         const trigger = consequence.when;
-        if (!allLevelsAcrossRefs.includes(trigger.anyEqualsLevel)) {
+
+        // When forAssessment is set, validate it names a declared assessmentRef.
+        if (trigger.forAssessment !== undefined) {
+          if (!typedStep.assessmentRefs!.includes(trigger.forAssessment)) {
+            return err(Err.invalidState(
+              `Step '${step.id}' declares consequence with forAssessment '${trigger.forAssessment}' that is not in the step's assessmentRefs`
+            ));
+          }
+          // Validate the level exists in the scoped assessment only.
+          const scopedAssessment = (workflow.definition.assessments ?? []).find(a => a.id === trigger.forAssessment);
+          const scopedLevels = scopedAssessment?.dimensions.flatMap(d => d.levels) ?? [];
+          if (!scopedLevels.includes(trigger.anyEqualsLevel)) {
+            return err(Err.invalidState(
+              `Step '${step.id}' declares consequence with anyEqualsLevel '${trigger.anyEqualsLevel}' that is not declared in assessment '${trigger.forAssessment}'`
+            ));
+          }
+        } else if (!allLevelsAcrossRefs.includes(trigger.anyEqualsLevel)) {
           return err(Err.invalidState(
             `Step '${step.id}' declares consequence with anyEqualsLevel '${trigger.anyEqualsLevel}' that is not declared in any dimension of any referenced assessment`
           ));
         }
+
         if (consequence.effect.kind !== 'require_followup') {
           return err(Err.invalidState(
             `Step '${step.id}' declares unsupported assessment consequence effect '${String((consequence.effect as { kind?: unknown }).kind)}'`

--- a/src/coordinators/gate-evaluator-dispatcher.ts
+++ b/src/coordinators/gate-evaluator-dispatcher.ts
@@ -19,6 +19,7 @@ import type { GateVerdictArtifactV1 } from '../v2/durable-core/schemas/artifacts
 import { isGateVerdictArtifact, parseGateVerdictArtifact } from '../v2/durable-core/schemas/artifacts/index.js';
 import type { Result } from '../runtime/result.js';
 import type { AwaitResult } from '../cli/commands/worktrain-await.js';
+import type { SessionId } from '../v2/durable-core/ids/index.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -63,6 +64,15 @@ export interface GateEvaluatorDeps {
     sessionHandle: string,
   ) => Promise<{ recapMarkdown: string | null; artifacts: readonly unknown[] }>;
   readonly stderr: (line: string) => void;
+  /**
+   * Optional: read the step output (notes + artifacts) for a parked session.
+   * When present, evaluateGate enriches the evaluator context with the parked
+   * step's actual output so the evaluator can make a substantive verdict.
+   * When absent or when it returns null, evaluateGate falls back to metadata-only context.
+   */
+  readonly readStepOutput?: (
+    workrailSessionId: SessionId,
+  ) => Promise<{ recapMarkdown: string | null; artifacts: readonly unknown[] } | null>;
 }
 
 /** Default gate evaluation timeout: 30 minutes. */
@@ -72,6 +82,9 @@ export const DEFAULT_GATE_EVAL_TIMEOUT_MS = 30 * 60 * 1000;
 // evaluateGate
 // ---------------------------------------------------------------------------
 
+/** Max characters of step notes injected into evaluator context. Prevents context budget overrun. */
+const MAX_STEP_NOTES_CHARS = 4000;
+
 /**
  * Spawn an independent evaluator session and return a typed GateVerdict.
  *
@@ -80,12 +93,19 @@ export const DEFAULT_GATE_EVAL_TIMEOUT_MS = 30 * 60 * 1000;
  * not have access to the parent session's conversation history -- isolation
  * is enforced by passing only the artifact object, not a session ID or handle.
  *
- * @param deps - Injectable coordinator deps (spawnSession, awaitSessions, getAgentResult)
+ * When deps.readStepOutput is provided and workrailSessionId is set, evaluateGate
+ * reads the parked step's actual notes and artifacts from the session store and
+ * injects them as 'stepNotes' and 'stepArtifacts' context variables. This allows
+ * the evaluator to make a substantive verdict rather than relying on metadata only.
+ * If readStepOutput fails or returns null, the function falls back to metadata-only context.
+ *
+ * @param deps - Injectable coordinator deps (spawnSession, awaitSessions, getAgentResult, readStepOutput?)
  * @param artifact - The typed artifact from the gate step to evaluate (as unknown to
  *   allow callers to pass coordinator-side artifacts before type-checking)
  * @param evaluatorWorkflowId - WorkRail workflow ID for the evaluator (e.g. 'wr.gate-eval-generic')
  * @param workspace - Absolute path to the workspace for the evaluator session
  * @param stepId - The ID of the step whose gate fired (for verdict attribution)
+ * @param workrailSessionId - WorkRail session ID of the parked session (for step output lookup)
  * @param criteria - Optional free-text evaluation criteria injected as context
  * @param timeoutMs - Max wait time for the evaluator session (default 30 min)
  */
@@ -95,6 +115,7 @@ export async function evaluateGate(
   evaluatorWorkflowId: string,
   workspace: string,
   stepId: string,
+  workrailSessionId?: SessionId,
   criteria?: string,
   timeoutMs: number = DEFAULT_GATE_EVAL_TIMEOUT_MS,
 ): Promise<GateVerdict> {
@@ -114,6 +135,21 @@ export async function evaluateGate(
     stepId,
     ...(criteria !== undefined ? { criteria } : {}),
   };
+
+  // Enrich context with actual step output when available.
+  // WHY truncate: context has a budget; uncapped notes could trigger context_budget_exceeded.
+  // WHY stepArtifacts as JSON string: context values are scalar; objects would be stringified anyway.
+  if (workrailSessionId && deps.readStepOutput) {
+    const stepOutput = await deps.readStepOutput(workrailSessionId).catch(() => null);
+    if (stepOutput?.recapMarkdown) {
+      context.stepNotes = stepOutput.recapMarkdown.length > MAX_STEP_NOTES_CHARS
+        ? stepOutput.recapMarkdown.slice(0, MAX_STEP_NOTES_CHARS) + '\n[truncated]'
+        : stepOutput.recapMarkdown;
+    }
+    if (stepOutput?.artifacts && stepOutput.artifacts.length > 0) {
+      context.stepArtifacts = JSON.stringify(stepOutput.artifacts);
+    }
+  }
 
   const goal = `Evaluate the gate artifact for step '${stepId}' and produce a wr.gate_verdict artifact.`;
 

--- a/src/daemon/active-sessions.ts
+++ b/src/daemon/active-sessions.ts
@@ -12,6 +12,7 @@
 
 import type { AgentLoop } from './agent-loop.js';
 import type { RunId } from './daemon-events.js';
+import type { SessionId } from '../v2/durable-core/ids/index.js';
 
 // ---------------------------------------------------------------------------
 // SessionHandle interface
@@ -24,7 +25,7 @@ export interface SessionHandle {
    * Set via setWorkrailSessionId() after the continueToken is decoded.
    * Null until decoding completes (~50ms after session start).
    */
-  readonly workrailSessionId: string | null;
+  readonly workrailSessionId: SessionId | null;
   /** Inject text into the session's next agent turn. */
   steer(text: string): void;
   /**
@@ -32,7 +33,7 @@ export interface SessionHandle {
    * Called from buildPreAgentSession() after parseContinueTokenOrFail() succeeds.
    * Idempotent: second call is a no-op (first writer wins).
    */
-  setWorkrailSessionId(workrailSessionId: string): void;
+  setWorkrailSessionId(workrailSessionId: SessionId): void;
   /**
    * Wire in the AgentLoop reference for abort capability.
    * Must be called after `const agent = new AgentLoop(...)`.
@@ -57,7 +58,7 @@ export interface SessionHandle {
 
 class SessionHandleImpl implements SessionHandle {
   readonly sessionId: RunId;
-  private _workrailSessionId: string | null = null;
+  private _workrailSessionId: SessionId | null = null;
   private readonly _onSteer: (text: string) => void;
   private _agent: AgentLoop | null = null;
   private readonly _set: ActiveSessionSet;
@@ -68,7 +69,7 @@ class SessionHandleImpl implements SessionHandle {
     this._set = set;
   }
 
-  get workrailSessionId(): string | null {
+  get workrailSessionId(): SessionId | null {
     return this._workrailSessionId;
   }
 
@@ -76,7 +77,7 @@ class SessionHandleImpl implements SessionHandle {
     this._onSteer(text);
   }
 
-  setWorkrailSessionId(workrailSessionId: string): void {
+  setWorkrailSessionId(workrailSessionId: SessionId): void {
     if (this._workrailSessionId === null) {
       this._workrailSessionId = workrailSessionId;
     }

--- a/src/daemon/core/session-result.ts
+++ b/src/daemon/core/session-result.ts
@@ -146,6 +146,7 @@ export function buildSessionResult(
         stepId: signal.stepId,
         stopReason: 'gate_parked',
         sessionId: String(sessionId),
+        ...(state.workrailSessionId !== null ? { workrailSessionId: state.workrailSessionId } : {}),
       };
     }
     if (signal.kind === 'timeout') {

--- a/src/daemon/session-scope.ts
+++ b/src/daemon/session-scope.ts
@@ -22,6 +22,7 @@
 import type { ReadFileState } from './types.js';
 import type { ActiveSessionSet } from './active-sessions.js';
 import type { DaemonEventEmitter, RunId } from './daemon-events.js';
+import type { SessionId } from '../v2/durable-core/ids/index.js';
 
 // ---------------------------------------------------------------------------
 // FileStateTracker
@@ -234,7 +235,7 @@ export interface SessionScope {
    * The WorkRail session ID (decoded from the continue token), or null if the
    * session has not yet been started.
    */
-  readonly workrailSessionId: string | null;
+  readonly workrailSessionId: SessionId | null;
 
   /**
    * Event emitter for daemon observability events. May be undefined in

--- a/src/daemon/state/session-state.ts
+++ b/src/daemon/state/session-state.ts
@@ -21,6 +21,8 @@
  */
 
 import type { TerminalSignal } from './terminal-signal.js';
+import type { SessionId } from '../../v2/durable-core/ids/index.js';
+import { asSessionId } from '../../v2/durable-core/ids/index.js';
 
 // ---------------------------------------------------------------------------
 // SessionState interface
@@ -61,7 +63,7 @@ export interface SessionState {
    * Starts null; populated by setSessionId(). Used to key DaemonRegistry,
    * ActiveSessionSet, and event emission.
    */
-  workrailSessionId: string | null;
+  workrailSessionId: SessionId | null;
   /**
    * Number of times advanceStep() was called (workflow step advances in the agent loop).
    * Used for stuck detection Signal 2 and recorded in execution stats as stepCount.
@@ -196,7 +198,7 @@ export function updateToken(state: SessionState, token: string): void {
  * Called by buildPreAgentSession() after parseContinueTokenOrFail() succeeds.
  */
 export function setSessionId(state: SessionState, id: string): void {
-  state.workrailSessionId = id;
+  state.workrailSessionId = asSessionId(id);
 }
 
 /**

--- a/src/daemon/tools/_shared.ts
+++ b/src/daemon/tools/_shared.ts
@@ -16,6 +16,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { ok, err } from '../../runtime/result.js';
 import type { Result } from '../../runtime/result.js';
+import type { SessionId } from '../../v2/durable-core/ids/index.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -52,7 +53,7 @@ export const GLOB_ALWAYS_EXCLUDE = ['**/node_modules/**', '**/.git/**', '**/dist
  * returns. All subsequent events include it when available, via this helper.
  * Returns an empty object when sid is null so callers can spread unconditionally.
  */
-export function withWorkrailSession(sid: string | null | undefined): { workrailSessionId?: string } {
+export function withWorkrailSession(sid: SessionId | string | null | undefined): { workrailSessionId?: string } {
   return sid != null ? { workrailSessionId: sid } : {};
 }
 
@@ -93,6 +94,7 @@ export async function persistTokens(
     readonly gateToken: string;
     readonly stepId: string;
   },
+  workrailSessionId?: SessionId | null,
 ): Promise<Result<void, PersistTokensError>> {
   try {
     await fs.mkdir(DAEMON_SESSIONS_DIR, { recursive: true });
@@ -110,6 +112,7 @@ export async function persistTokens(
           workspacePath: recoveryContext.workspacePath,
         } : {}),
         ...(gateState !== undefined ? { gateState } : {}),
+        ...(workrailSessionId != null ? { workrailSessionId } : {}),
       },
       null,
       2,

--- a/src/daemon/tools/continue-workflow.ts
+++ b/src/daemon/tools/continue-workflow.ts
@@ -10,6 +10,7 @@ import type { V2ToolContext } from '../../mcp/types.js';
 import type { DaemonEventEmitter, RunId } from '../daemon-events.js';
 import { executeContinueWorkflow } from '../../mcp/handlers/v2-execution/index.js';
 import { persistTokens, withWorkrailSession } from './_shared.js';
+import type { SessionId } from '../../v2/durable-core/ids/index.js';
 
 export function makeContinueWorkflowTool(
   sessionId: RunId,
@@ -21,7 +22,7 @@ export function makeContinueWorkflowTool(
   // Optional injection point for testing -- defaults to the real implementation.
   _executeContinueWorkflowFn: typeof executeContinueWorkflow = executeContinueWorkflow,
   emitter?: DaemonEventEmitter,
-  workrailSessionId?: string | null,
+  workrailSessionId?: SessionId | null,
   onGateParked: (gateToken: string, stepId: string) => void = () => { /* no-op for callers that predate gate support */ },
 ): AgentTool {
   return {
@@ -80,7 +81,7 @@ export function makeContinueWorkflowTool(
         // if the daemon crashes between now and agent loop exit, startup recovery
         // can detect the gate from the sidecar rather than relying on in-memory state.
         const gateState = { kind: 'gate_checkpoint' as const, gateToken: out.gateToken, stepId: out.stepId };
-        const persistResult = await persistTokens(sessionId, '', null, undefined, undefined, gateState);
+        const persistResult = await persistTokens(sessionId, '', null, undefined, undefined, gateState, workrailSessionId);
         if (persistResult.kind === 'err') {
           console.warn(`[WorkflowRunner] persistTokens failed (continue_workflow gate_checkpoint): ${persistResult.error.code} -- ${persistResult.error.message}`);
         }
@@ -236,7 +237,7 @@ export function makeCompleteStepTool(
   // Optional injection point for testing -- defaults to the real implementation.
   _executeContinueWorkflowFn: typeof executeContinueWorkflow = executeContinueWorkflow,
   emitter?: DaemonEventEmitter,
-  workrailSessionId?: string | null,
+  workrailSessionId?: SessionId | null,
   onGateParked: (gateToken: string, stepId: string) => void = () => { /* no-op for callers that predate gate support */ },
 ): AgentTool {
   return {
@@ -312,7 +313,7 @@ export function makeCompleteStepTool(
       // WHY NOT call onAdvance: the step did NOT advance to the next workflow step.
       if (out.kind === 'gate_checkpoint') {
         const gateState = { kind: 'gate_checkpoint' as const, gateToken: out.gateToken, stepId: out.stepId };
-        const persistResult = await persistTokens(sessionId, '', null, undefined, undefined, gateState);
+        const persistResult = await persistTokens(sessionId, '', null, undefined, undefined, gateState, workrailSessionId);
         if (persistResult.kind === 'err') {
           console.warn(`[WorkflowRunner] persistTokens failed (complete_step gate_checkpoint): ${persistResult.error.code} -- ${persistResult.error.message}`);
         }

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -29,6 +29,7 @@
  * and detect file modification between read and write.
  */
 import type { RunId } from './daemon-events.js';
+import type { SessionId } from '../v2/durable-core/ids/index.js';
 export type { RunId } from './daemon-events.js';
 
 export type ReadFileState = { content: string; timestamp: number; isPartialView: boolean };
@@ -425,6 +426,13 @@ export interface WorkflowRunGateParked {
    * gate evaluation; it needs this ID to find the right sidecar.
    */
   readonly sessionId: string;
+  /**
+   * The WorkRail session ID (sess_* branded ID) of the parked session.
+   * WHY on the result: lets the coordinator read the parked step's output from the
+   * session store without a second sidecar disk read. Absent when the WorkRail session
+   * ID was not yet decoded at gate time (e.g. agent crashed before token decode).
+   */
+  readonly workrailSessionId?: SessionId;
 }
 
 /** Result of a runWorkflow() call. Never throws. */

--- a/src/mcp/handlers/v2-advance-core/assessment-consequences.ts
+++ b/src/mcp/handlers/v2-advance-core/assessment-consequences.ts
@@ -1,43 +1,57 @@
-import type { AssessmentConsequenceDefinition, WorkflowStepDefinition } from '../../../types/workflow-definition.js';
+import type { WorkflowStepDefinition } from '../../../types/workflow-definition.js';
 import type { RecordedAssessmentV1 } from '../../../v2/durable-core/domain/assessment-record.js';
 
 export interface TriggeredAssessmentConsequenceV1 {
   readonly kind: 'require_followup';
   readonly assessmentId: string;
-  readonly firstMatchedDimensionId: string;
+  readonly dimensionId: string;
   readonly triggerLevel: string;
   readonly guidance: string;
 }
 
+/**
+ * Evaluate all assessment consequences declared on a step.
+ *
+ * Each consequence is evaluated independently against all recorded assessments.
+ * A consequence fires when ANY dimension across ANY recorded assessment equals
+ * its anyEqualsLevel. Multiple consequences with distinct trigger levels can
+ * fire in the same call -- callers receive one entry per fired consequence.
+ *
+ * Returns an empty array when no consequences fire (never returns undefined).
+ * Evaluation order follows the declaration order in assessmentConsequences.
+ */
 export function evaluateAssessmentConsequences(args: {
   readonly step: WorkflowStepDefinition | undefined;
   readonly recordedAssessments: readonly RecordedAssessmentV1[];
-}): TriggeredAssessmentConsequenceV1 | undefined {
-  if (!args.step?.assessmentConsequences || args.step.assessmentConsequences.length === 0) return undefined;
-  if (args.recordedAssessments.length === 0) return undefined;
+}): readonly TriggeredAssessmentConsequenceV1[] {
+  if (!args.step?.assessmentConsequences || args.step.assessmentConsequences.length === 0) return [];
+  if (args.recordedAssessments.length === 0) return [];
 
-  const consequence = args.step.assessmentConsequences[0];
-  if (!consequence) return undefined;
+  const triggered: TriggeredAssessmentConsequenceV1[] = [];
 
-  // Check all recorded assessments — fire on the first matching dimension found (in assessmentRefs order).
-  for (const recorded of args.recordedAssessments) {
-    const matched = recorded.dimensions.find(d => d.level === consequence.when.anyEqualsLevel);
-    if (matched) {
-      return {
-        kind: 'require_followup',
-        assessmentId: recorded.assessmentId,
-        firstMatchedDimensionId: matched.dimensionId,
-        triggerLevel: consequence.when.anyEqualsLevel,
-        guidance: consequence.effect.guidance,
-      };
+  for (const consequence of args.step.assessmentConsequences) {
+    const scopedToAssessment = consequence.when.forAssessment;
+
+    // When forAssessment is set, only the named assessment is checked.
+    // When absent, all recorded assessments are scanned -- the first match fires.
+    const candidateAssessments = scopedToAssessment
+      ? args.recordedAssessments.filter(r => r.assessmentId === scopedToAssessment)
+      : args.recordedAssessments;
+
+    for (const recorded of candidateAssessments) {
+      const matched = recorded.dimensions.find(d => d.level === consequence.when.anyEqualsLevel);
+      if (matched) {
+        triggered.push({
+          kind: 'require_followup',
+          assessmentId: recorded.assessmentId,
+          dimensionId: matched.dimensionId,
+          triggerLevel: consequence.when.anyEqualsLevel,
+          guidance: consequence.effect.guidance,
+        });
+        break; // This consequence fired -- move to the next one.
+      }
     }
   }
 
-  return undefined;
-}
-
-export function getDeclaredAssessmentConsequence(
-  step: WorkflowStepDefinition | undefined,
-): AssessmentConsequenceDefinition | undefined {
-  return step?.assessmentConsequences?.[0];
+  return triggered;
 }

--- a/src/mcp/handlers/v2-advance-core/index.ts
+++ b/src/mcp/handlers/v2-advance-core/index.ts
@@ -269,13 +269,13 @@ export function executeAdvanceCore(args: {
     const rawReasonsWithAssessmentRes = detectBlockingReasonsV1({
       outputRequirement,
       missingNotes,
-      assessmentFollowupRequired: v.triggeredAssessmentConsequence
-        ? {
-            assessmentId: v.triggeredAssessmentConsequence.assessmentId,
-            dimensionId: v.triggeredAssessmentConsequence.firstMatchedDimensionId,
-            level: v.triggeredAssessmentConsequence.triggerLevel,
-            guidance: v.triggeredAssessmentConsequence.guidance,
-          }
+      assessmentFollowupsRequired: v.triggeredAssessmentConsequences.length > 0
+        ? v.triggeredAssessmentConsequences.map(c => ({
+            assessmentId: c.assessmentId,
+            dimensionId: c.dimensionId,
+            level: c.triggerLevel,
+            guidance: c.guidance,
+          }))
         : undefined,
     });
     if (rawReasonsWithAssessmentRes.isErr()) {

--- a/src/mcp/handlers/v2-advance-core/input-validation.ts
+++ b/src/mcp/handlers/v2-advance-core/input-validation.ts
@@ -38,7 +38,7 @@ export interface ValidatedAdvanceInputs {
   readonly outputContract: OutputContract | undefined;
   readonly notesMarkdown: string | undefined;
   readonly artifacts: readonly unknown[];
-  readonly triggeredAssessmentConsequence: TriggeredAssessmentConsequenceV1 | undefined;
+  readonly triggeredAssessmentConsequences: readonly TriggeredAssessmentConsequenceV1[];
   readonly stepAssessments: readonly AssessmentDefinition[];
   readonly autonomy: 'guided' | 'full_auto_stop_on_user_deps' | 'full_auto_never_stop';
   readonly riskPolicy: 'conservative' | 'balanced' | 'aggressive';
@@ -116,7 +116,7 @@ export function validateAdvanceInputs(args: {
         artifacts: inputOutput?.artifacts ?? [],
       })
     : undefined;
-  const triggeredAssessmentConsequence = evaluateAssessmentConsequences({
+  const triggeredAssessmentConsequences = evaluateAssessmentConsequences({
     step: typedStep,
     recordedAssessments: assessmentValidation?.recordedAssessments ?? [],
   });
@@ -172,7 +172,7 @@ export function validateAdvanceInputs(args: {
     outputContract,
     notesMarkdown: inputOutput?.notesMarkdown,
     artifacts: inputOutput?.artifacts ?? [],
-    triggeredAssessmentConsequence,
+    triggeredAssessmentConsequences,
     stepAssessments,
     autonomy,
     riskPolicy,

--- a/src/mcp/handlers/v2-advance-core/outcome-blocked.ts
+++ b/src/mcp/handlers/v2-advance-core/outcome-blocked.ts
@@ -129,15 +129,15 @@ export function buildBlockedOutcome(args: {
     extraEventsToAppend.push(assessmentEventRes.value);
   }
 
-  if (validated?.triggeredAssessmentConsequence) {
+  for (const consequence of validated?.triggeredAssessmentConsequences ?? []) {
     const consequenceEventRes = buildAssessmentConsequenceAppliedEvent({
       sessionId: String(sessionId),
       attemptId: String(attemptId),
       scope: { runId: String(runId), nodeId: String(currentNodeId) },
-      assessmentId: validated.triggeredAssessmentConsequence.assessmentId,
-      dimensionId: validated.triggeredAssessmentConsequence.firstMatchedDimensionId,
-      level: validated.triggeredAssessmentConsequence.triggerLevel,
-      guidance: validated.triggeredAssessmentConsequence.guidance,
+      assessmentId: consequence.assessmentId,
+      dimensionId: consequence.dimensionId,
+      level: consequence.triggerLevel,
+      guidance: consequence.guidance,
       minted: { eventId: idFactory.mintEventId() },
     });
     if (consequenceEventRes.isErr()) {

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -828,12 +828,12 @@ export class TriggerRouter {
           // Dispatch gate evaluation fire-and-forget.
           void (async () => {
             try {
-              // WHY goal/workflowId as artifact context: the trigger router doesn't have
-              // direct access to the step's output artifacts without reading the session
-              // store (which requires the workrail session ID, not the sidecar session ID).
-              // Passing the goal and workflow ID gives the evaluator enough context to
-              // apply general quality standards. A future iteration can enrich this by
-              // reading the session store for the completed step's notes and typed artifacts.
+              // workrailSessionId is carried directly on the typed result -- no sidecar read needed.
+              // WHY on the result (not sidecar): WorkflowRunGateParked.workrailSessionId is the
+              // branded SessionId populated by buildSessionResult from state.workrailSessionId.
+              // The typed result is the single source of truth; the sidecar is for crash recovery only.
+              const gateWorkrailSessionId = result.workrailSessionId;
+
               const artifactContext = {
                 stepId,
                 workflowId: workflowTrigger.workflowId,
@@ -846,12 +846,14 @@ export class TriggerRouter {
                   awaitSessions: (handles, timeoutMs) => deps.awaitSessions(handles, timeoutMs),
                   getAgentResult: (handle) => deps.getAgentResult(handle),
                   stderr: (line) => process.stderr.write(line + '\n'),
+                  readStepOutput: (wrSessionId) => deps.getAgentResult(wrSessionId),
                 },
                 artifactContext,
                 'wr.gate-eval-generic',
                 workflowTrigger.workspacePath,
                 stepId,
-                undefined,
+                gateWorkrailSessionId,
+                undefined, // criteria
                 DEFAULT_GATE_EVAL_TIMEOUT_MS,
               );
 

--- a/src/types/workflow-definition.ts
+++ b/src/types/workflow-definition.ts
@@ -88,6 +88,11 @@ export interface AssessmentDefinition {
 /**
  * Trigger condition for an assessment consequence.
  * Fires when ANY dimension in the submitted assessment equals anyEqualsLevel.
+ *
+ * When forAssessment is specified, only the named assessment is checked.
+ * When absent, any recorded assessment that has a matching dimension fires the consequence.
+ * Use forAssessment when a step declares multiple assessmentRefs and each consequence
+ * should be scoped to a specific gate's verdict rather than any gate reaching that level.
  */
 export interface AssessmentConsequenceTriggerDefinition {
   /**
@@ -95,6 +100,12 @@ export interface AssessmentConsequenceTriggerDefinition {
    * For single-dimension assessments this is equivalent to an exact match.
    */
   readonly anyEqualsLevel: string;
+  /**
+   * Optional: scope this consequence to a specific assessment ID.
+   * When present, only the named assessment is checked for the level match.
+   * Must be one of the assessmentRefs declared on the same step.
+   */
+  readonly forAssessment?: string;
 }
 
 export interface AssessmentFollowupRequiredEffectDefinition {

--- a/src/v2/durable-core/domain/assessment-consequence-event-builder.ts
+++ b/src/v2/durable-core/domain/assessment-consequence-event-builder.ts
@@ -26,11 +26,15 @@ export function buildAssessmentConsequenceAppliedEvent(args: {
     return err({ code: 'ASSESSMENT_CONSEQUENCE_EVENT_INVARIANT_VIOLATION', message: 'assessment consequence fields are required' });
   }
 
+  // WHY include assessmentId+dimensionId in the dedupeKey: multiple consequences can fire
+  // in one attempt (one per declared assessmentConsequence that matches). Each must produce
+  // a distinct event. Using assessmentId:dimensionId makes the key unique per consequence
+  // AND idempotent on retry -- the same consequence always produces the same key.
   return ok({
     v: 1,
     eventId: args.minted.eventId,
     kind: EVENT_KIND.ASSESSMENT_CONSEQUENCE_APPLIED,
-    dedupeKey: `assessment_consequence_applied:${args.sessionId}:${args.scope.nodeId}:${args.attemptId}` as DomainEventV1['dedupeKey'],
+    dedupeKey: `assessment_consequence_applied:${args.sessionId}:${args.scope.nodeId}:${args.attemptId}:${args.assessmentId}:${args.dimensionId}` as DomainEventV1['dedupeKey'],
     scope: { runId: args.scope.runId, nodeId: args.scope.nodeId },
     data: {
       attemptId: args.attemptId,

--- a/src/v2/durable-core/domain/blocking-decision.ts
+++ b/src/v2/durable-core/domain/blocking-decision.ts
@@ -52,12 +52,12 @@ export function detectBlockingReasonsV1(args: {
    * Absent when notes are optional (outputContract steps, or notesOptional: true).
    */
   readonly missingNotes?: { readonly stepId: string };
-  readonly assessmentFollowupRequired?: {
+  readonly assessmentFollowupsRequired?: readonly {
     readonly assessmentId: string;
     readonly dimensionId: string;
     readonly level: string;
     readonly guidance: string;
-  };
+  }[];
 }): Result<readonly ReasonV1[], BlockingDecisionError> {
   const reasons: ReasonV1[] = [];
 
@@ -125,19 +125,19 @@ export function detectBlockingReasonsV1(args: {
     reasons.push({ kind: 'missing_notes', stepId: args.missingNotes.stepId });
   }
 
-  if (args.assessmentFollowupRequired) {
-    if (!DELIMITER_SAFE_ID_PATTERN.test(args.assessmentFollowupRequired.dimensionId)) {
+  for (const followup of args.assessmentFollowupsRequired ?? []) {
+    if (!DELIMITER_SAFE_ID_PATTERN.test(followup.dimensionId)) {
       return err({
         code: 'INVALID_DELIMITER_SAFE_ID',
-        message: `assessment dimension ID must be delimiter-safe: [a-z0-9_-]+ (got: ${args.assessmentFollowupRequired.dimensionId})`,
+        message: `assessment dimension ID must be delimiter-safe: [a-z0-9_-]+ (got: ${followup.dimensionId})`,
       });
     }
     reasons.push({
       kind: 'assessment_followup_required',
-      assessmentId: args.assessmentFollowupRequired.assessmentId,
-      dimensionId: args.assessmentFollowupRequired.dimensionId,
-      level: args.assessmentFollowupRequired.level,
-      guidance: args.assessmentFollowupRequired.guidance,
+      assessmentId: followup.assessmentId,
+      dimensionId: followup.dimensionId,
+      level: followup.level,
+      guidance: followup.guidance,
     });
   }
 

--- a/tests/lifecycle/bundled-workflow-smoke.test.ts
+++ b/tests/lifecycle/bundled-workflow-smoke.test.ts
@@ -135,6 +135,9 @@ function analyzeWorkflowWithAssessments(definition: WorkflowDefinition): Workflo
 function usesTemplateCalls(steps: readonly StepDefinition[]): boolean {
   for (const step of steps) {
     if ((step as any).templateCall) return true;
+    // v2 loop body lives at step.body; v1-style loop body at step.loop.steps
+    const body = (step as any).body;
+    if (body && usesTemplateCalls(body)) return true;
     const loopDef = (step as any).loop;
     if (loopDef?.steps && usesTemplateCalls(loopDef.steps)) return true;
   }

--- a/tests/unit/compiler/assessment-definition-validation.test.ts
+++ b/tests/unit/compiler/assessment-definition-validation.test.ts
@@ -385,4 +385,72 @@ describe('assessment declarations — workflow compiler', () => {
     expect(result.isErr()).toBe(true);
     expect(result._unsafeUnwrapErr().message).toContain("anyEqualsLevel 'medium'");
   });
+
+  it('accepts multiple assessment consequences on the same step', () => {
+    const workflow = mkWorkflow({
+      assessments: [
+        {
+          id: 'constraint_gate',
+          purpose: 'Constraint gate.',
+          dimensions: [{ id: 'specificity', purpose: 'Specificity', levels: ['low', 'high'] }],
+        },
+        {
+          id: 'type_gate',
+          purpose: 'Type gate.',
+          dimensions: [{ id: 'soundness', purpose: 'Type soundness', levels: ['low', 'high'] }],
+        },
+      ],
+      steps: [
+        {
+          id: 'step-1',
+          title: 'Step 1',
+          prompt: 'Assess.',
+          assessmentRefs: ['constraint_gate', 'type_gate'],
+          assessmentConsequences: [
+            {
+              when: { anyEqualsLevel: 'low', forAssessment: 'constraint_gate' },
+              effect: { kind: 'require_followup', guidance: 'Fix constraints.' },
+            },
+            {
+              when: { anyEqualsLevel: 'low', forAssessment: 'type_gate' },
+              effect: { kind: 'require_followup', guidance: 'Fix types.' },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = compiler.compile(workflow);
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('fails fast when forAssessment references an unknown assessmentRef', () => {
+    const workflow = mkWorkflow({
+      assessments: [
+        {
+          id: 'readiness_gate',
+          purpose: 'Readiness gate.',
+          dimensions: [{ id: 'confidence', purpose: 'Confidence', levels: ['low', 'high'] }],
+        },
+      ],
+      steps: [
+        {
+          id: 'step-1',
+          title: 'Step 1',
+          prompt: 'Assess.',
+          assessmentRefs: ['readiness_gate'],
+          assessmentConsequences: [
+            {
+              when: { anyEqualsLevel: 'low', forAssessment: 'unknown_gate' },
+              effect: { kind: 'require_followup', guidance: 'Fix.' },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = compiler.compile(workflow);
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr().message).toContain("forAssessment 'unknown_gate'");
+  });
 });

--- a/tests/unit/compiler/routine-injection-e2e.test.ts
+++ b/tests/unit/compiler/routine-injection-e2e.test.ts
@@ -140,12 +140,8 @@ describe('Lean workflow — Phase 1 orchestration with injected routine', () => 
     // Phase 1b-quick: lightweight inline design
     expect(stepIds).toContain('phase-1b-design-quick');
 
-    // Phase 1b-deep: expanded routine steps (5 from tension-driven-design)
-    const routine = loadRoutineJson('tension-driven-design.json');
-    for (const routineStep of routine.steps) {
-      const expandedId = `phase-1b-design-deep.${routineStep.id}`;
-      expect(stepIds, `Expected '${expandedId}' in compiled steps`).toContain(expandedId);
-    }
+    // Phase 1b-deep: constraint-anchored inline design step (was templateCall, now inline promptBlocks)
+    expect(stepIds).toContain('phase-1b-design-deep');
 
     // Phase 1c: challenge and select
     expect(stepIds).toContain('phase-1c-challenge-and-select');
@@ -177,9 +173,8 @@ describe('Lean workflow — Phase 1 orchestration with injected routine', () => 
     });
   });
 
-  it('deep design routine steps inherit compound runCondition (not Small AND not QUICK)', () => {
+  it('deep design step has compound runCondition (not Small AND not QUICK AND solutionFixed != true)', () => {
     const workflow = loadTopLevelWorkflowJson('coding-task-workflow-agentic.json');
-    const routine = loadRoutineJson('tension-driven-design.json');
 
     const result = resolveDefinitionSteps(workflow.steps, workflow.features ?? []);
     const steps = result._unsafeUnwrap().steps;
@@ -192,12 +187,9 @@ describe('Lean workflow — Phase 1 orchestration with injected routine', () => 
       ],
     };
 
-    for (const routineStep of routine.steps) {
-      const expandedId = `phase-1b-design-deep.${routineStep.id}`;
-      const step = steps.find(s => s.id === expandedId) as WorkflowStepDefinition;
-      expect(step, `Expected '${expandedId}' to exist`).toBeDefined();
-      expect(step.runCondition).toEqual(expectedRunCondition);
-    }
+    const deepStep = steps.find(s => s.id === 'phase-1b-design-deep') as WorkflowStepDefinition;
+    expect(deepStep, 'Expected phase-1b-design-deep to exist').toBeDefined();
+    expect(deepStep.runCondition).toEqual(expectedRunCondition);
   });
 
   it('both design paths produce design-candidates.md as unified output contract', () => {
@@ -210,9 +202,9 @@ describe('Lean workflow — Phase 1 orchestration with injected routine', () => 
     const quickStep = steps.find(s => s.id === 'phase-1b-design-quick') as WorkflowStepDefinition;
     expect(quickStep.prompt).toContain('design-candidates.md');
 
-    // Deep path's final step also writes to design-candidates.md (via routine arg)
-    const deliverStep = steps.find(s => s.id === 'phase-1b-design-deep.step-deliver') as WorkflowStepDefinition;
-    expect(deliverStep.prompt).toContain('design-candidates.md');
+    // Deep path (inline promptBlocks) also writes to design-candidates.md
+    const deepStep = steps.find(s => s.id === 'phase-1b-design-deep') as WorkflowStepDefinition;
+    expect(deepStep.prompt).toContain('design-candidates.md');
 
     // Challenge step reads from design-candidates.md
     const selectStep = steps.find(s => s.id === 'phase-1c-challenge-and-select') as WorkflowStepDefinition;
@@ -247,19 +239,17 @@ describe('Lean workflow — Phase 1 orchestration with injected routine', () => 
     expect(stepIds).toContain('phase-7-final-verification');
   });
 
-  it('arg substitution works in the deep design path (deliverableName)', () => {
+  it('deep design step prompt references derivedConstraints for constraint-anchored candidates', () => {
     const workflow = loadTopLevelWorkflowJson('coding-task-workflow-agentic.json');
 
     const result = resolveDefinitionSteps(workflow.steps, workflow.features ?? []);
     const steps = result._unsafeUnwrap().steps;
 
-    const deliverStep = steps.find(
-      s => s.id === 'phase-1b-design-deep.step-deliver',
-    ) as WorkflowStepDefinition;
-
-    expect(deliverStep).toBeDefined();
-    expect(deliverStep.prompt).toContain('design-candidates.md');
-    expect(deliverStep.prompt).not.toContain('{deliverableName}');
+    const deepStep = steps.find(s => s.id === 'phase-1b-design-deep') as WorkflowStepDefinition;
+    expect(deepStep).toBeDefined();
+    // Prompt must reference derivedConstraints and the output file
+    expect(deepStep.prompt).toContain('derivedConstraints');
+    expect(deepStep.prompt).toContain('design-candidates.md');
   });
 });
 

--- a/tests/unit/gate-evaluator-dispatcher.test.ts
+++ b/tests/unit/gate-evaluator-dispatcher.test.ts
@@ -181,7 +181,7 @@ describe('evaluateGate()', () => {
     });
 
     const CUSTOM_TIMEOUT = 5 * 60 * 1000;
-    await evaluateGate(deps, ARTIFACT, 'wr.gate-eval-generic', WORKSPACE, STEP_ID, undefined, CUSTOM_TIMEOUT);
+    await evaluateGate(deps, ARTIFACT, 'wr.gate-eval-generic', WORKSPACE, STEP_ID, undefined, undefined, CUSTOM_TIMEOUT);
 
     expect(capturedTimeout).toBe(CUSTOM_TIMEOUT);
   });
@@ -195,5 +195,100 @@ describe('evaluateGate()', () => {
 
     expect(verdict.verdict).toBe('uncertain');
     expect(verdict.rationale).toMatch(/session store unavailable/);
+  });
+});
+
+describe('evaluateGate() -- readStepOutput enrichment', () => {
+  const WORKSPACE = os.tmpdir();
+  const STEP_ID = 'design-gate';
+  const WR_SESSION_ID = 'sess_abc123';
+
+  function makeVerdictArtifact() {
+    return {
+      kind: 'wr.gate_verdict',
+      version: 1,
+      verdict: 'approved' as const,
+      confidence: 'high' as const,
+      rationale: 'Step output is complete and meets quality standards.',
+    };
+  }
+
+  function makeDepsWithOutput(overrides: Partial<GateEvaluatorDeps> = {}): GateEvaluatorDeps {
+    return {
+      spawnSession: async () => ({ kind: 'ok', value: 'sess_evaluator_001' }),
+      awaitSessions: async () => ({
+        results: [{ handle: 'sess_evaluator_001', outcome: 'success', status: 'complete', durationMs: 100 }],
+        allSucceeded: true,
+      }),
+      getAgentResult: async () => ({ recapMarkdown: null, artifacts: [makeVerdictArtifact()] }),
+      stderr: () => {},
+      ...overrides,
+    };
+  }
+
+  it('injects stepNotes into spawnSession context when readStepOutput returns notes', async () => {
+    let capturedContext: Record<string, unknown> | undefined;
+    const deps = makeDepsWithOutput({
+      spawnSession: async (_wfId, _goal, _workspace, context) => {
+        capturedContext = context as Record<string, unknown>;
+        return { kind: 'ok', value: 'sess_evaluator_001' };
+      },
+      readStepOutput: async () => ({ recapMarkdown: 'The design candidate A uses a sealed class.', artifacts: [] }),
+    });
+
+    await evaluateGate(deps, {}, 'wr.gate-eval-generic', WORKSPACE, STEP_ID, WR_SESSION_ID);
+
+    expect(capturedContext?.stepNotes).toBe('The design candidate A uses a sealed class.');
+  });
+
+  it('proceeds with metadata-only context when readStepOutput returns null', async () => {
+    let capturedContext: Record<string, unknown> | undefined;
+    const deps = makeDepsWithOutput({
+      spawnSession: async (_wfId, _goal, _workspace, context) => {
+        capturedContext = context as Record<string, unknown>;
+        return { kind: 'ok', value: 'sess_evaluator_001' };
+      },
+      readStepOutput: async () => null,
+    });
+
+    await evaluateGate(deps, {}, 'wr.gate-eval-generic', WORKSPACE, STEP_ID, WR_SESSION_ID);
+
+    expect(capturedContext?.stepNotes).toBeUndefined();
+    expect(capturedContext?.stepId).toBe(STEP_ID);
+  });
+
+  it('proceeds with metadata-only context when readStepOutput throws', async () => {
+    let capturedContext: Record<string, unknown> | undefined;
+    const deps = makeDepsWithOutput({
+      spawnSession: async (_wfId, _goal, _workspace, context) => {
+        capturedContext = context as Record<string, unknown>;
+        return { kind: 'ok', value: 'sess_evaluator_001' };
+      },
+      readStepOutput: async () => { throw new Error('session store unavailable'); },
+    });
+
+    await evaluateGate(deps, {}, 'wr.gate-eval-generic', WORKSPACE, STEP_ID, WR_SESSION_ID);
+
+    // Should not throw and should proceed without stepNotes
+    expect(capturedContext?.stepNotes).toBeUndefined();
+    expect(capturedContext?.stepId).toBe(STEP_ID);
+  });
+
+  it('truncates stepNotes exceeding 4000 characters', async () => {
+    const longNotes = 'x'.repeat(5000);
+    let capturedContext: Record<string, unknown> | undefined;
+    const deps = makeDepsWithOutput({
+      spawnSession: async (_wfId, _goal, _workspace, context) => {
+        capturedContext = context as Record<string, unknown>;
+        return { kind: 'ok', value: 'sess_evaluator_001' };
+      },
+      readStepOutput: async () => ({ recapMarkdown: longNotes, artifacts: [] }),
+    });
+
+    await evaluateGate(deps, {}, 'wr.gate-eval-generic', WORKSPACE, STEP_ID, WR_SESSION_ID);
+
+    const injectedNotes = capturedContext?.stepNotes as string;
+    expect(injectedNotes.length).toBeLessThan(5000);
+    expect(injectedNotes).toContain('[truncated]');
   });
 });

--- a/tests/unit/mcp/assessment-consequences.test.ts
+++ b/tests/unit/mcp/assessment-consequences.test.ts
@@ -3,7 +3,7 @@ import { evaluateAssessmentConsequences } from '../../../src/mcp/handlers/v2-adv
 import type { WorkflowStepDefinition } from '../../../src/types/workflow-definition.js';
 import type { RecordedAssessmentV1 } from '../../../src/mcp/handlers/v2-advance-core/assessment-validation.js';
 
-describe('evaluateAssessmentConsequences -- single dimension (equivalent to exact match)', () => {
+describe('evaluateAssessmentConsequences -- single consequence, single dimension', () => {
   const step: WorkflowStepDefinition = {
     id: 'step-1',
     title: 'Step 1',
@@ -28,16 +28,16 @@ describe('evaluateAssessmentConsequences -- single dimension (equivalent to exac
 
     expect(
       evaluateAssessmentConsequences({ step, recordedAssessments: [recorded] })
-    ).toEqual({
+    ).toEqual([{
       kind: 'require_followup',
       assessmentId: 'readiness_gate',
-      firstMatchedDimensionId: 'confidence',
+      dimensionId: 'confidence',
       triggerLevel: 'low',
       guidance: 'Gather more context before proceeding.',
-    });
+    }]);
   });
 
-  it('returns undefined when the dimension does not match', () => {
+  it('returns empty array when the dimension does not match', () => {
     const recorded: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
@@ -46,7 +46,7 @@ describe('evaluateAssessmentConsequences -- single dimension (equivalent to exac
       ],
     };
 
-    expect(evaluateAssessmentConsequences({ step, recordedAssessments: [recorded] })).toBeUndefined();
+    expect(evaluateAssessmentConsequences({ step, recordedAssessments: [recorded] })).toEqual([]);
   });
 });
 
@@ -75,13 +75,13 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
       ],
     };
 
-    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] })).toEqual({
+    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] })).toEqual([{
       kind: 'require_followup',
       assessmentId: 'readiness_gate',
-      firstMatchedDimensionId: 'evidence_quality',
+      dimensionId: 'evidence_quality',
       triggerLevel: 'low',
       guidance: 'Address all low dimensions before proceeding.',
-    });
+    }]);
   });
 
   it('fires when a non-first dimension is low', () => {
@@ -95,16 +95,16 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
       ],
     };
 
-    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] })).toEqual({
+    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] })).toEqual([{
       kind: 'require_followup',
       assessmentId: 'readiness_gate',
-      firstMatchedDimensionId: 'contradiction_resolution',
+      dimensionId: 'contradiction_resolution',
       triggerLevel: 'low',
       guidance: 'Address all low dimensions before proceeding.',
-    });
+    }]);
   });
 
-  it('returns the first matched dimension when multiple are low', () => {
+  it('returns the first matched dimension when multiple dimensions are low (one consequence fires once)', () => {
     const recorded: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
@@ -116,11 +116,12 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
     };
 
     const result = evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] });
-    expect(result?.firstMatchedDimensionId).toBe('evidence_quality');
-    expect(result?.triggerLevel).toBe('low');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.dimensionId).toBe('evidence_quality');
+    expect(result[0]?.triggerLevel).toBe('low');
   });
 
-  it('does not fire when all dimensions are high', () => {
+  it('returns empty array when all dimensions are high', () => {
     const recorded: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
@@ -131,20 +132,20 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
       ],
     };
 
-    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] })).toBeUndefined();
+    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] })).toEqual([]);
   });
 
-  it('does not fire when no dimensions are present', () => {
+  it('returns empty array when no dimensions are present', () => {
     const recorded: RecordedAssessmentV1 = {
       assessmentId: 'readiness_gate',
       normalizationNotes: [],
       dimensions: [],
     };
 
-    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] })).toBeUndefined();
+    expect(evaluateAssessmentConsequences({ step: stepWithAnyTrigger, recordedAssessments: [recorded] })).toEqual([]);
   });
 
-  it('fires on the first matching assessment when multiple refs are present', () => {
+  it('fires on the matching assessment when multiple refs are present', () => {
     const qualityGate: RecordedAssessmentV1 = {
       assessmentId: 'quality_gate',
       normalizationNotes: [],
@@ -166,16 +167,16 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
     };
 
     const result = evaluateAssessmentConsequences({ step: stepMultiRef, recordedAssessments: [qualityGate, coverageGate] });
-    expect(result).toEqual({
+    expect(result).toEqual([{
       kind: 'require_followup',
       assessmentId: 'coverage_gate',
-      firstMatchedDimensionId: 'completeness',
+      dimensionId: 'completeness',
       triggerLevel: 'low',
       guidance: 'Fix before proceeding.',
-    });
+    }]);
   });
 
-  it('does not fire when all dimensions across multiple refs are high', () => {
+  it('returns empty array when all dimensions across multiple refs are high', () => {
     const qualityGate: RecordedAssessmentV1 = {
       assessmentId: 'quality_gate',
       normalizationNotes: [],
@@ -196,6 +197,213 @@ describe('evaluateAssessmentConsequences -- anyEqualsLevel trigger', () => {
       ],
     };
 
-    expect(evaluateAssessmentConsequences({ step: stepMultiRef, recordedAssessments: [qualityGate, coverageGate] })).toBeUndefined();
+    expect(evaluateAssessmentConsequences({ step: stepMultiRef, recordedAssessments: [qualityGate, coverageGate] })).toEqual([]);
+  });
+});
+
+describe('evaluateAssessmentConsequences -- multiple consequences', () => {
+  it('fires all matching consequences independently', () => {
+    const step: WorkflowStepDefinition = {
+      id: 'multi-gate',
+      title: 'Multi-gate Step',
+      prompt: 'Assess.',
+      assessmentRefs: ['constraint_gate', 'type_gate'],
+      assessmentConsequences: [
+        {
+          when: { anyEqualsLevel: 'low' },
+          effect: { kind: 'require_followup', guidance: 'Rewrite vague constraints.' },
+        },
+        {
+          when: { anyEqualsLevel: 'unsound' },
+          effect: { kind: 'require_followup', guidance: 'Redesign unsound types as explicit variants.' },
+        },
+      ],
+    };
+
+    const constraintAssessment: RecordedAssessmentV1 = {
+      assessmentId: 'constraint_gate',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'specificity', level: 'low', normalization: 'exact' }],
+    };
+    const typeAssessment: RecordedAssessmentV1 = {
+      assessmentId: 'type_gate',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'soundness', level: 'unsound', normalization: 'exact' }],
+    };
+
+    const result = evaluateAssessmentConsequences({ step, recordedAssessments: [constraintAssessment, typeAssessment] });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      kind: 'require_followup',
+      assessmentId: 'constraint_gate',
+      dimensionId: 'specificity',
+      triggerLevel: 'low',
+      guidance: 'Rewrite vague constraints.',
+    });
+    expect(result[1]).toEqual({
+      kind: 'require_followup',
+      assessmentId: 'type_gate',
+      dimensionId: 'soundness',
+      triggerLevel: 'unsound',
+      guidance: 'Redesign unsound types as explicit variants.',
+    });
+  });
+
+  it('fires only the consequences whose level matches', () => {
+    const step: WorkflowStepDefinition = {
+      id: 'partial-gate',
+      title: 'Partial Gate',
+      prompt: 'Assess.',
+      assessmentRefs: ['gate_a', 'gate_b'],
+      assessmentConsequences: [
+        {
+          when: { anyEqualsLevel: 'low' },
+          effect: { kind: 'require_followup', guidance: 'Fix low.' },
+        },
+        {
+          when: { anyEqualsLevel: 'unsound' },
+          effect: { kind: 'require_followup', guidance: 'Fix unsound.' },
+        },
+      ],
+    };
+
+    const gateA: RecordedAssessmentV1 = {
+      assessmentId: 'gate_a',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'quality', level: 'low', normalization: 'exact' }],
+    };
+    const gateB: RecordedAssessmentV1 = {
+      assessmentId: 'gate_b',
+      normalizationNotes: [],
+      // 'sound' -- does not match 'unsound'
+      dimensions: [{ dimensionId: 'soundness', level: 'sound', normalization: 'exact' }],
+    };
+
+    const result = evaluateAssessmentConsequences({ step, recordedAssessments: [gateA, gateB] });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.triggerLevel).toBe('low');
+    expect(result[0]?.guidance).toBe('Fix low.');
+  });
+
+  it('returns empty array when no consequence level matches', () => {
+    const step: WorkflowStepDefinition = {
+      id: 'no-match-gate',
+      title: 'No Match',
+      prompt: 'Assess.',
+      assessmentRefs: ['gate_a'],
+      assessmentConsequences: [
+        { when: { anyEqualsLevel: 'low' }, effect: { kind: 'require_followup', guidance: 'Fix.' } },
+        { when: { anyEqualsLevel: 'unsound' }, effect: { kind: 'require_followup', guidance: 'Redesign.' } },
+      ],
+    };
+
+    const gateA: RecordedAssessmentV1 = {
+      assessmentId: 'gate_a',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'quality', level: 'high', normalization: 'exact' }],
+    };
+
+    expect(evaluateAssessmentConsequences({ step, recordedAssessments: [gateA] })).toEqual([]);
+  });
+});
+
+describe('evaluateAssessmentConsequences -- forAssessment scoping', () => {
+  it('fires only the consequence scoped to the assessment that matched', () => {
+    const step: WorkflowStepDefinition = {
+      id: 'scoped-gate',
+      title: 'Scoped Gate',
+      prompt: 'Assess.',
+      assessmentRefs: ['constraint_gate', 'type_gate'],
+      assessmentConsequences: [
+        {
+          when: { anyEqualsLevel: 'low', forAssessment: 'constraint_gate' },
+          effect: { kind: 'require_followup', guidance: 'Fix constraint specificity.' },
+        },
+        {
+          when: { anyEqualsLevel: 'low', forAssessment: 'type_gate' },
+          effect: { kind: 'require_followup', guidance: 'Redesign unsound types.' },
+        },
+      ],
+    };
+
+    // Only constraint_gate is low -- type_gate is high.
+    const constraintAssessment: RecordedAssessmentV1 = {
+      assessmentId: 'constraint_gate',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'specificity', level: 'low', normalization: 'exact' }],
+    };
+    const typeAssessment: RecordedAssessmentV1 = {
+      assessmentId: 'type_gate',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'soundness', level: 'high', normalization: 'exact' }],
+    };
+
+    const result = evaluateAssessmentConsequences({ step, recordedAssessments: [constraintAssessment, typeAssessment] });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      kind: 'require_followup',
+      assessmentId: 'constraint_gate',
+      dimensionId: 'specificity',
+      triggerLevel: 'low',
+      guidance: 'Fix constraint specificity.',
+    });
+  });
+
+  it('fires both scoped consequences when both assessments match', () => {
+    const step: WorkflowStepDefinition = {
+      id: 'both-low-gate',
+      title: 'Both Low Gate',
+      prompt: 'Assess.',
+      assessmentRefs: ['constraint_gate', 'type_gate'],
+      assessmentConsequences: [
+        {
+          when: { anyEqualsLevel: 'low', forAssessment: 'constraint_gate' },
+          effect: { kind: 'require_followup', guidance: 'Fix constraints.' },
+        },
+        {
+          when: { anyEqualsLevel: 'low', forAssessment: 'type_gate' },
+          effect: { kind: 'require_followup', guidance: 'Fix types.' },
+        },
+      ],
+    };
+
+    const constraintAssessment: RecordedAssessmentV1 = {
+      assessmentId: 'constraint_gate',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'specificity', level: 'low', normalization: 'exact' }],
+    };
+    const typeAssessment: RecordedAssessmentV1 = {
+      assessmentId: 'type_gate',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'soundness', level: 'low', normalization: 'exact' }],
+    };
+
+    const result = evaluateAssessmentConsequences({ step, recordedAssessments: [constraintAssessment, typeAssessment] });
+    expect(result).toHaveLength(2);
+    expect(result[0]?.guidance).toBe('Fix constraints.');
+    expect(result[1]?.guidance).toBe('Fix types.');
+  });
+
+  it('does not fire a scoped consequence for an assessment that scored high', () => {
+    const step: WorkflowStepDefinition = {
+      id: 'none-low-gate',
+      title: 'None Low Gate',
+      prompt: 'Assess.',
+      assessmentRefs: ['gate_a'],
+      assessmentConsequences: [
+        {
+          when: { anyEqualsLevel: 'low', forAssessment: 'gate_a' },
+          effect: { kind: 'require_followup', guidance: 'Fix gate_a.' },
+        },
+      ],
+    };
+
+    const assessment: RecordedAssessmentV1 = {
+      assessmentId: 'gate_a',
+      normalizationNotes: [],
+      dimensions: [{ dimensionId: 'quality', level: 'high', normalization: 'exact' }],
+    };
+
+    expect(evaluateAssessmentConsequences({ step, recordedAssessments: [assessment] })).toEqual([]);
   });
 });

--- a/workflows/coding-task-workflow-agentic.json
+++ b/workflows/coding-task-workflow-agentic.json
@@ -1,7 +1,7 @@
 {
   "id": "wr.coding-task",
   "name": "Agentic Task Dev Workflow",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Use this to implement a software feature or task. Follows a plan-then-execute approach with architecture decisions, invariant tracking, and final verification.",
   "about": "## Agentic Coding Task Workflow\n\nThis workflow structures the full lifecycle of a software implementation task: from understanding and classifying the work, through architecture decisions and incremental implementation, to final verification and handoff.\n\n### What it does\n\nThe workflow guides an AI agent through a disciplined plan-then-execute process. It begins by analyzing the task to determine complexity, risk, and the right level of rigor (QUICK, STANDARD, or THOROUGH). For non-trivial tasks, it then gathers codebase context, surfaces invariants and non-goals, generates competing design candidates, and selects an approach before writing a single line of code. Implementation proceeds slice by slice, with built-in verification gates after each slice. A final integration verification pass confirms acceptance criteria are met before handoff.\n\n### Upstream context (Phase 0.5)\n\nPhase 0.5 looks for any upstream document that has already defined what to build -- a Shape Up pitch, PRD, BRD, RFC, design doc, user story with acceptance criteria, Jira epic, or equivalent. The agent uses whatever tools are available (repo search, WebFetch, Confluence/Notion/Glean MCPs, Memory MCP) to find it. If found, two flags are set: `upstreamSpecDetected` (something exists) and `solutionFixed` (whether the document commits to a specific technical direction). When `solutionFixed = true`, design ideation phases (1a-1c) are skipped and Phase 1d translates the upstream constraints directly into an engineering approach. When `solutionFixed = false`, design ideation runs normally but is constrained by whatever the upstream document does specify. The plan audit (Phase 4) checks for drift against `upstreamBoundaries` whenever an upstream document was found.\n\n### When to use it\n\nUse this workflow whenever you are implementing a feature, fixing a non-trivial bug, or making an architectural change in a real codebase. It is especially valuable when:\n- The task touches multiple files or systems\n- There is meaningful risk of regressions or invariant violations\n- You want the agent to surface trade-offs and commit to a reasoned design decision rather than guessing\n- You need a resumable, auditable record of what was decided and why\n\nFor quick one-liner fixes or very small changes, the workflow includes a fast path that skips heavyweight planning.\n\n### What it produces\n\n- An `implementation_plan.md` artifact covering the selected approach, vertical slices, test design, and philosophy alignment\n- A `spec.md` for large or high-risk tasks, capturing observable behavior and acceptance criteria\n- Step-level notes in WorkRail that serve as a durable execution log\n- A PR-ready handoff summary with acceptance criteria status, invariant proofs, and follow-up tickets\n\n### How to get good results\n\n- Provide a clear task description and at least partial acceptance criteria before starting\n- If you have coding philosophy or project conventions configured in session rules or Memory MCP, the workflow will apply them automatically as a design lens\n- Let the workflow classify complexity and rigor itself; override only if the classification is clearly wrong\n- For large or high-risk tasks, review the architecture decision step before implementation begins",
   "examples": [
@@ -127,6 +127,20 @@
           ]
         }
       ]
+    },
+    {
+      "id": "constraint-derivation-gate",
+      "purpose": "Ensures constraints derived from codebase patterns are specific enough to falsify wrong design candidates -- not generic aspirations that provide false confidence without blocking anything.",
+      "dimensions": [
+        {
+          "id": "constraint_specificity",
+          "purpose": "Each derived constraint names a specific observed pattern, the components it governs, and the prohibited alternative. A constraint like 'follow existing patterns' is vague. A specific constraint names the pattern and what it forbids.",
+          "levels": [
+            "vague",
+            "specific"
+          ]
+        }
+      ]
     }
   ],
   "preconditions": [
@@ -152,7 +166,7 @@
     {
       "id": "phase-0-understand-and-classify",
       "title": "Phase 0: Understand & Classify",
-      "prompt": "Understand this before you touch anything.\n\nMake sure the expected behavior is clear enough to proceed. If it really isn't, ask me only what you can't answer yourself. Don't ask me things you can find with tools.\n\nThen dig through the code. Figure out:\n- where this starts and what the call chain looks like\n- which files, modules, and functions matter\n- what patterns this should follow\n- how this repo verifies similar work\n- what the real risks, invariants, and non-goals are\n\nFigure out what philosophy to use while doing the work. Prefer, in order: Memory MCP (`mcp_memory_conventions`, `mcp_memory_prefer`, `mcp_memory_recall`), active session/Firebender rules, repo patterns, then me only if those still conflict or aren't enough.\n\nRecord where that philosophy lives, not a summary. If the stated rules and repo patterns disagree, capture the conflict.\n\nOnce you actually understand the task, classify it:\n- `taskComplexity`: Small / Medium / Large\n- `riskLevel`: Low / Medium / High\n- `rigorMode`: QUICK / STANDARD / THOROUGH\n- `automationLevel`: High / Medium / Low\n- `prStrategy`: SinglePR / MultiPR\n\nUse this guidance:\n- QUICK: small, low-risk, clear path, little ambiguity\n- STANDARD: medium scope or moderate risk\n- THOROUGH: large scope, architectural uncertainty, or high-risk change\n\nThen force a context-clarity check. Score each from 0-2 and give one sentence of evidence for each score:\n- `entryPointClarity`: 0 = clear entry point and call chain, 1 = partial chain with gaps, 2 = still unclear where behavior starts or flows\n- `boundaryClarity`: 0 = clear boundary, 1 = likely boundary but some uncertainty, 2 = patch-vs-boundary decision still unclear\n- `invariantClarity`: 0 = important invariants are explicit, 1 = some are inferred or uncertain, 2 = important invariants are still unclear\n- `verificationClarity`: 0 = clear deterministic verification path, 1 = partial verification path, 2 = verification is still weak or unclear\n\nUse the rubric, not vibes:\n- QUICK: do not run the deeper context batch; if the rubric says you're missing too much context, your classification is probably wrong and you should reclassify upward before moving on\n- STANDARD: run the deeper context batch if the total score is 3 or more, or if `boundaryClarity`, `invariantClarity`, or `verificationClarity` is 2\n- THOROUGH: always run the deeper context batch\n\nThe deeper context batch is:\n- `routine-context-gathering` with `focus=COMPLETENESS`\n- `routine-context-gathering` with `focus=DEPTH`\n\nAfter the batch, synthesize what changed, what stayed the same, and what is still unknown. If the extra context changes the classification, update it before you leave this step.\n\nCapture:\n- `taskComplexity`\n- `riskLevel`\n- `rigorMode`\n- `automationLevel`\n- `prStrategy`\n- `contextSummary`\n- `candidateFiles`\n- `invariants`\n- `nonGoals`\n- `openQuestions` (only real human-decision questions)\n- `philosophySources`\n- `philosophyConflicts`\n\n**Architecture alignment check (do this last, after candidateFiles is known):**\n\nFor each candidate file, scan for violations of the philosophy you just discovered. Name each violation explicitly and specifically (e.g. \"runWorkflow() is 4900 lines -- violates compose-with-small-pure-functions\", \"tool factories use params: any -- violates validate-at-boundaries\"). Do not assert absence without checking. If you found no violations, list the principles you checked and why each passes.\n\nThen decide:\n- `architectureViolations`: list of specific violations found (may be empty)\n- `architectureStartsFromScratch`: true if violations are significant enough that the correct design starts from the user's philosophy rather than adapting the existing code. False if violations are minor or out of scope for this task.\n\nIf `architectureStartsFromScratch` is true, the design phase will be constrained: Candidate A (simplest) must still honor the philosophy -- adapting an existing violation is not a valid candidate. Record this now so the design phase uses it.",
+      "prompt": "Understand this before you touch anything.\n\nMake sure the expected behavior is clear enough to proceed. If it really isn't, ask me only what you can't answer yourself. Don't ask me things you can find with tools.\n\nThen dig through the code. Figure out:\n- where this starts and what the call chain looks like\n- which files, modules, and functions matter\n- what patterns this should follow\n- how this repo verifies similar work\n- what the real risks, invariants, and non-goals are\n\nFigure out what philosophy to use while doing the work. Prefer, in order: Memory MCP (`mcp_memory_conventions`, `mcp_memory_prefer`, `mcp_memory_recall`), active session/Firebender rules, repo patterns, then me only if those still conflict or aren't enough.\n\nRecord where that philosophy lives, not a summary. If the stated rules and repo patterns disagree, capture the conflict.\n\nOnce you actually understand the task, classify it:\n- `taskComplexity`: Small / Medium / Large\n- `riskLevel`: Low / Medium / High\n- `rigorMode`: QUICK / STANDARD / THOROUGH\n- `automationLevel`: High / Medium / Low\n- `prStrategy`: SinglePR / MultiPR\n\nUse this guidance:\n- QUICK: small, low-risk, clear path, little ambiguity\n- STANDARD: medium scope or moderate risk\n- THOROUGH: large scope, architectural uncertainty, or high-risk change\n\nThen force a context-clarity check. Score each from 0-2 and give one sentence of evidence for each score:\n- `entryPointClarity`: 0 = clear entry point and call chain, 1 = partial chain with gaps, 2 = still unclear where behavior starts or flows\n- `boundaryClarity`: 0 = clear boundary, 1 = likely boundary but some uncertainty, 2 = patch-vs-boundary decision still unclear\n- `invariantClarity`: 0 = important invariants are explicit, 1 = some are inferred or uncertain, 2 = important invariants are still unclear\n- `verificationClarity`: 0 = clear deterministic verification path, 1 = partial verification path, 2 = verification is still weak or unclear\n\nUse the rubric, not vibes:\n- QUICK: do not run the deeper context batch; if the rubric says you're missing too much context, your classification is probably wrong and you should reclassify upward before moving on\n- STANDARD: run the deeper context batch if the total score is 3 or more, or if `boundaryClarity`, `invariantClarity`, or `verificationClarity` is 2\n- THOROUGH: always run the deeper context batch\n\nThe deeper context batch is:\n- `routine-context-gathering` with `focus=COMPLETENESS`\n- `routine-context-gathering` with `focus=DEPTH`\n\nAfter the batch, synthesize what changed, what stayed the same, and what is still unknown. If the extra context changes the classification, update it before you leave this step.\n\nCapture:\n- `taskComplexity`\n- `riskLevel`\n- `rigorMode`\n- `automationLevel`\n- `prStrategy`\n- `contextSummary`\n- `candidateFiles`\n- `invariants`\n- `nonGoals`\n- `openQuestions` (only real human-decision questions)\n- `philosophySources`\n- `philosophyConflicts`\n\n**Architecture alignment check (do this last, after candidateFiles is known):**\n\nFor each candidate file, scan for violations of the philosophy you just discovered. Name each violation explicitly and specifically (e.g. \"runWorkflow() is 4900 lines -- violates compose-with-small-pure-functions\", \"tool factories use params: any -- violates validate-at-boundaries\"). Do not assert absence without checking. If you found no violations, list the principles you checked and why each passes.\n\nThen decide:\n- `architectureViolations`: list of specific violations found (may be empty)\n- `architectureStartsFromScratch`: true if violations are significant enough that the correct design starts from the user's philosophy rather than adapting the existing code. False if violations are minor or out of scope for this task.\n\nIf `architectureStartsFromScratch` is true, the design phase will be constrained: Candidate A (simplest) must still honor the philosophy -- adapting an existing violation is not a valid candidate. Record this now so the design phase uses it.\n\n**Constraint Derivation (mandatory after architecture check, before leaving Phase 0):**\n\nThe architecture check above finds violations in existing code. This step converts what you observed into forward-facing rules that will gate your design.\n\nFor each structural pattern you observed in the candidate files, write the rule it implies for NEW code. A rule must be specific: name the pattern, the component(s) it governs, and what it forbids. Generic rules ('follow existing patterns') fail the constraint-specificity gate.\n\nExamples of specific constraints:\n- 'All display strings are pre-computed in the Reducer via DateFormatterService -- never computed in ViewModel, UseCase, or Repository'\n- 'DateFormatterService is responsible for: takes a date value, returns a formatted string -- it must not receive or reference UI model types'\n- 'Every new Repository method must be suspend fun and return Result<T> -- synchronous return types are not allowed in this layer'\n\nIf you observed no constraining patterns (genuinely no relevant conventions in this codebase for this task), explicitly state what you checked and why nothing constraining was found. Empty constraints are valid only with justification.\n\nStore as `derivedConstraints`: array of strings. Each string is one specific forward-facing rule.\n\nThese constraints will be used in Phase 0-6 for a pre-design gate and must be cited by each design candidate in Phase 1b.",
       "requireConfirmation": {
         "or": [
           {
@@ -211,6 +225,64 @@
       "id": "phase-0-5-upstream-context",
       "title": "Phase 0.5: Locate Upstream Context",
       "prompt": "Before you start designing, find out what has already been decided upstream. Use whatever tools you have -- repo search, WebFetch, MCP integrations (Confluence, Notion, Google Docs, Glean, Linear, Jira), Memory MCP, whatever is available.\n\nLook for any document that describes this work: a pitch, PRD, BRD, RFC, design doc, user story with acceptance criteria, epic, Jira ticket, or equivalent. Also scan for URLs in the task description -- if someone linked a document, read it.\n\nIf nothing relevant exists, say so and move on. Do not fabricate context.\n\nIf you find something, read it and commit to three questions:\n\n1. **Is the problem fixed?** Does this document commit to a specific problem or need -- or is the framing still open?\n2. **Is the solution fixed?** Does this document commit to a specific technical direction -- or is that still yours to decide?\n3. **What are the hard boundaries?** Extract any explicit effort bounds, out-of-scope exclusions, required constraints, acceptance criteria, or invariants that must hold. Free-form summary -- do not force a schema onto it.\n\nFor the two booleans: if you are genuinely uncertain, default `solutionFixed = false`. Running design ideation when it wasn't strictly needed is a smaller cost than skipping it when it was.\n\nCapture:\n- `upstreamSpecDetected` (boolean)\n- `upstreamSource` (string: where you found it, or 'none')\n- `upstreamContext` (string: short summary of what you found and why it's relevant)\n- `problemFixed` (boolean)\n- `solutionFixed` (boolean)\n- `upstreamBoundaries` (string: the hard constraints extracted -- effort bound, out-of-scope items, required invariants, acceptance criteria)",
+      "requireConfirmation": false
+    },
+    {
+      "id": "phase-0-6-design-constraints",
+      "title": "Phase 0-6: Pre-Design Constraint Gate",
+      "runCondition": {
+        "and": [
+          {
+            "var": "rigorMode",
+            "not_equals": "QUICK"
+          },
+          {
+            "var": "taskComplexity",
+            "not_equals": "Small"
+          }
+        ]
+      },
+      "promptBlocks": {
+        "goal": "Verify derived constraints are actionable gates, not placeholders. Then apply three forward-facing checks before any design candidate is generated.",
+        "constraints": [
+          "Do not generate design candidates in this step. This step only checks and gates.",
+          "Each check is independent -- a failure in one does not skip the others.",
+          "If any check fails, record what specifically failed before advancing.",
+          "The three checks are mandatory -- do not skip them even if they feel redundant with Phase 0."
+        ],
+        "procedure": [
+          "1. **Constraint quality check.** Read `derivedConstraints`. For each constraint: could it fail to block a wrong candidate? If yes, it is too vague -- rewrite it. A specific constraint names the pattern, the components, and the prohibited alternative.",
+          "2. **Nullable field gate.** For every type you plan to propose: does it have a nullable field? If yes, does it represent two distinct states? Name the illegal states this nullable type makes representable. Record the finding.",
+          "3. **Interface responsibility gate.** For every interface you plan to extend: state its responsibility in one sentence ('X takes Y, returns Z'). Does the behavior you are adding violate that? Name the violation if yes.",
+          "4. Set `constraintGatePassed` to true if all three checks passed with no violations, false otherwise."
+        ],
+        "outputRequired": {
+          "derivedConstraints": "Refined constraint list after quality check -- each constraint is specific enough to falsify a wrong candidate",
+          "nullableFieldFindings": "For each proposed type: the nullable fields found and whether they encode distinct states",
+          "interfaceResponsibilities": "For each interface to be extended: one-sentence responsibility and verdict on whether new behavior violates it",
+          "constraintGatePassed": "true if no violations found, false if candidates must be constrained"
+        },
+        "verify": [
+          "Each constraint in derivedConstraints names a specific pattern, the components it governs, and the prohibited alternative.",
+          "Every type you plan to propose has been checked for nullable fields encoding distinct states.",
+          "Every interface you plan to extend has a stated responsibility.",
+          "If constraintGatePassed is false, the violations are named explicitly -- not summarized as 'some concerns exist'."
+        ]
+      },
+      "assessmentRefs": [
+        "constraint-derivation-gate"
+      ],
+      "assessmentConsequences": [
+        {
+          "when": {
+            "anyEqualsLevel": "vague"
+          },
+          "effect": {
+            "kind": "require_followup",
+            "guidance": "Rewrite the vague constraints so each names the specific pattern, the component(s) it governs, and the prohibited alternative. A constraint that could apply to any codebase is not specific enough to gate design candidates."
+          }
+        }
+      ],
       "requireConfirmation": false
     },
     {
@@ -326,6 +398,22 @@
             "equals": true
           },
           "text": "Architecture-first constraint is active (`architectureStartsFromScratch = true`). Before selecting a candidate, verify: does the leading option start from the user's philosophy, or does it adapt an existing violation? Adapting a code structure that was already identified as a philosophy violation is NOT a valid candidate -- even as Candidate A (simplest). The simplest valid candidate is the simplest design that honors the philosophy."
+        },
+        {
+          "id": "phase-1c-constraint-citation",
+          "when": {
+            "and": [
+              {
+                "var": "rigorMode",
+                "not_equals": "QUICK"
+              },
+              {
+                "var": "taskComplexity",
+                "not_equals": "Small"
+              }
+            ]
+          },
+          "text": "\n\n**Constraint citation check (fires when phase-0-6 ran):** Before selecting a direction, verify that each candidate in `design-candidates.md` explicitly cites which `derivedConstraints` it satisfies. A candidate that does not address a derived constraint either satisfies it by construction (state why) or violates it (which disqualifies it unless the constraint is wrong). If a candidate violates a derived constraint, that is a structural finding -- not a tradeoff to accept."
         }
       ],
       "assessmentRefs": [

--- a/workflows/coding-task-workflow-agentic.json
+++ b/workflows/coding-task-workflow-agentic.json
@@ -1,7 +1,7 @@
 {
   "id": "wr.coding-task",
   "name": "Agentic Task Dev Workflow",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Use this to implement a software feature or task. Follows a plan-then-execute approach with architecture decisions, invariant tracking, and final verification.",
   "about": "## Agentic Coding Task Workflow\n\nThis workflow structures the full lifecycle of a software implementation task: from understanding and classifying the work, through architecture decisions and incremental implementation, to final verification and handoff.\n\n### What it does\n\nThe workflow guides an AI agent through a disciplined plan-then-execute process. It begins by analyzing the task to determine complexity, risk, and the right level of rigor (QUICK, STANDARD, or THOROUGH). For non-trivial tasks, it then gathers codebase context, surfaces invariants and non-goals, generates competing design candidates, and selects an approach before writing a single line of code. Implementation proceeds slice by slice, with built-in verification gates after each slice. A final integration verification pass confirms acceptance criteria are met before handoff.\n\n### Upstream context (Phase 0.5)\n\nPhase 0.5 looks for any upstream document that has already defined what to build -- a Shape Up pitch, PRD, BRD, RFC, design doc, user story with acceptance criteria, Jira epic, or equivalent. The agent uses whatever tools are available (repo search, WebFetch, Confluence/Notion/Glean MCPs, Memory MCP) to find it. If found, two flags are set: `upstreamSpecDetected` (something exists) and `solutionFixed` (whether the document commits to a specific technical direction). When `solutionFixed = true`, design ideation phases (1a-1c) are skipped and Phase 1d translates the upstream constraints directly into an engineering approach. When `solutionFixed = false`, design ideation runs normally but is constrained by whatever the upstream document does specify. The plan audit (Phase 4) checks for drift against `upstreamBoundaries` whenever an upstream document was found.\n\n### When to use it\n\nUse this workflow whenever you are implementing a feature, fixing a non-trivial bug, or making an architectural change in a real codebase. It is especially valuable when:\n- The task touches multiple files or systems\n- There is meaningful risk of regressions or invariant violations\n- You want the agent to surface trade-offs and commit to a reasoned design decision rather than guessing\n- You need a resumable, auditable record of what was decided and why\n\nFor quick one-liner fixes or very small changes, the workflow includes a fast path that skips heavyweight planning.\n\n### What it produces\n\n- An `implementation_plan.md` artifact covering the selected approach, vertical slices, test design, and philosophy alignment\n- A `spec.md` for large or high-risk tasks, capturing observable behavior and acceptance criteria\n- Step-level notes in WorkRail that serve as a durable execution log\n- A PR-ready handoff summary with acceptance criteria status, invariant proofs, and follow-up tickets\n\n### How to get good results\n\n- Provide a clear task description and at least partial acceptance criteria before starting\n- If you have coding philosophy or project conventions configured in session rules or Memory MCP, the workflow will apply them automatically as a design lens\n- Let the workflow classify complexity and rigor itself; override only if the classification is clearly wrong\n- For large or high-risk tasks, review the architecture decision step before implementation begins",
   "examples": [
@@ -130,14 +130,50 @@
     },
     {
       "id": "constraint-derivation-gate",
-      "purpose": "Ensures constraints derived from codebase patterns are specific enough to falsify wrong design candidates -- not generic aspirations that provide false confidence without blocking anything.",
+      "purpose": "Ensures the agent consulted all three constraint sources (philosophy, codebase conventions, team/project rules) and produced constraints specific enough to falsify wrong candidates.",
       "dimensions": [
         {
           "id": "constraint_specificity",
-          "purpose": "Each derived constraint names a specific observed pattern, the components it governs, and the prohibited alternative. A constraint like 'follow existing patterns' is vague. A specific constraint names the pattern and what it forbids.",
+          "purpose": "Each constraint names a specific subject, the rule it implies, and the prohibited alternative. 'Follow patterns' is vague; it cannot falsify a wrong candidate. Score low if any constraint is vague; high if all are specific.",
           "levels": [
-            "vague",
-            "specific"
+            "low",
+            "high"
+          ]
+        },
+        {
+          "id": "constraint_source_coverage",
+          "purpose": "All three sources checked: philosophy, codebase conventions, team/project rules. A source with no constraints must be explicitly justified -- silent omission is not acceptable. Score low if any source is unchecked without justification; high otherwise.",
+          "levels": [
+            "low",
+            "high"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "type-design-gate",
+      "purpose": "Ensures no proposed type uses nullable fields to encode distinct states. Nullable fields that represent two or more states make illegal combinations representable and violate make-illegal-states-unrepresentable.",
+      "dimensions": [
+        {
+          "id": "type_design_soundness",
+          "purpose": "Every proposed type checked for nullable fields encoding distinct states. If loading/absent/error are encoded as nullable fields, the type must use explicit variants. Score low if any such type exists; high if all types are sound.",
+          "levels": [
+            "low",
+            "high"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "interface-responsibility-gate",
+      "purpose": "Ensures the agent has stated the one-sentence responsibility of every interface it plans to extend, and has verified that new behavior does not violate that responsibility. An unstated responsibility is a silent coupling risk.",
+      "dimensions": [
+        {
+          "id": "interface_responsibility_stated",
+          "purpose": "For every interface or service to be extended: its responsibility is one sentence and the new behavior does not violate it. Score low if any responsibility is unstated or violated; high if all are stated and verified.",
+          "levels": [
+            "low",
+            "high"
           ]
         }
       ]
@@ -166,7 +202,7 @@
     {
       "id": "phase-0-understand-and-classify",
       "title": "Phase 0: Understand & Classify",
-      "prompt": "Understand this before you touch anything.\n\nMake sure the expected behavior is clear enough to proceed. If it really isn't, ask me only what you can't answer yourself. Don't ask me things you can find with tools.\n\nThen dig through the code. Figure out:\n- where this starts and what the call chain looks like\n- which files, modules, and functions matter\n- what patterns this should follow\n- how this repo verifies similar work\n- what the real risks, invariants, and non-goals are\n\nFigure out what philosophy to use while doing the work. Prefer, in order: Memory MCP (`mcp_memory_conventions`, `mcp_memory_prefer`, `mcp_memory_recall`), active session/Firebender rules, repo patterns, then me only if those still conflict or aren't enough.\n\nRecord where that philosophy lives, not a summary. If the stated rules and repo patterns disagree, capture the conflict.\n\nOnce you actually understand the task, classify it:\n- `taskComplexity`: Small / Medium / Large\n- `riskLevel`: Low / Medium / High\n- `rigorMode`: QUICK / STANDARD / THOROUGH\n- `automationLevel`: High / Medium / Low\n- `prStrategy`: SinglePR / MultiPR\n\nUse this guidance:\n- QUICK: small, low-risk, clear path, little ambiguity\n- STANDARD: medium scope or moderate risk\n- THOROUGH: large scope, architectural uncertainty, or high-risk change\n\nThen force a context-clarity check. Score each from 0-2 and give one sentence of evidence for each score:\n- `entryPointClarity`: 0 = clear entry point and call chain, 1 = partial chain with gaps, 2 = still unclear where behavior starts or flows\n- `boundaryClarity`: 0 = clear boundary, 1 = likely boundary but some uncertainty, 2 = patch-vs-boundary decision still unclear\n- `invariantClarity`: 0 = important invariants are explicit, 1 = some are inferred or uncertain, 2 = important invariants are still unclear\n- `verificationClarity`: 0 = clear deterministic verification path, 1 = partial verification path, 2 = verification is still weak or unclear\n\nUse the rubric, not vibes:\n- QUICK: do not run the deeper context batch; if the rubric says you're missing too much context, your classification is probably wrong and you should reclassify upward before moving on\n- STANDARD: run the deeper context batch if the total score is 3 or more, or if `boundaryClarity`, `invariantClarity`, or `verificationClarity` is 2\n- THOROUGH: always run the deeper context batch\n\nThe deeper context batch is:\n- `routine-context-gathering` with `focus=COMPLETENESS`\n- `routine-context-gathering` with `focus=DEPTH`\n\nAfter the batch, synthesize what changed, what stayed the same, and what is still unknown. If the extra context changes the classification, update it before you leave this step.\n\nCapture:\n- `taskComplexity`\n- `riskLevel`\n- `rigorMode`\n- `automationLevel`\n- `prStrategy`\n- `contextSummary`\n- `candidateFiles`\n- `invariants`\n- `nonGoals`\n- `openQuestions` (only real human-decision questions)\n- `philosophySources`\n- `philosophyConflicts`\n\n**Architecture alignment check (do this last, after candidateFiles is known):**\n\nFor each candidate file, scan for violations of the philosophy you just discovered. Name each violation explicitly and specifically (e.g. \"runWorkflow() is 4900 lines -- violates compose-with-small-pure-functions\", \"tool factories use params: any -- violates validate-at-boundaries\"). Do not assert absence without checking. If you found no violations, list the principles you checked and why each passes.\n\nThen decide:\n- `architectureViolations`: list of specific violations found (may be empty)\n- `architectureStartsFromScratch`: true if violations are significant enough that the correct design starts from the user's philosophy rather than adapting the existing code. False if violations are minor or out of scope for this task.\n\nIf `architectureStartsFromScratch` is true, the design phase will be constrained: Candidate A (simplest) must still honor the philosophy -- adapting an existing violation is not a valid candidate. Record this now so the design phase uses it.\n\n**Constraint Derivation (mandatory after architecture check, before leaving Phase 0):**\n\nThe architecture check above finds violations in existing code. This step converts what you observed into forward-facing rules that will gate your design.\n\nFor each structural pattern you observed in the candidate files, write the rule it implies for NEW code. A rule must be specific: name the pattern, the component(s) it governs, and what it forbids. Generic rules ('follow existing patterns') fail the constraint-specificity gate.\n\nExamples of specific constraints:\n- 'All display strings are pre-computed in the Reducer via DateFormatterService -- never computed in ViewModel, UseCase, or Repository'\n- 'DateFormatterService is responsible for: takes a date value, returns a formatted string -- it must not receive or reference UI model types'\n- 'Every new Repository method must be suspend fun and return Result<T> -- synchronous return types are not allowed in this layer'\n\nIf you observed no constraining patterns (genuinely no relevant conventions in this codebase for this task), explicitly state what you checked and why nothing constraining was found. Empty constraints are valid only with justification.\n\nStore as `derivedConstraints`: array of strings. Each string is one specific forward-facing rule.\n\nThese constraints will be used in Phase 0-6 for a pre-design gate and must be cited by each design candidate in Phase 1b.",
+      "prompt": "Understand this before you touch anything.\n\nMake sure the expected behavior is clear enough to proceed. If it really isn't, ask me only what you can't answer yourself. Don't ask me things you can find with tools.\n\nThen dig through the code. Figure out:\n- where this starts and what the call chain looks like\n- which files, modules, and functions matter\n- what patterns this should follow\n- how this repo verifies similar work\n- what the real risks, invariants, and non-goals are\n\nFigure out what philosophy to use while doing the work. Prefer, in order: Memory MCP (`mcp_memory_conventions`, `mcp_memory_prefer`, `mcp_memory_recall`), active session/Firebender rules, repo patterns, then me only if those still conflict or aren't enough.\n\nRecord where that philosophy lives, not a summary. If the stated rules and repo patterns disagree, capture the conflict.\n\nOnce you actually understand the task, classify it:\n- `taskComplexity`: Small / Medium / Large\n- `riskLevel`: Low / Medium / High\n- `rigorMode`: QUICK / STANDARD / THOROUGH\n- `automationLevel`: High / Medium / Low\n- `prStrategy`: SinglePR / MultiPR\n\nUse this guidance:\n- QUICK: small, low-risk, clear path, little ambiguity\n- STANDARD: medium scope or moderate risk\n- THOROUGH: large scope, architectural uncertainty, or high-risk change\n\nThen force a context-clarity check. Score each from 0-2 and give one sentence of evidence for each score:\n- `entryPointClarity`: 0 = clear entry point and call chain, 1 = partial chain with gaps, 2 = still unclear where behavior starts or flows\n- `boundaryClarity`: 0 = clear boundary, 1 = likely boundary but some uncertainty, 2 = patch-vs-boundary decision still unclear\n- `invariantClarity`: 0 = important invariants are explicit, 1 = some are inferred or uncertain, 2 = important invariants are still unclear\n- `verificationClarity`: 0 = clear deterministic verification path, 1 = partial verification path, 2 = verification is still weak or unclear\n\nUse the rubric, not vibes:\n- QUICK: do not run the deeper context batch; if the rubric says you're missing too much context, your classification is probably wrong and you should reclassify upward before moving on\n- STANDARD: run the deeper context batch if the total score is 3 or more, or if `boundaryClarity`, `invariantClarity`, or `verificationClarity` is 2\n- THOROUGH: always run the deeper context batch\n\nThe deeper context batch is:\n- `routine-context-gathering` with `focus=COMPLETENESS`\n- `routine-context-gathering` with `focus=DEPTH`\n\nAfter the batch, synthesize what changed, what stayed the same, and what is still unknown. If the extra context changes the classification, update it before you leave this step.\n\nCapture:\n- `taskComplexity`\n- `riskLevel`\n- `rigorMode`\n- `automationLevel`\n- `prStrategy`\n- `contextSummary`\n- `candidateFiles`\n- `invariants`\n- `nonGoals`\n- `openQuestions` (only real human-decision questions)\n- `philosophySources`\n- `philosophyConflicts`\n\n**Architecture alignment check (do this last, after candidateFiles is known):**\n\nFor each candidate file, scan for violations of the philosophy you just discovered. Name each violation explicitly and specifically (e.g. \"runWorkflow() is 4900 lines -- violates compose-with-small-pure-functions\", \"tool factories use params: any -- violates validate-at-boundaries\"). Do not assert absence without checking. If you found no violations, list the principles you checked and why each passes.\n\nThen decide:\n- `architectureViolations`: list of specific violations found (may be empty)\n- `architectureStartsFromScratch`: true if violations are significant enough that the correct design starts from the user's philosophy rather than adapting the existing code. False if violations are minor or out of scope for this task.\n\nIf `architectureStartsFromScratch` is true, the design phase will be constrained: Candidate A (simplest) must still honor the philosophy -- adapting an existing violation is not a valid candidate. Record this now so the design phase uses it.\n\n**Constraint Derivation (mandatory after architecture check, before leaving Phase 0):**\n\nThe architecture check above finds violations in existing code. This step converts what you observed into forward-facing rules that will gate your design -- before a single candidate is written.\n\nCollect constraints from all three sources. Each source catches different failure modes:\n\n**Source 1 -- General coding philosophy** (from session rules, AGENTS.md, CLAUDE.md): What principles from the philosophy apply specifically to this task? Do not list all principles -- only ones that constrain your design space. Example: 'make illegal states unrepresentable' applied here means: 'the loading/error/success states must not be encoded as three nullable fields.'\n\n**Source 2 -- Codebase conventions** (from observed patterns in candidate files): For each recurring pattern you observed, write the rule it implies for new code. Example: 'FormattedDates is always computed in the Reducer' implies 'all display strings must be pre-computed in the Reducer -- never in ViewModel, UseCase, or call site.'\n\n**Source 3 -- Explicit team/project rules** (from AGENTS.md conventions, ADRs, architecture docs, README): Read these if present. Explicit documented rules have higher authority than inferred conventions. Example from a project doc: 'Repository methods must be suspend fun returning Result<T> -- synchronous or nullable-returning methods are not allowed in this layer.'\n\nA constraint is specific when: it names the subject (which component/layer/type), the rule (what must/must not happen), and the prohibited alternative. Generic constraints ('follow patterns', 'maintain separation') fail the specificity gate.\n\nIf a source has no applicable constraints for this task, state what you checked and why. Empty is valid with justification; empty without justification fails the coverage gate.\n\nStore as `derivedConstraints`: array of strings tagged with source. Format: '[PHILOSOPHY] rule text' | '[CONVENTION] rule text' | '[TEAM_RULE] rule text'\n\nThese constraints gate Phase 0-6 and must be cited by each design candidate in Phase 1b.",
       "requireConfirmation": {
         "or": [
           {
@@ -251,10 +287,10 @@
           "The three checks are mandatory -- do not skip them even if they feel redundant with Phase 0."
         ],
         "procedure": [
-          "1. **Constraint quality check.** Read `derivedConstraints`. For each constraint: could it fail to block a wrong candidate? If yes, it is too vague -- rewrite it. A specific constraint names the pattern, the components, and the prohibited alternative.",
-          "2. **Nullable field gate.** For every type you plan to propose: does it have a nullable field? If yes, does it represent two distinct states? Name the illegal states this nullable type makes representable. Record the finding.",
-          "3. **Interface responsibility gate.** For every interface you plan to extend: state its responsibility in one sentence ('X takes Y, returns Z'). Does the behavior you are adding violate that? Name the violation if yes.",
-          "4. Set `constraintGatePassed` to true if all three checks passed with no violations, false otherwise."
+          "1. **Constraint quality + coverage check.** Read `derivedConstraints`. For each constraint: is it specific enough to falsify a wrong candidate? If vague, rewrite it. Then verify all three sources (PHILOSOPHY, CONVENTION, TEAM_RULE) are represented or explicitly justified as empty.",
+          "2. **Nullable field gate.** For every type you plan to propose or modify: does it have a nullable or optional field? If yes, does that field represent two distinct states? Name every illegal state combination the nullable type makes representable.",
+          "3. **Interface responsibility gate.** For every interface, abstract class, or service you plan to extend: write its responsibility in one sentence ('X takes Y, returns Z'). Does the behavior you are adding violate that responsibility?",
+          "4. Set `constraintGatePassed` to true only if all three checks produced no blocking violations."
         ],
         "outputRequired": {
           "derivedConstraints": "Refined constraint list after quality check -- each constraint is specific enough to falsify a wrong candidate",
@@ -270,16 +306,18 @@
         ]
       },
       "assessmentRefs": [
-        "constraint-derivation-gate"
+        "constraint-derivation-gate",
+        "type-design-gate",
+        "interface-responsibility-gate"
       ],
       "assessmentConsequences": [
         {
           "when": {
-            "anyEqualsLevel": "vague"
+            "anyEqualsLevel": "low"
           },
           "effect": {
             "kind": "require_followup",
-            "guidance": "Rewrite the vague constraints so each names the specific pattern, the component(s) it governs, and the prohibited alternative. A constraint that could apply to any codebase is not specific enough to gate design candidates."
+            "guidance": "Address whichever gate scored low: constraint_specificity -- rewrite vague constraints to name subject, rule, and prohibited alternative. constraint_source_coverage -- justify any unchecked source (philosophy, conventions, team rules). type_design_soundness -- redesign nullable fields encoding distinct states as explicit variants. interface_responsibility_stated -- state one-sentence responsibility for each interface you extend and verify no violation."
           }
         }
       ],
@@ -331,7 +369,7 @@
     },
     {
       "id": "phase-1b-design-deep",
-      "title": "Phase 1b: Design Generation (Injected Routine — Tension-Driven Design)",
+      "title": "Phase 1b: Design Candidates (Tension-Driven, Constraint-Anchored)",
       "runCondition": {
         "and": [
           {
@@ -348,12 +386,32 @@
           }
         ]
       },
-      "templateCall": {
-        "templateId": "wr.templates.routine.tension-driven-design",
-        "args": {
-          "deliverableName": "design-candidates.md"
-        }
-      }
+      "promptBlocks": {
+        "goal": "Generate design candidates that resolve the identified tensions differently -- each anchored to the derivedConstraints from Phase 0-6 and the user's coding philosophy.",
+        "constraints": [
+          "Read `derivedConstraints` from context before generating any candidate. Every candidate must satisfy or explicitly exempt each constraint.",
+          "A candidate that violates a TEAM_RULE or CONVENTION constraint is not a valid candidate -- remove it or revise it before including it.",
+          "A candidate that violates a PHILOSOPHY constraint should be called out explicitly as a tradeoff, not silently ignored.",
+          "Generate candidates that vary how they resolve tensions -- not just surface variations of the same approach.",
+          "Do not generate more than 4 candidates. Quality over quantity.",
+          "Write output to `design-candidates.md`."
+        ],
+        "procedure": [
+          "1. **Orient from constraints.** Read `derivedConstraints`. For each constraint tagged [TEAM_RULE] or [CONVENTION], write one sentence: 'Candidate X must satisfy this because...' or 'This constraint rules out approach Y because...' This orientation step is not optional -- it is what makes the candidates grounded rather than generic.",
+          "2. **Discover tensions.** Read the candidate files and the problem description. What are the real tensions the design must resolve? (e.g. type safety vs ergonomics, performance vs simplicity, consistency with existing pattern vs improving on it.) List 2-4 tensions explicitly.",
+          "3. **Generate candidates.** For each candidate: (a) one-sentence summary of the approach; (b) which tensions it resolves and which it accepts; (c) which derivedConstraints it satisfies and how; (d) which derivedConstraints it conflicts with and why that conflict is acceptable or why the constraint might be wrong.",
+          "4. **Mandatory candidates (standalone mode):** (a) simplest change that satisfies criteria without new architecture; (b) the approach that most faithfully extends the existing codebase pattern while satisfying derivedConstraints.",
+          "5. **Compare.** Rank candidates by how well each serves the philosophy and satisfies the derivedConstraints. Note which constraint violations are tradeoffs vs disqualifiers.",
+          "6. Write to `design-candidates.md` with the structure: Tensions | Candidates | Constraint Satisfaction Matrix | Recommendation."
+        ],
+        "verify": [
+          "Every candidate in design-candidates.md explicitly addresses each derivedConstraint (satisfies it, exempts it with justification, or flags a tradeoff).",
+          "No candidate silently violates a [TEAM_RULE] constraint.",
+          "The tensions section names at least 2 real tensions specific to this task.",
+          "The recommended candidate is the one that best satisfies derivedConstraints, not just the one with fewest downsides."
+        ]
+      },
+      "requireConfirmation": false
     },
     {
       "id": "phase-1c-challenge-and-select",

--- a/workflows/coding-task-workflow-agentic.json
+++ b/workflows/coding-task-workflow-agentic.json
@@ -312,12 +312,24 @@
       ],
       "assessmentConsequences": [
         {
-          "when": {
-            "anyEqualsLevel": "low"
-          },
+          "when": { "anyEqualsLevel": "low", "forAssessment": "constraint-derivation-gate" },
           "effect": {
             "kind": "require_followup",
-            "guidance": "Address whichever gate scored low: constraint_specificity -- rewrite vague constraints to name subject, rule, and prohibited alternative. constraint_source_coverage -- justify any unchecked source (philosophy, conventions, team rules). type_design_soundness -- redesign nullable fields encoding distinct states as explicit variants. interface_responsibility_stated -- state one-sentence responsibility for each interface you extend and verify no violation."
+            "guidance": "One or more constraints scored low on specificity or source coverage. Rewrite vague constraints to name the specific subject, rule, and prohibited alternative. For any unchecked source (philosophy, codebase conventions, team/project rules): explicitly state what you checked and why no constraints apply, or add the missing constraints."
+          }
+        },
+        {
+          "when": { "anyEqualsLevel": "low", "forAssessment": "type-design-gate" },
+          "effect": {
+            "kind": "require_followup",
+            "guidance": "At least one proposed type has a nullable or optional field that encodes semantically distinct states. Redesign that type: replace the nullable field with explicit state variants (a discriminated union or sealed class) so that illegal state combinations cannot be constructed."
+          }
+        },
+        {
+          "when": { "anyEqualsLevel": "low", "forAssessment": "interface-responsibility-gate" },
+          "effect": {
+            "kind": "require_followup",
+            "guidance": "At least one interface you plan to extend has an unstated responsibility. For each interface: write one sentence stating what it takes, what it returns, and what invariant it preserves. Then verify the new behavior does not violate that responsibility before proceeding to design."
           }
         }
       ],


### PR DESCRIPTION
## Summary

- Gate evaluator now receives the parked step's actual notes and typed artifacts, enabling substantive verdicts instead of always returning \`uncertain\`
- \`WorkflowRunGateParked\` gains \`workrailSessionId?: SessionId\` -- populated by \`buildSessionResult\` from \`state.workrailSessionId\` so the coordinator no longer needs a second sidecar disk read (typed result is the single source of truth)
- \`readStepOutput?\` optional dep added to \`GateEvaluatorDeps\`; \`evaluateGate\` enriches evaluator context with \`stepNotes\` (truncated to 4000 chars) and \`stepArtifacts\`; null/throw falls back to metadata-only context gracefully
- \`workrailSessionId\` typed as \`SessionId\` throughout the daemon layer (\`SessionState\`, \`SessionScope\`, \`SessionHandle\`, \`persistTokens\`, tool factories) -- prevents mixing with daemon-local \`RunId\` strings at compile time

## Test plan

- [ ] \`npm run build\` passes clean
- [ ] \`npx vitest run\` -- all 396 test files pass (6163 tests)
- [ ] 4 new unit tests for \`readStepOutput\`: notes injected, null fallback, throw fallback, truncation at 4000 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)