### PR TITLE
feat(engine): PendingDraftReviewPoller, review_draft_submitted event, crash recovery

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -3875,6 +3875,37 @@ Open questions: does `wr.dispatch` replace `workflowId` in trigger config, or co
 
 ---
 
+### Multi-workflow reviewer: route PRs to prod audit, arch audit, or mr-review based on context (May 15, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 14** | Cor:3 Cap:3 Eff:3 Lev:3 Con:2 | Blocked: no
+
+The reviewer-assigned MR review feature currently hardcodes `wr.mr-review` as the review workflow. But `wr.production-readiness-audit` and `wr.architecture-scalability-audit` exist and are suited to different kinds of PRs. A dependency bump needs a different lens than a core engine change. A PR touching the daemon's session lock needs different scrutiny than a documentation update.
+
+**The opportunity:** when a PR is assigned to you, WorkTrain should choose the right workflow (or combination) based on what the PR actually changes -- not always run the same generalist review. Deeper, more targeted findings with less noise.
+
+**Routing signals (static, zero LLM turns -- same principle as `routeTask()` in the adaptive pipeline):**
+- `wr.production-readiness-audit`: PRs touching runtime paths -- daemon, trigger system, agent loop, session store, delivery pipeline. High blast radius if broken.
+- `wr.architecture-scalability-audit`: PRs changing interfaces, type contracts, module boundaries, or core domain types.
+- `wr.mr-review`: general correctness, completeness vs. requirements, test coverage. The default fallback and the only one that checks "was the right thing implemented?"
+- Multiple workflows: large PRs touching multiple concerns -- run in parallel, merge findings into one `wr.review_verdict`, organize the draft review body by workflow.
+- Skip / lightweight: dependency bumps, docs-only, chore commits -- no draft review created, or a one-line summary comment only.
+
+**Implementation shape:**
+- New optional `reviewWorkflowId` field on `TriggerDefinition` -- explicit per-trigger override. When absent, the router auto-selects.
+- New `routeReviewWorkflow(pr, trigger): string[]` pure function (in `src/coordinators/routing/`) that maps PR metadata to one or more workflow IDs via file path patterns and diff shape. No LLM.
+- When multiple workflows are selected, each runs as a parallel `spawn_agent` child under a thin coordinator session that merges findings into a single `wr.review_verdict`.
+- Draft review body is organized by workflow: "**Production readiness** (3 findings) ... **Architecture** (1 finding)..."
+
+**Things to hash out:**
+- What file path patterns cleanly identify runtime vs. interface vs. general? `src/daemon/`, `src/v2/durable-core/` for runtime; `src/*/types.ts`, `src/v2/ports/` for interfaces. Worth auditing the codebase to validate coverage before shipping.
+- When multiple workflows run in parallel and produce conflicting severity assessments, how are they merged? Proposal: highest severity wins at the `wr.review_verdict` level; all individual findings are surfaced in the draft body.
+- For the skip/lightweight case, should WorkTrain post "no findings" as a draft review (so the author sees acknowledgment) or skip posting entirely? Skipping is less noisy.
+- Should the routing decision be visible to the operator? Yes -- log it as a `review_workflow_routed` signal so the operator can see why `wr.production-readiness-audit` was chosen.
+
+---
+
 ### Automated reviewer-assigned MR review with identity-matched comments (May 15, 2026)
 
 **Status: idea** | Priority: high

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -3875,6 +3875,36 @@ Open questions: does `wr.dispatch` replace `workflowId` in trigger config, or co
 
 ---
 
+### worktrain review <pr-number>: one-off PR review CLI command (May 15, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 13** | Cor:3 Cap:2 Eff:3 Lev:3 Con:2 | Blocked: no
+
+There is no simple way to trigger a review of a specific PR without either setting up polling triggers or hand-crafting a JSON webhook payload with the branch name, PR number, and URL manually. This is too much friction for ad-hoc reviews.
+
+**The fix:** `worktrain review <pr-number>` -- a CLI command that:
+1. Calls `gh pr view <pr-number> --json number,title,headRefName,url,baseRefName` to fetch PR metadata
+2. Constructs the correct `WorkflowTrigger` with all required context fields (`itemNumber`, `itemUrl`, `prBranch`) already populated
+3. Dispatches `wr.mr-review` (or the workflow selected by `routeReviewWorkflow()`) via `TriggerRouter.dispatch()` with `branchStrategy: 'read-only'`
+4. If `reviewerIdentity` is configured in `~/.workrail/config.json`, creates the draft review and starts the poller automatically
+5. Prints a link to the WorkTrain Console session so the operator can watch progress
+
+**Optional flags:**
+- `--workflow wr.production-readiness-audit` -- override workflow selection
+- `--no-draft` -- run the review but don't create a GitHub draft (just log findings to the console)
+- `--repo owner/repo` -- specify repo explicitly (default: current directory's git remote)
+
+**Why this matters:** the polling triggers handle the automated case (assigned PRs fire automatically), but operators need a simple way to say "review this PR right now" for ad-hoc cases -- PRs not assigned to them, PRs they want a second pass on, or just testing the review pipeline. A single command with no config required (besides having the daemon running) is the right UX.
+
+**Implementation:** new `src/cli/commands/worktrain-review.ts` following the same pattern as `worktrain-spawn.ts`. Uses `gh pr view` via `execFile` for PR metadata, then calls into the daemon dispatch path.
+
+**Things to hash out:**
+- Should this require the daemon to be running, or should it spin up a one-shot session directly? Running through the daemon is cleaner (uses the full pipeline including sidecar write and poller) but requires the daemon. A direct `runWorkflow()` call without the daemon is simpler for scripts. Proposal: daemon-required for the full feature (draft review, poller); add a `--standalone` flag for environments without a running daemon.
+- When `reviewerIdentity` is not configured, should `--no-draft` be the implicit default, or should the command error out asking you to configure it?
+
+---
+
 ### Self-review before merge: WorkTrain runs review families on its own PRs and fixes blocking findings (May 15, 2026)
 
 **Status: idea** | Priority: high

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -2970,6 +2970,39 @@ Simplify third-party and team workflow hookup by requiring explicit `workspacePa
 
 ## Console
 
+### Live turn-level log stream for active sessions (May 15, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 13** | Cor:3 Cap:2 Eff:3 Lev:2 Con:3 | Blocked: no
+
+The console shows step-level progress (which workflow phase the session is on) but nothing at the turn level: which tool the agent called, what it returned, how long it took, what the agent said between tool calls. Diagnosing a slow or stuck session currently requires grepping through raw conversation JSONL files -- not practical while a session is live.
+
+**What's needed:** a `worktrain logs --follow <sessionId>` CLI command (and/or a "Live" tab in the console) that streams tool-call-level activity as it happens:
+
+```
+[09:52:14] Turn 12  Bash       → cd /worktrees/abc && npx vitest run
+[09:52:31] Turn 12  Bash       ← exit 0, 396 tests pass  [17s]
+[09:52:31] Turn 13  complete_step → phase-2-scope-and-completeness
+[09:52:31] ADVANCE  phase-2 → phase-3-state-hypothesis
+[09:53:02] Turn 14  Bash       → gh pr diff 1022
+[09:53:04] Turn 14  Bash       ← 847 lines  [2s]
+```
+
+**The data already exists.** `DaemonEventEmitter` fires `tool_called`, `tool_error`, `step_advanced`, and `session_completed` events on every turn. The conversation JSONL captures every message. The gap is purely presentation -- nothing consumes these events into a human-readable live feed.
+
+**Two surfaces:**
+1. `worktrain logs --follow <sessionId>` -- CLI command, streams to stdout, pipe-friendly. Reads from the daemon event stream (JSONL file in `~/.workrail/data/`) and tails it in real time.
+2. Console "Live" tab -- same data in the browser, auto-updating without refresh. Especially useful for long-running sessions where you want to keep an eye without a terminal.
+
+**Things to hash out:**
+- How much of the tool output to show inline vs. truncate? A `gh pr diff` result is 800 lines; showing all of it destroys the log readability. Proposal: first 3 lines + byte count for long outputs; full output available via `--verbose`.
+- Should `worktrain logs` work for completed sessions too (replay)? Yes -- same format, just not tailing. `worktrain logs <sessionId>` (no `--follow`) replays the full conversation history in readable form.
+- LLM text output between tool calls: show it? Yes, but dim/indented. The agent's reasoning is valuable for debugging wrong decisions.
+- Should the console Live tab replace the existing session detail view or augment it? Augment -- step-level detail stays, Live tab adds the turn-level stream as a separate tab.
+
+---
+
 ### Workflows tab: incorrect source attribution for bundled workflows (Apr 21, 2026)
 
 **Status: bug** | Priority: low

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -3875,6 +3875,63 @@ Open questions: does `wr.dispatch` replace `workflowId` in trigger config, or co
 
 ---
 
+### Self-review before merge: WorkTrain runs review families on its own PRs and fixes blocking findings (May 15, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 15** | Cor:3 Cap:3 Eff:3 Lev:3 Con:3 | Blocked: no
+
+When WorkTrain opens a PR through the autonomous pipeline, it currently hands off immediately after `gh pr create`. A human reviewer is then expected to catch issues. This breaks the self-improvement loop: WorkTrain's coding quality is only as good as the review bar it applies to others, and right now it doesn't apply that bar to itself before shipping.
+
+**The fix:** after creating a PR, the coordinator runs the same review workflows (via `spawn_agent`) on WorkTrain's own output before considering the task done. If findings are `clean` or `minor` with no blockers, the PR is considered shippable. If findings are `blocking`, WorkTrain spawns a fix session, applies the changes to the same worktree branch, pushes the amendment, and re-reviews. This loop continues until findings are clean or a configured retry limit is hit, at which case it escalates to the operator outbox.
+
+**Why this is different from the reviewer-assigned feature:** the reviewer feature posts findings as draft comments under the operator's identity for human PRs. This feature fixes findings autonomously on WorkTrain's own PRs -- no posting, no approval gate, just code changes. The output is a clean PR, not a review comment.
+
+**Already partially implemented:** the adaptive pipeline coordinator already has a review phase and a fix-iteration loop in `full-pipeline.ts`. What's missing is (a) routing the review findings back into the worktree rather than creating a new branch, and (b) running the full review family (prod audit, arch audit, mr-review) not just `wr.mr-review`.
+
+**Things to hash out:**
+- What is the right retry cap before escalating? Two fix iterations seems right -- if the coding agent can't fix blocking findings in two attempts, a human needs to look.
+- Should the fix sessions run in the same worktree as the coding session, or a fresh worktree branched from the PR branch? Same worktree is simpler; fresh worktree is cleaner if the fix touches many files.
+- How does WorkTrain distinguish a pre-existing issue on main from a regression it introduced? The diff is the boundary: only findings anchored to changed lines are WorkTrain's responsibility to fix. Pre-existing issues in unchanged code get filed as backlog items, not fixed in this PR.
+- What happens to the fix commits in the PR history? They should be squashable -- the PR should tell the story of the feature, not the internal review-fix iterations.
+
+---
+
+### PR lifecycle management: babysit any PR from open to merged (May 15, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 14** | Cor:3 Cap:3 Eff:3 Lev:3 Con:2 | Blocked: no
+
+Everything between "PR opened" and "PR merged" is currently invisible to WorkTrain. CI fails silently. Reviewers request changes and nobody responds. The PR goes stale. A rebase conflict appears and blocks merge. Even for PRs WorkTrain opens autonomously, a human has to watch and intervene.
+
+This entry covers the full lifecycle management capability -- for both WorkTrain-created PRs and any PR the operator explicitly asks WorkTrain to babysit.
+
+**Scope:**
+
+1. **CI failure handling**: poll CI status on open PRs. On failure, read the failing job logs, determine root cause, spawn a fix session, push to the PR branch, re-trigger CI. If the failure is flaky (same test fails intermittently with no code change), flag it as infrastructure noise rather than a code problem.
+
+2. **Reviewer comment resolution**: poll for new review comments on the PR. Classify each comment: (a) actionable change requested → spawn fix session, apply, push, reply "Done"; (b) question or discussion → draft a response for operator approval before posting; (c) nitpick / style → apply automatically if it's a clear single-line fix, otherwise defer to operator. Never post responses autonomously without operator approval for non-trivial content.
+
+3. **Rebase on conflict**: when the PR branch falls behind main and has merge conflicts, fetch main, rebase, resolve conflicts deterministically where possible (ours vs. theirs based on context), push force-with-lease. If conflicts are non-trivial, flag for operator.
+
+4. **Re-review requests**: after pushing fixes, re-request review from the original reviewers so they know the PR is ready for another look.
+
+5. **Stale PR detection**: if a PR has been open for N days with no activity from reviewers, ping the reviewer(s) or escalate to the operator outbox.
+
+6. **Non-WorkTrain PRs**: the operator can assign WorkTrain to any PR (via reviewer assignment, a comment trigger like `/worktrain babysit`, or explicit dispatch) and WorkTrain takes over lifecycle management from that point.
+
+**Trigger mechanism:** a `github_prs_poll` trigger with `authorLogin` filter (the operator or WorkTrain's bot account) scoped to the operator's repos. WorkTrain polls for PRs in states that need action (CI failing, changes requested, behind main, review overdue) and dispatches a lifecycle management session for each.
+
+**Things to hash out:**
+- What is the right polling interval for lifecycle management vs. review? CI failure is time-sensitive (minutes); stale PR detection is not (hours). Different intervals per event type.
+- Responding to reviewer comments requires posting as the operator -- same `reviewerIdentity` mechanism as the draft review feature. No posting without approval for substantive responses.
+- For flaky CI: how many consecutive failures on the same test across different commits before WorkTrain declares it infrastructure noise vs. a real regression?
+- Force-push for rebases requires `--force-with-lease` and a CI re-trigger. Should WorkTrain do this autonomously or always request operator approval first? Proposal: autonomous for clean rebases (no conflicts); operator approval required for conflict resolution.
+- What is the right retry limit for the CI fix loop before escalating? Three attempts seems right -- if WorkTrain can't fix a CI failure in three tries, a human needs to look.
+
+---
+
 ### Multi-workflow reviewer: route PRs to prod audit, arch audit, or mr-review based on context (May 15, 2026)
 
 **Status: idea** | Priority: high

--- a/src/daemon/startup-recovery.ts
+++ b/src/daemon/startup-recovery.ts
@@ -229,11 +229,32 @@ export async function runStartupRecovery(
   // site valid without positional changes. Production passes the key from startTriggerListener;
   // tests that don't exercise the resume path can omit it.
   apiKey: string = '',
+  /**
+   * Optional trigger index for recovering pending-draft review pollers.
+   * When provided, pending-draft sidecars found in sessionsDir are used to restart
+   * PendingDraftReviewPoller instances for each orphaned review. The trigger index
+   * is needed to look up reviewerIdentity.token (which is NOT stored in the sidecar).
+   * When absent, pending-draft recovery is skipped (sidecars are left on disk).
+   */
+  triggerIndex?: ReadonlyMap<string, import('../trigger/types.js').TriggerDefinition>,
+  /**
+   * Optional ReviewApprovalAdapter for restarting pollers after crash recovery.
+   * Defaults to GitHubReviewApprovalAdapter if absent and a sidecar is found.
+   */
+  reviewApprovalAdapterFn?: () => import('../trigger/review-approval-adapter.js').ReviewApprovalAdapter,
 ): Promise<void> {
   // Phase A: Delete all queue-issue-*.json sidecars unconditionally.
   // WHY first: queue-issue cleanup is independent of session state and must
   // always run, even if session recovery fails or ctx is absent.
   await clearQueueIssueSidecars(sessionsDir);
+
+  // Phase B: Restart PendingDraftReviewPoller for any orphaned pending-draft sidecars.
+  // WHY here (after queue-issue cleanup, before session recovery): pending-draft recovery
+  // is independent of session token state and runs regardless of ctx being present.
+  // Requires triggerIndex to look up reviewerIdentity.token (not stored in the sidecar).
+  if (ctx?.v2 && triggerIndex && triggerIndex.size > 0) {
+    await recoverPendingDraftPollers(sessionsDir, ctx, triggerIndex, reviewApprovalAdapterFn);
+  }
 
   // Read all parseable session files.
   const sessions = await readAllDaemonSessions(sessionsDir);
@@ -667,6 +688,71 @@ export async function clearQueueIssueSidecars(sessionsDir: string): Promise<void
  * file is orphaned. It holds no useful state (the rename never completed), so we
  * discard it unconditionally.
  */
+/**
+ * Restart PendingDraftReviewPoller instances for orphaned pending-draft sidecars.
+ *
+ * Called by runStartupRecovery() when triggerIndex is available. For each
+ * pending-draft-*.json sidecar found, looks up the trigger by triggerId to get
+ * the reviewerIdentity.token (which is NOT stored in the sidecar for security),
+ * then restarts polling. If the trigger no longer exists, logs a warning and
+ * deletes the sidecar.
+ *
+ * Non-fatal: any error is caught and logged. Never throws.
+ */
+async function recoverPendingDraftPollers(
+  sessionsDir: string,
+  ctx: import('../mcp/types.js').V2ToolContext,
+  triggerIndex: ReadonlyMap<string, import('../trigger/types.js').TriggerDefinition>,
+  reviewApprovalAdapterFn?: () => import('../trigger/review-approval-adapter.js').ReviewApprovalAdapter,
+): Promise<void> {
+  const { readAllPendingDraftSidecars, PendingDraftReviewPoller, GitHubReviewApprovalAdapter } =
+    await import('../trigger/pending-draft-review-poller.js').then(async (m) => ({
+      readAllPendingDraftSidecars: m.readAllPendingDraftSidecars,
+      PendingDraftReviewPoller: m.PendingDraftReviewPoller,
+      GitHubReviewApprovalAdapter: (await import('../trigger/review-approval-adapter.js')).GitHubReviewApprovalAdapter,
+    }));
+
+  const sidecars = await readAllPendingDraftSidecars(sessionsDir);
+  if (sidecars.length === 0) return;
+
+  console.log(`[StartupRecovery] Found ${sidecars.length} orphaned pending-draft review sidecar(s). Restarting pollers.`);
+
+  for (const sidecar of sidecars) {
+    const trigger = triggerIndex.get(sidecar.triggerId);
+    if (!trigger?.reviewerIdentity) {
+      console.warn(
+        `[StartupRecovery] Pending-draft sidecar trigger '${sidecar.triggerId}' not found or has no reviewerIdentity. ` +
+        `Deleting sidecar for daemonSessionId=${sidecar.daemonSessionId}.`,
+      );
+      await fs.unlink(path.join(sessionsDir, `pending-draft-${sidecar.daemonSessionId}.json`)).catch(() => {});
+      continue;
+    }
+
+    const adapter = reviewApprovalAdapterFn ? reviewApprovalAdapterFn() : new GitHubReviewApprovalAdapter();
+    if (!ctx.v2) continue;
+
+    const poller = new PendingDraftReviewPoller(adapter, {
+      prNumber: sidecar.prNumber,
+      prRepo: sidecar.prRepo,
+      reviewId: sidecar.reviewId,
+      token: trigger.reviewerIdentity.token,
+      login: trigger.reviewerIdentity.login,
+      workrailSessionId: sidecar.workrailSessionId,
+      daemonSessionId: sidecar.daemonSessionId,
+      sessionStore: ctx.v2.sessionStore,
+      gate: ctx.v2.gate,
+      mintEventId: ctx.v2.idFactory.mintEventId.bind(ctx.v2.idFactory),
+      sessionsDir,
+    });
+    poller.start();
+
+    console.log(
+      `[StartupRecovery] Restarted PendingDraftReviewPoller: ` +
+      `daemonSessionId=${sidecar.daemonSessionId} prRepo=${sidecar.prRepo} prNumber=${sidecar.prNumber}`,
+    );
+  }
+}
+
 async function clearStrayTmpFiles(sessionsDir: string): Promise<void> {
   let entries: string[];
   try {

--- a/src/trigger/pending-draft-review-poller.ts
+++ b/src/trigger/pending-draft-review-poller.ts
@@ -1,0 +1,272 @@
+/**
+ * PendingDraftReviewPoller: platform-agnostic draft review submission detector.
+ *
+ * Polls on a fixed interval, delegating the "is it submitted?" check entirely
+ * to the ReviewApprovalAdapter. GitHub checks GET /reviews/:id; GitLab (future)
+ * will check its own signal -- the poller is unaware of either.
+ *
+ * Lifecycle:
+ * 1. Caller writes pending-draft sidecar BEFORE calling start().
+ * 2. start() begins polling; returns immediately (non-blocking).
+ * 3. On submission detected: appends review_draft_submitted to session event log,
+ *    deletes the sidecar, calls onSubmitted callback, stops itself.
+ * 4. stop() cancels the interval regardless of state (safe to call before start).
+ *
+ * WHY follows PollingScheduler pattern (class with start/stop, mutable interval
+ * handle): Node.js interval management requires mutable handles. The pattern is
+ * established in the codebase and is the correct imperative shell for I/O polling.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { ReviewApprovalAdapter, CheckSubmissionOpts } from './review-approval-adapter.js';
+import type { SessionEventLogAppendStorePortV2, SessionEventLogReadonlyStorePortV2 } from '../v2/ports/session-event-log-store.port.js';
+import type { ExecutionSessionGateV2 } from '../v2/usecases/execution-session-gate.js';
+import { asSessionId } from '../v2/durable-core/ids/index.js';
+import { buildSessionIndex } from '../v2/durable-core/session-index.js';
+import { asSortedEventLog } from '../v2/durable-core/sorted-event-log.js';
+import { okAsync } from 'neverthrow';
+import { EVENT_KIND } from '../v2/durable-core/constants.js';
+import { DAEMON_SESSIONS_DIR } from '../daemon/tools/_shared.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PendingDraftReviewPollerOptions {
+  readonly prNumber: number;
+  readonly prRepo: string;
+  readonly reviewId: number;
+  readonly token: string;
+  readonly login: string;
+  /** WorkRail session ID (sess_...) for appending events to the session log. */
+  readonly workrailSessionId: string;
+  /** Daemon-local session UUID (keys the pending-draft sidecar file). */
+  readonly daemonSessionId: string;
+  /** How often to poll in milliseconds. Default: 45 000 (45s). */
+  readonly pollIntervalMs?: number;
+  /** Injectable session store for appending the review_draft_submitted event. */
+  readonly sessionStore: SessionEventLogAppendStorePortV2 & SessionEventLogReadonlyStorePortV2;
+  /** Gate for acquiring the session lock needed by sessionStore.append(). */
+  readonly gate: ExecutionSessionGateV2;
+  /** Injectable event ID factory. */
+  readonly mintEventId: () => string;
+  /** Injectable sessions directory (for sidecar deletion). Default: DAEMON_SESSIONS_DIR. */
+  readonly sessionsDir?: string;
+  /**
+   * Called when submission is detected, after the event is appended and the sidecar deleted.
+   * Fire-and-forget from the caller's perspective -- errors are logged internally.
+   */
+  readonly onSubmitted?: (submittedAt: string) => void;
+}
+
+export interface PendingDraftSidecar {
+  readonly reviewId: number;
+  readonly prNumber: number;
+  readonly prRepo: string;
+  readonly daemonSessionId: string;
+  readonly workrailSessionId: string;
+  readonly token: string;
+  readonly login: string;
+  readonly createdAt: string;
+  readonly triggerId: string;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 45_000;
+
+// ---------------------------------------------------------------------------
+// PendingDraftReviewPoller
+// ---------------------------------------------------------------------------
+
+export class PendingDraftReviewPoller {
+  private _intervalHandle: ReturnType<typeof setInterval> | undefined = undefined;
+  private _stopped = false;
+
+  constructor(
+    private readonly adapter: ReviewApprovalAdapter,
+    private readonly opts: PendingDraftReviewPollerOptions,
+  ) {}
+
+  /**
+   * Begin polling. Returns immediately -- polling runs in the background.
+   * Safe to call only once; subsequent calls are no-ops.
+   */
+  start(): void {
+    if (this._stopped || this._intervalHandle !== undefined) return;
+    const intervalMs = this.opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this._intervalHandle = setInterval(() => {
+      void this._tick().catch((e: unknown) => {
+        console.warn(
+          `[PendingDraftReviewPoller] Unexpected error in tick: ` +
+          `daemonSessionId=${this.opts.daemonSessionId} ` +
+          `${e instanceof Error ? e.message : String(e)}`,
+        );
+      });
+    }, intervalMs);
+  }
+
+  /**
+   * Stop polling. Safe to call before start() or after already stopped.
+   */
+  stop(): void {
+    this._stopped = true;
+    if (this._intervalHandle !== undefined) {
+      clearInterval(this._intervalHandle);
+      this._intervalHandle = undefined;
+    }
+  }
+
+  private async _tick(): Promise<void> {
+    if (this._stopped) return;
+
+    const checkOpts: CheckSubmissionOpts = {
+      prNumber: this.opts.prNumber,
+      prRepo: this.opts.prRepo,
+      token: this.opts.token,
+      login: this.opts.login,
+      reviewId: this.opts.reviewId,
+    };
+
+    const result = await this.adapter.checkSubmission(checkOpts);
+
+    if (result.kind === 'err') {
+      console.warn(
+        `[PendingDraftReviewPoller] Submission check failed: ` +
+        `daemonSessionId=${this.opts.daemonSessionId} ` +
+        `prRepo=${this.opts.prRepo} prNumber=${this.opts.prNumber} ` +
+        `error=${result.error.message}`,
+      );
+      return; // Retry on next tick.
+    }
+
+    if (result.kind === 'pending') {
+      return; // Still waiting.
+    }
+
+    // Submitted. Stop polling before doing I/O to avoid double-fire.
+    this.stop();
+
+    const { submittedAt } = result;
+    console.log(
+      `[PendingDraftReviewPoller] Draft review submitted: ` +
+      `daemonSessionId=${this.opts.daemonSessionId} ` +
+      `prRepo=${this.opts.prRepo} prNumber=${this.opts.prNumber} ` +
+      `reviewId=${this.opts.reviewId} submittedAt=${submittedAt}`,
+    );
+
+    // Append review_draft_submitted event to session log (same gate-lock pattern
+    // as recordCommitShasStage in delivery-pipeline.ts).
+    if (this.opts.workrailSessionId) {
+      const sid = asSessionId(this.opts.workrailSessionId);
+      await this.opts.gate.withHealthySessionLock(sid, (lock) =>
+        this.opts.sessionStore.load(sid).andThen((truth) => {
+          const sortedResult = asSortedEventLog(truth.events);
+          if (sortedResult.isErr()) return okAsync(undefined as void);
+          const index = buildSessionIndex(sortedResult.value);
+          const runId = this.opts.daemonSessionId;
+          const event = {
+            v: 1 as const,
+            eventId: this.opts.mintEventId(),
+            eventIndex: index.nextEventIndex,
+            sessionId: this.opts.workrailSessionId,
+            kind: EVENT_KIND.REVIEW_DRAFT_SUBMITTED,
+            dedupeKey: `review_draft_submitted:${this.opts.reviewId}`,
+            scope: { runId },
+            data: {
+              reviewId: this.opts.reviewId,
+              prUrl: `https://github.com/${this.opts.prRepo}/pull/${this.opts.prNumber}`,
+              submittedAt,
+            },
+            timestampMs: Date.now(),
+          };
+          return this.opts.sessionStore.append(lock, { events: [event], snapshotPins: [] });
+        })
+      ).match(
+        () => { /* success -- no-op */ },
+        (err) => {
+          console.warn(
+            `[PendingDraftReviewPoller] Failed to append review_draft_submitted event: ` +
+            `daemonSessionId=${this.opts.daemonSessionId} err=${JSON.stringify(err)}`,
+          );
+        },
+      );
+    }
+
+    // Delete pending-draft sidecar.
+    const sessionsDir = this.opts.sessionsDir ?? DAEMON_SESSIONS_DIR;
+    const sidecarPath = path.join(sessionsDir, `pending-draft-${this.opts.daemonSessionId}.json`);
+    await fs.unlink(sidecarPath).catch((e: unknown) => {
+      console.warn(
+        `[PendingDraftReviewPoller] Could not delete pending-draft sidecar: ` +
+        `${sidecarPath} ${e instanceof Error ? e.message : String(e)}`,
+      );
+    });
+
+    // Notify caller.
+    try { this.opts.onSubmitted?.(submittedAt); } catch { /* fire-and-forget */ }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sidecar helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a pending-draft sidecar before starting the poller.
+ * Must be called BEFORE PendingDraftReviewPoller.start() -- crash recovery
+ * depends on the sidecar existing before the background task begins.
+ */
+export async function writePendingDraftSidecar(
+  sidecar: PendingDraftSidecar,
+  sessionsDir: string = DAEMON_SESSIONS_DIR,
+): Promise<void> {
+  const sidecarPath = path.join(sessionsDir, `pending-draft-${sidecar.daemonSessionId}.json`);
+  const tmpPath = `${sidecarPath}.tmp`;
+  await fs.writeFile(tmpPath, JSON.stringify(sidecar, null, 2), 'utf8');
+  await fs.rename(tmpPath, sidecarPath);
+}
+
+/**
+ * Read all pending-draft sidecars from the sessions directory.
+ * Used by startup recovery to restart pollers after a daemon crash.
+ */
+export async function readAllPendingDraftSidecars(
+  sessionsDir: string = DAEMON_SESSIONS_DIR,
+): Promise<PendingDraftSidecar[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(sessionsDir);
+  } catch {
+    return [];
+  }
+
+  const sidecars: PendingDraftSidecar[] = [];
+  for (const entry of entries) {
+    if (!entry.startsWith('pending-draft-') || !entry.endsWith('.json')) continue;
+    const filePath = path.join(sessionsDir, entry);
+    try {
+      const raw = await fs.readFile(filePath, 'utf8');
+      const parsed = JSON.parse(raw) as Partial<PendingDraftSidecar>;
+      if (
+        typeof parsed.reviewId === 'number' &&
+        typeof parsed.prNumber === 'number' &&
+        typeof parsed.prRepo === 'string' &&
+        typeof parsed.daemonSessionId === 'string' &&
+        typeof parsed.workrailSessionId === 'string' &&
+        typeof parsed.token === 'string' &&
+        typeof parsed.login === 'string' &&
+        typeof parsed.triggerId === 'string'
+      ) {
+        sidecars.push(parsed as PendingDraftSidecar);
+      } else {
+        console.warn(`[PendingDraftReviewPoller] Skipping malformed pending-draft sidecar: ${filePath}`);
+      }
+    } catch (e: unknown) {
+      console.warn(
+        `[PendingDraftReviewPoller] Could not read pending-draft sidecar ${filePath}: ` +
+        `${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+  return sidecars;
+}

--- a/src/trigger/review-approval-adapter.ts
+++ b/src/trigger/review-approval-adapter.ts
@@ -56,26 +56,77 @@ export type CreateDraftReviewResult =
 // ReviewApprovalAdapter interface
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// CheckSubmissionOpts / CheckSubmissionResult
+// ---------------------------------------------------------------------------
+
+export interface CheckSubmissionOpts {
+  readonly prNumber: number;
+  readonly prRepo: string;
+  readonly token: string;
+  readonly login: string;
+  /** The platform-specific review ID returned by createDraftReview. */
+  readonly reviewId: number;
+}
+
 /**
- * Adapter for creating and monitoring GitHub PENDING draft reviews.
+ * Result of checking whether a pending review has been submitted.
  *
- * WHY interface (not class): allows injectable fakes in tests that avoid
- * real GitHub API calls. Production code uses GitHubReviewApprovalAdapter.
+ * WHY discriminated union (not boolean): callers need to distinguish "still
+ * pending", "submitted", and "error" without string-parsing or null checks.
+ * Each variant carries only the fields relevant to that state.
+ */
+export type CheckSubmissionResult =
+  | { readonly kind: 'pending' }
+  | { readonly kind: 'submitted'; readonly submittedAt: string }
+  | { readonly kind: 'err'; readonly error: ReviewApprovalError };
+
+// ---------------------------------------------------------------------------
+// ReviewApprovalAdapter interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Platform-agnostic adapter for creating draft reviews and polling for submission.
+ *
+ * WHY interface (not class): allows injectable fakes in tests and enables
+ * platform-specific implementations (GitHub, GitLab, future) without coupling
+ * the polling loop to any single platform's API.
+ *
+ * Implementations:
+ * - GitHubReviewApprovalAdapter: uses GitHub REST API (pending draft review)
+ * - Future GitLabReviewApprovalAdapter: different creation + polling mechanism
+ *
+ * The PendingDraftReviewPoller calls checkSubmission() on each tick -- it is
+ * entirely platform-agnostic. All platform-specific logic lives in the adapter.
  */
 export interface ReviewApprovalAdapter {
   /**
-   * Create a PENDING GitHub draft review under the operator's identity.
+   * Create a platform-appropriate draft/pending review under the operator's identity.
    *
-   * Performs a pre-creation GET check for an existing PENDING draft by
-   * reviewerLogin on the same PR. If found, returns the existing reviewId
-   * (reused: true). Otherwise POSTs a new draft review.
+   * The adapter handles the platform-specific creation mechanism:
+   * - GitHub: POST /pulls/:number/reviews with no event field (creates PENDING draft)
+   * - GitLab (future): create a draft note batch, or commit to a review-staging branch
    *
-   * An in-process mutex (keyed by `${prRepo}#${prNumber}`) prevents duplicate
-   * POST calls from concurrent sessions finishing at the same time.
+   * Performs a pre-creation check for an existing pending review by the same login
+   * to avoid duplicates when two sessions finish concurrently for the same PR.
    *
    * Returns err on network failure or non-2xx API response.
    */
   createDraftReview(opts: CreateDraftReviewOpts): Promise<CreateDraftReviewResult>;
+
+  /**
+   * Check whether the pending review has been submitted (published) by the operator.
+   *
+   * Called by PendingDraftReviewPoller on each polling tick. Returns:
+   * - { kind: 'pending' }: review still exists in draft/pending state
+   * - { kind: 'submitted', submittedAt }: operator published it (any non-pending state)
+   * - { kind: 'err', error }: network/API failure (poller should log and retry)
+   *
+   * WHY on the adapter (not the poller): submission detection is platform-specific.
+   * GitHub polls GET /reviews and checks state !== 'PENDING'. GitLab will check
+   * a different signal (note published, branch merged, etc.). The poller is dumb.
+   */
+  checkSubmission(opts: CheckSubmissionOpts): Promise<CheckSubmissionResult>;
 }
 
 // ---------------------------------------------------------------------------
@@ -224,6 +275,47 @@ export class GitHubReviewApprovalAdapter implements ReviewApprovalAdapter {
     }
 
     return { kind: 'ok', reviewId: null };
+  }
+
+  async checkSubmission(opts: CheckSubmissionOpts): Promise<CheckSubmissionResult> {
+    const { prNumber, prRepo, token, reviewId } = opts;
+    const apiUrl = `https://api.github.com/repos/${prRepo}/pulls/${prNumber}/reviews/${reviewId}`;
+    let response: { ok: boolean; status: number; json(): Promise<unknown> };
+    try {
+      response = await this.fetchFn(apiUrl, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+    } catch (e) {
+      return { kind: 'err', error: { kind: 'network_error', message: `GET review failed: ${e instanceof Error ? e.message : String(e)}` } };
+    }
+
+    // 404 means the review was deleted -- treat as submitted/gone.
+    if (response.status === 404) {
+      return { kind: 'submitted', submittedAt: new Date().toISOString() };
+    }
+    if (!response.ok) {
+      return { kind: 'err', error: { kind: 'api_error', message: `GET review returned HTTP ${response.status}`, status: response.status } };
+    }
+
+    let body: unknown;
+    try { body = await response.json(); } catch {
+      return { kind: 'err', error: { kind: 'parse_error', message: 'Failed to parse GET review response' } };
+    }
+
+    const obj = body as Record<string, unknown>;
+    const state = obj['state'];
+    // Any state other than PENDING means the operator acted on the review.
+    if (state !== 'PENDING') {
+      const submittedAt = typeof obj['submitted_at'] === 'string'
+        ? obj['submitted_at']
+        : new Date().toISOString();
+      return { kind: 'submitted', submittedAt };
+    }
+    return { kind: 'pending' };
   }
 }
 

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -479,7 +479,7 @@ export async function startTriggerListener(
   // call executeContinueWorkflow with intent: 'rehydrate' for sessions with progress).
   // WHY pass runWorkflowFn: crash-recovered sessions resume via runWorkflow; passing the
   // enricher-wrapped fn ensures recovered root sessions also receive context enrichment.
-  await runStartupRecovery(undefined, undefined, ctx, undefined, undefined, runWorkflowFn, apiKey).catch((err: unknown) => {
+  await runStartupRecovery(undefined, undefined, ctx, undefined, undefined, runWorkflowFn, apiKey, triggerIndex).catch((err: unknown) => {
     console.warn(
       '[TriggerListener] Startup recovery encountered an unexpected error:',
       err instanceof Error ? err.message : String(err),

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -48,6 +48,8 @@ import { resumeFromGate } from '../daemon/gate-resume.js';
 import type { ReviewApprovalAdapter } from './review-approval-adapter.js';
 import { GitHubReviewApprovalAdapter } from './review-approval-adapter.js';
 import { parseReviewVerdictArtifact } from '../v2/durable-core/schemas/artifacts/review-verdict.js';
+import { PendingDraftReviewPoller, writePendingDraftSidecar } from './pending-draft-review-poller.js';
+import { randomUUID } from 'node:crypto';
 
 /**
  * Default production exec function: promisify(execFile).
@@ -327,6 +329,8 @@ async function maybeRunPostWorkflowActions(
   originalResult: WorkflowRunResult,
   reviewApprovalAdapter: ReviewApprovalAdapter,
   notificationService?: NotificationService,
+  ctx?: V2ToolContext,
+  triggerId?: string,
 ): Promise<void> {
   if (originalResult._tag !== 'success') return;
   if (!workflowTrigger.reviewerIdentity) return;
@@ -359,9 +363,9 @@ async function maybeRunPostWorkflowActions(
   }
 
   // Extract PR number and repo from context (injected by github_prs_poll polling adapter).
-  const ctx = workflowTrigger.context as Record<string, unknown> | undefined;
-  const prNumber = typeof ctx?.['itemNumber'] === 'number' ? ctx['itemNumber'] : undefined;
-  const prUrl = typeof ctx?.['itemUrl'] === 'string' ? ctx['itemUrl'] : undefined;
+  const triggerCtx = workflowTrigger.context as Record<string, unknown> | undefined;
+  const prNumber = typeof triggerCtx?.['itemNumber'] === 'number' ? triggerCtx['itemNumber'] : undefined;
+  const prUrl = typeof triggerCtx?.['itemUrl'] === 'string' ? triggerCtx['itemUrl'] : undefined;
 
   if (prNumber === undefined || prUrl === undefined) {
     console.warn(
@@ -411,8 +415,62 @@ async function maybeRunPostWorkflowActions(
     `prRepo=${prRepo} prNumber=${prNumber} reviewId=${reviewId}`,
   );
 
+  // Write pending-draft sidecar BEFORE starting the poller (crash recovery invariant).
+  const daemonSessionId = originalResult.sessionId ?? randomUUID();
+  const workrailSessionId = originalResult.sessionWorkspacePath
+    ? '' // session ID not directly available here; use empty string if absent
+    : '';
+  // Prefer the workrail session ID from the result if available.
+  // WorkflowRunSuccess.lastStepArtifacts carries the session context but not the session ID.
+  // The sidecar only needs it for the session event log write-back; we skip the event if absent.
+  const resolvedWorkrailSessionId = (originalResult as { workrailSessionId?: string }).workrailSessionId ?? '';
+
+  if (ctx?.v2 && resolvedWorkrailSessionId) {
+    try {
+      await writePendingDraftSidecar({
+        reviewId,
+        prNumber,
+        prRepo,
+        daemonSessionId,
+        workrailSessionId: resolvedWorkrailSessionId,
+        token: reviewerIdentity.token,
+        login: reviewerIdentity.login,
+        createdAt: new Date().toISOString(),
+        triggerId: triggerId ?? '',
+      });
+    } catch (e: unknown) {
+      console.warn(
+        `[TriggerRouter] Failed to write pending-draft sidecar: ` +
+        `${e instanceof Error ? e.message : String(e)}`,
+      );
+      // Non-fatal: poller still starts; crash recovery won't work but review still posts.
+    }
+
+    // Start PendingDraftReviewPoller as a fire-and-forget background task.
+    // WHY fire-and-forget: poller runs until operator publishes (could be hours).
+    // Awaiting it would hold the queue callback slot. Same pattern as gate evaluation.
+    const poller = new PendingDraftReviewPoller(reviewApprovalAdapter, {
+      prNumber,
+      prRepo,
+      reviewId,
+      token: reviewerIdentity.token,
+      login: reviewerIdentity.login,
+      workrailSessionId: resolvedWorkrailSessionId,
+      daemonSessionId,
+      sessionStore: ctx.v2.sessionStore,
+      gate: ctx.v2.gate,
+      mintEventId: ctx.v2.idFactory.mintEventId.bind(ctx.v2.idFactory),
+      onSubmitted: (submittedAt) => {
+        console.log(
+          `[TriggerRouter] Review published by operator: workflowId=${workflowTrigger.workflowId} ` +
+          `prRepo=${prRepo} prNumber=${prNumber} submittedAt=${submittedAt}`,
+        );
+      },
+    });
+    poller.start();
+  }
+
   // Notify operator that draft is ready.
-  // PR3 will also start PendingDraftReviewPoller here (fire-and-forget).
   notificationService?.notify(originalResult, `WorkTrain review draft ready on PR #${prNumber} -- open in GitHub to review findings`);
 }
 
@@ -1059,7 +1117,7 @@ export class TriggerRouter {
       // Post-workflow review actions: create a PENDING draft review when reviewerIdentity is set.
       // Uses workflowTrigger (which carries reviewerIdentity forwarded from TriggerDefinition).
       // Uses originalResult to avoid callbackUrl delivery_failed suppressing review posting.
-      await maybeRunPostWorkflowActions(workflowTrigger, originalResult, this._reviewApprovalAdapter, this.notificationService);
+      await maybeRunPostWorkflowActions(workflowTrigger, originalResult, this._reviewApprovalAdapter, this.notificationService, this.ctx, trigger.id);
     });
 
     return { _tag: 'enqueued', triggerId: trigger.id };
@@ -1223,7 +1281,7 @@ export class TriggerRouter {
       // Post-workflow review actions: create a PENDING draft review when reviewerIdentity is set.
       // reviewerIdentity is forwarded from TriggerDefinition onto WorkflowTrigger so this path
       // can access it without a triggerId lookup.
-      await maybeRunPostWorkflowActions(workflowTrigger, result, this._reviewApprovalAdapter, this.notificationService);
+      await maybeRunPostWorkflowActions(workflowTrigger, result, this._reviewApprovalAdapter, this.notificationService, this.ctx);
     });
     return workflowTrigger.workflowId;
   }

--- a/src/v2/durable-core/constants.ts
+++ b/src/v2/durable-core/constants.ts
@@ -275,6 +275,7 @@ export const EVENT_KIND = {
   DECISION_TRACE_APPENDED: 'decision_trace_appended',
   RUN_COMPLETED: 'run_completed',
   DELIVERY_RECORDED: 'delivery_recorded',
+  REVIEW_DRAFT_SUBMITTED: 'review_draft_submitted',
 } as const;
 
 export type EventKindV1 = typeof EVENT_KIND[keyof typeof EVENT_KIND];

--- a/src/v2/durable-core/schemas/session/events.ts
+++ b/src/v2/durable-core/schemas/session/events.ts
@@ -361,6 +361,22 @@ export const DomainEventV1Schema = z.discriminatedUnion('kind', [
       prUrl: z.string().optional(),
     }),
   }),
+  /**
+   * review_draft_submitted: appended by PendingDraftReviewPoller after detecting
+   * that the operator published the pending draft review.
+   *
+   * WHY a session event: makes review submission visible in the console and
+   * queryable from the session store, consistent with delivery_recorded.
+   */
+  DomainEventEnvelopeV1Schema.extend({
+    kind: z.literal('review_draft_submitted'),
+    scope: z.object({ runId: z.string().min(1) }),
+    data: z.object({
+      reviewId: z.number().int().positive(),
+      prUrl: z.string(),
+      submittedAt: z.string(),
+    }),
+  }),
 ]);
 
 export type DomainEventV1 = z.infer<typeof DomainEventV1Schema>;


### PR DESCRIPTION
## Summary

Completes the reviewer-assigned MR review feature end-to-end.

- **Platform-agnostic polling**: `ReviewApprovalAdapter` gains a `checkSubmission()` method -- all platform-specific submission detection lives in the adapter. GitHub checks `GET /reviews/:id` for non-PENDING state. A future GitLab adapter will implement a different signal without touching the poller at all.
- **`PendingDraftReviewPoller`**: dumb timer that delegates to `adapter.checkSubmission()` on each tick. Appends `review_draft_submitted` domain event on detection; deletes the pending-draft sidecar; notifies the caller.
- **`review_draft_submitted` domain event**: added to `EVENT_KIND` and `DomainEventV1Schema` (same pattern as `delivery_recorded`). Makes review submission visible in the console.
- **Crash recovery**: writes `pending-draft-<sessionId>.json` sidecar BEFORE starting the poller. Stores `triggerId` (not the token -- secrets don't go in sidecars). `runStartupRecovery()` scans for orphaned sidecars and restarts pollers on daemon start, looking up the token from the trigger index.
- **`trigger-listener.ts`**: passes trigger index to `runStartupRecovery()` to enable pending-draft recovery.

## Context

Depends on PR #1022 and PR #1023. Part 3 of 3 for the reviewer-assigned MR review feature.

**GitHub API verified**: draft reviews are created by omitting `event` (not passing `"PENDING"` -- that returns 422). Account-level: visible in browser "Finish your review" panel.

## Test plan

- [x] `npm run build` -- clean
- [x] `npx vitest run` -- 396/396 pass
- [ ] Unit tests for `PendingDraftReviewPoller` and updated `ReviewApprovalAdapter.checkSubmission()` -- follow-up