### PR TITLE
fix(engine): use relative dates in cli-worktrain-diagnose tests

### DIFF
--- a/tests/unit/cli-worktrain-diagnose.test.ts
+++ b/tests/unit/cli-worktrain-diagnose.test.ts
@@ -44,8 +44,8 @@ import {
 // ---------------------------------------------------------------------------
 
 const EVENTS_DIR = '/fake/events/daemon';
-const TODAY = '2026-05-09';
-const YESTERDAY = '2026-05-08';
+const TODAY = new Date().toISOString().slice(0, 10);
+const YESTERDAY = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
 
 function makeReadFile(files: Record<string, string>): (path: string) => string | null {
   return (path: string) => files[path] ?? null;
@@ -550,7 +550,7 @@ describe('resultCategory', () => {
 
 describe('analyzeFleet', () => {
   const FLEET_EVENTS_DIR = '/fleet/events';
-  const TODAY_FILE = `${FLEET_EVENTS_DIR}/2026-05-09.jsonl`;
+  const TODAY_FILE = `${FLEET_EVENTS_DIR}/${new Date().toISOString().slice(0, 10)}.jsonl`;
 
   function makeReadDir(files: Record<string, string>): (dir: string) => readonly string[] | null {
     return (dir: string) => {


### PR DESCRIPTION
## Summary

- Fixes 17 failing tests in `tests/unit/cli-worktrain-diagnose.test.ts` that have been broken since 2026-05-09
- `parseDaemonEvents` scans the last 7 days of event log files using `new Date()` at runtime; the tests had hardcoded file paths at `2026-05-09.jsonl` which fell outside the 7-day window, causing every test to return `NOT_FOUND`
- Replace `const TODAY = '2026-05-09'` and `const YESTERDAY = '2026-05-08'` with dynamic date computation

## Test plan

- [ ] `npx vitest run tests/unit/cli-worktrain-diagnose.test.ts` -- 36/36 pass (was 17 failing)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)