### PR TITLE
fix(engine): complete TriggerDefinition.reviewerIdentity removal and cleanup

### DIFF
--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -197,29 +197,36 @@ The delivery pipeline was extracted into `delivery-pipeline.ts` with explicit st
 
 ### Pluggable output delivery: workflows produce structured artifacts, delivery is configured externally (May 19, 2026)
 
-**Status: partial** | Shipped PRs #1054, #1055 (Phases 1-3)
+**Status: partial** | Phases 1-7 shipped (PRs #1054, #1055, #1062-#1063, #1065, #1067, May 20 2026), needs verification + Phase 8 gaps remain
 
 **Score: 12** | Cor:2 Cap:3 Eff:1 Lev:3 Con:2 | Blocked: no
 
-**What shipped (Phases 1-3, May 20 2026):**
-- `DeliveryAdapter<K>` generic interface, `AdapterConfig` discriminated union, `DeliveryConfig` (source: 'explicit' | 'synthesized'), `resolveDeliveryConfig()` pure function, `CliInboxAdapter` -- in `src/trigger/delivery-adapter.ts`
-- `synthesizeDeliveryConfig()` migration shim wires legacy `autoCommit`/`reviewerIdentity`/`callbackUrl` fields into typed `DeliveryConfig` on every `TriggerDefinition`
-- `delivery: { kind: cli_inbox }` YAML block in triggers.yml activates explicit delivery; `adapter.deliver()` fires for `cli_inbox` adapters on session completion
-- `DeliveryPlannedEvent` added to daemon event log at session start
+**What shipped (all phases complete):**
+- `DeliveryAdapter<K>` generic interface, `AdapterConfig` discriminated union, `DeliveryConfig` (source: 'explicit'|'synthesized'), `CliInboxAdapter`, `GitCommitDeliveryContext` interface
+- `synthesizeDeliveryConfig()` migration shim; `_runDeliveryByKind()` unified delivery dispatch
+- `delivery: { kind: github_draft_review, token: $TOKEN, login: user }` YAML block replacing legacy `reviewerIdentity`
+- Inline review comments posted to PR diff for findings with `file`+`startLine` fields
+- Gate resume: `PendingDraftReviewPoller` calls `resumeFromGate()` fire-and-forget when operator submits review -- `human_approval` gate loop completes automatically
+- `PendingDeliverySidecar` self-contained format (token in state, no trigger index lookup on restart)
 - `TriggerRouterOptions` object replaces 14 positional constructor params
+- `reviewerIdentity` fully removed from `WorkflowTrigger`, `TriggerDefinition`, and YAML parser
+- `callbackUrl` delivery unified through `runCallbackUrlDelivery()` named action
+- `triggers.yml` migrated to `delivery:` block format
 - Full design doc at `docs/plans/output-delivery-design.md`
 
-**What remains (Phase 4):**
-- Replace `maybeRunDelivery()` (git_commit) and `maybeRunPostWorkflowActions()` (github_draft_review) with `adapter.deliver()` calls for all adapter kinds -- this is when operators can switch review posting from GitHub to GitLab/Slack by changing config
-- Extend `delivery: { kind: ... }` YAML block to support adapter-specific fields (token/login for github_draft_review, webhookUrl for slack_webhook)
-- Deprecate and remove `reviewerIdentity` from `WorkflowTrigger` (currently duplicates `deliveryConfig`)
-- `worktrain trigger validate` should print the resolved delivery adapter per trigger
-- Shared `OutboxMessage` type extraction (currently duplicated between `CliInboxAdapter` and `worktrain-inbox.ts`)
-- Long-term: event-sourced delivery bus (C3 from design doc) for full auditability
+**Needs verification before declaring fully production-ready:**
+- End-to-end test: fire a real `wr.mr-review` session with `delivery: { kind: github_draft_review }` in triggers.yml (no reviewerIdentity) and confirm draft review posts, inline comments appear, and gate resumes when operator submits
+- Manual verification that `recoverPendingDeliveryPollers()` correctly restarts pollers after daemon crash
+- Philosophical alignment audit: ensure the `DeliveryAdapter` layer boundary (trigger/ not daemon/) holds for all new code; verify `source: 'explicit'|'synthesized'` discriminant is used only where intended and not leaking as a gate for unrelated decisions
+- Code verification: confirm `writePendingDeliverySidecar()` is called at every review posting site (not just one)
 
-**Things still to hash out for Phase 4:**
-- YAML delivery block currently only supports `kind:` (flat scalar). Adapter-specific fields (token, login) need a sub-object parser extension.
-- dispatch() path still has no deliver() call -- sessions started programmatically don't get delivery notifications yet.
+**Known remaining gaps (Phase 8+):**
+- `dispatch()` path delivery (programmatic sessions don't get delivery notifications)
+- Slack/GitLab adapters
+- Event-sourced delivery bus (C3 from design doc) for full auditability
+- `callbackUrl` still fires through separate `runCallbackUrlDelivery()` path rather than `_runDeliveryByKind()`
+- `worktrain trigger validate` doesn't yet show resolved delivery adapter per trigger
+- Shared `OutboxMessage` type extraction (duplicated between `CliInboxAdapter` and `worktrain-inbox.ts`)
 
 ---
 

--- a/src/daemon/startup-recovery.ts
+++ b/src/daemon/startup-recovery.ts
@@ -248,12 +248,13 @@ export async function runStartupRecovery(
   // always run, even if session recovery fails or ctx is absent.
   await clearQueueIssueSidecars(sessionsDir);
 
-  // Phase B: Restart PendingDraftReviewPoller for any orphaned pending-draft sidecars.
-  // WHY here (after queue-issue cleanup, before session recovery): pending-draft recovery
-  // is independent of session token state and runs regardless of ctx being present.
-  // Requires triggerIndex to look up reviewerIdentity.token (not stored in the sidecar).
+  // Phase B: Restart pollers for orphaned pending review sidecars.
+  // Both old (pending-draft-*.json) and new (pending-delivery-*.json) formats.
   if (ctx?.v2 && triggerIndex && triggerIndex.size > 0) {
     await recoverPendingDraftPollers(sessionsDir, ctx, triggerIndex, reviewApprovalAdapterFn);
+  }
+  if (ctx?.v2) {
+    await recoverPendingDeliveryPollers(sessionsDir, ctx, reviewApprovalAdapterFn);
   }
 
   // Read all parseable session files.
@@ -691,18 +692,15 @@ export async function clearQueueIssueSidecars(sessionsDir: string): Promise<void
 /**
  * Restart PendingDraftReviewPoller instances for orphaned pending-draft sidecars.
  *
- * Called by runStartupRecovery() when triggerIndex is available. For each
- * pending-draft-*.json sidecar found, looks up the trigger by triggerId to get
- * the reviewerIdentity.token (which is NOT stored in the sidecar for security),
- * then restarts polling. If the trigger no longer exists, logs a warning and
- * deletes the sidecar.
+ * Token is read directly from the sidecar (self-contained) -- no trigger index lookup needed.
+ * Sidecars without token/login (created before Phase 7) are deleted; they cannot be recovered.
  *
  * Non-fatal: any error is caught and logged. Never throws.
  */
 async function recoverPendingDraftPollers(
   sessionsDir: string,
   ctx: import('../mcp/types.js').V2ToolContext,
-  triggerIndex: ReadonlyMap<string, import('../trigger/types.js').TriggerDefinition>,
+  _triggerIndex: ReadonlyMap<string, import('../trigger/types.js').TriggerDefinition>,
   reviewApprovalAdapterFn?: () => import('../trigger/review-approval-adapter.js').ReviewApprovalAdapter,
 ): Promise<void> {
   const { readAllPendingDraftSidecars, PendingDraftReviewPoller, GitHubReviewApprovalAdapter } =
@@ -717,12 +715,13 @@ async function recoverPendingDraftPollers(
 
   console.log(`[StartupRecovery] Found ${sidecars.length} orphaned pending-draft review sidecar(s). Restarting pollers.`);
 
+  // WHY token from sidecar (not trigger): TriggerDefinition.reviewerIdentity was removed.
+  // Old pending-draft sidecars now store the token directly in the sidecar itself.
   for (const sidecar of sidecars) {
-    const trigger = triggerIndex.get(sidecar.triggerId);
-    if (!trigger?.reviewerIdentity) {
+    if (!sidecar.token || !sidecar.login) {
       console.warn(
-        `[StartupRecovery] Pending-draft sidecar trigger '${sidecar.triggerId}' not found or has no reviewerIdentity. ` +
-        `Deleting sidecar for daemonSessionId=${sidecar.daemonSessionId}.`,
+        `[StartupRecovery] Pending-draft sidecar for daemonSessionId=${sidecar.daemonSessionId} ` +
+        `has no token/login. Deleting (pre-Phase7 sidecar without self-contained credentials).`,
       );
       await fs.unlink(path.join(sessionsDir, `pending-draft-${sidecar.daemonSessionId}.json`)).catch(() => {});
       continue;
@@ -735,8 +734,8 @@ async function recoverPendingDraftPollers(
       prNumber: sidecar.prNumber,
       prRepo: sidecar.prRepo,
       reviewId: sidecar.reviewId,
-      token: trigger.reviewerIdentity.token,
-      login: trigger.reviewerIdentity.login,
+      token: sidecar.token,
+      login: sidecar.login,
       workrailSessionId: sidecar.workrailSessionId,
       daemonSessionId: sidecar.daemonSessionId,
       sessionStore: ctx.v2.sessionStore,
@@ -750,6 +749,60 @@ async function recoverPendingDraftPollers(
       `[StartupRecovery] Restarted PendingDraftReviewPoller: ` +
       `daemonSessionId=${sidecar.daemonSessionId} prRepo=${sidecar.prRepo} prNumber=${sidecar.prNumber}`,
     );
+  }
+}
+
+/**
+ * Restart pollers for orphaned pending-delivery-*.json sidecars (generalized format).
+ * Token and credentials are embedded in the sidecar state -- no external lookup needed.
+ * Dispatches by adapterId; only 'github_draft_review' is implemented today.
+ *
+ * Non-fatal: any error is caught and logged. Never throws.
+ */
+async function recoverPendingDeliveryPollers(
+  sessionsDir: string,
+  ctx: import('../mcp/types.js').V2ToolContext,
+  reviewApprovalAdapterFn?: () => import('../trigger/review-approval-adapter.js').ReviewApprovalAdapter,
+): Promise<void> {
+  const { readAllPendingDeliverySidecars, PendingDraftReviewPoller } =
+    await import('../trigger/pending-draft-review-poller.js');
+  const { GitHubReviewApprovalAdapter } =
+    await import('../trigger/review-approval-adapter.js');
+
+  const sidecars = await readAllPendingDeliverySidecars(sessionsDir);
+  if (sidecars.length === 0) return;
+
+  console.log(`[StartupRecovery] Found ${sidecars.length} orphaned pending-delivery sidecar(s). Restarting pollers.`);
+
+  for (const sidecar of sidecars) {
+    if (sidecar.adapterId !== 'github_draft_review') {
+      console.warn(`[StartupRecovery] Unknown adapterId '${sidecar.adapterId}' -- skipping.`);
+      continue;
+    }
+
+    const s = sidecar.state as { reviewId?: number; prNumber?: number; prRepo?: string; token?: string; login?: string; workrailSessionId?: string };
+    if (!s.reviewId || !s.prNumber || !s.prRepo || !s.token || !s.login) {
+      console.warn(`[StartupRecovery] Incomplete pending-delivery sidecar state for ${sidecar.daemonSessionId} -- skipping.`);
+      continue;
+    }
+
+    if (!ctx.v2) continue;
+    const adapter = reviewApprovalAdapterFn ? reviewApprovalAdapterFn() : new GitHubReviewApprovalAdapter();
+    const poller = new PendingDraftReviewPoller(adapter, {
+      prNumber: s.prNumber,
+      prRepo: s.prRepo,
+      reviewId: s.reviewId,
+      token: s.token,
+      login: s.login,
+      workrailSessionId: s.workrailSessionId ?? '',
+      daemonSessionId: sidecar.daemonSessionId,
+      sessionStore: ctx.v2.sessionStore,
+      gate: ctx.v2.gate,
+      mintEventId: ctx.v2.idFactory.mintEventId.bind(ctx.v2.idFactory),
+      sessionsDir,
+    });
+    poller.start();
+    console.log(`[StartupRecovery] Restarted pending-delivery poller: daemonSessionId=${sidecar.daemonSessionId}`);
   }
 }
 

--- a/src/trigger/polling-scheduler.ts
+++ b/src/trigger/polling-scheduler.ts
@@ -732,7 +732,6 @@ function buildGitLabWorkflowTrigger(
     ...(trigger.branchStrategy !== undefined ? { branchStrategy: trigger.branchStrategy } : {}),
     ...(trigger.baseBranch !== undefined ? { baseBranch: trigger.baseBranch } : {}),
     ...(trigger.branchPrefix !== undefined ? { branchPrefix: trigger.branchPrefix } : {}),
-    ...(trigger.reviewerIdentity !== undefined ? { reviewerIdentity: trigger.reviewerIdentity } : {}),
   };
 }
 
@@ -787,7 +786,6 @@ function buildGitHubWorkflowTrigger(
     ...(trigger.branchStrategy !== undefined ? { branchStrategy: trigger.branchStrategy } : {}),
     ...(trigger.baseBranch !== undefined ? { baseBranch: trigger.baseBranch } : {}),
     ...(trigger.branchPrefix !== undefined ? { branchPrefix: trigger.branchPrefix } : {}),
-    ...(trigger.reviewerIdentity !== undefined ? { reviewerIdentity: trigger.reviewerIdentity } : {}),
   };
 }
 

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -1237,18 +1237,6 @@ export class TriggerRouter {
       await this._runDeliveryByKind(workflowTrigger, originalResult, trigger.id, deliveryDeps);
 
       // Deprecation: warn when legacy reviewerIdentity on TriggerDefinition is redundant with
-      // explicit delivery: { kind: github_draft_review } block. Uses trigger.reviewerIdentity
-      // (from TriggerDefinition) since WorkflowTrigger.reviewerIdentity was removed in Phase 5.
-      if (
-        trigger.reviewerIdentity !== undefined &&
-        workflowTrigger.deliveryConfig?.source === 'explicit' &&
-        workflowTrigger.deliveryConfig.adapters.some(a => a.kind === 'github_draft_review')
-      ) {
-        console.warn(
-          `[TriggerRouter] reviewerIdentity in triggers.yml is redundant when delivery: { kind: github_draft_review } is configured ` +
-          `(triggerId=${trigger.id}). Remove reviewerIdentity from triggers.yml.`,
-        );
-      }
     });
 
     return { _tag: 'enqueued', triggerId: trigger.id };

--- a/src/trigger/trigger-store.ts
+++ b/src/trigger/trigger-store.ts
@@ -1777,9 +1777,7 @@ export function validateTriggerStrict(
   // Rule: reviewer-identity-without-read-only (warning)
   // reviewer-assigned PR review sessions need branchStrategy: 'read-only' to checkout the PR
   // branch in an isolated worktree so concurrent reviews don't clobber the main checkout.
-  // Applies to both legacy reviewerIdentity and explicit delivery: { kind: github_draft_review }.
   const hasReviewDelivery =
-    trigger.reviewerIdentity !== undefined ||
     trigger.deliveryConfig?.adapters.some(a => a.kind === 'github_draft_review') === true;
   if (hasReviewDelivery && trigger.branchStrategy !== 'read-only') {
     issues.push({

--- a/src/trigger/types.ts
+++ b/src/trigger/types.ts
@@ -698,20 +698,6 @@ export interface TriggerDefinition {
   readonly branchStrategy?: 'worktree' | 'none' | 'read-only';
 
   /**
-   * Platform-agnostic reviewer identity. The `platform` field discriminates
-   * which ReviewApprovalAdapter implementation is used at dispatch time.
-   * New platforms (e.g. 'jira', 'linear') are added as new union members
-   * without changing existing callers.
-   *
-   * In YAML:
-   *   reviewerIdentity:
-   *     platform: github          # or: gitlab
-   *     token: $GITHUB_REVIEWER_TOKEN
-   *     login: etienneb
-   */
-  readonly reviewerIdentity?: ReviewerIdentity;
-
-  /**
    * Delivery configuration for this trigger.
    * Always set by validateAndResolveTrigger(): explicit YAML block or synthesized from legacy fields.
    */

--- a/triggers.yml
+++ b/triggers.yml
@@ -47,8 +47,8 @@ triggers:
     concurrencyMode: parallel
     branchStrategy: read-only
     autoCommit: false
-    reviewerIdentity:
-      platform: github
+    delivery:
+      kind: github_draft_review
       token: $GITHUB_REVIEWER_TOKEN
       login: EtienneBBeaulac
     contextMapping:


### PR DESCRIPTION
## Summary

Cleanup commit completing what Phase 7 left unfinished due to cherry-pick conflicts.

- **Removes `TriggerDefinition.reviewerIdentity`** -- was unintentionally left during Phase 7 cherry-pick. `PendingDraftSidecar` already stores `token` directly, so trigger index lookup is no longer needed.
- **`recoverPendingDraftPollers()`** now reads token from sidecar directly (no `triggerIndex` dependency). Sidecars without token (pre-Phase 7) are deleted on startup.
- **Adds `recoverPendingDeliveryPollers()`** to `startup-recovery.ts` -- was missing from main after cherry-pick conflicts skipped it.
- Removes stale `reviewerIdentity` forwarding from `polling-scheduler.ts`
- Removes stale deprecation warning in `trigger-router.ts`
- Removes stale `reviewerIdentity` check from `validateTriggerStrict` in `trigger-store.ts`
- **Migrates `triggers.yml`**: `reviewerIdentity:` → `delivery: { kind: github_draft_review }`
- Updates backlog: delivery feature marked `partial` with verification requirements noted

## Test plan

- [x] 6235/6235 tests pass
- [x] `tsc --noEmit` clean
- [x] `TriggerDefinition.reviewerIdentity` removed -- tsc confirms no remaining callers
- [x] `recoverPendingDeliveryPollers()` present in startup-recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)