### PR TITLE
feat(engine): add session namespace with events/kill/resume/retry subcommands

### DIFF
--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -52,7 +52,7 @@ import {
   formatDiagnosticJson,
   formatFleetSummary,
 } from './cli/commands/worktrain-diagnose.js';
-import { parseSessionLog, formatSessionLog } from './cli/commands/worktrain-session-log.js';
+import { parseSessionEvents, formatSessionEvents } from './cli/commands/worktrain-session-log.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -1109,8 +1109,8 @@ program
     const readFile = (filePath: string): string | null => {
       try { return fs.readFileSync(filePath, 'utf8'); } catch { return null; }
     };
-    const result = parseSessionLog(sessionId, eventsDir, 7, readFile);
-    process.stdout.write(formatSessionLog(result) + '\n');
+    const result = parseSessionEvents(sessionId, eventsDir, 7, readFile);
+    process.stdout.write(formatSessionEvents(result) + '\n');
   });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -1094,24 +1094,89 @@ program
   });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// SESSION-LOG COMMAND
+// SESSION NAMESPACE: events, kill, resume, retry
 // ═══════════════════════════════════════════════════════════════════════════
 
 program
-  .command('session-log <sessionId>')
-  .description(
-    'Print a time-annotated turn-by-turn replay of a daemon session. ' +
-    'Shows LLM calls, tool executions with durations, step advances, and the final outcome. ' +
-    'Accepts a full session ID or a prefix. Searches the last 7 days of daemon event logs.',
-  )
-  .action((sessionId: string) => {
-    const eventsDir = path.join(os.homedir(), '.workrail', 'events', 'daemon');
-    const readFile = (filePath: string): string | null => {
-      try { return fs.readFileSync(filePath, 'utf8'); } catch { return null; }
-    };
-    const result = parseSessionEvents(sessionId, eventsDir, 7, readFile);
-    process.stdout.write(formatSessionEvents(result) + '\n');
-  });
+  .command('session')
+  .description('Inspect and control individual daemon sessions.\nSubcommands: events, kill, resume, retry');
+
+{
+  const sessionCmd = program.commands.find((c) => c.name() === 'session')!;
+
+  sessionCmd
+    .command('events <sessionId>')
+    .description(
+      'Print a time-annotated turn-by-turn replay of a daemon session. ' +
+      'Shows LLM calls, tool executions with durations, step advances, and the final outcome. ' +
+      'Accepts a full session ID or a prefix. Searches the last 7 days of daemon event logs.',
+    )
+    .action((sessionId: string) => {
+      const eventsDir = path.join(os.homedir(), '.workrail', 'events', 'daemon');
+      const readFile = (filePath: string): string | null => {
+        try { return fs.readFileSync(filePath, 'utf8'); } catch { return null; }
+      };
+      const result = parseSessionEvents(sessionId, eventsDir, 7, readFile);
+      process.stdout.write(formatSessionEvents(result) + '\n');
+    });
+
+  sessionCmd
+    .command('kill <sessionId>')
+    .description('Abort a running session. Requires --force or confirmation prompt.')
+    .option('--force', 'Skip confirmation prompt')
+    .action(async (sessionId: string, options: { force?: boolean }) => {
+      const { executeWorktrainSessionKillCommand } = await import('./cli/commands/worktrain-session-kill.js');
+      const result = await executeWorktrainSessionKillCommand({ sessionId, force: options.force });
+      interpretCliResultWithoutDI(result);
+    });
+
+  sessionCmd
+    .command('resume <sessionId>')
+    .description('Re-fire an orphaned session that crash recovery did not restart.')
+    .action(async (sessionId: string) => {
+      const { executeWorktrainSessionResumeCommand } = await import('./cli/commands/worktrain-session-resume.js');
+      const result = await executeWorktrainSessionResumeCommand({ sessionId });
+      interpretCliResultWithoutDI(result);
+    });
+
+  sessionCmd
+    .command('retry <sessionId>')
+    .description('Re-run a session from scratch with the same goal and context. Requires --force or confirmation prompt.')
+    .option('--force', 'Skip confirmation prompt')
+    .action(async (sessionId: string, options: { force?: boolean }) => {
+      const { executeWorktrainSessionRetryCommand } = await import('./cli/commands/worktrain-session-retry.js');
+      const result = await executeWorktrainSessionRetryCommand({ sessionId, force: options.force });
+      interpretCliResultWithoutDI(result);
+    });
+
+  // Hidden migration shim for old `session-log` command.
+  sessionCmd.addCommand(
+    new Command('log')
+      .description('(removed)')
+      .argument('<sessionId>', 'session ID')
+      .action(() => {
+        process.stderr.write(
+          '\'worktrain session-log\' was renamed. Use: worktrain session events <sessionId>\n',
+        );
+        process.exit(1);
+      }),
+    { hidden: true },
+  );
+}
+
+// Hidden migration shim for the old top-level `session-log` command.
+program.addCommand(
+  new Command('session-log')
+    .description('(removed)')
+    .argument('<sessionId>', 'session ID')
+    .action(() => {
+      process.stderr.write(
+        '\'worktrain session-log\' was renamed. Use: worktrain session events <sessionId>\n',
+      );
+      process.exit(1);
+    }),
+  { hidden: true },
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // HEALTH COMMAND (renamed from `status <sessionId>`)

--- a/src/cli/commands/worktrain-session-kill.ts
+++ b/src/cli/commands/worktrain-session-kill.ts
@@ -1,0 +1,39 @@
+/**
+ * WorkTrain session kill command.
+ *
+ * Aborts a running daemon session.
+ *
+ * STUB: The daemon HTTP endpoint (POST /api/v2/sessions/:id/abort) does not
+ * yet exist. This command returns a clear "not yet implemented" error until
+ * the daemon route ships. The CLI surface is registered now so operators can
+ * discover it and scripts can be written against it.
+ *
+ * Design invariants:
+ * - Returns CliResult -- never throws, never calls process.exit directly.
+ * - Requires --force or a y/N confirmation for the destructive action.
+ */
+
+import type { CliResult } from '../types/cli-result.js';
+import { failure } from '../types/cli-result.js';
+
+export interface WorktrainSessionKillCommandOpts {
+  readonly sessionId: string;
+  readonly force?: boolean;
+}
+
+/**
+ * Execute the session kill command.
+ *
+ * Currently returns a "not yet implemented" failure -- the daemon HTTP route
+ * (POST /api/v2/sessions/:id/abort) does not yet exist. The CLI surface is
+ * registered now; the implementation ships when the daemon route does.
+ */
+export async function executeWorktrainSessionKillCommand(
+  opts: WorktrainSessionKillCommandOpts,
+): Promise<CliResult> {
+  return failure(
+    `session kill is not yet implemented -- the daemon abort endpoint is pending.\n` +
+    `Session ID: ${opts.sessionId}\n` +
+    `Follow-up: POST /api/v2/sessions/:id/abort on the daemon HTTP server.`,
+  );
+}

--- a/src/cli/commands/worktrain-session-log.ts
+++ b/src/cli/commands/worktrain-session-log.ts
@@ -5,7 +5,7 @@
  * of any session (live or completed) in the last N days.
  *
  * Design invariants:
- * - parseSessionLog() is a pure function: no direct I/O, readFile is injected
+ * - parseSessionEvents() is a pure function: no direct I/O, readFile is injected
  * - SessionLogResult is a discriminated union -- exhaustiveness enforced at compile time
  * - tool_called events are skipped; only tool_call_started/completed/failed produce lines
  * - argsSummary is tracked via a FIFO queue per toolName (tools run sequentially)
@@ -100,7 +100,7 @@ function matchesQuery(eventSessionId: string, query: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// parseSessionLog -- pure, injected I/O
+// parseSessionEvents -- pure, injected I/O
 // ---------------------------------------------------------------------------
 
 /**
@@ -111,7 +111,7 @@ function matchesQuery(eventSessionId: string, query: string): boolean {
  * @param daysBack - How many days back to scan (default 7)
  * @param readFile - Injected file reader: returns file contents or null if not found
  */
-export function parseSessionLog(
+export function parseSessionEvents(
   sessionIdQuery: string,
   eventsDir: string,
   daysBack: number,
@@ -295,7 +295,7 @@ export function parseSessionLog(
 }
 
 // ---------------------------------------------------------------------------
-// formatSessionLog -- pure renderer
+// formatSessionEvents -- pure renderer
 // ---------------------------------------------------------------------------
 
 const SLOW_THRESHOLD_MS = 10_000;
@@ -313,7 +313,7 @@ function fmtDuration(ms: number): string {
  * Format a SessionLogResult as a human-readable string.
  * Pure: no I/O, chalk for color.
  */
-export function formatSessionLog(result: SessionLogResult): string {
+export function formatSessionEvents(result: SessionLogResult): string {
   if (result.kind === 'not_found') {
     return chalk.red(`Session not found: ${result.sessionIdQuery}`) +
       `\nSearched the last ${result.daysBack} days of daemon event logs.`;

--- a/src/cli/commands/worktrain-session-resume.ts
+++ b/src/cli/commands/worktrain-session-resume.ts
@@ -1,0 +1,36 @@
+/**
+ * WorkTrain session resume command.
+ *
+ * Re-fires an orphaned daemon session that crash recovery did not restart.
+ *
+ * STUB: The daemon HTTP endpoint (POST /api/v2/sessions/:id/resume) does not
+ * yet exist. This command returns a clear "not yet implemented" error until
+ * the daemon route ships.
+ *
+ * Design invariants:
+ * - Returns CliResult -- never throws, never calls process.exit directly.
+ * - Should guard against resuming successfully-completed sessions (daemon route concern).
+ */
+
+import type { CliResult } from '../types/cli-result.js';
+import { failure } from '../types/cli-result.js';
+
+export interface WorktrainSessionResumeCommandOpts {
+  readonly sessionId: string;
+}
+
+/**
+ * Execute the session resume command.
+ *
+ * Currently returns a "not yet implemented" failure -- the daemon HTTP route
+ * (POST /api/v2/sessions/:id/resume) does not yet exist.
+ */
+export async function executeWorktrainSessionResumeCommand(
+  opts: WorktrainSessionResumeCommandOpts,
+): Promise<CliResult> {
+  return failure(
+    `session resume is not yet implemented -- the daemon resume endpoint is pending.\n` +
+    `Session ID: ${opts.sessionId}\n` +
+    `Follow-up: POST /api/v2/sessions/:id/resume on the daemon HTTP server.`,
+  );
+}

--- a/src/cli/commands/worktrain-session-retry.ts
+++ b/src/cli/commands/worktrain-session-retry.ts
@@ -1,0 +1,38 @@
+/**
+ * WorkTrain session retry command.
+ *
+ * Re-fires a session from scratch with the same goal and context.
+ *
+ * STUB: The daemon HTTP endpoint (POST /api/v2/sessions/:id/retry) does not
+ * yet exist. This command returns a clear "not yet implemented" error until
+ * the daemon route ships.
+ *
+ * Design invariants:
+ * - Returns CliResult -- never throws, never calls process.exit directly.
+ * - Requires --force or a y/N confirmation (destructive -- starts a new session).
+ * - Should guard against retrying already-running sessions (daemon route concern).
+ */
+
+import type { CliResult } from '../types/cli-result.js';
+import { failure } from '../types/cli-result.js';
+
+export interface WorktrainSessionRetryCommandOpts {
+  readonly sessionId: string;
+  readonly force?: boolean;
+}
+
+/**
+ * Execute the session retry command.
+ *
+ * Currently returns a "not yet implemented" failure -- the daemon HTTP route
+ * (POST /api/v2/sessions/:id/retry) does not yet exist.
+ */
+export async function executeWorktrainSessionRetryCommand(
+  opts: WorktrainSessionRetryCommandOpts,
+): Promise<CliResult> {
+  return failure(
+    `session retry is not yet implemented -- the daemon retry endpoint is pending.\n` +
+    `Session ID: ${opts.sessionId}\n` +
+    `Follow-up: POST /api/v2/sessions/:id/retry on the daemon HTTP server.`,
+  );
+}

--- a/tests/unit/cli-worktrain-session-events.test.ts
+++ b/tests/unit/cli-worktrain-session-events.test.ts
@@ -1,14 +1,14 @@
 /**
- * Unit tests for worktrain session-log -- parseSessionLog() and formatSessionLog().
+ * Unit tests for worktrain session-log -- parseSessionEvents() and formatSessionEvents().
  *
- * parseSessionLog() is exported and tested with an injected readFile fake.
+ * parseSessionEvents() is exported and tested with an injected readFile fake.
  * No filesystem access. Pattern follows cli-worktrain-diagnose.test.ts.
  */
 
 import { describe, it, expect } from 'vitest';
 import {
-  parseSessionLog,
-  formatSessionLog,
+  parseSessionEvents,
+  formatSessionEvents,
   type SessionLogResult,
 } from '../../src/cli/commands/worktrain-session-log.js';
 
@@ -60,12 +60,12 @@ const SID = 'aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee';
 const EVENTS_FILE = `${EVENTS_DIR}/${TODAY}.jsonl`;
 
 // ---------------------------------------------------------------------------
-// parseSessionLog
+// parseSessionEvents
 // ---------------------------------------------------------------------------
 
-describe('parseSessionLog', () => {
+describe('parseSessionEvents', () => {
   it('returns not_found when no events match', () => {
-    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({}));
+    const result = parseSessionEvents(SID, EVENTS_DIR, 7, makeReadFile({}));
     expect(result.kind).toBe('not_found');
     if (result.kind === 'not_found') {
       expect(result.sessionIdQuery).toBe(SID);
@@ -83,7 +83,7 @@ describe('parseSessionLog', () => {
       sessionCompleted(SID, 'success', 'stop', 2000),
     ].join('\n');
 
-    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+    const result = parseSessionEvents(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
     expect(result.kind).toBe('found');
     if (result.kind !== 'found') return;
 
@@ -109,7 +109,7 @@ describe('parseSessionLog', () => {
       sessionStarted(SID),
       sessionStarted(sid2),
     ].join('\n');
-    const result = parseSessionLog('aaaa1111', EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+    const result = parseSessionEvents('aaaa1111', EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
     expect(result.kind).toBe('ambiguous');
     if (result.kind === 'ambiguous') {
       expect(result.candidates).toContain(SID);
@@ -127,7 +127,7 @@ describe('parseSessionLog', () => {
       sessionCompleted(SID, 'success'),
     ].join('\n');
 
-    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+    const result = parseSessionEvents(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
     expect(result.kind).toBe('found');
     if (result.kind !== 'found') return;
 
@@ -144,7 +144,7 @@ describe('parseSessionLog', () => {
       // No tool_call_completed -- daemon crashed
     ].join('\n');
 
-    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+    const result = parseSessionEvents(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
     expect(result.kind).toBe('found');
     if (result.kind !== 'found') return;
 
@@ -172,7 +172,7 @@ describe('parseSessionLog', () => {
       sessionCompleted(SID, 'success', '', 3000),
     ].join('\n');
 
-    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({
+    const result = parseSessionEvents(SID, EVENTS_DIR, 7, makeReadFile({
       [yesterdayFile]: yesterdayEvents,
       [todayFile]: todayEvents,
     }));
@@ -191,7 +191,7 @@ describe('parseSessionLog', () => {
     ].join('\n');
 
     expect(() => {
-      const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+      const result = parseSessionEvents(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
       expect(result.kind).toBe('found');
     }).not.toThrow();
   });
@@ -204,7 +204,7 @@ describe('parseSessionLog', () => {
       sessionCompleted(SID, 'stuck', 'stall', 2000),
     ].join('\n');
 
-    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+    const result = parseSessionEvents(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
     expect(result.kind).toBe('found');
     if (result.kind !== 'found') return;
 
@@ -224,7 +224,7 @@ describe('parseSessionLog', () => {
       sessionCompleted(SID, 'error'),
     ].join('\n');
 
-    const result = parseSessionLog(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
+    const result = parseSessionEvents(SID, EVENTS_DIR, 7, makeReadFile({ [EVENTS_FILE]: lines }));
     expect(result.kind).toBe('found');
     if (result.kind !== 'found') return;
 
@@ -241,10 +241,10 @@ describe('parseSessionLog', () => {
 // formatSessionLog
 // ---------------------------------------------------------------------------
 
-describe('formatSessionLog', () => {
+describe('formatSessionEvents', () => {
   it('not_found output contains the session ID query', () => {
     const result: SessionLogResult = { kind: 'not_found', sessionIdQuery: 'abc123', daysBack: 7 };
-    const output = formatSessionLog(result);
+    const output = formatSessionEvents(result);
     expect(output).toContain('abc123');
     expect(output).toContain('7');
   });
@@ -255,7 +255,7 @@ describe('formatSessionLog', () => {
       sessionIdQuery: 'aaaa',
       candidates: ['aaaa-1111', 'aaaa-2222'],
     };
-    const output = formatSessionLog(result);
+    const output = formatSessionEvents(result);
     expect(output).toContain('aaaa-1111');
     expect(output).toContain('aaaa-2222');
   });
@@ -271,7 +271,7 @@ describe('formatSessionLog', () => {
         { kind: 'session_end', ts: 2000, outcome: 'success' },
       ],
     };
-    const output = formatSessionLog(result);
+    const output = formatSessionEvents(result);
     expect(output).toContain(SID);
     expect(output).toContain('Bash');
     expect(output).toContain('500ms');
@@ -288,7 +288,7 @@ describe('formatSessionLog', () => {
         { kind: 'tool', ts: 1200, toolName: 'Bash', argsSummary: '', durationMs: 15000, isError: false, summary: '' },
       ],
     };
-    const output = formatSessionLog(result);
+    const output = formatSessionEvents(result);
     expect(output).toContain('SLOW');
     expect(output).toContain('15.0s');
   });
@@ -303,7 +303,7 @@ describe('formatSessionLog', () => {
         { kind: 'tool', ts: 1200, toolName: 'Bash', argsSummary: '', durationMs: null, isError: false, summary: '' },
       ],
     };
-    const output = formatSessionLog(result);
+    const output = formatSessionEvents(result);
     expect(output).toContain('crashed');
   });
 });

--- a/tests/unit/cli-worktrain-session-events.test.ts
+++ b/tests/unit/cli-worktrain-session-events.test.ts
@@ -238,7 +238,7 @@ describe('parseSessionEvents', () => {
 });
 
 // ---------------------------------------------------------------------------
-// formatSessionLog
+// formatSessionEvents
 // ---------------------------------------------------------------------------
 
 describe('formatSessionEvents', () => {


### PR DESCRIPTION
## Summary

- Renames `worktrain session-log` to `worktrain session events <id>` (exports renamed `parseSessionLog`→`parseSessionEvents`, `formatSessionLog`→`formatSessionEvents`)
- Adds `worktrain session` namespace with `events`, `kill`, `resume`, `retry` subcommands
- `session kill/resume/retry` are stubs returning "not yet implemented" until daemon HTTP endpoints ship (follow-up ticket filed)
- Hidden migration shim: `worktrain session-log` and `worktrain session log` both print migration message

**Depends on PR #1040** (daemon subcommands)

## Test plan

- [ ] `npx vitest run tests/unit/cli-worktrain-session-events.test.ts` -- 14 tests pass
- [ ] `npx vitest run` -- full suite passes
- [ ] `tsc --noEmit` -- clean
- [ ] Manual: `worktrain session events <id>` works; `worktrain session-log <id>` prints migration message

Generated with [Claude Code](https://claude.ai/claude-code)