### PR TITLE
feat(engine): add worktrain session-log command for turn-by-turn replay

### DIFF
--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -52,6 +52,7 @@ import {
   formatDiagnosticJson,
   formatFleetSummary,
 } from './cli/commands/worktrain-diagnose.js';
+import { parseSessionLog, formatSessionLog } from './cli/commands/worktrain-session-log.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -1033,6 +1034,26 @@ program
       const analysis = analyzeFleet(readDir, readFile, eventsDir, options.workflow);
       process.stdout.write(formatFleetSummary(analysis, { ascii: options.ascii ?? false }) + '\n');
     }
+  });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SESSION-LOG COMMAND
+// ═══════════════════════════════════════════════════════════════════════════
+
+program
+  .command('session-log <sessionId>')
+  .description(
+    'Print a time-annotated turn-by-turn replay of a daemon session. ' +
+    'Shows LLM calls, tool executions with durations, step advances, and the final outcome. ' +
+    'Accepts a full session ID or a prefix. Searches the last 7 days of daemon event logs.',
+  )
+  .action((sessionId: string) => {
+    const eventsDir = path.join(os.homedir(), '.workrail', 'events', 'daemon');
+    const readFile = (filePath: string): string | null => {
+      try { return fs.readFileSync(filePath, 'utf8'); } catch { return null; }
+    };
+    const result = parseSessionLog(sessionId, eventsDir, 7, readFile);
+    process.stdout.write(formatSessionLog(result) + '\n');
   });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/cli/commands/worktrain-session-log.ts
+++ b/src/cli/commands/worktrain-session-log.ts
@@ -1,0 +1,397 @@
+/**
+ * WorkTrain session-log command.
+ *
+ * Reads the daemon event log and renders a time-annotated turn-by-turn replay
+ * of any session (live or completed) in the last N days.
+ *
+ * Design invariants:
+ * - parseSessionLog() is a pure function: no direct I/O, readFile is injected
+ * - SessionLogResult is a discriminated union -- exhaustiveness enforced at compile time
+ * - tool_called events are skipped; only tool_call_started/completed/failed produce lines
+ * - argsSummary is tracked via a FIFO queue per toolName (tools run sequentially)
+ * - Orphaned tool_call_started (daemon crash mid-tool) emits a tool line with durationMs null
+ * - Events are sorted by ts after merging across daily files (cross-midnight safety)
+ */
+
+import chalk from 'chalk';
+
+// ---------------------------------------------------------------------------
+// SessionLogLine -- discriminated union of renderable log line types
+// ---------------------------------------------------------------------------
+
+export type SessionLogLine =
+  | {
+      readonly kind: 'llm_turn';
+      readonly ts: number;
+      readonly messageCount: number;
+      readonly modelId?: string;
+    }
+  | {
+      readonly kind: 'tool';
+      readonly ts: number;
+      readonly toolName: string;
+      /** First 200 chars of the tool call params (from tool_call_started argsSummary). */
+      readonly argsSummary: string;
+      /** Wall-clock duration in ms. null when daemon crashed mid-tool. */
+      readonly durationMs: number | null;
+      readonly isError: boolean;
+      /** First 200 chars of the result or error message. */
+      readonly summary: string;
+    }
+  | {
+      readonly kind: 'step_advance';
+      readonly ts: number;
+      readonly stepId?: string;
+    }
+  | {
+      readonly kind: 'agent_stuck';
+      readonly ts: number;
+      readonly reason: string;
+      readonly detail?: string;
+    }
+  | {
+      readonly kind: 'session_end';
+      readonly ts: number;
+      readonly outcome: string;
+      readonly detail?: string;
+    };
+
+// ---------------------------------------------------------------------------
+// SessionLogResult -- discriminated union of parse outcomes
+// ---------------------------------------------------------------------------
+
+export type SessionLogResult =
+  | {
+      readonly kind: 'found';
+      readonly sessionId: string;
+      readonly workflowId: string;
+      readonly startedAt: number;
+      readonly lines: readonly SessionLogLine[];
+    }
+  | {
+      readonly kind: 'not_found';
+      readonly sessionIdQuery: string;
+      readonly daysBack: number;
+    }
+  | {
+      readonly kind: 'ambiguous';
+      readonly sessionIdQuery: string;
+      readonly candidates: readonly string[];
+    };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build file paths for the last `daysBack` days. Newest first. */
+function buildFilePaths(eventsDir: string, daysBack: number): string[] {
+  const paths: string[] = [];
+  const now = Date.now();
+  for (let i = 0; i < daysBack; i++) {
+    const date = new Date(now - i * 86400000).toISOString().slice(0, 10);
+    paths.push(`${eventsDir}/${date}.jsonl`);
+  }
+  return paths;
+}
+
+/** Returns true if the event's sessionId starts with the query (case-sensitive prefix match). */
+function matchesQuery(eventSessionId: string, query: string): boolean {
+  return eventSessionId.startsWith(query);
+}
+
+// ---------------------------------------------------------------------------
+// parseSessionLog -- pure, injected I/O
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse daemon event log files and produce a turn-by-turn SessionLogResult.
+ *
+ * @param sessionIdQuery - Full session ID or prefix to search for
+ * @param eventsDir - Absolute path to ~/.workrail/events/daemon/
+ * @param daysBack - How many days back to scan (default 7)
+ * @param readFile - Injected file reader: returns file contents or null if not found
+ */
+export function parseSessionLog(
+  sessionIdQuery: string,
+  eventsDir: string,
+  daysBack: number,
+  readFile: (path: string) => string | null,
+): SessionLogResult {
+  const filePaths = buildFilePaths(eventsDir, daysBack);
+
+  // Collect raw events for matching session IDs
+  const eventsBySession = new Map<string, Array<Record<string, unknown>>>();
+
+  for (const filePath of filePaths) {
+    const content = readFile(filePath);
+    if (!content) continue;
+
+    for (const rawLine of content.split('\n')) {
+      const line = rawLine.trim();
+      if (!line) continue;
+
+      let event: Record<string, unknown>;
+      try {
+        event = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue; // malformed JSONL -- skip silently
+      }
+
+      const eventSessionId = typeof event['sessionId'] === 'string' ? event['sessionId'] : null;
+      if (!eventSessionId) continue;
+      if (!matchesQuery(eventSessionId, sessionIdQuery)) continue;
+
+      let bucket = eventsBySession.get(eventSessionId);
+      if (!bucket) {
+        bucket = [];
+        eventsBySession.set(eventSessionId, bucket);
+      }
+      bucket.push(event);
+    }
+  }
+
+  // No matching sessions
+  if (eventsBySession.size === 0) {
+    return { kind: 'not_found', sessionIdQuery, daysBack };
+  }
+
+  // Ambiguous prefix
+  if (eventsBySession.size > 1) {
+    return {
+      kind: 'ambiguous',
+      sessionIdQuery,
+      candidates: [...eventsBySession.keys()],
+    };
+  }
+
+  const [sessionId, rawEvents] = [...eventsBySession.entries()][0]!;
+
+  // Sort all events by ts
+  rawEvents.sort((a, b) => {
+    const ta = typeof a['ts'] === 'number' ? a['ts'] : 0;
+    const tb = typeof b['ts'] === 'number' ? b['ts'] : 0;
+    return ta - tb;
+  });
+
+  // Extract session metadata
+  let workflowId = 'unknown';
+  let startedAt = 0;
+
+  for (const event of rawEvents) {
+    if (event['kind'] === 'session_started') {
+      if (typeof event['workflowId'] === 'string') workflowId = event['workflowId'];
+      if (typeof event['ts'] === 'number') startedAt = event['ts'];
+      break;
+    }
+  }
+
+  // Fold events into SessionLogLine[]
+  // Pending argsSummary per toolName: FIFO queue because tools run sequentially.
+  // WHY Map<string, string[]>: same tool can be called multiple times in one turn.
+  // Sequential execution guarantees tool_call_started fires before tool_call_completed
+  // for the same tool, so FIFO pop gives the correct argsSummary.
+  const pendingArgs = new Map<string, string[]>();
+
+  const lines: SessionLogLine[] = [];
+
+  for (const event of rawEvents) {
+    const kind = event['kind'];
+    const ts = typeof event['ts'] === 'number' ? event['ts'] : 0;
+
+    // Skip coarse tool_called events -- tool_call_started/completed/failed are used instead.
+    // WHY: both fire for every tool call. Using tool_called would double-render every tool.
+    if (kind === 'tool_called') continue;
+
+    if (kind === 'llm_turn_started') {
+      lines.push({
+        kind: 'llm_turn',
+        ts,
+        messageCount: typeof event['messageCount'] === 'number' ? event['messageCount'] : 0,
+        ...(typeof event['modelId'] === 'string' ? { modelId: event['modelId'] } : {}),
+      });
+      continue;
+    }
+
+    if (kind === 'tool_call_started') {
+      const toolName = typeof event['toolName'] === 'string' ? event['toolName'] : 'unknown';
+      const argsSummary = typeof event['argsSummary'] === 'string' ? event['argsSummary'] : '';
+      const queue = pendingArgs.get(toolName) ?? [];
+      queue.push(argsSummary);
+      pendingArgs.set(toolName, queue);
+      continue;
+    }
+
+    if (kind === 'tool_call_completed') {
+      const toolName = typeof event['toolName'] === 'string' ? event['toolName'] : 'unknown';
+      const durationMs = typeof event['durationMs'] === 'number' ? event['durationMs'] : null;
+      const resultSummary = typeof event['resultSummary'] === 'string' ? event['resultSummary'] : '';
+      const queue = pendingArgs.get(toolName);
+      const argsSummary = queue?.shift() ?? '';
+      if (queue && queue.length === 0) pendingArgs.delete(toolName);
+      lines.push({ kind: 'tool', ts, toolName, argsSummary, durationMs, isError: false, summary: resultSummary });
+      continue;
+    }
+
+    if (kind === 'tool_call_failed') {
+      const toolName = typeof event['toolName'] === 'string' ? event['toolName'] : 'unknown';
+      const durationMs = typeof event['durationMs'] === 'number' ? event['durationMs'] : null;
+      const errorMessage = typeof event['errorMessage'] === 'string' ? event['errorMessage'] : '';
+      const queue = pendingArgs.get(toolName);
+      const argsSummary = queue?.shift() ?? '';
+      if (queue && queue.length === 0) pendingArgs.delete(toolName);
+      lines.push({ kind: 'tool', ts, toolName, argsSummary, durationMs, isError: true, summary: errorMessage });
+      continue;
+    }
+
+    if (kind === 'step_advanced') {
+      lines.push({
+        kind: 'step_advance',
+        ts,
+        ...(typeof event['stepId'] === 'string' ? { stepId: event['stepId'] } : {}),
+      });
+      continue;
+    }
+
+    if (kind === 'agent_stuck') {
+      lines.push({
+        kind: 'agent_stuck',
+        ts,
+        reason: typeof event['reason'] === 'string' ? event['reason'] : 'unknown',
+        ...(typeof event['detail'] === 'string' ? { detail: event['detail'] } : {}),
+      });
+      continue;
+    }
+
+    if (kind === 'session_completed' || kind === 'session_aborted') {
+      const outcome = kind === 'session_aborted'
+        ? 'aborted'
+        : (typeof event['outcome'] === 'string' ? event['outcome'] : 'unknown');
+      lines.push({
+        kind: 'session_end',
+        ts,
+        outcome,
+        ...(typeof event['detail'] === 'string' ? { detail: event['detail'] } : {}),
+      });
+      continue;
+    }
+  }
+
+  // Flush any orphaned tool_call_started (daemon crashed mid-tool)
+  for (const [toolName, queue] of pendingArgs.entries()) {
+    for (const argsSummary of queue) {
+      lines.push({
+        kind: 'tool',
+        ts: lines.length > 0 ? (lines[lines.length - 1]!.ts + 1) : startedAt,
+        toolName,
+        argsSummary,
+        durationMs: null,
+        isError: false,
+        summary: '',
+      });
+    }
+  }
+
+  return { kind: 'found', sessionId, workflowId, startedAt, lines };
+}
+
+// ---------------------------------------------------------------------------
+// formatSessionLog -- pure renderer
+// ---------------------------------------------------------------------------
+
+const SLOW_THRESHOLD_MS = 10_000;
+
+function fmtTs(ts: number): string {
+  return new Date(ts).toISOString().slice(11, 19); // HH:MM:SS
+}
+
+function fmtDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * Format a SessionLogResult as a human-readable string.
+ * Pure: no I/O, chalk for color.
+ */
+export function formatSessionLog(result: SessionLogResult): string {
+  if (result.kind === 'not_found') {
+    return chalk.red(`Session not found: ${result.sessionIdQuery}`) +
+      `\nSearched the last ${result.daysBack} days of daemon event logs.`;
+  }
+
+  if (result.kind === 'ambiguous') {
+    return chalk.yellow(`Ambiguous session ID prefix: ${result.sessionIdQuery}`) +
+      '\nMatching sessions:\n' +
+      result.candidates.map((c) => `  ${c}`).join('\n');
+  }
+
+  const header = [
+    chalk.bold(`Session: ${result.sessionId}`),
+    `Workflow: ${result.workflowId}`,
+    `Started:  ${new Date(result.startedAt).toISOString()}`,
+    '',
+  ].join('\n');
+
+  let turnIndex = 0;
+  const renderedLines: string[] = [];
+
+  for (const line of result.lines) {
+    const ts = chalk.dim(`[${fmtTs(line.ts)}]`);
+
+    if (line.kind === 'llm_turn') {
+      turnIndex++;
+      const model = line.modelId ? chalk.dim(` (${line.modelId})`) : '';
+      renderedLines.push(`${ts} ${chalk.cyan(`Turn ${turnIndex}`)}  ${line.messageCount} msgs${model}`);
+      continue;
+    }
+
+    if (line.kind === 'tool') {
+      const arrow = chalk.dim('→');
+      const name = chalk.yellow(line.toolName.padEnd(12));
+      const args = chalk.dim(line.argsSummary.slice(0, 60));
+      const startLine = `${ts} ${arrow} ${name} ${args}`;
+
+      let endLine: string;
+      if (line.durationMs === null) {
+        endLine = `${ts} ${chalk.red('←')} ${name} ${chalk.red('[crashed mid-call]')}`;
+      } else {
+        const dur = fmtDuration(line.durationMs);
+        const durStr = line.durationMs > SLOW_THRESHOLD_MS
+          ? chalk.yellow(`(${dur}) ← SLOW`)
+          : chalk.dim(`(${dur})`);
+        const errStr = line.isError ? chalk.red(' ← ERROR') : '';
+        const summaryStr = line.summary ? chalk.dim(`  "${line.summary.slice(0, 50)}"`) : '';
+        endLine = `${ts} ${chalk.dim('←')} ${name} ${durStr}${errStr}${summaryStr}`;
+      }
+
+      renderedLines.push(startLine);
+      renderedLines.push(endLine);
+      continue;
+    }
+
+    if (line.kind === 'step_advance') {
+      const stepStr = line.stepId ? chalk.dim(` → ${line.stepId}`) : '';
+      renderedLines.push(`${ts} ${chalk.green('ADVANCE')}${stepStr}`);
+      continue;
+    }
+
+    if (line.kind === 'agent_stuck') {
+      const detail = line.detail ? chalk.dim(`  ${line.detail.slice(0, 80)}`) : '';
+      renderedLines.push(`${ts} ${chalk.red(`STUCK [${line.reason}]`)}${detail}`);
+      continue;
+    }
+
+    if (line.kind === 'session_end') {
+      const outcomeColor = line.outcome === 'success' ? chalk.green : chalk.red;
+      const detail = line.detail ? chalk.dim(`  ${line.detail.slice(0, 80)}`) : '';
+      renderedLines.push(`${ts} ${outcomeColor(`DONE [${line.outcome}]`)}${detail}`);
+      continue;
+    }
+  }
+
+  if (renderedLines.length === 0) {
+    renderedLines.push(chalk.dim('(no turn data -- session may predate fine-grained event logging)'));
+  }
+
+  return header + renderedLines.join('\n');
+}

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -232,10 +232,6 @@ export interface LlmTurnCompletedEvent {
  * file path) that AgentLoop cannot see. The fine-grained stream adds timing
  * and lifecycle without replacing the coarse stream.
  *
- * IMPORTANT for log readers: both streams fire for every tool call. Any
- * consumer that reads the event log must skip `tool_called` when using
- * `tool_call_started/completed/failed`, or it will double-render every tool.
- *
  * WHY argsSummary: raw params may be large (e.g. file contents in Write tool).
  * Truncating to 200 chars gives observability without bloating the event log.
  */

--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -232,6 +232,10 @@ export interface LlmTurnCompletedEvent {
  * file path) that AgentLoop cannot see. The fine-grained stream adds timing
  * and lifecycle without replacing the coarse stream.
  *
+ * IMPORTANT for log readers: both streams fire for every tool call. Any
+ * consumer that reads the event log must skip `tool_called` when using
+ * `tool_call_started/completed/failed`, or it will double-render every tool.
+ *
  * WHY argsSummary: raw params may be large (e.g. file contents in Write tool).
  * Truncating to 200 chars gives observability without bloating the event log.
  */

--- a/tests/unit/cli-worktrain-session-log.test.ts
+++ b/tests/unit/cli-worktrain-session-log.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Unit tests for worktrain session-log -- parseSessionLog() and formatSessionLog().
+ *
+ * parseSessionLog() is exported and tested with an injected readFile fake.
+ * No filesystem access. Pattern follows cli-worktrain-diagnose.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseSessionLog,
+  formatSessionLog,
+  type SessionLogResult,
+} from '../../src/cli/commands/worktrain-session-log.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const EVENTS_DIR = '/fake/events/daemon';
+const TODAY = new Date().toISOString().slice(0, 10);
+const YESTERDAY = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+
+function makeReadFile(files: Record<string, string>): (path: string) => string | null {
+  return (p: string) => files[p] ?? null;
+}
+
+function evt(obj: Record<string, unknown>): string {
+  return JSON.stringify(obj);
+}
+
+function sessionStarted(sessionId: string, workflowId = 'wr.test', ts = 1000): string {
+  return evt({ kind: 'session_started', sessionId, workflowId, ts });
+}
+function llmTurnStarted(sessionId: string, ts = 1100, messageCount = 1, modelId = 'claude-test'): string {
+  return evt({ kind: 'llm_turn_started', sessionId, messageCount, modelId, ts });
+}
+function toolCallStarted(sessionId: string, toolName: string, argsSummary: string, ts = 1200): string {
+  return evt({ kind: 'tool_call_started', sessionId, toolName, argsSummary, ts });
+}
+function toolCallCompleted(sessionId: string, toolName: string, durationMs: number, resultSummary: string, ts = 1300): string {
+  return evt({ kind: 'tool_call_completed', sessionId, toolName, durationMs, resultSummary, ts });
+}
+function toolCallFailed(sessionId: string, toolName: string, durationMs: number, errorMessage: string, ts = 1300): string {
+  return evt({ kind: 'tool_call_failed', sessionId, toolName, durationMs, errorMessage, ts });
+}
+function toolCalled(sessionId: string, toolName: string, ts = 1250): string {
+  return evt({ kind: 'tool_called', sessionId, toolName, ts });
+}
+function stepAdvanced(sessionId: string, stepId: string, ts = 1400): string {
+  return evt({ kind: 'step_advanced', sessionId, stepId, ts });
+}
+function sessionCompleted(sessionId: string, outcome: string, detail = '', ts = 2000): string {
+  return evt({ kind: 'session_completed', sessionId, workflowId: 'wr.test', outcome, detail, ts });
+}
+function agentStuck(sessionId: string, reason: string, detail = '', ts = 1500): string {
+  return evt({ kind: 'agent_stuck', sessionId, reason, detail, ts });
+}
+
+const SID = 'aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee';
+const EVENTS_FILE = `${EVENTS_DIR}/${TODAY}.jsonl`;
+
+// ---------------------------------------------------------------------------
+// parseSessionLog
+// ---------------------------------------------------------------------------
+
+describe('parseSessionLog', () => {
+  it('returns not_found when no events match', () => {
+    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({}));
+    expect(result.kind).toBe('not_found');
+    if (result.kind === 'not_found') {
+      expect(result.sessionIdQuery).toBe(SID);
+      expect(result.daysBack).toBe(7);
+    }
+  });
+
+  it('returns found with all line types for a full session', () => {
+    const lines = [
+      sessionStarted(SID),
+      llmTurnStarted(SID, 1100, 3, 'claude-haiku'),
+      toolCallStarted(SID, 'Bash', '{"command":"ls"}', 1200),
+      toolCallCompleted(SID, 'Bash', 500, 'file1.ts\nfile2.ts', 1700),
+      stepAdvanced(SID, 'phase-1', 1800),
+      sessionCompleted(SID, 'success', 'stop', 2000),
+    ].join('\n');
+
+    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') return;
+
+    expect(result.sessionId).toBe(SID);
+    expect(result.workflowId).toBe('wr.test');
+
+    const kinds = result.lines.map((l) => l.kind);
+    expect(kinds).toEqual(['llm_turn', 'tool', 'step_advance', 'session_end']);
+
+    const toolLine = result.lines[1];
+    expect(toolLine?.kind).toBe('tool');
+    if (toolLine?.kind === 'tool') {
+      expect(toolLine.toolName).toBe('Bash');
+      expect(toolLine.argsSummary).toBe('{"command":"ls"}');
+      expect(toolLine.durationMs).toBe(500);
+      expect(toolLine.isError).toBe(false);
+    }
+  });
+
+  it('returns ambiguous when multiple sessions match the prefix', () => {
+    const sid2 = 'aaaa1111-bbbb-cccc-dddd-ffffffffffff';
+    const lines = [
+      sessionStarted(SID),
+      sessionStarted(sid2),
+    ].join('\n');
+    const result = parseSessionLog('aaaa1111', EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind === 'ambiguous') {
+      expect(result.candidates).toContain(SID);
+      expect(result.candidates).toContain(sid2);
+    }
+  });
+
+  it('skips tool_called events -- only tool_call_completed produces a tool line', () => {
+    const lines = [
+      sessionStarted(SID),
+      llmTurnStarted(SID),
+      toolCallStarted(SID, 'Bash', '{"command":"echo hi"}', 1200),
+      toolCalled(SID, 'Bash', 1250), // coarse event -- must be skipped
+      toolCallCompleted(SID, 'Bash', 100, 'hi', 1300),
+      sessionCompleted(SID, 'success'),
+    ].join('\n');
+
+    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') return;
+
+    // Must be exactly one tool line (not two)
+    const toolLines = result.lines.filter((l) => l.kind === 'tool');
+    expect(toolLines.length).toBe(1);
+  });
+
+  it('emits a tool line with durationMs null for an orphaned tool_call_started (daemon crash)', () => {
+    const lines = [
+      sessionStarted(SID),
+      llmTurnStarted(SID),
+      toolCallStarted(SID, 'Bash', '{"command":"sleep 999"}', 1200),
+      // No tool_call_completed -- daemon crashed
+    ].join('\n');
+
+    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') return;
+
+    const toolLines = result.lines.filter((l) => l.kind === 'tool');
+    expect(toolLines.length).toBe(1);
+    const tl = toolLines[0];
+    if (tl?.kind === 'tool') {
+      expect(tl.durationMs).toBeNull();
+      expect(tl.toolName).toBe('Bash');
+    }
+  });
+
+  it('merges events from two daily files for cross-midnight sessions', () => {
+    const yesterdayFile = `${EVENTS_DIR}/${YESTERDAY}.jsonl`;
+    const todayFile = `${EVENTS_DIR}/${TODAY}.jsonl`;
+
+    const yesterdayEvents = [
+      sessionStarted(SID, 'wr.test', 1000),
+      llmTurnStarted(SID, 1100),
+    ].join('\n');
+
+    const todayEvents = [
+      toolCallStarted(SID, 'Read', '{"filePath":"/src/foo.ts"}', 2000),
+      toolCallCompleted(SID, 'Read', 200, '(file contents)', 2200),
+      sessionCompleted(SID, 'success', '', 3000),
+    ].join('\n');
+
+    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({
+      [yesterdayFile]: yesterdayEvents,
+      [todayFile]: todayEvents,
+    }));
+
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') return;
+    const kinds = result.lines.map((l) => l.kind);
+    expect(kinds).toEqual(['llm_turn', 'tool', 'session_end']);
+  });
+
+  it('skips malformed JSONL lines silently', () => {
+    const lines = [
+      sessionStarted(SID),
+      'not valid json {{{}',
+      sessionCompleted(SID, 'success'),
+    ].join('\n');
+
+    expect(() => {
+      const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+      expect(result.kind).toBe('found');
+    }).not.toThrow();
+  });
+
+  it('emits agent_stuck line for agent_stuck event', () => {
+    const lines = [
+      sessionStarted(SID),
+      llmTurnStarted(SID),
+      agentStuck(SID, 'stall', 'LLM API call timed out', 1500),
+      sessionCompleted(SID, 'stuck', 'stall', 2000),
+    ].join('\n');
+
+    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') return;
+
+    const stuckLine = result.lines.find((l) => l.kind === 'agent_stuck');
+    expect(stuckLine).toBeDefined();
+    if (stuckLine?.kind === 'agent_stuck') {
+      expect(stuckLine.reason).toBe('stall');
+    }
+  });
+
+  it('marks tool line as isError for tool_call_failed', () => {
+    const lines = [
+      sessionStarted(SID),
+      llmTurnStarted(SID),
+      toolCallStarted(SID, 'Bash', '{"command":"bad"}', 1200),
+      toolCallFailed(SID, 'Bash', 50, 'command not found', 1250),
+      sessionCompleted(SID, 'error'),
+    ].join('\n');
+
+    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') return;
+
+    const toolLine = result.lines.find((l) => l.kind === 'tool');
+    expect(toolLine?.kind).toBe('tool');
+    if (toolLine?.kind === 'tool') {
+      expect(toolLine.isError).toBe(true);
+      expect(toolLine.summary).toBe('command not found');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatSessionLog
+// ---------------------------------------------------------------------------
+
+describe('formatSessionLog', () => {
+  it('not_found output contains the session ID query', () => {
+    const result: SessionLogResult = { kind: 'not_found', sessionIdQuery: 'abc123', daysBack: 7 };
+    const output = formatSessionLog(result);
+    expect(output).toContain('abc123');
+    expect(output).toContain('7');
+  });
+
+  it('ambiguous output lists candidate sessions', () => {
+    const result: SessionLogResult = {
+      kind: 'ambiguous',
+      sessionIdQuery: 'aaaa',
+      candidates: ['aaaa-1111', 'aaaa-2222'],
+    };
+    const output = formatSessionLog(result);
+    expect(output).toContain('aaaa-1111');
+    expect(output).toContain('aaaa-2222');
+  });
+
+  it('found output contains session ID and tool name', () => {
+    const result: SessionLogResult = {
+      kind: 'found',
+      sessionId: SID,
+      workflowId: 'wr.test',
+      startedAt: 1000,
+      lines: [
+        { kind: 'tool', ts: 1200, toolName: 'Bash', argsSummary: '{"command":"ls"}', durationMs: 500, isError: false, summary: 'file1.ts' },
+        { kind: 'session_end', ts: 2000, outcome: 'success' },
+      ],
+    };
+    const output = formatSessionLog(result);
+    expect(output).toContain(SID);
+    expect(output).toContain('Bash');
+    expect(output).toContain('500ms');
+    expect(output).toContain('success');
+  });
+
+  it('SLOW annotation appears for tools taking >10s', () => {
+    const result: SessionLogResult = {
+      kind: 'found',
+      sessionId: SID,
+      workflowId: 'wr.test',
+      startedAt: 1000,
+      lines: [
+        { kind: 'tool', ts: 1200, toolName: 'Bash', argsSummary: '', durationMs: 15000, isError: false, summary: '' },
+      ],
+    };
+    const output = formatSessionLog(result);
+    expect(output).toContain('SLOW');
+    expect(output).toContain('15.0s');
+  });
+
+  it('crashed annotation appears for durationMs null', () => {
+    const result: SessionLogResult = {
+      kind: 'found',
+      sessionId: SID,
+      workflowId: 'wr.test',
+      startedAt: 1000,
+      lines: [
+        { kind: 'tool', ts: 1200, toolName: 'Bash', argsSummary: '', durationMs: null, isError: false, summary: '' },
+      ],
+    };
+    const output = formatSessionLog(result);
+    expect(output).toContain('crashed');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds \`worktrain session-log <sessionId>\` -- reads the daemon event log and renders a time-annotated turn-by-turn replay of any session (live or completed)
- Shows LLM turns with message count + model, tool calls with durations (SLOW annotation >10s, ERROR for failures, \`[crashed mid-call]\` for daemon-killed-mid-tool), step advances, agent_stuck events, and final outcome
- Searches last 7 days of daemon event logs; supports session ID prefix lookup with ambiguity detection
- Uses only fine-grained \`tool_call_started/completed/failed\` events (not \`tool_called\`) to avoid double-rendering
- Pure \`parseSessionLog()\` with injected \`readFile\` -- no filesystem dependency, fully testable

## Test plan

- [ ] \`npx vitest run tests/unit/cli-worktrain-session-log.test.ts\` -- 14 tests pass
- [ ] \`npx vitest run\` -- full suite 397/397
- [ ] \`tsc --noEmit\` -- clean
- [ ] Manual: \`worktrain session-log <id>\` against a real session ID from \`~/.workrail/events/daemon/\`

Generated with [Claude Code](https://claude.ai/claude-code)