### PR TITLE
feat(engine): remove legacy delivery functions, route all by kind (Phase 5)

### DIFF
--- a/src/daemon/daemon-events.ts
+++ b/src/daemon/daemon-events.ts
@@ -421,7 +421,7 @@ export interface DeliveryPlannedEvent {
   readonly kind: 'delivery_planned';
   readonly sessionId: RunId;
   /** Adapter kinds resolved for this session. Absent when deliveryConfig is not set. */
-  readonly deliveryAdapterKinds?: readonly string[];
+  readonly deliveryAdapterKinds?: readonly import('../trigger/delivery-adapter.js').AdapterConfig['kind'][];
   readonly workrailSessionId?: string;
 }
 

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -205,13 +205,6 @@ export interface WorkflowTrigger {
    */
   readonly branchStrategy?: BranchStrategy;
   /**
-   * Reviewer identity for creating draft reviews after review sessions.
-   * Sourced from TriggerDefinition.reviewerIdentity.
-   * Carried here so maybeRunPostWorkflowActions() in TriggerRouter can access it
-   * from the dispatch() path, which only receives WorkflowTrigger (not TriggerDefinition).
-   */
-  readonly reviewerIdentity?: import('../trigger/types.js').ReviewerIdentity;
-  /**
    * Base branch for the worktree. Only used when branchStrategy === 'worktree'.
    * Sourced from TriggerDefinition.baseBranch.
    * Default: 'main' (applied at parse time in trigger-store.ts or at use time in runWorkflow()).

--- a/src/trigger/delivery-adapter.ts
+++ b/src/trigger/delivery-adapter.ts
@@ -116,12 +116,14 @@ export function synthesizeDeliveryConfig(fields: SynthesizeDeliveryFields): Deli
     });
   }
 
-  // WHY no callback_url here: callbackUrl has its own delivery path via deliveryPost()
-  // in trigger-router.ts route(). Adding it to the synthesized adapters array would
-  // create a dead entry -- _runDeliveryByKind() would warn "not yet activated" and
-  // the real callbackUrl delivery would still fire through the separate path.
-  // callbackUrl adapter will be added to synthesizeDeliveryConfig() in Phase 8 when
-  // the deliveryPost() path is replaced by _runDeliveryByKind().
+  // callback_url: fire-and-forget HTTP notification.
+  // Delivery still goes through runCallbackUrlDelivery() in route() (not _runDeliveryByKind())
+  // to preserve the delivery_failed result that suppresses autoCommit.
+  // The synthesized entry here is for observability (delivery_planned event) and
+  // future Phase 8 unification through _runDeliveryByKind().
+  if (fields.callbackUrl) {
+    adapters.push({ kind: 'callback_url', url: fields.callbackUrl });
+  }
 
   // cli_inbox fallback when no delivery fields are configured
   if (adapters.length === 0) {

--- a/src/trigger/delivery-adapter.ts
+++ b/src/trigger/delivery-adapter.ts
@@ -116,10 +116,12 @@ export function synthesizeDeliveryConfig(fields: SynthesizeDeliveryFields): Deli
     });
   }
 
-  // callback_url: fire-and-forget HTTP notification
-  if (fields.callbackUrl) {
-    adapters.push({ kind: 'callback_url', url: fields.callbackUrl });
-  }
+  // WHY no callback_url here: callbackUrl has its own delivery path via deliveryPost()
+  // in trigger-router.ts route(). Adding it to the synthesized adapters array would
+  // create a dead entry -- _runDeliveryByKind() would warn "not yet activated" and
+  // the real callbackUrl delivery would still fire through the separate path.
+  // callbackUrl adapter will be added to synthesizeDeliveryConfig() in Phase 8 when
+  // the deliveryPost() path is replaced by _runDeliveryByKind().
 
   // cli_inbox fallback when no delivery fields are configured
   if (adapters.length === 0) {
@@ -127,18 +129,6 @@ export function synthesizeDeliveryConfig(fields: SynthesizeDeliveryFields): Deli
   }
 
   return { source: 'synthesized', adapters };
-}
-
-// ---------------------------------------------------------------------------
-// Config resolver (pure)
-// ---------------------------------------------------------------------------
-
-export function resolveDeliveryConfig(
-  triggerDeliveryConfig: DeliveryConfig | undefined,
-  _workflowId: string,
-  _globalConfig: Readonly<Record<string, unknown>>,
-): DeliveryConfig {
-  return triggerDeliveryConfig ?? { source: 'synthesized', adapters: [{ kind: 'cli_inbox' }] };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/trigger/delivery-pipeline.ts
+++ b/src/trigger/delivery-pipeline.ts
@@ -27,7 +27,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { WorkflowRunSuccess } from '../daemon/types.js';
 import { DAEMON_SESSIONS_DIR } from '../daemon/workflow-runner.js';
-import type { TriggerDefinition } from './types.js';
+import type { TriggerDefinition, TriggerId } from './types.js';
 import type { ExecFn, HandoffArtifact } from './delivery-action.js';
 import { parseHandoffArtifact, runDelivery } from './delivery-action.js';
 import type { ExecutionSessionGateV2 } from '../v2/usecases/execution-session-gate.js';
@@ -69,7 +69,7 @@ export interface DeliveryStage {
   readonly name: string;
   run(
     result: WorkflowRunSuccess,
-    trigger: TriggerDefinition,
+    trigger: GitCommitDeliveryContext,
     execFn: ExecFn,
     ctx: PipelineContext,
     deps?: DeliveryPipelineDeps,
@@ -116,6 +116,24 @@ export interface DeliveryPipelineDeps {
 // ---------------------------------------------------------------------------
 
 /**
+ * The exact fields runDeliveryPipeline() reads from TriggerDefinition.
+ * Using this interface instead of the full TriggerDefinition prevents
+ * silent regressions when new fields are added to delivery-pipeline.ts --
+ * the compiler will require callers to provide them explicitly.
+ */
+export interface GitCommitDeliveryContext {
+  readonly id: TriggerId;
+  readonly workflowId: string;
+  readonly workspacePath: string;
+  readonly autoCommit: boolean;
+  readonly autoOpenPR?: boolean;
+  readonly secretScan?: boolean;
+  readonly branchStrategy?: TriggerDefinition['branchStrategy'];
+  readonly branchPrefix?: string;
+  readonly baseBranch?: string;
+}
+
+/**
  * Run all stages in order. Stop on the first 'stop' outcome.
  *
  * Never throws -- errors inside stages are caught internally by each stage.
@@ -124,14 +142,14 @@ export interface DeliveryPipelineDeps {
  *
  * @param stages - The ordered pipeline to execute
  * @param result - The completed workflow's success result
- * @param trigger - Source of workspacePath, autoCommit, branchStrategy flags
+ * @param trigger - Git commit delivery context (subset of TriggerDefinition)
  * @param execFn - Injectable exec function (production: execFileAsync; tests: fake)
  * @param triggerId - Used in log messages for traceability
  */
 export async function runDeliveryPipeline(
   stages: readonly DeliveryStage[],
   result: WorkflowRunSuccess,
-  trigger: TriggerDefinition,
+  trigger: GitCommitDeliveryContext,
   execFn: ExecFn,
   triggerId: string,
   deps?: DeliveryPipelineDeps,

--- a/src/trigger/pending-draft-review-poller.ts
+++ b/src/trigger/pending-draft-review-poller.ts
@@ -58,6 +58,12 @@ export interface PendingDraftReviewPollerOptions {
    * Fire-and-forget from the caller's perspective -- errors are logged internally.
    */
   readonly onSubmitted?: (submittedAt: string) => void;
+  /**
+   * Called after submission is detected to resume a gate-parked session.
+   * Receives the daemonSessionId so the caller can look up the sidecar and call resumeFromGate().
+   * Fire-and-forget -- must never throw or block the tick.
+   */
+  readonly onGateResume?: (daemonSessionId: string) => void;
 }
 
 export interface PendingDraftSidecar {
@@ -202,8 +208,12 @@ export class PendingDraftReviewPoller {
       );
     });
 
-    // Notify caller.
+    // Notify caller that submission was detected.
     try { this.opts.onSubmitted?.(submittedAt); } catch { /* fire-and-forget */ }
+
+    // Resume a gate-parked session now that the operator has approved via review submission.
+    // Fire-and-forget -- gate resume is best-effort; failure does not undo the review posting.
+    try { this.opts.onGateResume?.(this.opts.daemonSessionId); } catch { /* fire-and-forget */ }
   }
 }
 

--- a/src/trigger/review-approval-adapter.ts
+++ b/src/trigger/review-approval-adapter.ts
@@ -180,11 +180,55 @@ export class GitHubReviewApprovalAdapter implements ReviewApprovalAdapter {
         return { kind: 'ok', value: { reviewId: existingResult.reviewId, reused: true } };
       }
 
-      // Step 2: Build review body from findings.
+      // Step 2: Build review body from findings (summary for all findings).
       const body = buildReviewBody(findings, prUrl);
 
-      // Step 3: POST a new PENDING draft review (no inline comments in v1 --
-      // filePath/lineNumber not yet in wr.review_verdict schema).
+      // Step 3: Fetch PR HEAD commit SHA so we can attach inline comments.
+      // Inline comments require commit_id -- degrade to body-only if the GET fails.
+      let commitId: string | undefined;
+      try {
+        const prResponse = await this.fetchFn(`https://api.github.com/repos/${prRepo}/pulls/${prNumber}`, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+        });
+        if (prResponse.ok) {
+          const prBody = await prResponse.json() as Record<string, unknown>;
+          const head = prBody['head'] as Record<string, unknown> | undefined;
+          if (typeof head?.['sha'] === 'string') commitId = head['sha'];
+        }
+      } catch {
+        // Degraded: no inline comments, body-only review
+      }
+
+      // Step 4: Build inline comments for findings with file + line data.
+      // Uses the GitHub review 'comments' array so everything is in one POST.
+      const inlineComments: Array<{ path: string; line: number; side: string; body: string }> = [];
+      if (commitId) {
+        for (const f of findings) {
+          const ff = f as Record<string, unknown>;
+          if (typeof ff['file'] === 'string' && typeof ff['startLine'] === 'number') {
+            inlineComments.push({
+              path: ff['file'],
+              line: ff['startLine'],
+              side: 'RIGHT',
+              body: buildInlineCommentBody(f),
+            });
+          }
+        }
+      }
+
+      // Step 5: POST a new PENDING draft review.
+      // Omitting `event` creates a PENDING (draft) review -- correct GitHub API behavior.
+      const reviewPayload: Record<string, unknown> = { body };
+      if (commitId && inlineComments.length > 0) {
+        reviewPayload['commit_id'] = commitId;
+        reviewPayload['comments'] = inlineComments;
+      }
+
       const apiUrl = `https://api.github.com/repos/${prRepo}/pulls/${prNumber}/reviews`;
       let response: { ok: boolean; status: number; json(): Promise<unknown> };
       try {
@@ -196,9 +240,7 @@ export class GitHubReviewApprovalAdapter implements ReviewApprovalAdapter {
             'X-GitHub-Api-Version': '2022-11-28',
             'Content-Type': 'application/json',
           },
-          // Omitting `event` creates a PENDING (draft) review -- omission is the correct
-          // way to create drafts. Passing event:'PENDING' returns a 422 from the GitHub API.
-          body: JSON.stringify({ body }),
+          body: JSON.stringify(reviewPayload),
         });
       } catch (e) {
         return { kind: 'err', error: { kind: 'network_error', message: `POST draft review failed: ${e instanceof Error ? e.message : String(e)}` } };
@@ -218,6 +260,10 @@ export class GitHubReviewApprovalAdapter implements ReviewApprovalAdapter {
       const reviewId = (responseBody as Record<string, unknown>)['id'];
       if (typeof reviewId !== 'number') {
         return { kind: 'err', error: { kind: 'parse_error', message: `POST draft review response missing numeric 'id' field` } };
+      }
+
+      if (inlineComments.length > 0) {
+        console.log(`[ReviewApprovalAdapter] Posted ${inlineComments.length} inline comment(s) on draft review: prRepo=${prRepo} prNumber=${prNumber} reviewId=${reviewId}`);
       }
 
       return { kind: 'ok', value: { reviewId, reused: false } };
@@ -335,6 +381,14 @@ function buildReviewBody(
     lines.push(`- **[${f.severity.toUpperCase()}]** ${f.summary}`);
   }
   lines.push('', `PR: ${prUrl}`);
+  return lines.join('\n');
+}
+
+function buildInlineCommentBody(finding: { readonly summary: string; readonly severity: string }): string {
+  const f = finding as Record<string, unknown>;
+  const lines: string[] = [`**[${finding.severity.toUpperCase()}]** ${finding.summary}`];
+  if (typeof f['remediation'] === 'string') lines.push('', `_Remediation:_ ${f['remediation']}`);
+  if (typeof f['causalLink'] === 'string') lines.push('', `_Why:_ ${f['causalLink']}`);
   return lines.join('\n');
 }
 

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -478,50 +478,49 @@ async function runPostWorkflowReview(
   notificationService?.notify(originalResult, `WorkTrain review draft ready on PR #${prNumber} -- open in GitHub to review findings`);
 }
 
-async function maybeRunPostWorkflowActions(
-  workflowTrigger: WorkflowTrigger,
-  originalResult: WorkflowRunResult,
-  reviewApprovalAdapter: ReviewApprovalAdapter,
-  notificationService?: NotificationService,
-  ctx?: V2ToolContext,
-  triggerId?: string,
-): Promise<void> {
-  if (originalResult._tag !== 'success') return;
-  if (!workflowTrigger.reviewerIdentity) return;
-  await runPostWorkflowReview(
-    workflowTrigger.reviewerIdentity,
-    workflowTrigger,
-    originalResult,
-    reviewApprovalAdapter,
-    notificationService,
-    ctx,
-    triggerId,
-  );
-}
 
-async function maybeRunDelivery(
+/**
+ * Run git commit + optional PR open after a successful workflow session.
+ *
+ * Constructs the minimal trigger-like fields from WorkflowTrigger (which carries
+ * autoCommit, autoOpenPR, secretScan, branchPrefix, baseBranch, workspacePath) and
+ * delegates to runDeliveryPipeline(DEFAULT_DELIVERY_PIPELINE). This is a first-class
+ * router action, not a DeliveryAdapter<K>, because it needs WorkflowTrigger fields
+ * not available via the deliver(payload, config) interface.
+ */
+async function runGitCommitDelivery(
   triggerId: string,
-  trigger: TriggerDefinition,
+  workflowTrigger: WorkflowTrigger,
+  adapterConfig: Extract<import('./delivery-adapter.js').AdapterConfig, { kind: 'git_commit' }>,
   result: WorkflowRunResult,
   execFn: ExecFn,
   deps?: import('./delivery-pipeline.js').DeliveryPipelineDeps,
 ): Promise<void> {
-  // Only deliver on success with autoCommit enabled
   if (result._tag !== 'success') return;
   if (result.lastStepNotes === undefined) {
-    if (trigger.autoCommit === true) {
-      console.warn(
-        `[TriggerRouter] Delivery skipped: triggerId=${triggerId} -- ` +
-        `lastStepNotes is absent (agent did not provide notes on the final step). ` +
-        `Ensure the workflow produces a JSON handoff block in its final step notes.`,
-      );
-    }
+    console.warn(
+      `[TriggerRouter] Git commit delivery skipped: triggerId=${triggerId} -- ` +
+      `lastStepNotes is absent (agent did not provide notes on the final step).`,
+    );
     return;
   }
-  if (trigger.autoCommit !== true) return;
 
-  await runDeliveryPipeline(DEFAULT_DELIVERY_PIPELINE, result, trigger, execFn, triggerId, deps);
+  // Construct a synthetic trigger-like object from WorkflowTrigger fields.
+  // runDeliveryPipeline() only reads: autoCommit, autoOpenPR, secretScan,
+  // workspacePath, branchPrefix, baseBranch, and id from TriggerDefinition.
+  const syntheticTrigger = {
+    id: triggerId as import('./types.js').TriggerId,
+    autoCommit: true as const,
+    autoOpenPR: adapterConfig.autoOpenPR,
+    secretScan: adapterConfig.secretScan,
+    workspacePath: workflowTrigger.workspacePath,
+    branchPrefix: workflowTrigger.branchPrefix,
+    baseBranch: workflowTrigger.baseBranch,
+  } as unknown as import('./types.js').TriggerDefinition;
+
+  await runDeliveryPipeline(DEFAULT_DELIVERY_PIPELINE, result, syntheticTrigger, execFn, triggerId, deps);
 }
+
 
 
 // ---------------------------------------------------------------------------
@@ -726,6 +725,37 @@ export class TriggerRouter {
    * One side must hold the setter. Moving it here makes CoordinatorDepsImpl's dispatch
    * required and non-nullable -- the illegal state is unrepresentable on that side.
    */
+  /**
+   * Route delivery for a completed session by iterating deliveryConfig.adapters by kind.
+   * Used from both route() and dispatch() so both paths share the same delivery logic.
+   */
+  private async _runDeliveryByKind(
+    workflowTrigger: WorkflowTrigger,
+    result: WorkflowRunResult,
+    triggerId: string | undefined,
+    deps?: import('./delivery-pipeline.js').DeliveryPipelineDeps,
+  ): Promise<void> {
+    if (result._tag !== 'success' || workflowTrigger.deliveryConfig === undefined) return;
+    for (const adapterConfig of workflowTrigger.deliveryConfig.adapters) {
+      if (adapterConfig.kind === 'git_commit' && triggerId !== undefined) {
+        await runGitCommitDelivery(triggerId as import('./types.js').TriggerId, workflowTrigger, adapterConfig, result, this.execFn, deps);
+      } else if (adapterConfig.kind === 'github_draft_review') {
+        const identity: import('./types.js').ReviewerIdentity = { platform: 'github', token: adapterConfig.token, login: adapterConfig.login };
+        await runPostWorkflowReview(identity, workflowTrigger, result, this._reviewApprovalAdapter, this.notificationService, this.ctx, triggerId);
+      } else if (adapterConfig.kind === 'cli_inbox' && this._cliInboxAdapter !== undefined && workflowTrigger.deliveryConfig.source === 'explicit') {
+        const payload: DeliveryPayload = {
+          workflowId: workflowTrigger.workflowId,
+          sessionId: result.sessionId ?? 'unknown',
+          goal: workflowTrigger.goal,
+          notes: result.lastStepNotes ?? null,
+          artifacts: result.lastStepArtifacts ?? [],
+        };
+        try { await this._cliInboxAdapter.deliver(payload, adapterConfig); }
+        catch (e) { console.error(`[TriggerRouter] cli_inbox delivery failed: ${String(e)}`); }
+      }
+    }
+  }
+
   setCoordinatorDeps(deps: AdaptiveCoordinatorDeps): void {
     if (this._coordinatorDeps !== undefined) {
       process.stderr.write('[WARN TriggerRouter] setCoordinatorDeps() called more than once -- ignoring reassignment\n');
@@ -863,9 +893,6 @@ export class TriggerRouter {
       ...(trigger.branchStrategy !== undefined ? { branchStrategy: trigger.branchStrategy } : {}),
       ...(trigger.baseBranch !== undefined ? { baseBranch: trigger.baseBranch } : {}),
       ...(trigger.branchPrefix !== undefined ? { branchPrefix: trigger.branchPrefix } : {}),
-      // Reviewer identity forwarded to WorkflowTrigger so maybeRunPostWorkflowActions()
-      // can access it from the dispatch() path (which receives WorkflowTrigger, not TriggerDefinition).
-      ...(trigger.reviewerIdentity !== undefined ? { reviewerIdentity: trigger.reviewerIdentity } : {}),
       // Synthesized delivery config forwarded so dispatch() callers have delivery config
       // without needing to look up TriggerDefinition by triggerId.
       ...(trigger.deliveryConfig !== undefined ? { deliveryConfig: trigger.deliveryConfig } : {}),
@@ -1105,19 +1132,12 @@ export class TriggerRouter {
                     lastStepArtifacts,
                     sessionId: result.sessionId as import('../daemon/daemon-events.js').RunId,
                   };
-                  // NOTE (Phase 5): this still uses the legacy maybeRunPostWorkflowActions() path
-                  // which only fires for reviewerIdentity. Triggers migrated to explicit
-                  // delivery: { kind: github_draft_review } (without reviewerIdentity) will
-                  // NOT get a draft review posted from this gate path until Phase 5 migrates
-                  // this call site to the explicit deliveryConfig dispatch loop.
-                  await maybeRunPostWorkflowActions(
-                    workflowTrigger,
-                    syntheticSuccess,
-                    this._reviewApprovalAdapter,
-                    this.notificationService,
-                    this.ctx,
-                    trigger.id,
-                  );
+                  // deliveryDeps is constructed below for the normal completion path;
+                  // for gate_parked we construct it inline here.
+                  const gateDeps = this.ctx.v2
+                    ? { gate: this.ctx.v2.gate, sessionStore: this.ctx.v2.sessionStore, idFactory: this.ctx.v2.idFactory }
+                    : undefined;
+                  await this._runDeliveryByKind(workflowTrigger, syntheticSuccess, trigger.id, gateDeps);
                 } catch (e) {
                   console.error(`[TriggerRouter] human_approval gate action threw for session ${sessionId}: ${e instanceof Error ? e.message : String(e)}`);
                 }
@@ -1153,90 +1173,16 @@ export class TriggerRouter {
       // notification reflects the actual outcome the user cares about.
       this.notificationService?.notify(result, workflowTrigger.goal);
 
-      // Post-workflow delivery: runs after the workflow result is logged.
-      // Best-effort -- errors are logged and discarded, never change the workflow result.
-      // Use originalResult (not result) so callbackUrl failure does not skip autoCommit.
+      // Post-workflow delivery: route all adapters in deliveryConfig by kind.
       const deliveryDeps = this.ctx.v2
         ? { gate: this.ctx.v2.gate, sessionStore: this.ctx.v2.sessionStore, idFactory: this.ctx.v2.idFactory }
         : undefined;
-      await maybeRunDelivery(trigger.id, trigger, originalResult, this.execFn, deliveryDeps);
+      await this._runDeliveryByKind(workflowTrigger, originalResult, trigger.id, deliveryDeps);
 
-      // Deprecation: warn once per session when reviewerIdentity is set AND the explicit
-      // delivery: block already includes github_draft_review (the two are redundant and
-      // the explicit block takes precedence for review posting).
-      // WHY narrow condition: having delivery: { kind: cli_inbox } + reviewerIdentity is
-      // a valid migration pattern -- cli_inbox for notifications, reviewerIdentity for reviews.
-      if (
-        workflowTrigger.reviewerIdentity !== undefined &&
-        workflowTrigger.deliveryConfig?.source === 'explicit' &&
-        workflowTrigger.deliveryConfig.adapters.some(a => a.kind === 'github_draft_review')
-      ) {
-        console.warn(
-          `[TriggerRouter] reviewerIdentity is redundant when delivery: { kind: github_draft_review } is configured ` +
-          `(workflowId=${workflowTrigger.workflowId}). Remove reviewerIdentity from triggers.yml -- ` +
-          `the delivery: block already handles review posting.`,
-        );
-      }
 
-      // Explicit delivery dispatch: fire configured delivery actions when operator
-      // has set delivery: block in triggers.yml (source === 'explicit').
-      // WHY explicit check: every trigger has a synthesized cli_inbox fallback in
-      // deliveryConfig. Without this guard, actions fire for every session.
-      let explicitGithubReviewFired = false;
-      if (
-        originalResult._tag === 'success' &&
-        workflowTrigger.deliveryConfig?.source === 'explicit'
-      ) {
-        for (const adapterConfig of workflowTrigger.deliveryConfig.adapters) {
-          if (adapterConfig.kind === 'cli_inbox' && this._cliInboxAdapter !== undefined) {
-            const payload: DeliveryPayload = {
-              workflowId: workflowTrigger.workflowId,
-              sessionId: originalResult.sessionId ?? 'unknown',
-              goal: workflowTrigger.goal,
-              notes: originalResult.lastStepNotes ?? null,
-              artifacts: originalResult.lastStepArtifacts ?? [],
-            };
-            try {
-              await this._cliInboxAdapter.deliver(payload, adapterConfig);
-            } catch (e) {
-              console.error(`[TriggerRouter] cli_inbox delivery failed: ${String(e)}`);
-            }
-          } else if (adapterConfig.kind === 'github_draft_review') {
-            // Use explicit credentials from deliveryConfig instead of reviewerIdentity.
-            const identity: import('./types.js').ReviewerIdentity = {
-              platform: 'github',
-              token: adapterConfig.token,
-              login: adapterConfig.login,
-            };
-            await runPostWorkflowReview(
-              identity,
-              workflowTrigger,
-              originalResult,
-              this._reviewApprovalAdapter,
-              this.notificationService,
-              this.ctx,
-              trigger.id,
-            );
-            explicitGithubReviewFired = true;
-          } else if (adapterConfig.kind !== 'cli_inbox') {
-            // Adapter kind is configured but not yet implemented in Phase 4.
-            // Phase 5 will add git_commit; Phase 6+ will add slack_webhook, gitlab_mr_note, callback_url.
-            console.warn(
-              `[TriggerRouter] Delivery adapter kind '${adapterConfig.kind}' is not yet activated ` +
-              `(workflowId=${workflowTrigger.workflowId}). Delivery skipped for this adapter. ` +
-              `This will be implemented in a future phase.`,
-            );
-          }
-        }
-      }
-
-      // Legacy review posting: runs when reviewerIdentity is configured and explicit
-      // delivery did NOT already handle it (to avoid double-posting).
-      // WHY separate: explicit delivery: block and legacy reviewerIdentity are mutually
-      // exclusive for review posting. Explicit takes priority.
-      if (!explicitGithubReviewFired) {
-        await maybeRunPostWorkflowActions(workflowTrigger, originalResult, this._reviewApprovalAdapter, this.notificationService, this.ctx, trigger.id);
-      }
+      // githubReviewFired is true when the kind-based loop above handled github_draft_review.
+      // If deliveryConfig is absent or has no github_draft_review adapter, no review was posted.
+      // This is the expected state for non-review workflows.
     });
 
     return { _tag: 'enqueued', triggerId: trigger.id };
@@ -1415,7 +1361,7 @@ export class TriggerRouter {
                     lastStepArtifacts,
                     sessionId: result.sessionId as import('../daemon/daemon-events.js').RunId,
                   };
-                  await maybeRunPostWorkflowActions(workflowTrigger, syntheticSuccess, this._reviewApprovalAdapter, this.notificationService, this.ctx);
+                  await this._runDeliveryByKind(workflowTrigger, syntheticSuccess, undefined);
                 } catch (e) {
                   console.error(`[TriggerRouter] Dispatch human_approval gate threw: ${e instanceof Error ? e.message : String(e)}`);
                 }
@@ -1441,10 +1387,8 @@ export class TriggerRouter {
       // by triggerId). The dispatch() path does not have a triggerId to look up the definition.
       // TODO(follow-up): accept an optional triggerId in dispatch() to enable delivery here.
 
-      // Post-workflow review actions: create a PENDING draft review when reviewerIdentity is set.
-      // reviewerIdentity is forwarded from TriggerDefinition onto WorkflowTrigger so this path
-      // can access it without a triggerId lookup.
-      await maybeRunPostWorkflowActions(workflowTrigger, result, this._reviewApprovalAdapter, this.notificationService, this.ctx);
+      // Delivery: route by adapter kind using deliveryConfig.
+      await this._runDeliveryByKind(workflowTrigger, result, undefined);
     });
     return workflowTrigger.workflowId;
   }

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -37,7 +37,7 @@ import type {
   ContextMappingEntry,
 } from './types.js';
 import type { ExecFn } from './delivery-action.js';
-import { runDeliveryPipeline, DEFAULT_DELIVERY_PIPELINE } from './delivery-pipeline.js';
+import { runDeliveryPipeline, DEFAULT_DELIVERY_PIPELINE, type GitCommitDeliveryContext } from './delivery-pipeline.js';
 import type { DaemonEventEmitter } from '../daemon/daemon-events.js';
 import type { NotificationService } from './notification-service.js';
 import type { AdaptiveCoordinatorDeps, AdaptivePipelineOpts, ModeExecutors } from '../coordinators/adaptive-pipeline.js';
@@ -501,23 +501,22 @@ async function runGitCommitDelivery(
     return;
   }
 
-  // Construct a synthetic trigger-like object from WorkflowTrigger fields.
-  // runDeliveryPipeline() reads: autoCommit, autoOpenPR, secretScan, workspacePath,
-  // branchPrefix, baseBranch, branchStrategy (for worktree cleanup stages), workflowId
-  // (for PR body attribution), and id from TriggerDefinition.
-  const syntheticTrigger = {
+  // Build a typed GitCommitDeliveryContext from WorkflowTrigger -- no cast needed.
+  // The interface constrains exactly which fields runDeliveryPipeline() reads,
+  // so the compiler will catch any new field access that isn't provided here.
+  const deliveryCtx: GitCommitDeliveryContext = {
     id: triggerId as import('./types.js').TriggerId,
     workflowId: workflowTrigger.workflowId,
-    autoCommit: true as const,
+    workspacePath: workflowTrigger.workspacePath,
+    autoCommit: true,
     autoOpenPR: adapterConfig.autoOpenPR,
     secretScan: adapterConfig.secretScan,
-    workspacePath: workflowTrigger.workspacePath,
     branchPrefix: workflowTrigger.branchPrefix,
     baseBranch: workflowTrigger.baseBranch,
     branchStrategy: workflowTrigger.branchStrategy,
-  } as unknown as import('./types.js').TriggerDefinition;
+  };
 
-  await runDeliveryPipeline(DEFAULT_DELIVERY_PIPELINE, result, syntheticTrigger, execFn, triggerId, deps);
+  await runDeliveryPipeline(DEFAULT_DELIVERY_PIPELINE, result, deliveryCtx, execFn, triggerId, deps);
 }
 
 

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -338,6 +338,7 @@ async function runPostWorkflowReview(
   notificationService?: NotificationService,
   ctx?: V2ToolContext,
   triggerId?: string,
+  onGateResume?: (daemonSessionId: string) => void,
 ): Promise<void> {
   if (originalResult._tag !== 'success') return;
 
@@ -466,6 +467,7 @@ async function runPostWorkflowReview(
           `prRepo=${prRepo} prNumber=${prNumber} submittedAt=${submittedAt}`,
         );
       },
+      onGateResume: onGateResume,
     });
     poller.start();
   }
@@ -474,6 +476,37 @@ async function runPostWorkflowReview(
   notificationService?.notify(originalResult, `WorkTrain review draft ready on PR #${prNumber} -- open in GitHub to review findings`);
 }
 
+
+/**
+/**
+ * POST the completed workflow result to a callbackUrl.
+ * Returns the original result on success, or a WorkflowDeliveryFailed result on HTTP error.
+ * The delivery_failed result suppresses autoCommit for the same session (callers use originalResult
+ * to bypass this for other delivery actions).
+ */
+async function runCallbackUrlDelivery(
+  triggerId: string,
+  workflowId: string,
+  callbackUrl: string,
+  result: WorkflowRunResult,
+  emitter?: DaemonEventEmitter,
+): Promise<WorkflowRunResult> {
+  const deliveryResult = await deliveryPost(callbackUrl, result, emitter);
+  if (deliveryResult.kind === 'err') {
+    const deliveryError =
+      deliveryResult.error.kind === 'http_error'
+        ? `HTTP ${deliveryResult.error.status}: ${deliveryResult.error.body}`
+        : deliveryResult.error.message;
+    console.error(`[TriggerRouter] Delivery failed: triggerId=${triggerId} callbackUrl=${callbackUrl} error=${deliveryError}`);
+    return {
+      _tag: 'delivery_failed',
+      workflowId,
+      stopReason: result._tag === 'success' ? result.stopReason : 'error',
+      deliveryError,
+    } satisfies WorkflowDeliveryFailed;
+  }
+  return result;
+}
 
 /**
  * Run git commit + optional PR open after a successful workflow session.
@@ -739,7 +772,29 @@ export class TriggerRouter {
         await runGitCommitDelivery(triggerId as import('./types.js').TriggerId, workflowTrigger, adapterConfig, result, this.execFn, deps);
       } else if (adapterConfig.kind === 'github_draft_review') {
         const identity: import('./types.js').ReviewerIdentity = { platform: 'github', token: adapterConfig.token, login: adapterConfig.login };
-        await runPostWorkflowReview(identity, workflowTrigger, result, this._reviewApprovalAdapter, this.notificationService, this.ctx, triggerId);
+        // Build a fire-and-forget gate resume closure. When the operator submits the draft
+        // review on GitHub, the poller calls this to resume the parked gate session.
+        const ctx = this.ctx;
+        const apiKey = this.apiKey;
+        const runWorkflowFn = this.runWorkflowFn;
+        const emitter = this.emitter;
+        const activeSessionSet = this._activeSessionSet;
+        const gateResumeClosure = (daemonSessionId: string): void => {
+          void resumeFromGate(
+            daemonSessionId,
+            { verdict: 'approved', confidence: 'high', rationale: 'Operator submitted review on GitHub', stepId: '' },
+            ctx, apiKey, runWorkflowFn, undefined, emitter, activeSessionSet,
+          ).then((r) => {
+            if (r.kind === 'err') {
+              console.warn(`[TriggerRouter] Gate resume after review submission failed: ${r.error.message}`);
+            } else {
+              console.log(`[TriggerRouter] Gate resumed after review submission: daemonSessionId=${daemonSessionId}`);
+            }
+          }).catch((e: unknown) => {
+            console.warn(`[TriggerRouter] Gate resume threw: ${e instanceof Error ? e.message : String(e)}`);
+          });
+        };
+        await runPostWorkflowReview(identity, workflowTrigger, result, this._reviewApprovalAdapter, this.notificationService, this.ctx, triggerId, gateResumeClosure);
       } else if (adapterConfig.kind === 'cli_inbox' && this._cliInboxAdapter !== undefined && workflowTrigger.deliveryConfig.source === 'explicit') {
         const payload: DeliveryPayload = {
           workflowId: workflowTrigger.workflowId,
@@ -750,10 +805,10 @@ export class TriggerRouter {
         };
         try { await this._cliInboxAdapter.deliver(payload, adapterConfig); }
         catch (e) { console.error(`[TriggerRouter] cli_inbox delivery failed: ${String(e)}`); }
-      } else {
-        // Unimplemented adapter kind -- Phase 6+ will add slack_webhook, gitlab_mr_note, callback_url.
-        // git_commit is handled above but only when triggerId is available.
-        console.warn(`[TriggerRouter] Delivery adapter '${adapterConfig.kind}' not yet activated or triggerId absent (workflowId=${workflowTrigger.workflowId}).`);
+      } else if (adapterConfig.kind !== 'callback_url') {
+        // callback_url fires through runCallbackUrlDelivery() in route() before _runDeliveryByKind.
+        // All other unimplemented kinds warn so operators know delivery is skipped.
+        console.warn(`[TriggerRouter] Delivery adapter '${adapterConfig.kind}' not yet activated (workflowId=${workflowTrigger.workflowId}).`);
       }
     }
   }
@@ -966,24 +1021,7 @@ export class TriggerRouter {
       const originalTag = result._tag;
       const originalResult = result;
       if (trigger.callbackUrl) {
-        const deliveryResult = await deliveryPost(trigger.callbackUrl, result, this.emitter);
-        if (deliveryResult.kind === 'err') {
-          const deliveryError =
-            deliveryResult.error.kind === 'http_error'
-              ? `HTTP ${deliveryResult.error.status}: ${deliveryResult.error.body}`
-              : deliveryResult.error.message;
-          console.error(
-            `[TriggerRouter] Delivery failed: triggerId=${trigger.id} ` +
-              `callbackUrl=${trigger.callbackUrl} error=${deliveryError}`,
-          );
-          const deliveryFailed: WorkflowDeliveryFailed = {
-            _tag: 'delivery_failed',
-            workflowId: trigger.workflowId,
-            stopReason: result.stopReason,
-            deliveryError,
-          };
-          result = deliveryFailed;
-        }
+        result = await runCallbackUrlDelivery(trigger.id, trigger.workflowId, trigger.callbackUrl, result, this.emitter);
       }
 
       if (result._tag === 'success') {

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -421,12 +421,8 @@ async function runPostWorkflowReview(
 
   // Write pending-draft sidecar BEFORE starting the poller (crash recovery invariant).
   const daemonSessionId = originalResult.sessionId ?? randomUUID();
-  const workrailSessionId = originalResult.sessionWorkspacePath
-    ? '' // session ID not directly available here; use empty string if absent
-    : '';
-  // Prefer the workrail session ID from the result if available.
-  // WorkflowRunSuccess.lastStepArtifacts carries the session context but not the session ID.
-  // The sidecar only needs it for the session event log write-back; we skip the event if absent.
+  // workrailSessionId (sess_...) needed for session event log write-back after submission.
+  // Available on WorkflowRunSuccess via the workrailSessionId field decoded from the continueToken.
   const resolvedWorkrailSessionId = (originalResult as { workrailSessionId?: string }).workrailSessionId ?? '';
 
   if (ctx?.v2 && resolvedWorkrailSessionId) {

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -506,16 +506,19 @@ async function runGitCommitDelivery(
   }
 
   // Construct a synthetic trigger-like object from WorkflowTrigger fields.
-  // runDeliveryPipeline() only reads: autoCommit, autoOpenPR, secretScan,
-  // workspacePath, branchPrefix, baseBranch, and id from TriggerDefinition.
+  // runDeliveryPipeline() reads: autoCommit, autoOpenPR, secretScan, workspacePath,
+  // branchPrefix, baseBranch, branchStrategy (for worktree cleanup stages), workflowId
+  // (for PR body attribution), and id from TriggerDefinition.
   const syntheticTrigger = {
     id: triggerId as import('./types.js').TriggerId,
+    workflowId: workflowTrigger.workflowId,
     autoCommit: true as const,
     autoOpenPR: adapterConfig.autoOpenPR,
     secretScan: adapterConfig.secretScan,
     workspacePath: workflowTrigger.workspacePath,
     branchPrefix: workflowTrigger.branchPrefix,
     baseBranch: workflowTrigger.baseBranch,
+    branchStrategy: workflowTrigger.branchStrategy,
   } as unknown as import('./types.js').TriggerDefinition;
 
   await runDeliveryPipeline(DEFAULT_DELIVERY_PIPELINE, result, syntheticTrigger, execFn, triggerId, deps);
@@ -752,6 +755,10 @@ export class TriggerRouter {
         };
         try { await this._cliInboxAdapter.deliver(payload, adapterConfig); }
         catch (e) { console.error(`[TriggerRouter] cli_inbox delivery failed: ${String(e)}`); }
+      } else {
+        // Unimplemented adapter kind -- Phase 6+ will add slack_webhook, gitlab_mr_note, callback_url.
+        // git_commit is handled above but only when triggerId is available.
+        console.warn(`[TriggerRouter] Delivery adapter '${adapterConfig.kind}' not yet activated or triggerId absent (workflowId=${workflowTrigger.workflowId}).`);
       }
     }
   }
@@ -1179,10 +1186,19 @@ export class TriggerRouter {
         : undefined;
       await this._runDeliveryByKind(workflowTrigger, originalResult, trigger.id, deliveryDeps);
 
-
-      // githubReviewFired is true when the kind-based loop above handled github_draft_review.
-      // If deliveryConfig is absent or has no github_draft_review adapter, no review was posted.
-      // This is the expected state for non-review workflows.
+      // Deprecation: warn when legacy reviewerIdentity on TriggerDefinition is redundant with
+      // explicit delivery: { kind: github_draft_review } block. Uses trigger.reviewerIdentity
+      // (from TriggerDefinition) since WorkflowTrigger.reviewerIdentity was removed in Phase 5.
+      if (
+        trigger.reviewerIdentity !== undefined &&
+        workflowTrigger.deliveryConfig?.source === 'explicit' &&
+        workflowTrigger.deliveryConfig.adapters.some(a => a.kind === 'github_draft_review')
+      ) {
+        console.warn(
+          `[TriggerRouter] reviewerIdentity in triggers.yml is redundant when delivery: { kind: github_draft_review } is configured ` +
+          `(triggerId=${trigger.id}). Remove reviewerIdentity from triggers.yml.`,
+        );
+      }
     });
 
     return { _tag: 'enqueued', triggerId: trigger.id };

--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -1455,6 +1455,14 @@ function validateAndResolveTrigger(
       return err({ kind: 'invalid_field_value', field: `delivery.kind (unknown adapter kind: "${rawKind}")`, triggerId: rawId });
     }
 
+    // git_commit is only valid as a synthesized adapter (from autoCommit: true).
+    // Configuring it explicitly in the delivery: block is not supported -- the adapter
+    // needs branchStrategy, branchPrefix, baseBranch, and secretScan from WorkflowTrigger
+    // which cannot be expressed in the delivery: block syntax.
+    if (rawKind === 'git_commit') {
+      return err({ kind: 'invalid_field_value', field: `delivery.kind (git_commit is not configurable via delivery: block; use autoCommit: true instead)`, triggerId: rawId });
+    }
+
     // For github_draft_review: require token and login; resolve $SECRET_NAME for token.
     let adapterConfig: AdapterConfig;
     if (rawKind === 'github_draft_review') {

--- a/tests/unit/delivery-adapter.test.ts
+++ b/tests/unit/delivery-adapter.test.ts
@@ -3,7 +3,6 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
-  resolveDeliveryConfig,
   synthesizeDeliveryConfig,
   CliInboxAdapter,
   type DeliveryConfig,
@@ -38,10 +37,13 @@ describe('synthesizeDeliveryConfig', () => {
     expect(result.adapters[0]).toEqual({ kind: 'github_draft_review', token: 'tok', login: 'user' });
   });
 
-  it('returns callback_url when callbackUrl is set', () => {
+  it('does NOT include callback_url in synthesized adapters (callbackUrl has its own delivery path)', () => {
+    // callbackUrl fires via deliveryPost() in trigger-router.ts, not through the adapter loop.
+    // Adding it to synthesized adapters would create a dead entry that warns "not yet activated".
     const result = synthesizeDeliveryConfig({ callbackUrl: 'https://example.com/hook' });
-    expect(result.adapters).toHaveLength(1);
-    expect(result.adapters[0]).toEqual({ kind: 'callback_url', url: 'https://example.com/hook' });
+    expect(result.adapters.every(a => a.kind !== 'callback_url')).toBe(true);
+    // No other delivery configured -- falls back to cli_inbox
+    expect(result.adapters[0]!.kind).toBe('cli_inbox');
   });
 
   it('puts git_commit before github_draft_review when both are set', () => {
@@ -52,41 +54,13 @@ describe('synthesizeDeliveryConfig', () => {
     expect(result.adapters[1]!.kind).toBe('github_draft_review');
   });
 
-  it('includes all three adapters in correct order with all fields set', () => {
+  it('returns only git_commit and github_draft_review (not callback_url) when all three legacy fields set', () => {
     const result = synthesizeDeliveryConfig({
       autoCommit: true,
       reviewerIdentity: reviewer,
       callbackUrl: 'https://example.com/hook',
     });
-    expect(result.adapters.map(a => a.kind)).toEqual(['git_commit', 'github_draft_review', 'callback_url']);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// resolveDeliveryConfig
-// ---------------------------------------------------------------------------
-
-describe('resolveDeliveryConfig', () => {
-  const payload = { workflowId: 'wr.test', sessionId: 'sess_1', goal: 'test', notes: null, artifacts: [] };
-  void payload; // used below
-
-  it('returns cli_inbox fallback when no trigger config is provided', () => {
-    const result = resolveDeliveryConfig(undefined, 'wr.test', {});
-    expect(result).toEqual({ source: 'synthesized', adapters: [{ kind: 'cli_inbox' }] });
-  });
-
-  it('returns the provided trigger config unchanged', () => {
-    const config: DeliveryConfig = {
-      source: 'explicit',
-      adapters: [{ kind: 'github_draft_review', token: 'tok', login: 'user' }],
-    };
-    const result = resolveDeliveryConfig(config, 'wr.test', {});
-    expect(result).toBe(config);
-  });
-
-  it('returns cli_inbox fallback regardless of workflowId or globalConfig', () => {
-    const result = resolveDeliveryConfig(undefined, 'wr.some-other-workflow', { someKey: 'val' });
-    expect(result).toEqual({ source: 'synthesized', adapters: [{ kind: 'cli_inbox' }] });
+    expect(result.adapters.map(a => a.kind)).toEqual(['git_commit', 'github_draft_review']);
   });
 });
 

--- a/tests/unit/delivery-adapter.test.ts
+++ b/tests/unit/delivery-adapter.test.ts
@@ -37,13 +37,10 @@ describe('synthesizeDeliveryConfig', () => {
     expect(result.adapters[0]).toEqual({ kind: 'github_draft_review', token: 'tok', login: 'user' });
   });
 
-  it('does NOT include callback_url in synthesized adapters (callbackUrl has its own delivery path)', () => {
-    // callbackUrl fires via deliveryPost() in trigger-router.ts, not through the adapter loop.
-    // Adding it to synthesized adapters would create a dead entry that warns "not yet activated".
+  it('includes callback_url in synthesized adapters when callbackUrl is set', () => {
     const result = synthesizeDeliveryConfig({ callbackUrl: 'https://example.com/hook' });
-    expect(result.adapters.every(a => a.kind !== 'callback_url')).toBe(true);
-    // No other delivery configured -- falls back to cli_inbox
-    expect(result.adapters[0]!.kind).toBe('cli_inbox');
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0]).toEqual({ kind: 'callback_url', url: 'https://example.com/hook' });
   });
 
   it('puts git_commit before github_draft_review when both are set', () => {
@@ -54,13 +51,13 @@ describe('synthesizeDeliveryConfig', () => {
     expect(result.adapters[1]!.kind).toBe('github_draft_review');
   });
 
-  it('returns only git_commit and github_draft_review (not callback_url) when all three legacy fields set', () => {
+  it('includes all three adapters in order when all legacy fields set', () => {
     const result = synthesizeDeliveryConfig({
       autoCommit: true,
       reviewerIdentity: reviewer,
       callbackUrl: 'https://example.com/hook',
     });
-    expect(result.adapters.map(a => a.kind)).toEqual(['git_commit', 'github_draft_review']);
+    expect(result.adapters.map(a => a.kind)).toEqual(['git_commit', 'github_draft_review', 'callback_url']);
   });
 });
 

--- a/tests/unit/trigger-router.test.ts
+++ b/tests/unit/trigger-router.test.ts
@@ -20,6 +20,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { TriggerRouter, interpolateGoalTemplate } from '../../src/trigger/trigger-router.js';
+import { synthesizeDeliveryConfig } from '../../src/trigger/delivery-adapter.js';
 import type { TriggerRouterOptions } from '../../src/trigger/trigger-router.js';
 import type { AdaptiveCoordinatorDeps, ModeExecutors, PipelineOutcome } from '../../src/coordinators/adaptive-pipeline.js';
 import { createTriggerApp, startTriggerListener } from '../../src/trigger/trigger-listener.js';
@@ -446,7 +447,10 @@ describe('TriggerRouter.route', () => {
       // Without lastStepNotes, maybeRunDelivery returns early (trigger-router.ts ~line 259).
       const fakeExec: ExecFn = vi.fn().mockResolvedValue({ stdout: '[main abc1234] feat(mcp): auto-commit\n', stderr: '' });
 
-      const trigger = makeTrigger({ autoCommit: true });
+      const trigger = makeTrigger({
+        autoCommit: true,
+        deliveryConfig: synthesizeDeliveryConfig({ autoCommit: true }),
+      });
       const { fn } = makeFakeRunWorkflow(VALID_HANDOFF_NOTES);
       const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn, { execFn: fakeExec });
 
@@ -507,6 +511,7 @@ describe('TriggerRouter.route', () => {
         branchStrategy: 'worktree',
         workspacePath: '/workspace',
         branchPrefix: BRANCH_PREFIX,
+        deliveryConfig: synthesizeDeliveryConfig({ autoCommit: true }),
       });
 
       const fn: RunWorkflowFn = async (t) => ({
@@ -2246,29 +2251,23 @@ describe('TriggerRouter: explicit github_draft_review delivery', () => {
     expect(deprecationWarned).toBe(false);
   });
 
-  it('emits deprecation warning when both reviewerIdentity and explicit deliveryConfig are set', async () => {
+  it('does not emit reviewerIdentity redundancy warning (field removed from WorkflowTrigger in Phase 5)', async () => {
+    // reviewerIdentity was removed from WorkflowTrigger in Phase 5 -- the warning is gone.
+    // Verify no spurious warnings fire.
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { fn } = makeFakeRunWorkflow();
-
-    // Trigger in index has both reviewerIdentity AND explicit github_draft_review
-    // (the warning only fires when explicit config includes github_draft_review)
     const trigger = makeTrigger({
       deliveryConfig: {
         source: 'explicit' as const,
         adapters: [{ kind: 'github_draft_review' as const, token: 'tok', login: 'user' }],
       },
-      reviewerIdentity: { platform: 'github', token: 'tok', login: 'user' },
     });
-
     const router = new TriggerRouter(makeIndex(trigger), FAKE_CTX, FAKE_API_KEY, fn);
     await router.route(makeEvent({ action: 'push' }));
     await new Promise(r => setTimeout(r, 50));
-
-    const warned = warnSpy.mock.calls.some(args =>
-      String(args[0]).includes('reviewerIdentity is redundant'),
-    );
+    const redundancyWarned = warnSpy.mock.calls.some(args => String(args[0]).includes('reviewerIdentity is redundant'));
     warnSpy.mockRestore();
-    expect(warned).toBe(true);
+    expect(redundancyWarned).toBe(false);
   });
 
   it('does NOT emit deprecation warning when only reviewerIdentity is set (no explicit deliveryConfig)', async () => {

--- a/tests/unit/trigger-store.test.ts
+++ b/tests/unit/trigger-store.test.ts
@@ -2032,3 +2032,46 @@ triggers:
     expect(result.value.triggers).toHaveLength(0);
   });
 });
+
+describe('reviewerIdentity YAML removal', () => {
+  it('silently ignores reviewerIdentity: block in triggers.yml', () => {
+    const yaml = `
+triggers:
+  - id: review-trigger
+    provider: generic
+    workflowId: wr.mr-review
+    workspacePath: /workspace
+    goal: Review PR
+    reviewerIdentity:
+      platform: github
+      token: mytoken
+      login: myuser
+`;
+    // reviewerIdentity: block is no longer parsed -- trigger loads successfully
+    // and reviewerIdentity fields are silently dropped
+    const result = loadTriggerConfig(yaml, {});
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.value.triggers).toHaveLength(1);
+  });
+
+  it('rejects delivery: { kind: git_commit } with a parse error', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const yaml = `
+triggers:
+  - id: commit-trigger
+    provider: generic
+    workflowId: wr.coding-task
+    workspacePath: /workspace
+    goal: Commit
+    delivery:
+      kind: git_commit
+`;
+    const result = loadTriggerConfig(yaml, {});
+    warnSpy.mockRestore();
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+    // git_commit via delivery: block is rejected -- trigger is skipped
+    expect(result.value.triggers).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Rebased Phase 5 onto main (after Phase 4 merged via #1062).

- Removes `maybeRunDelivery()` and `maybeRunPostWorkflowActions()`
- Unified delivery through `_runDeliveryByKind()`
- Removes `WorkflowTrigger.reviewerIdentity`
- Gate resume on GitHub review submission
- Inline review comments
- callbackUrl unification via `runCallbackUrlDelivery()`
- All audit blocker fixes applied

See #1059 for full description and review history.