### PR TITLE
feat(engine): activate github_draft_review via delivery: YAML block (Phase 4)

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -197,22 +197,29 @@ The delivery pipeline was extracted into `delivery-pipeline.ts` with explicit st
 
 ### Pluggable output delivery: workflows produce structured artifacts, delivery is configured externally (May 19, 2026)
 
-**Status: idea** | Priority: high
+**Status: partial** | Shipped PRs #1054, #1055 (Phases 1-3)
 
 **Score: 12** | Cor:2 Cap:3 Eff:1 Lev:3 Con:2 | Blocked: no
 
-Workflows currently hardcode their delivery mechanism. `wr.mr-review` parks at a `requireConfirmation` gate before posting a GitHub draft review -- which means the review sits in a local worktree file, invisible to anyone, until a human approves it via `worktrain inbox`. This conflates two orthogonal concerns: **delivery** (how the result reaches the human) and **gating** (whether execution should pause for human approval before proceeding). The current design forces every workflow to treat delivery as a control flow decision, and there is no way to route output to Slack, a webhook, a GitLab MR note, or any other channel without editing the workflow definition.
+**What shipped (Phases 1-3, May 20 2026):**
+- `DeliveryAdapter<K>` generic interface, `AdapterConfig` discriminated union, `DeliveryConfig` (source: 'explicit' | 'synthesized'), `resolveDeliveryConfig()` pure function, `CliInboxAdapter` -- in `src/trigger/delivery-adapter.ts`
+- `synthesizeDeliveryConfig()` migration shim wires legacy `autoCommit`/`reviewerIdentity`/`callbackUrl` fields into typed `DeliveryConfig` on every `TriggerDefinition`
+- `delivery: { kind: cli_inbox }` YAML block in triggers.yml activates explicit delivery; `adapter.deliver()` fires for `cli_inbox` adapters on session completion
+- `DeliveryPlannedEvent` added to daemon event log at session start
+- `TriggerRouterOptions` object replaces 14 positional constructor params
+- Full design doc at `docs/plans/output-delivery-design.md`
 
-The underlying issue is broader than mr-review: any workflow that produces a meaningful artifact (a PR link, a deploy summary, a coding task report) has no principled way to notify the operator or deliver the result to the right place. Operators using GitLab instead of GitHub, or teams that want Slack notifications, are blocked entirely.
+**What remains (Phase 4):**
+- Replace `maybeRunDelivery()` (git_commit) and `maybeRunPostWorkflowActions()` (github_draft_review) with `adapter.deliver()` calls for all adapter kinds -- this is when operators can switch review posting from GitHub to GitLab/Slack by changing config
+- Extend `delivery: { kind: ... }` YAML block to support adapter-specific fields (token/login for github_draft_review, webhookUrl for slack_webhook)
+- Deprecate and remove `reviewerIdentity` from `WorkflowTrigger` (currently duplicates `deliveryConfig`)
+- `worktrain trigger validate` should print the resolved delivery adapter per trigger
+- Shared `OutboxMessage` type extraction (currently duplicated between `CliInboxAdapter` and `worktrain-inbox.ts`)
+- Long-term: event-sourced delivery bus (C3 from design doc) for full auditability
 
-A clean model: workflows declare what they produce via typed output contracts (`kind: "draft_review"`, `kind: "summary"`, `kind: "pr_link"`). Delivery is configured on the trigger or as a user/org preference via pluggable output adapters. The `requireConfirmation` gate remains a separate, explicit concept for cases where execution genuinely needs to pause -- but it is not the delivery mechanism; it uses the configured delivery channel to send the "awaiting approval" notification.
-
-**Things to hash out:**
-- What does the output contract declaration look like in the workflow JSON schema? Does it live on the final step, on the workflow root, or as a separate `outputs` block?
-- Where is the adapter configured -- per trigger in `triggers.yml`, globally in `.workrailrc`, or both? What happens when neither is set (sensible default: CLI inbox)?
-- Does the gate's "awaiting approval" message go through the same delivery channel, or does it always go to CLI inbox regardless?
-- GitLab MR notes are not the same as GitHub draft reviews -- some adapters are lossless (Slack, webhook) but others require semantic translation. How much of that translation lives in the adapter vs. the workflow's output contract?
-- First phase scope: is it sufficient to wire up GitHub draft review posting as the first real adapter and define the interface, leaving Slack/GitLab/webhook for follow-on phases?
+**Things still to hash out for Phase 4:**
+- YAML delivery block currently only supports `kind:` (flat scalar). Adapter-specific fields (token, login) need a sub-object parser extension.
+- dispatch() path still has no deliver() call -- sessions started programmatically don't get delivery notifications yet.
 
 ---
 

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -325,7 +325,13 @@ function validateHmac(rawBody: Buffer, secret: string, headerValue: string): boo
  * (polls until operator publishes, could take hours). Awaiting it would hold the
  * queue slot. Same pattern as gate evaluation: void (async () => { ... })().
  */
-async function maybeRunPostWorkflowActions(
+/**
+ * Core review posting logic: create draft review, write sidecar, start poller.
+ * Extracted from maybeRunPostWorkflowActions() so the explicit deliveryConfig path
+ * can call it with credentials from AdapterConfig rather than reviewerIdentity.
+ */
+async function runPostWorkflowReview(
+  reviewerIdentity: import('./types.js').ReviewerIdentity,
   workflowTrigger: WorkflowTrigger,
   originalResult: WorkflowRunResult,
   reviewApprovalAdapter: ReviewApprovalAdapter,
@@ -334,9 +340,6 @@ async function maybeRunPostWorkflowActions(
   triggerId?: string,
 ): Promise<void> {
   if (originalResult._tag !== 'success') return;
-  if (!workflowTrigger.reviewerIdentity) return;
-
-  const { reviewerIdentity } = workflowTrigger;
 
   // Find wr.review_verdict artifact.
   const artifacts = originalResult.lastStepArtifacts;
@@ -473,6 +476,27 @@ async function maybeRunPostWorkflowActions(
 
   // Notify operator that draft is ready.
   notificationService?.notify(originalResult, `WorkTrain review draft ready on PR #${prNumber} -- open in GitHub to review findings`);
+}
+
+async function maybeRunPostWorkflowActions(
+  workflowTrigger: WorkflowTrigger,
+  originalResult: WorkflowRunResult,
+  reviewApprovalAdapter: ReviewApprovalAdapter,
+  notificationService?: NotificationService,
+  ctx?: V2ToolContext,
+  triggerId?: string,
+): Promise<void> {
+  if (originalResult._tag !== 'success') return;
+  if (!workflowTrigger.reviewerIdentity) return;
+  await runPostWorkflowReview(
+    workflowTrigger.reviewerIdentity,
+    workflowTrigger,
+    originalResult,
+    reviewApprovalAdapter,
+    notificationService,
+    ctx,
+    triggerId,
+  );
 }
 
 async function maybeRunDelivery(
@@ -1132,26 +1156,27 @@ export class TriggerRouter {
         : undefined;
       await maybeRunDelivery(trigger.id, trigger, originalResult, this.execFn, deliveryDeps);
 
-      // Post-workflow review actions: create a PENDING draft review when reviewerIdentity is set.
-      // Uses workflowTrigger (which carries reviewerIdentity forwarded from TriggerDefinition).
-      // Uses originalResult to avoid callbackUrl delivery_failed suppressing review posting.
-      await maybeRunPostWorkflowActions(workflowTrigger, originalResult, this._reviewApprovalAdapter, this.notificationService, this.ctx, trigger.id);
+      // Deprecation: warn once per session when both legacy reviewerIdentity and explicit
+      // deliveryConfig are set -- explicit delivery: block takes precedence.
+      if (workflowTrigger.reviewerIdentity !== undefined && workflowTrigger.deliveryConfig?.source === 'explicit') {
+        console.warn(
+          `[TriggerRouter] reviewerIdentity is deprecated when an explicit delivery: block is configured ` +
+          `(workflowId=${workflowTrigger.workflowId}). Remove reviewerIdentity from triggers.yml and use ` +
+          `delivery: { kind: github_draft_review, token: $TOKEN, login: ... } instead.`,
+        );
+      }
 
-      // Explicit delivery notification: fire adapter.deliver() for cli_inbox adapters
-      // when the operator has explicitly configured a delivery: block in triggers.yml.
-      // WHY only cli_inbox: git_commit and github_draft_review are still handled by
-      // maybeRunDelivery() and maybeRunPostWorkflowActions() above. Phase 4 will replace
-      // those paths with adapter.deliver() calls for all adapter kinds.
+      // Explicit delivery dispatch: fire configured delivery actions when operator
+      // has set delivery: block in triggers.yml (source === 'explicit').
       // WHY explicit check: every trigger has a synthesized cli_inbox fallback in
-      // deliveryConfig. Without this guard, deliver() would fire for every session,
-      // flooding outbox.jsonl for all triggers regardless of configuration.
+      // deliveryConfig. Without this guard, actions fire for every session.
+      let explicitGithubReviewFired = false;
       if (
         originalResult._tag === 'success' &&
-        workflowTrigger.deliveryConfig?.source === 'explicit' &&
-        this._cliInboxAdapter !== undefined
+        workflowTrigger.deliveryConfig?.source === 'explicit'
       ) {
         for (const adapterConfig of workflowTrigger.deliveryConfig.adapters) {
-          if (adapterConfig.kind === 'cli_inbox') {
+          if (adapterConfig.kind === 'cli_inbox' && this._cliInboxAdapter !== undefined) {
             const payload: DeliveryPayload = {
               workflowId: workflowTrigger.workflowId,
               sessionId: originalResult.sessionId ?? 'unknown',
@@ -1164,8 +1189,33 @@ export class TriggerRouter {
             } catch (e) {
               console.error(`[TriggerRouter] cli_inbox delivery failed: ${String(e)}`);
             }
+          } else if (adapterConfig.kind === 'github_draft_review') {
+            // Use explicit credentials from deliveryConfig instead of reviewerIdentity.
+            const identity: import('./types.js').ReviewerIdentity = {
+              platform: 'github',
+              token: adapterConfig.token,
+              login: adapterConfig.login,
+            };
+            await runPostWorkflowReview(
+              identity,
+              workflowTrigger,
+              originalResult,
+              this._reviewApprovalAdapter,
+              this.notificationService,
+              this.ctx,
+              trigger.id,
+            );
+            explicitGithubReviewFired = true;
           }
         }
+      }
+
+      // Legacy review posting: runs when reviewerIdentity is configured and explicit
+      // delivery did NOT already handle it (to avoid double-posting).
+      // WHY separate: explicit delivery: block and legacy reviewerIdentity are mutually
+      // exclusive for review posting. Explicit takes priority.
+      if (!explicitGithubReviewFired) {
+        await maybeRunPostWorkflowActions(workflowTrigger, originalResult, this._reviewApprovalAdapter, this.notificationService, this.ctx, trigger.id);
       }
     });
 

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -1105,6 +1105,11 @@ export class TriggerRouter {
                     lastStepArtifacts,
                     sessionId: result.sessionId as import('../daemon/daemon-events.js').RunId,
                   };
+                  // NOTE (Phase 5): this still uses the legacy maybeRunPostWorkflowActions() path
+                  // which only fires for reviewerIdentity. Triggers migrated to explicit
+                  // delivery: { kind: github_draft_review } (without reviewerIdentity) will
+                  // NOT get a draft review posted from this gate path until Phase 5 migrates
+                  // this call site to the explicit deliveryConfig dispatch loop.
                   await maybeRunPostWorkflowActions(
                     workflowTrigger,
                     syntheticSuccess,
@@ -1156,13 +1161,20 @@ export class TriggerRouter {
         : undefined;
       await maybeRunDelivery(trigger.id, trigger, originalResult, this.execFn, deliveryDeps);
 
-      // Deprecation: warn once per session when both legacy reviewerIdentity and explicit
-      // deliveryConfig are set -- explicit delivery: block takes precedence.
-      if (workflowTrigger.reviewerIdentity !== undefined && workflowTrigger.deliveryConfig?.source === 'explicit') {
+      // Deprecation: warn once per session when reviewerIdentity is set AND the explicit
+      // delivery: block already includes github_draft_review (the two are redundant and
+      // the explicit block takes precedence for review posting).
+      // WHY narrow condition: having delivery: { kind: cli_inbox } + reviewerIdentity is
+      // a valid migration pattern -- cli_inbox for notifications, reviewerIdentity for reviews.
+      if (
+        workflowTrigger.reviewerIdentity !== undefined &&
+        workflowTrigger.deliveryConfig?.source === 'explicit' &&
+        workflowTrigger.deliveryConfig.adapters.some(a => a.kind === 'github_draft_review')
+      ) {
         console.warn(
-          `[TriggerRouter] reviewerIdentity is deprecated when an explicit delivery: block is configured ` +
-          `(workflowId=${workflowTrigger.workflowId}). Remove reviewerIdentity from triggers.yml and use ` +
-          `delivery: { kind: github_draft_review, token: $TOKEN, login: ... } instead.`,
+          `[TriggerRouter] reviewerIdentity is redundant when delivery: { kind: github_draft_review } is configured ` +
+          `(workflowId=${workflowTrigger.workflowId}). Remove reviewerIdentity from triggers.yml -- ` +
+          `the delivery: block already handles review posting.`,
         );
       }
 
@@ -1206,6 +1218,14 @@ export class TriggerRouter {
               trigger.id,
             );
             explicitGithubReviewFired = true;
+          } else if (adapterConfig.kind !== 'cli_inbox') {
+            // Adapter kind is configured but not yet implemented in Phase 4.
+            // Phase 5 will add git_commit; Phase 6+ will add slack_webhook, gitlab_mr_note, callback_url.
+            console.warn(
+              `[TriggerRouter] Delivery adapter kind '${adapterConfig.kind}' is not yet activated ` +
+              `(workflowId=${workflowTrigger.workflowId}). Delivery skipped for this adapter. ` +
+              `This will be implemented in a future phase.`,
+            );
           }
         }
       }

--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -1834,13 +1834,17 @@ export function validateTriggerStrict(
   // Rule: reviewer-identity-without-read-only (warning)
   // reviewer-assigned PR review sessions need branchStrategy: 'read-only' to checkout the PR
   // branch in an isolated worktree so concurrent reviews don't clobber the main checkout.
-  if (trigger.reviewerIdentity && trigger.branchStrategy !== 'read-only') {
+  // Applies to both legacy reviewerIdentity and explicit delivery: { kind: github_draft_review }.
+  const hasReviewDelivery =
+    trigger.reviewerIdentity !== undefined ||
+    trigger.deliveryConfig?.adapters.some(a => a.kind === 'github_draft_review') === true;
+  if (hasReviewDelivery && trigger.branchStrategy !== 'read-only') {
     issues.push({
       rule: 'reviewer-identity-without-read-only',
       severity: 'warning',
       triggerId: id,
       message:
-        'reviewerIdentity is set but branchStrategy is not "read-only" -- reviewer sessions ' +
+        'Review delivery is configured but branchStrategy is not "read-only" -- reviewer sessions ' +
         'should use branchStrategy: read-only to checkout the PR branch in an isolated worktree',
       suggestedFix: 'branchStrategy: read-only',
     });

--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -132,7 +132,7 @@ interface ParsedTriggerRaw {
   reviewerIdentity?: { platform?: string; token?: string; login?: string };
   // Explicit delivery configuration. When present, overrides the synthesized default
   // from synthesizeDeliveryConfig(). Assembled and validated in validateAndResolveTrigger().
-  delivery?: { kind?: string };
+  delivery?: { kind?: string; token?: string; login?: string };
   // Polling trigger source (present for gitlab_poll, github_issues_poll, github_prs_poll).
   // Stored as raw strings; resolved and validated in validateAndResolveTrigger().
   // Fields from all providers are unioned here -- the assembler validates which
@@ -512,7 +512,9 @@ function parseTriggersYaml(
             const dlValueResult = parseScalar(dlRawValue, lineIndex + 1);
             if (dlValueResult.kind === 'err') return dlValueResult;
             switch (dlKey) {
-              case 'kind': delivery.kind = dlValueResult.value; break;
+              case 'kind':  delivery.kind = dlValueResult.value; break;
+              case 'token': delivery.token = dlValueResult.value; break;
+              case 'login': delivery.login = dlValueResult.value; break;
               default: break; // unknown sub-keys silently ignored
             }
           }
@@ -1452,9 +1454,28 @@ function validateAndResolveTrigger(
     if (!KNOWN_ADAPTER_KINDS.has(rawKind as AdapterConfig['kind'])) {
       return err({ kind: 'invalid_field_value', field: `delivery.kind (unknown adapter kind: "${rawKind}")`, triggerId: rawId });
     }
+
+    // For github_draft_review: require token and login; resolve $SECRET_NAME for token.
+    let adapterConfig: AdapterConfig;
+    if (rawKind === 'github_draft_review') {
+      const rawToken = raw.delivery.token?.trim();
+      const rawLogin = raw.delivery.login?.trim();
+      if (!rawToken) {
+        return err({ kind: 'missing_field', field: 'delivery.token (required for github_draft_review)', triggerId: rawId });
+      }
+      if (!rawLogin) {
+        return err({ kind: 'missing_field', field: 'delivery.login (required for github_draft_review)', triggerId: rawId });
+      }
+      const tokenResult = resolveSecret(rawToken, rawId, env);
+      if (tokenResult.kind === 'err') return tokenResult;
+      adapterConfig = { kind: 'github_draft_review', token: tokenResult.value, login: rawLogin };
+    } else {
+      adapterConfig = { kind: rawKind as AdapterConfig['kind'] } as AdapterConfig;
+    }
+
     explicitDeliveryConfig = {
       source: 'explicit' as const,
-      adapters: [{ kind: rawKind as AdapterConfig['kind'] } as AdapterConfig],
+      adapters: [adapterConfig],
     };
   }
 

--- a/tests/unit/trigger-router.test.ts
+++ b/tests/unit/trigger-router.test.ts
@@ -2211,3 +2211,79 @@ describe('TriggerRouter: cli_inbox explicit delivery', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 4: explicit github_draft_review delivery
+// ---------------------------------------------------------------------------
+
+describe('TriggerRouter: explicit github_draft_review delivery', () => {
+  it('explicit github_draft_review config fires runPostWorkflowReview, not maybeRunPostWorkflowActions', async () => {
+    // Verify that when explicit deliveryConfig has github_draft_review, the review path fires.
+    // We can't easily verify the exact token used without an integration setup,
+    // but we can verify that maybeRunPostWorkflowActions() is NOT called (no reviewerIdentity on WorkflowTrigger)
+    // while the explicit path IS attempted (errors are swallowed as warnings).
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fn } = makeFakeRunWorkflow();
+
+    const trigger = makeTrigger({
+      deliveryConfig: {
+        source: 'explicit' as const,
+        adapters: [{ kind: 'github_draft_review' as const, token: 'explicit-token', login: 'myuser' }],
+      },
+      // No reviewerIdentity -- explicit path should fire, legacy path should NOT
+    });
+
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn);
+    await router.route(makeEvent({ action: 'push' }));
+    await new Promise(r => setTimeout(r, 50));
+    warnSpy.mockRestore();
+
+    // If explicit path fires and review context is missing, it logs a warning and continues.
+    // What matters: no crash, and the deprecation warning was NOT emitted (no reviewerIdentity).
+    const deprecationWarned = warnSpy.mock.calls.some(args =>
+      String(args[0]).includes('reviewerIdentity is deprecated'),
+    );
+    expect(deprecationWarned).toBe(false);
+  });
+
+  it('emits deprecation warning when both reviewerIdentity and explicit deliveryConfig are set', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fn } = makeFakeRunWorkflow();
+
+    // Trigger in index has both reviewerIdentity AND explicit deliveryConfig
+    const trigger = makeTrigger({
+      deliveryConfig: {
+        source: 'explicit' as const,
+        adapters: [{ kind: 'cli_inbox' as const }],
+      },
+      reviewerIdentity: { platform: 'github', token: 'tok', login: 'user' },
+    });
+
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn);
+    await router.route(makeEvent({ action: 'push' }));
+    await new Promise(r => setTimeout(r, 50));
+
+    const warned = warnSpy.mock.calls.some(args =>
+      String(args[0]).includes('reviewerIdentity is deprecated'),
+    );
+    warnSpy.mockRestore();
+    expect(warned).toBe(true);
+  });
+
+  it('does NOT emit deprecation warning when only reviewerIdentity is set (no explicit deliveryConfig)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fn } = makeFakeRunWorkflow();
+    const trigger = makeTrigger({
+      reviewerIdentity: { platform: 'github', token: 'tok', login: 'user' },
+    });
+    const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn);
+    await router.route(makeEvent({ action: 'push' }));
+    await new Promise(r => setTimeout(r, 50));
+
+    const warned = warnSpy.mock.calls.some(args =>
+      String(args[0]).includes('reviewerIdentity is deprecated'),
+    );
+    warnSpy.mockRestore();
+    expect(warned).toBe(false);
+  });
+});

--- a/tests/unit/trigger-router.test.ts
+++ b/tests/unit/trigger-router.test.ts
@@ -2250,11 +2250,12 @@ describe('TriggerRouter: explicit github_draft_review delivery', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { fn } = makeFakeRunWorkflow();
 
-    // Trigger in index has both reviewerIdentity AND explicit deliveryConfig
+    // Trigger in index has both reviewerIdentity AND explicit github_draft_review
+    // (the warning only fires when explicit config includes github_draft_review)
     const trigger = makeTrigger({
       deliveryConfig: {
         source: 'explicit' as const,
-        adapters: [{ kind: 'cli_inbox' as const }],
+        adapters: [{ kind: 'github_draft_review' as const, token: 'tok', login: 'user' }],
       },
       reviewerIdentity: { platform: 'github', token: 'tok', login: 'user' },
     });
@@ -2264,7 +2265,7 @@ describe('TriggerRouter: explicit github_draft_review delivery', () => {
     await new Promise(r => setTimeout(r, 50));
 
     const warned = warnSpy.mock.calls.some(args =>
-      String(args[0]).includes('reviewerIdentity is deprecated'),
+      String(args[0]).includes('reviewerIdentity is redundant'),
     );
     warnSpy.mockRestore();
     expect(warned).toBe(true);

--- a/tests/unit/trigger-store.test.ts
+++ b/tests/unit/trigger-store.test.ts
@@ -1942,3 +1942,93 @@ describe('delivery: block parsing', () => {
     expect(result.value.triggers).toHaveLength(0);
   });
 });
+
+describe('delivery: block with adapter-specific fields', () => {
+  it('parses delivery: { kind: github_draft_review, token, login } correctly', () => {
+    const yaml = `
+triggers:
+  - id: review-trigger
+    provider: generic
+    workflowId: wr.mr-review
+    workspacePath: /workspace
+    goal: Review PR
+    delivery:
+      kind: github_draft_review
+      token: mytoken
+      login: myuser
+`;
+    const result = loadTriggerConfig(yaml, {});
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    const trigger = result.value.triggers[0];
+    expect(trigger?.deliveryConfig?.source).toBe('explicit');
+    const adapter = trigger?.deliveryConfig?.adapters[0];
+    expect(adapter?.kind).toBe('github_draft_review');
+    if (adapter?.kind === 'github_draft_review') {
+      expect(adapter.token).toBe('mytoken');
+      expect(adapter.login).toBe('myuser');
+    }
+  });
+
+  it('resolves $SECRET_NAME for delivery token', () => {
+    const yaml = `
+triggers:
+  - id: review-trigger
+    provider: generic
+    workflowId: wr.mr-review
+    workspacePath: /workspace
+    goal: Review PR
+    delivery:
+      kind: github_draft_review
+      token: $REVIEW_TOKEN
+      login: myuser
+`;
+    const result = loadTriggerConfig(yaml, { REVIEW_TOKEN: 'resolved-token' });
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    const adapter = result.value.triggers[0]?.deliveryConfig?.adapters[0];
+    if (adapter?.kind === 'github_draft_review') {
+      expect(adapter.token).toBe('resolved-token');
+    }
+  });
+
+  it('rejects delivery: { kind: github_draft_review } without token', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const yaml = `
+triggers:
+  - id: review-trigger
+    provider: generic
+    workflowId: wr.mr-review
+    workspacePath: /workspace
+    goal: Review PR
+    delivery:
+      kind: github_draft_review
+      login: myuser
+`;
+    const result = loadTriggerConfig(yaml, {});
+    warnSpy.mockRestore();
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.value.triggers).toHaveLength(0);
+  });
+
+  it('rejects delivery: { kind: github_draft_review } without login', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const yaml = `
+triggers:
+  - id: review-trigger
+    provider: generic
+    workflowId: wr.mr-review
+    workspacePath: /workspace
+    goal: Review PR
+    delivery:
+      kind: github_draft_review
+      token: mytoken
+`;
+    const result = loadTriggerConfig(yaml, {});
+    warnSpy.mockRestore();
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.value.triggers).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Rebased version of #1058 onto current main (after Phase 1-3 landed via #1055).

Phase 4: operators can configure GitHub draft review delivery via `delivery: { kind: github_draft_review, token: $TOKEN, login: user }` in triggers.yml, replacing the legacy `reviewerIdentity` field.

See #1058 for full description and review history.