### PR TITLE
feat(engine): SessionCortex, conditional gates, Bedrock-only daemon, dev loop

### DIFF
--- a/.cursor/rules/workrail-executor.mdc
+++ b/.cursor/rules/workrail-executor.mdc
@@ -1,8 +1,6 @@
 ---
-name: workrail-executor
 description: Executes WorkRail workflows step by step using the WorkRail MCP tools. Use when the user wants to run a workflow, follow a structured process, or resume a previous workflow session. Handles start, continue, checkpoint, and resume operations, interpreting each step's instructions faithfully and advancing only when the step is complete.
-model: inherit
-callable: true
+globs: *
 ---
 
 # WorkRail Executor

--- a/.workrail/design-candidates-challenge.md
+++ b/.workrail/design-candidates-challenge.md
@@ -1,0 +1,94 @@
+# Hypothesis Challenge: Removing `requireConfirmation` from `wr.mr-review` phase-6
+
+**Date:** 2026-05-20
+**Challenger workflow:** `wr.routine-hypothesis-challenge`
+**Target candidate:** Candidate A -- remove `requireConfirmation: { kind: 'human_approval' }` from `phase-6-final-handoff` entirely
+
+---
+
+## Target Claim
+
+Candidate A is correct: removing `requireConfirmation` from `phase-6-final-handoff` in `wr.mr-review` allows coordinator-spawned sessions to return `wr.review_verdict` to the parent (fixing C1), while GitHub draft review invisibility provides sufficient safety (C2), and no meaningful work is lost because `resumeFromGate()` does nothing useful anyway.
+
+---
+
+## Strongest Counter-Argument
+
+**Candidate A treats a documented temporary hack as a permanent design decision.**
+
+The `awaitSessions()` implementation in `coordinator-deps.ts` (lines 308-311) explicitly comments: *"Gate checkpoint: treat as terminal for now. PR 2 will dispatch the gate evaluator."* The `paused_at_gate` -> `outcome: 'failed'` mapping is a known, acknowledged workaround -- not an architectural invariant. Candidate A removes the gate (the symptom) rather than fixing the coordinator's gate evaluation (the root cause). Candidate B is the principled fix: it wires `paused_at_gate` to a `coordinator_eval` gate evaluation, making the session properly terminal-success so `getAgentResult()` can read the `wr.review_verdict` artifact. Removing the gate because the coordinator cannot handle it is an architectural patch, not an architectural fix.
+
+**Secondary: the draft posting -> verdict routing ordering is already broken for all wr.mr-review sessions**, not just gate-parked ones. The delivery adapter fires fire-and-forget AFTER `runWorkflowFn` returns in `TriggerRouter`. The coordinator calls `getAgentResult()` before the draft is posted. This means Candidate A does not introduce a new race -- it already exists. But it also means the C2 "draft invisibility" safety argument was never what the gate was providing. The gate was providing session-level durable state: the `review_draft_submitted` event in the WorkRail session log, and the operator-driven `resumeFromGate()` call that advances the terminal step. Removing the gate removes this durable record.
+
+---
+
+## Weak Assumptions / Evidence Gaps
+
+1. **"GitHub drafts are invisible" is partially true, not a platform guarantee.** PENDING drafts are invisible in the GitHub UI to PR authors and reviewers. They are NOT invisible to the GitHub REST API -- any automation with repo read access can enumerate PENDING draft reviews. In organizations with CI bots or review automation this is a real exposure. This is an organizational dependency masquerading as a platform safety property.
+
+2. **"resumeFromGate() does no meaningful work" is correct for the current session but wrong for observability.** The gate resume call writes a `review_draft_submitted` event to the WorkRail session log. Removing the gate removes this record. For standalone sessions (not coordinator-spawned), this is the only durable signal that the operator actually published the review. WorkRail would lose the ability to distinguish "review was drafted and abandoned" from "review was drafted and published."
+
+3. **The C1 bug fix is real but mis-attributed.** The coordinator cannot read `wr.review_verdict` because `getAgentResult()` is only called for sessions where `awaitSessions()` returns `success`. A gate-parked session returns `failed` and the coordinator escalates before calling `getAgentResult()`. Candidate A fixes this by making the session succeed -- but Candidate B fixes it by making `paused_at_gate` sessions evaluable and eventually terminal-success. The attribution of "removing the gate fixes C1" is correct only if the coordinator's gate evaluation path is never going to be built.
+
+---
+
+## Likely Failure Modes if Candidate A is Adopted
+
+| Failure Mode | Severity | Likelihood |
+|---|---|---|
+| Organization adds API-level review monitoring; PENDING drafts are now visible to automation before operator review | Medium | Low-Medium |
+| Operator never publishes a draft review; no durable record in WorkRail that it was abandoned | Low | High (this is normal usage) |
+| `wr.gate-eval-generic` is built later for other gates; `wr.mr-review` has no mechanism to opt in without a workflow version bump | Medium | High |
+| Coordinator pipeline auto-merges based on `wr.review_verdict: clean`, but the GitHub draft (posted asynchronously) contains blocking findings the coordinator never saw | High | Low (requires review agent to produce inconsistent artifact vs findings) |
+
+---
+
+## Alternative Explanations
+
+**Why the gate looks safe to remove:**
+The current gate's only observable effect is delaying the `gate_parked` -> `failed` coordinator escalation path. Since the draft is posted before the gate fires and `resumeFromGate()` advances only the terminal step, it appears to do nothing useful in autonomous mode. This appearance is correct for the coordinator scenario but incorrect for the standalone and observability scenarios.
+
+**Why Candidate C is the right pragmatic choice:**
+- `verdict: clean` and `verdict: minor` reviews have no high-severity findings. The probability that an autonomous draft of a clean review would embarrass the organization if seen early is very low.
+- `verdict: blocking` reviews contain Critical or Major findings. These are exactly the reviews where organizational safety concerns are highest: the content could unfairly characterize a developer's work, could be based on a false-positive finding, or could trigger a PR close before the author has a chance to respond.
+- Candidate C preserves the gate exactly where its C2 value is highest (blocking verdicts) while removing it where it only causes C1 problems (clean/minor verdicts).
+
+---
+
+## Critical Tests
+
+To verify Candidate A is wrong (not merely suboptimal):
+
+1. **Test:** Run a standalone `wr.mr-review` session via a webhook trigger configured with `github_draft_review` delivery. The operator never submits the draft. After 30 days, query the WorkRail session store for whether the review was published. **Expected (Candidate A):** session store shows `complete` with no publication record. Operator has no audit trail. **Expected (Candidate B/C):** session store retains `gate_parked` state, startup recovery detects the abandoned gate, and an escalation is posted to the outbox.
+
+2. **Test:** Run `wr.mr-review` as a coordinator child session (FULL pipeline Stage 7). The review agent produces `verdict: blocking`. With Candidate A: the coordinator reads the `blocking` verdict, runs `runAuditChain()`, and posts the draft -- which now has no operator-approval gate. The draft could contain findings that were contradicted by the audit chain. **Expected (Candidate C):** blocking verdicts still trigger the gate; the draft is never posted without operator review.
+
+3. **Architectural test:** Add a `review_draft_submitted` event query to WorkRail console. With Candidate A, this query returns nothing for sessions where the operator chose not to publish. With Candidate B/C, the gate state is preserved until the operator acts or the session times out.
+
+---
+
+## Verdict: Revise (reject Candidate A as-is; prefer Candidate C as pragmatic, Candidate B as principled)
+
+**Reject Candidate A for three reasons:**
+1. It papers over a documented temporary architectural hack (`awaitSessions()` PR 2 comment) instead of fixing it.
+2. It removes the only durable record of operator gate-resume in standalone sessions.
+3. It makes the safety property irrecoverable -- once the gate is gone, blocking-verdict sessions have no operator review step without a workflow version bump.
+
+**Recommend Candidate C** as the pragmatic path:
+- Remove the gate for `clean` and `minor` verdicts (satisfies C1, C3, C5 for the common case)
+- Retain the gate for `blocking` verdicts (preserves C2 where it matters most)
+- Implement as a conditional `requireConfirmation` using the existing `{ or: [...] }` pattern already used in the workflow (see `phase-0-understand-and-classify` and `phase-5-final-validation`)
+
+**Recommend Candidate B** as the principled long-term path:
+- Fix `awaitSessions()` to properly evaluate `paused_at_gate` sessions via `wr.gate-eval-generic`
+- Once the coordinator can evaluate gates, `requireConfirmation` in `wr.mr-review` becomes a quality checkpoint rather than a C1 bug
+
+---
+
+## Next Action
+
+If the team proceeds with Candidate A: add an explicit comment to the workflow documenting the lost audit trail property and add a `postToOutbox` call in the delivery adapter when `resumeFromGate` would have fired. This partially restores observability.
+
+If the team proceeds with Candidate C: implement conditional `requireConfirmation` using `{ var: 'verdict', equals: 'blocking' }` in the step definition. Verify via lifecycle tests that `clean` and `minor` verdict sessions complete without gate, and `blocking` verdict sessions park at the gate.
+
+If the team proceeds with Candidate B: wire the `paused_at_gate` -> `coordinator_eval` path in `awaitSessions()` (the PR 2 comment). This fixes the root cause and makes `requireConfirmation` safe to keep in the workflow for all verdict types.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,7 +337,15 @@ worktrain console
 - Reads `triggers.yml` from the repo root (same as production)
 - All `worktrain` commands talk to port 3200 regardless of how the daemon was started -- they work identically against a dev daemon
 
-**No watch mode for the daemon** -- unlike the MCP server, the daemon has in-flight sessions that would be killed ungracefully on restart. To test a code change: stop the daemon (Ctrl-C), run `npm run build`, restart with `npm run dev:daemon`.
+**No watch mode for the daemon** -- unlike the MCP server, the daemon has in-flight sessions that would be killed ungracefully on restart.
+
+**Investigating rg hangs** -- there is a known intermittent issue where `rg` run inside a worktree hangs for 120s before being killed by the stall timer. Root cause is not yet confirmed. To capture diagnostics when the hang occurs, run this in a third terminal alongside the daemon:
+
+```bash
+npm run dev:watch-hangs
+```
+
+This polls for rg processes in worktrees and auto-captures `lsof` (open files), `sample` (call stack / blocked syscall), and `opensnoop` (real-time file opens) when any rg takes longer than 2 seconds. Diagnostics are written to `~/.workrail/dev/rg-hang-<timestamp>.txt`. To test a code change: stop the daemon (Ctrl-C), run `npm run build`, restart with `npm run dev:daemon`.
 
 **To wipe dev session state between test runs:**
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,36 @@ npm run dev:mcp
 
 **Config note:** The project `.mcp.json` `workrail` entry should shadow the global `~/.claude/settings.json` entry when Claude Code is started from this repo. Verify via `/mcp` on first use -- if two `workrail` entries appear, rename the `.mcp.json` entry to `workrail-dev`.
 
+### Local dev loop (daemon / WorkTrain)
+
+To test the WorkTrain daemon from a branch before merging -- including full autonomous pipeline runs, webhook dispatch, and end-to-end review flows:
+
+```bash
+# Terminal 1: build and start an isolated daemon instance
+npm run build && npm run dev:daemon
+
+# Terminal 2: use any worktrain command against the running dev daemon
+worktrain dispatch --pr 1051 -w /path/to/repo
+worktrain dispatch "implement the foo feature" -w /path/to/repo
+worktrain logs --follow
+worktrain diagnose
+worktrain session events <id>
+worktrain console
+```
+
+**What `dev:daemon` does differently from the production daemon:**
+- Writes all session data, logs, and sidecars to `~/.workrail/dev/` instead of `~/.workrail/` -- no contamination of production sessions
+- Sets `WORKRAIL_DEFAULT_WORKSPACE` to the repo root automatically
+- Reads `triggers.yml` from the repo root (same as production)
+- All `worktrain` commands talk to port 3200 regardless of how the daemon was started -- they work identically against a dev daemon
+
+**No watch mode for the daemon** -- unlike the MCP server, the daemon has in-flight sessions that would be killed ungracefully on restart. To test a code change: stop the daemon (Ctrl-C), run `npm run build`, restart with `npm run dev:daemon`.
+
+**To wipe dev session state between test runs:**
+```bash
+rm -rf ~/.workrail/dev
+```
+
 ## When adding a new engine feature
 
 A "new engine feature" means any of:

--- a/docs/authoring-v2.md
+++ b/docs/authoring-v2.md
@@ -308,6 +308,30 @@ The boolean form (`requireConfirmation: true`) is equivalent to `{ "kind": "coor
 
 MCP sessions are unaffected by gate kind -- `requireConfirmation` never fires for MCP sessions (only daemon sessions with `is_autonomous: 'true'` context).
 
+#### Conditional gates
+
+Both gate kinds accept an optional `condition` field that controls whether the gate fires at all:
+
+```json
+{ "requireConfirmation": { "kind": "human_approval", "condition": { "not": { "var": "recommendation", "equals": "clean" } } } }
+```
+
+When `condition` is present, the gate only fires if the condition evaluates to `true` against the session context at advance time. When absent, the gate fires unconditionally (same as `{ "kind": "..." }` without a condition).
+
+**Critical invariant:** The context variable referenced in a `condition` must be set by a **prior step**, not by the gated step itself. `requireConfirmation` is evaluated when the engine advances INTO the step -- before the step executes. A variable produced by the current step's outputContract or agent notes is not yet in context when the condition fires.
+
+Wrong:
+```json
+{ "kind": "human_approval", "condition": { "not": { "var": "verdict", "equals": "clean" } } }
+```
+`verdict` is the field the agent will set on the `wr.review_verdict` artifact in THIS step -- it doesn't exist in context yet.
+
+Correct:
+```json
+{ "kind": "human_approval", "condition": { "not": { "var": "recommendation", "equals": "clean" } } }
+```
+`recommendation` is set by a prior synthesis step via `inputContext`.
+
 ---
 
 ### Assessment-gate authoring (v1)

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -468,6 +468,24 @@ Canonical current rules for authoring good WorkRail workflows. workflow.schema.j
 **Source refs**
 - `workflows/coding-task-workflow-agentic.json` (example) — Uses confirmation for real review barriers like MultiPR checkpoints.
 
+### conditional-gate-context-timing
+- **Level**: required
+- **Status**: active
+- **Scope**: step.confirmation, workflow.authoring
+- **Rule**: The context variable referenced in a requireConfirmation condition must be set by a prior step, not by the gated step itself.
+- **Why**: requireConfirmation is evaluated when the engine advances INTO the step, before the step runs. A variable set by the gated step is not yet in context when the condition fires -- it will be undefined and the condition will silently produce the wrong result.
+- **Enforced by**: advisory
+
+**Checks**
+- The condition var must reference a context key set by a previous step via inputContext.
+- Do not reference output artifact fields produced by the current step -- those are not yet in context at gate evaluation time.
+
+**Anti-patterns**
+- Conditioning on verdict (set by the current step's outputContract) instead of recommendation (set by a prior synthesis step)
+
+**Source refs**
+- `src/mcp/handlers/v2-advance-core/index.ts` (runtime) — isGateRequired() is called at advance time, before the step executes.
+
 
 ## Assessment gates
 ### assessment-use-for-bounded-judgment

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -114,6 +114,66 @@ A session harness is a layer that sits between the agent loop and the engine and
 
 ---
 
+### wr.mr-review spawns full workflow children -- blocking review MVP (May 21, 2026)
+
+**Status: bug** | Priority: critical
+
+**Score: 15** | Cor:3 Cap:3 Eff:3 Lev:3 Con:3 | Blocked: no
+
+`wr.mr-review` phase-4b spawns reviewer families via `spawn_agent` with `workflowId: wr.mr-review`. Each child independently runs the full 9-phase review from scratch -- rebuilding context, running synthesis loops, potentially spawning its own sub-agents. Three children × full review session = 3× the token cost, 200+ turns per child, and the parent's stall timer fires before any child advances a step (C2 callback only fires on step advances, not LLM turns -- see C2 bug below). The session confirmed: parent died at turn 67, all three children ran to max_turns or stuck independently, results were never collected.
+
+**Immediate fix (MVP unblock):** Change phase-4b to spawn bounded routines instead of full `wr.mr-review` instances. Options: (a) use `wr.routine-hypothesis-challenge` for adversarial review passes, (b) use a custom bounded auditor routine that takes the parent's pre-assembled fact packet as context and returns a structured finding report, (c) remove parallel delegation entirely for now and run reviewer families sequentially as steps. Option (c) is the safest MVP fix -- no infrastructure changes needed, just workflow edits.
+
+**Related:** The C2 stall timer bug (parent stall timer not reset by child LLM activity) makes this worse but is a separate issue.
+
+---
+
+### C2 callback bug: parent stall timer not reset by child LLM activity (May 21, 2026)
+
+**Status: bug** | Priority: high
+
+**Score: 13** | Cor:3 Cap:1 Eff:3 Lev:2 Con:3 | Blocked: no
+
+`spawn_agent` is supposed to use the C2 mechanism to reset the parent's stall timer whenever a child session makes progress, preventing the parent from being killed while legitimately waiting for children. The callback (`notifyParentActivity`) is only wired to the `onAdvance` closure -- it fires only when a child **advances a workflow step**. Children that spend their first 2+ minutes in phase-0 research (no step advances) do not reset the parent's stall timer at all. The parent's `stallTimeoutSeconds=120` fires while children are actively running, killing the parent.
+
+**Evidence:** `df8c006c` stalled at 07:57:43 exactly 120s after spawning children at 07:55:29. Children `5a2f73c8`, `4429275c`, `9d58c9fe` were making LLM turns every 3-5 seconds the entire time but no step advances occurred, so C2 never fired.
+
+**Fix:** Wire `notifyParentActivity` to `onLlmTurnStarted` and `onLlmTurnCompleted` in `buildAgentCallbacks()` in `agent-loop-runner.ts`, not just to `onAdvance`. The comment on lines 192-204 already describes this intent but it's not implemented -- `notifyParentActivity` is only passed to `onAdvance`, not to `agentCallbacks`.
+
+---
+
+### Coordinator-intercepted delegation: workflow-declared parallel tasks owned by coordinator, not agent (May 21, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 11** | Cor:2 Cap:3 Eff:1 Lev:3 Con:1 | Blocked: no
+
+**Needs full exploration before any implementation.** The design direction is promising but has open questions that require a `wr.discovery` session before coding begins.
+
+**The problem:** `spawn_agent` as a tool called from within the agent loop puts too much responsibility on the agent: it decides to delegate, constructs child tasks, blocks waiting for children, and synthesizes results -- all while burning turns and stall timer budget. The parent's stall timer has no awareness that the agent is legitimately waiting for children. When a review workflow spawns 3 parallel reviewer families, the parent dies waiting because C2 doesn't fire fast enough.
+
+**The direction:** The coordinator intercepts structured delegation instead of the agent executing it. A workflow step emits a `wr.coordinator_signal` artifact with `signalKind: delegation_needed` and a task list. The coordinator sees it, spawns bounded task agents autonomously (not workflow sessions -- just goal + tools + return last message), waits for them deterministically outside any agent loop, assembles results, and steers them back into the parent session via `agent.steer()`. The parent's stall timer is irrelevant because the parent's agent loop is **parked** (not running) during delegation.
+
+**Why this is architecturally better than the current model:**
+- Parent stall timer never fires during child execution -- parent isn't running
+- Children are bounded task workers, not full workflow instances
+- Coordinator owns delegation logic deterministically (no LLM routing)
+- Results are assembled and injected cleanly before the parent resumes
+
+**What the workflow declares:** A step can include a `delegationSpec` (needs design) describing what tasks to parallelize, what context to pass each, and how to assemble results. The coordinator reads this at step advance time and decides whether to handle delegation or pass through to the normal advance path.
+
+**Open questions (need discovery before implementation):**
+- Does `wr.coordinator_signal` need a new variant, or does the existing `delegation_needed` signalKind suffice?
+- Should delegation be declared in the workflow JSON (compile-time) or emitted by the agent (runtime)? Compile-time is more predictable; runtime is more flexible.
+- How does the coordinator know which bounded task type to use for each delegation? Does the workflow specify this?
+- What is the interface for a "bounded task agent"? Just goal + tools + end_turn with findings in the last message? Or something more structured?
+- How does this interact with `spawn_agent` as an agent-initiated tool? Both probably have their place -- bounded parallel reviewer families via coordinator vs. dynamic agent-initiated delegation for less structured cases.
+- Is `wr.mr-review` the only workflow that needs this, or does `wr.coding-task` parallel slice execution also benefit?
+
+**MVP path (before coordinator interception):** Fix `wr.mr-review` to use bounded routines or sequential reviewer passes (see above). Coordinator interception is the right long-term architecture but not required to unblock MVP review.
+
+---
+
 ### wr.coding-task forEach loop exposes broken agent-facing state (Apr 30, 2026)
 
 **Status: done** | Shipped May 1, 2026 (PR #926)

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -385,6 +385,29 @@ Agents asked to rebase a branch routinely make the same mistakes: they skip conf
 
 ---
 
+### spawn_agent task worker mode: workflowId-less bounded task spawning (May 21, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 13** | Cor:2 Cap:3 Eff:2 Lev:3 Con:3 | Blocked: no
+
+`spawn_agent` currently requires a `workflowId`, which forces all child sessions into a workflow container even when the child's job is simply "execute this bounded task and return findings." This is architecturally wrong: it makes illegal states representable (a reviewer family that re-runs the full parent workflow), it uses stringly-typed context (no compile-time enforcement that `reviewFactPacket` has the required fields), and it violates the principle that types must constrain not just label.
+
+The proper architecture is a `taskWorker` mode on `spawn_agent`: spawn a bare agent session with goal + tools + typed context contract, runs until `end_turn`, parent reads findings from the final assistant message. No workflow, no `complete_step`, no phases. The task worker terminates naturally when its work is done.
+
+**Current shim:** `wr.routine-reviewer-family` is a 1-step workflow that approximates this behavior. It is explicitly marked as a temporary shim in its description. It should be replaced when this item ships.
+
+**What the proper design requires:**
+- `spawn_agent` gains a `mode: 'task_worker'` field (or workflowId becomes optional)
+- A typed `taskContext` schema replaces the free-form `context: Record<string, unknown>` for task worker spawns
+- The engine validates `taskContext` against the declared schema at spawn time (validate at boundaries)
+- The parent reads the child's final message as the task result -- no artifacts, no outputContract
+- Cancellation propagates: if the parent is aborted, task worker children are also aborted
+
+**Prerequisite for:** coordinator-intercepted delegation (above), proper reviewer family implementation, any future bounded task delegation pattern.
+
+---
+
 ### Per-role model configuration: different models for different session roles (May 21, 2026)
 
 **Status: idea** | Priority: high

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4583,6 +4583,29 @@ The desired behavior: certain content (rules, behavioral constraints, workspace 
 
 ---
 
+### Operator-facing capability toggles: named, discoverable WorkTrain behaviors (May 20, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 11** | Cor:1 Cap:3 Eff:1 Lev:3 Con:2 | Blocked: no
+
+There is no operator-facing concept of "what WorkTrain does." To enable autonomous PR review, an operator must write a `github_prs_poll` trigger with the right provider, workflowId, branchStrategy, delivery config, and agent config -- 15+ lines of YAML requiring deep knowledge of WorkTrain internals. There is no way to look at a config and understand at a human level what behaviors are active. Operators cannot discover what WorkTrain is capable of, only configure it from scratch.
+
+The idea: a `capabilities.yml` or `capabilities:` section in config declares named, toggleable behaviors. Each capability is a pre-configured, opinionated behavior that just works when enabled. Examples: `pr_review` (automatically reviews open PRs assigned to a reviewer), `queue_processor` (picks up tickets assigned to WorkTrain from GitHub), `dependency_bumps` (auto-reviews and merges clean dependabot PRs), `self_improvement` (runs WorkTrain on WorkTrain's own issue queue). The capabilities layer generates the underlying triggers -- operators never write trigger YAML unless they need fine-grained control.
+
+This makes WorkTrain feel like a product rather than a framework. An operator starting fresh can enable `pr_review: true` and have it work without reading documentation about polling providers, delivery adapters, or branch strategies.
+
+**Key design question:** Is this a config-generation layer (capabilities compile down to triggers.yml at daemon start) or a replacement for triggers.yml (capabilities ARE the configuration, triggers are an implementation detail)? The first is backward compatible and lower risk; the second is the cleaner long-term UX. A discovery session is needed before implementation.
+
+**Things to hash out:**
+- Where does capability config live -- `~/.workrail/capabilities.yml`, a section in `config.json`, or alongside triggers.yml in the workspace?
+- How do capabilities interact with existing hand-written triggers -- do they coexist, override, or merge?
+- What is the right set of first-party capabilities to ship? PR review and queue processor are clear; what else is there?
+- Should capabilities expose the same configuration knobs as triggers (model, timeouts, branch strategy), or hide them entirely with sensible defaults?
+- Does `worktrain init` become the entry point for enabling capabilities, replacing manual trigger authoring?
+
+---
+
 ## Platform Vision (longer-term)
 
 ### Epic-mode: full autonomous delivery of a multi-task feature from discovery to merged PRs (Apr 30, 2026)

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -245,6 +245,36 @@ The delivery pipeline was extracted into `delivery-pipeline.ts` with explicit st
 
 ## WorkTrain Daemon
 
+### Dedicated Philosophy Compliance Gate Routine in `wr.coding-task` (May 20, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 11** | Cor:3 Cap:2 Eff:2 Lev:2 Con:2 | Blocked: no
+
+Implementing agents suffer from severe "focus-split" during active coding sessions (handling typescript compilations, terminal test errors, and multi-file logic), causing them to overlook high-level coding philosophies (immutability, exact ESM imports, avoiding parallel mutable states, type safety over primitives). Currently, there is no step in the `wr.coding-task` workflow that forces a late-stage cognitive audit checking for repository-level principles before handoff. This leads to codebases slowly decaying into localized patches despite system-wide instructions.
+
+**Things to hash out:**
+- How should the `routine-philosophy-audit` be modeled? It should likely run as a separate read-only session with a dedicated, isolated subagent that only receives the git diff and the repository principles.
+- What should the `wr.contracts.philosophy_compliance` artifact structure look like? A simple JSON schema mapping modified files to the specific principles applied or trade-offs made.
+- At what point should this gate fire? In Phase 7 (Final Verification) after the build and tests pass but before the handoff PR is created.
+
+---
+
+### Autonomous Session Context Pruning in WorkTrain Daemon (May 20, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 11** | Cor:2 Cap:2 Eff:2 Lev:3 Con:2 | Blocked: no
+
+As long-running autonomous sessions proceed slice-by-slice, their context window gets bloated with thousands of lines of terminal outputs, compiler dumps, and raw file reads. This "attention decay" causes the agent to lose track of high-level system rules and repository philosophies in the noise of the active session, leading to compile-first-design-last shortcuts. Because MCP servers are stateless, the engine cannot prune context. However, the WorkTrain daemon manages the active LLM context and conversation payload directly.
+
+**Things to hash out:**
+- Should the daemon support a `pruneContext` directive at step boundaries in the workflow definition?
+- How do we preserve essential session history (such as the initial task description, the implementation plan, and high-level decisions) while purging intermediate tool outputs and prior compilation failures?
+- Does context pruning affect the agent's ability to maintain cross-turn consistency, and if so, how can we summarize the pruned turns to mitigate it?
+
+---
+
 ### Git rebase workflow for agents (May 20, 2026)
 
 **Status: idea** | Priority: high

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -130,15 +130,9 @@ A session harness is a layer that sits between the agent loop and the engine and
 
 ### C2 callback bug: parent stall timer not reset by child LLM activity (May 21, 2026)
 
-**Status: bug** | Priority: high
+**Status: done** | Shipped PR #1054 (May 19, 2026)
 
-**Score: 13** | Cor:3 Cap:1 Eff:3 Lev:2 Con:3 | Blocked: no
-
-`spawn_agent` is supposed to use the C2 mechanism to reset the parent's stall timer whenever a child session makes progress, preventing the parent from being killed while legitimately waiting for children. The callback (`notifyParentActivity`) is only wired to the `onAdvance` closure -- it fires only when a child **advances a workflow step**. Children that spend their first 2+ minutes in phase-0 research (no step advances) do not reset the parent's stall timer at all. The parent's `stallTimeoutSeconds=120` fires while children are actively running, killing the parent.
-
-**Evidence:** `df8c006c` stalled at 07:57:43 exactly 120s after spawning children at 07:55:29. Children `5a2f73c8`, `4429275c`, `9d58c9fe` were making LLM turns every 3-5 seconds the entire time but no step advances occurred, so C2 never fired.
-
-**Fix:** Wire `notifyParentActivity` to `onLlmTurnStarted` and `onLlmTurnCompleted` in `buildAgentCallbacks()` in `agent-loop-runner.ts`, not just to `onAdvance`. The comment on lines 192-204 already describes this intent but it's not implemented -- `notifyParentActivity` is only passed to `onAdvance`, not to `agentCallbacks`.
+Fixed in `src/daemon/runner/agent-loop-runner.ts` -- `notifyParentActivity` now fires in `onLlmTurnStarted` and `onToolCallStarted`, not just `onAdvance`. The fix was diagnosed and shipped two days before this backlog item was written.
 
 ---
 

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -450,6 +450,36 @@ All three bugs fixed. `WorkflowContextSlots` typed interface + `extractContextSl
 
 ---
 
+### Richer PR context pre-assembly: inject diff, description, commits, and linked ticket before first turn (May 21, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 13** | Cor:3 Cap:2 Eff:3 Lev:2 Con:3 | Blocked: no
+
+The `context-assembly` subsystem already runs before the first LLM turn and injects a `## Prior Context` section into the system prompt. For `pr_review` tasks, it currently fetches only a file list (`gh pr diff --name-only`) and prior session notes. The agent must spend turns fetching the actual diff content, PR description, linked issues, and commit history itself -- work that deterministic scripts could do in under a second before the session starts.
+
+**What to add to `context-assembly/index.ts` for `pr_review` tasks:**
+
+- **Full diff** (`gh pr diff <n>`) -- the actual changed lines, not just filenames. Truncate to a budget (e.g. 50KB) if large; include a note when truncated. This is the single highest-value addition: the agent currently reads individual files to reconstruct what the diff is doing.
+- **PR description + body** (`gh pr view <n> --json title,body,labels,milestone,state`) -- acceptance criteria and intent live here.
+- **Linked issues** (`gh pr view <n> --json closingIssuesReferences`) -- follows "closes #N" references and fetches issue body. One level deep only.
+- **Commit list with messages** (`gh pr view <n> --json commits`) -- author intent is often clearer in commit messages than in the diff.
+- **Existing review comments** (`gh pr view <n> --json reviews,comments`) -- prior reviewer feedback and author responses. Only relevant for re-review sessions.
+
+**Where it fits:** `assembleGitDiff()` in `src/context-assembly/index.ts` already has the `pr_review` branch with the `gh` CLI call. Expanding it and adding sibling functions follows the existing pattern. The `renderContextBundle()` function adds rendered sections to the system prompt.
+
+**Implementation notes:**
+- All fetches should be parallel (`Promise.all`) with individual timeouts and graceful fallback on failure
+- The total injected context budget matters -- full diffs can be large. Use `gh pr diff --stat` as a summary fallback when diff exceeds budget
+- `contextMapping` in `triggers.yml` already passes `itemNumber: "$.pull_request.number"` -- no trigger config changes needed
+
+**Things to hash out:**
+- What's the right budget for full diff injection? 50KB covers most PRs; very large diffs need truncation with a clear note
+- Should linked issue fetch be depth-1 only, or follow issue->epic->spec chains?
+- For re-review sessions, how do we distinguish first review (no prior comments relevant) from re-review (prior comments are primary context)?
+
+---
+
 ### MemoryStore: indexed session history as a coordinator and enricher dependency (Apr 30, 2026)
 
 **Status: idea** | Priority: medium

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -325,6 +325,23 @@ Agents asked to rebase a branch routinely make the same mistakes: they skip conf
 
 ---
 
+### Per-role model configuration: different models for different session roles (May 21, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 12** | Cor:2 Cap:3 Eff:2 Lev:2 Con:2 | Blocked: no
+
+Child sessions spawned via `spawn_agent` currently inherit no model configuration from the parent trigger -- they fall through to the default Bedrock model (`us.anthropic.claude-sonnet-4-6`), which may differ from the parent's intended model. More broadly, different roles in a pipeline have genuinely different model requirements: a reviewer family doing targeted code analysis benefits from a capable model; a gate evaluator doing a simple verdict check could use a cheaper/faster model; a coordinator deciding routing needs deterministic behavior more than raw capability.
+
+There is no way today to say "use Haiku for sub-agents, Sonnet for the main agent" or "use Sonnet for review, Haiku for gate evaluation." All sessions in a pipeline use whichever model was configured on the trigger (for root sessions) or the default (for child sessions).
+
+**Things to hash out:**
+- Where does model config live for child sessions? Options: (a) spawn_agent spec includes a model field the spawner can set; (b) workflow author declares a `agentModel` at the step level for steps that spawn; (c) a workspace-level role mapping (`{ "reviewer": "haiku", "main": "sonnet", "gate_eval": "haiku" }`) that the daemon uses to resolve models by session role
+- Is this a trigger concern (configure per-trigger which model each spawned role uses) or a workflow concern (workflow declares model requirements per step)?
+- How does this interact with ProviderConfig DU (above) -- ideally they compose cleanly
+
+---
+
 ### ProviderConfig: first-class LLM provider concept with interchangeable providers (May 20, 2026)
 
 **Status: idea** | Priority: high

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -4583,6 +4583,25 @@ The desired behavior: certain content (rules, behavioral constraints, workspace 
 
 ---
 
+### Unified daemon control plane: consolidate trigger listener and console into one HTTP server (May 20, 2026)
+
+**Status: idea** | Priority: medium
+
+**Score: 10** | Cor:2 Cap:2 Eff:1 Lev:3 Con:2 | Blocked: no
+
+WorkTrain currently runs two separate HTTP servers per daemon instance: the trigger listener on port 3200 (webhooks, session steer) and the console on port 3456 (read-only session/worktree data, plus `/api/v2/auto/dispatch` bolted on). This means `worktrain dispatch` requires `worktrain console` to be running alongside the daemon, `worktrain console` cannot dispatch sessions when run standalone, and there is no single operator-facing control plane. The dispatch endpoint on the console is marked "LOCAL DEVELOPER USE ONLY" with a security TODO, which is a signal it was added to the wrong server.
+
+The right architecture is one HTTP server per daemon instance -- the trigger listener on port 3200 -- serving everything the operator and CLI need: webhooks, session steer, operator dispatch, session state queries, worktree state, trigger list, and health. The console becomes a pure frontend that reads from this one server. `worktrain dispatch`, `worktrain logs`, and all other CLI commands talk to port 3200 only. `worktrain console` opens the browser UI pointing at the same port.
+
+This would let `npm run dev:daemon` give a fully functional WorkTrain instance with one process and one port instead of requiring a second terminal for `worktrain console`.
+
+**Things to hash out:**
+- Does the console frontend need CORS changes when served from the same port as the API?
+- What happens to the standalone `worktrain console` command for users who don't have the daemon running -- does it still work as a read-only view of the session store?
+- Should the migration be incremental (mount console routes on the trigger listener in addition to the console server) or a clean cutover?
+
+---
+
 ### Operator-facing capability toggles: named, discoverable WorkTrain behaviors (May 20, 2026)
 
 **Status: idea** | Priority: high

--- a/docs/ideas/backlog.md
+++ b/docs/ideas/backlog.md
@@ -325,11 +325,31 @@ Agents asked to rebase a branch routinely make the same mistakes: they skip conf
 
 ---
 
+### ProviderConfig: first-class LLM provider concept with interchangeable providers (May 20, 2026)
+
+**Status: idea** | Priority: high
+
+**Score: 14** | Cor:2 Cap:3 Eff:1 Lev:3 Con:3 | Blocked: no
+
+WorkTrain has no first-class LLM provider concept. Credentials are threaded as a raw `apiKey: string` parameter through 9 call sites (trigger-listener -> TriggerRouter -> runWorkflow -> startup-recovery -> gate-resume -> buildAgentReadySession -> constructTools -> spawn-agent -> buildPreAgentSession -> buildAgentClient), but `buildAgentClient` is the ONLY consumer. All other sites are pure pass-through couriers. The immediate symptom -- daemon fails to start with `missing_api_key` when only Bedrock credentials are present -- was patched with a `hasBedrock` guard, but the underlying threading antipattern remains. Without a typed ProviderConfig concept, adding a new provider (Ollama, Vertex, OpenAI) requires changing if-branches in a single growing function rather than adding a new variant to a discriminated union.
+
+**The right architecture:** `ProviderConfig = { kind: 'anthropic'; apiKey: string } | { kind: 'bedrock' } | { kind: 'ollama'; baseUrl: string }` resolved once at the composition root (`startTriggerListener`). `buildAgentClient(providerConfig, trigger)` becomes the sole construction site with `Result<{agentClient, modelId}, ProviderError>` return type (no throw). The `apiKey: string | undefined` parameter is deleted from all 9 call sites. New providers plug in by adding a union variant -- exhaustiveness checking enforces that all switch sites handle the new case. This also provides a natural anchor for Bedrock credential expiry detection (backlog score 14).
+
+**Design doc:** `docs/plans/provider-config-design.md` (completed May 20, 2026). Selected direction is the ProviderConfig DU after `wr.discovery` session. Full rationale, rejected alternatives, and implementation constraints are documented there.
+
+**Upgrade trigger from current patch:** When Bedrock credential expiry detection (this backlog) is scoped, check if it needs a stateful refreshable credential handle. If yes, implement ProviderConfig DU at that time. If Ollama support is being built first, ProviderConfig DU is required as a prerequisite (Ollama needs a `baseUrl` that doesn't come from env).
+
+**Things to hash out:**
+- When `agentConfig.model` specifies a provider prefix (e.g. `anthropic/claude-opus`) but only Bedrock creds are present, should `buildAgentClient` fail fast with a clear error or fall back to Bedrock with the model stripped of its prefix?
+- Should ProviderConfig be resolved from `config.json` (operator-declared default) or purely from env detection? `config.json` gives better startup observability but adds schema complexity.
+
+---
+
 ### Local LLM support: use Gemma, Llama, or any Ollama-compatible model as the agent backend (May 15, 2026)
 
 **Status: idea** | Priority: high
 
-**Score: 13** | Cor:2 Cap:3 Eff:2 Lev:3 Con:3 | Blocked: no
+**Score: 13** | Cor:2 Cap:3 Eff:2 Lev:3 Con:3 | Blocked: yes (needs ProviderConfig DU above)
 
 WorkTrain currently supports two backends: Anthropic direct (`ANTHROPIC_API_KEY`) and Amazon Bedrock (`AWS_PROFILE`). Both are cloud APIs with per-token costs, rate limits, and latency. A local LLM backend would enable: offline operation, zero API cost for iteration and testing, privacy for sensitive codebases, and much faster iteration cycles on workflow development.
 
@@ -337,7 +357,7 @@ WorkTrain currently supports two backends: Anthropic direct (`ANTHROPIC_API_KEY`
 
 **Implementation path:** `AgentClientInterface` in `agent-loop.ts` is already duck-typed -- it only requires `messages.create(params, options)` returning `Promise<Anthropic.Message>`. Ollama's `/api/chat` endpoint with `stream: false` can be wrapped in a thin adapter that maps to this interface. The key translation: Ollama uses OpenAI-style tool calling format, not Anthropic's `tool_use` content blocks -- the adapter needs to normalize this.
 
-**Where it fits:** `buildAgentClient()` in `src/daemon/core/agent-client.ts` parses `agentConfig.model` and constructs the right client. Adding an `ollama/` prefix case there is the natural extension point. No changes needed to AgentLoop, runWorkflow, or any workflow definitions.
+**Where it fits:** Requires ProviderConfig DU (item above) as a prerequisite -- Ollama needs a `baseUrl` that is not an env var, making it structurally incompatible with the current env-read-only approach in `buildAgentClient`. Once ProviderConfig DU ships, adding Ollama is one new union variant + one new class implementing `AgentClientInterface`.
 
 **Things to hash out:**
 - Ollama tool calling quality varies significantly by model -- Llama 3.2 and Gemma 3 support tool use but reliability is lower than Claude. How does WorkTrain handle an agent that frequently hallucinates tool names or ignores tool results?

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "preinstall": "node -e \"const v=parseInt(process.versions.node.split('.')[0],10); if(v<20){console.error('WorkRail requires Node.js >=20. Current: '+process.versions.node+'\\nPlease upgrade: https://nodejs.org/'); process.exit(1);}\"",
     "dev:mcp": "pkill -f \"$(pwd)/dist/mcp-server.js\" 2>/dev/null; sleep 0.5; WORKRAIL_TRANSPORT=http WORKRAIL_ENABLE_SESSION_TOOLS=true node dist/mcp-server.js",
     "dev:mcp:watch": "pkill -f \"$(pwd)/dist/mcp-server.js\" 2>/dev/null; sleep 0.5; WORKRAIL_TRANSPORT=http WORKRAIL_ENABLE_SESSION_TOOLS=true nodemon --watch dist --ext js --delay 2 --exec 'node dist/mcp-server.js'",
+    "dev:daemon": "WORKRAIL_TRIGGERS_ENABLED=true WORKRAIL_DATA_DIR=$HOME/.workrail/dev WORKRAIL_DEFAULT_WORKSPACE=$(pwd) node dist/cli-worktrain.js daemon",
     "web:dev": "npm run build && node dist/cli-worktrain.js console",
     "web:ci": "node dist/cli-worktrain.js console",
     "web:typecheck": "tsc -p tsconfig.web.json",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "dev:mcp": "pkill -f \"$(pwd)/dist/mcp-server.js\" 2>/dev/null; sleep 0.5; WORKRAIL_TRANSPORT=http WORKRAIL_ENABLE_SESSION_TOOLS=true node dist/mcp-server.js",
     "dev:mcp:watch": "pkill -f \"$(pwd)/dist/mcp-server.js\" 2>/dev/null; sleep 0.5; WORKRAIL_TRANSPORT=http WORKRAIL_ENABLE_SESSION_TOOLS=true nodemon --watch dist --ext js --delay 2 --exec 'node dist/mcp-server.js'",
     "dev:daemon": "WORKRAIL_TRIGGERS_ENABLED=true WORKRAIL_DATA_DIR=$HOME/.workrail/dev WORKRAIL_DEFAULT_WORKSPACE=$(pwd) node dist/cli-worktrain.js daemon",
+    "dev:watch-hangs": "bash scripts/watch-rg-hangs.sh",
     "web:dev": "npm run build && node dist/cli-worktrain.js console",
     "web:ci": "node dist/cli-worktrain.js console",
     "web:typecheck": "tsc -p tsconfig.web.json",

--- a/scripts/watch-rg-hangs.sh
+++ b/scripts/watch-rg-hangs.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# watch-rg-hangs.sh
+#
+# Monitors for rg processes whose cwd is inside ~/.workrail/worktrees/ and captures
+# diagnostics when they run suspiciously long.
+#
+# Usage (in a separate terminal):
+#   ./scripts/watch-rg-hangs.sh
+#
+# Requires: lsof, sample, opensnoop (all available on macOS without sudo)
+
+HANG_THRESHOLD_MS=2000
+OUTPUT_DIR="$HOME/.workrail/dev"
+mkdir -p "$OUTPUT_DIR"
+
+echo "Watching for rg processes in worktrees (threshold: ${HANG_THRESHOLD_MS}ms)..."
+echo "Output dir: $OUTPUT_DIR"
+echo "Press Ctrl-C to stop."
+echo ""
+
+declare -A REPORTED_PIDS
+
+capture_diagnostics() {
+  local PID=$1
+  local ELAPSED_AT_CAPTURE=$2
+  local TIMESTAMP
+  TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+  local OUT="$OUTPUT_DIR/rg-hang-$TIMESTAMP.txt"
+  REPORTED_PIDS[$PID]=1
+
+  echo ""
+  echo "=== SLOW rg DETECTED: PID $PID (${ELAPSED_AT_CAPTURE}ms and counting) ==="
+  echo "Capturing to: $OUT"
+
+  {
+    echo "rg hang diagnostic -- $(date)"
+    echo "PID: $PID  elapsed_at_capture: ${ELAPSED_AT_CAPTURE}ms"
+    echo ""
+
+    echo "=== COMMAND LINE ==="
+    ps -p "$PID" -o pid,etime,command 2>/dev/null
+    echo ""
+
+    echo "=== WORKING DIRECTORY ==="
+    lsof -p "$PID" 2>/dev/null | grep cwd
+    echo ""
+
+    echo "=== ALL OPEN FILES (lsof) ==="
+    lsof -p "$PID" 2>/dev/null
+    echo ""
+
+    echo "=== CALL STACK (sample 5s) ==="
+    # sample shows which syscall the process is blocked in
+    sample "$PID" 5 2>/dev/null
+    echo ""
+
+    echo "=== OPEN FILES AFTER SAMPLE ==="
+    lsof -p "$PID" 2>/dev/null
+    echo ""
+
+  } | tee "$OUT"
+
+  # opensnoop traces open() calls in real time -- shows the next file rg tries to open
+  echo "=== OPENSNOOP (15s) ===" >> "$OUT"
+  echo "(tracing open() calls for PID $PID...)"
+  timeout 15 opensnoop -p "$PID" 2>/dev/null | tee -a "$OUT" &
+  local SNOOP_PID=$!
+
+  # Poll until rg exits, printing elapsed every 5s
+  local START_MS
+  START_MS=$(date +%s%3N)
+  while kill -0 "$PID" 2>/dev/null; do
+    sleep 1
+    local NOW_MS
+    NOW_MS=$(date +%s%3N)
+    local TOTAL=$(( NOW_MS - START_MS + ELAPSED_AT_CAPTURE ))
+    echo "  still running... ${TOTAL}ms total"
+  done
+
+  local FINAL_MS
+  FINAL_MS=$(( $(date +%s%3N) - START_MS + ELAPSED_AT_CAPTURE ))
+  echo "" >> "$OUT"
+  echo "=== FINAL: PID $PID exited after ${FINAL_MS}ms total ===" | tee -a "$OUT"
+  kill $SNOOP_PID 2>/dev/null
+  echo "Full diagnostics saved: $OUT"
+  echo ""
+}
+
+while true; do
+  # Find all rg processes
+  while IFS= read -r RG_PID; do
+    [[ -z "$RG_PID" ]] && continue
+    [[ -n "${REPORTED_PIDS[$RG_PID]}" ]] && continue
+
+    # Check if its cwd is inside a worktree
+    CWD=$(lsof -p "$RG_PID" 2>/dev/null | awk '/cwd/ {print $NF}')
+    [[ "$CWD" != *"/.workrail/worktrees/"* ]] && continue
+
+    # Track start time
+    local_start=$(date +%s%3N)
+
+    # Wait to see if it finishes quickly
+    while kill -0 "$RG_PID" 2>/dev/null; do
+      sleep 0.05
+      local_elapsed=$(( $(date +%s%3N) - local_start ))
+      if [ "$local_elapsed" -ge "$HANG_THRESHOLD_MS" ]; then
+        # Still running after threshold -- capture diagnostics
+        if [[ -z "${REPORTED_PIDS[$RG_PID]}" ]]; then
+          capture_diagnostics "$RG_PID" "$local_elapsed"
+        fi
+        break
+      fi
+    done
+
+  done < <(pgrep rg 2>/dev/null)
+
+  sleep 0.2
+done

--- a/spec/authoring-spec.json
+++ b/spec/authoring-spec.json
@@ -994,7 +994,7 @@
           ],
           "sourceRefs": [
             {
-              "kind": "implementation",
+              "kind": "runtime",
               "path": "src/mcp/handlers/v2-advance-core/index.ts",
               "note": "isGateRequired() is called at advance time, before the step executes."
             }

--- a/spec/authoring-spec.json
+++ b/spec/authoring-spec.json
@@ -3,7 +3,7 @@
   "version": 3,
   "title": "WorkRail Authoring Rules",
   "purpose": "Canonical current rules for authoring good WorkRail workflows. workflow.schema.json remains the source of truth for legal structure.",
-  "lastReviewed": "2026-05-14",
+  "lastReviewed": "2026-05-20",
   "principles": [
     "Schema defines what is valid. These rules define what is good.",
     "Prefer current authoring rules over design rationale or historical notes.",
@@ -977,6 +977,34 @@
           "antiPatterns": [
             "Confirming every draft or artifact creation by default",
             "Using requireConfirmation as a substitute for clear loop or rigor policy"
+          ]
+        },
+        {
+          "id": "conditional-gate-context-timing",
+          "status": "active",
+          "level": "required",
+          "scope": [
+            "step.confirmation",
+            "workflow.authoring"
+          ],
+          "rule": "The context variable referenced in a requireConfirmation condition must be set by a prior step, not by the gated step itself.",
+          "why": "requireConfirmation is evaluated when the engine advances INTO the step, before the step runs. A variable set by the gated step is not yet in context when the condition fires -- it will be undefined and the condition will silently produce the wrong result.",
+          "enforcement": [
+            "advisory"
+          ],
+          "sourceRefs": [
+            {
+              "kind": "implementation",
+              "path": "src/mcp/handlers/v2-advance-core/index.ts",
+              "note": "isGateRequired() is called at advance time, before the step executes."
+            }
+          ],
+          "checks": [
+            "The condition var must reference a context key set by a previous step via inputContext.",
+            "Do not reference output artifact fields produced by the current step -- those are not yet in context at gate evaluation time."
+          ],
+          "antiPatterns": [
+            "Conditioning on verdict (set by the current step's outputContract) instead of recommendation (set by a prior synthesis step)"
           ]
         }
       ]

--- a/spec/workflow.schema.json
+++ b/spec/workflow.schema.json
@@ -845,6 +845,10 @@
               "type": "string",
               "enum": ["coordinator_eval", "human_approval"],
               "description": "coordinator_eval: spawn wr.gate-eval-generic; human_approval: route to human approval mechanism (e.g. GitHub draft review)"
+            },
+            "condition": {
+              "$ref": "#/$defs/condition",
+              "description": "Conditional logic that determines if confirmation is required"
             }
           },
           "required": ["kind"],

--- a/src/cli/commands/worktrain-await.ts
+++ b/src/cli/commands/worktrain-await.ts
@@ -81,7 +81,7 @@ export interface WorktrainAwaitCommandOpts {
  *                    NOT the same as 'timeout': the session was not stuck or slow, we simply
  *                    no longer needed it.
  */
-export type SessionOutcome = 'success' | 'failed' | 'timeout' | 'not_found' | 'not_awaited';
+export type SessionOutcome = 'success' | 'paused_at_gate' | 'failed' | 'timeout' | 'not_found' | 'not_awaited';
 
 export interface SessionResult {
   readonly handle: string;

--- a/src/coordinators/pr-review.ts
+++ b/src/coordinators/pr-review.ts
@@ -1105,10 +1105,12 @@ export async function runPrReviewCoordinator(
       const elapsedMs = sessionResult.durationMs;
       const handle = sessionResult.handle;
 
-      // Get notes and artifacts for this session
+      // Get notes and artifacts for this session.
+      // paused_at_gate: pre-gate artifacts are available (the gate fires after the step emits
+      // its artifact); treat the same as success for artifact reading.
       let notes: string | null = null;
       let artifacts: readonly unknown[] = [];
-      if (sessionResult.outcome === 'success') {
+      if (sessionResult.outcome === 'success' || sessionResult.outcome === 'paused_at_gate') {
         const agentResult = await deps.getAgentResult(handle);
         notes = agentResult.recapMarkdown;
         artifacts = agentResult.artifacts;
@@ -1152,8 +1154,8 @@ export async function runPrReviewCoordinator(
         prNumber: prNum,
         severity,
         merged: false,
-        escalated: sessionResult.outcome !== 'success' || severity === 'blocking' || severity === 'unknown',
-        escalationReason: sessionResult.outcome !== 'success'
+        escalated: (sessionResult.outcome !== 'success' && sessionResult.outcome !== 'paused_at_gate') || severity === 'blocking' || severity === 'unknown',
+        escalationReason: (sessionResult.outcome !== 'success' && sessionResult.outcome !== 'paused_at_gate')
           ? `session ${sessionResult.outcome}`
           : severity === 'blocking' || severity === 'unknown'
             ? `severity: ${severity}`

--- a/src/daemon/core/agent-client.ts
+++ b/src/daemon/core/agent-client.ts
@@ -33,12 +33,12 @@ import type { WorkflowTrigger } from '../types.js';
  * When absent, detects AWS credentials in env (Bedrock) vs. direct API key.
  *
  * @param trigger - WorkflowTrigger carrying optional agentConfig.model override.
- * @param apiKey - Anthropic API key (used only when not using Bedrock).
+ * @param apiKey - Anthropic API key. Required when not using Bedrock; ignored when AWS credentials are present.
  * @param env - Process environment variables (for AWS credential detection).
  */
 export function buildAgentClient(
   trigger: WorkflowTrigger,
-  apiKey: string,
+  apiKey: string | undefined,
   env: NodeJS.ProcessEnv,
 ): { agentClient: Anthropic | AnthropicBedrock; modelId: string } {
   if (trigger.agentConfig?.model) {
@@ -51,8 +51,13 @@ export function buildAgentClient(
     }
     const provider = trigger.agentConfig.model.slice(0, slashIdx);
     const modelId = trigger.agentConfig.model.slice(slashIdx + 1);
+    if (provider !== 'amazon-bedrock' && !apiKey) {
+      throw new Error(
+        `ANTHROPIC_API_KEY is required when not using Bedrock (agentConfig.model="${trigger.agentConfig.model}")`,
+      );
+    }
     const agentClient: Anthropic | AnthropicBedrock =
-      provider === 'amazon-bedrock' ? new AnthropicBedrock() : new Anthropic({ apiKey });
+      provider === 'amazon-bedrock' ? new AnthropicBedrock() : new Anthropic({ apiKey: apiKey! });
     return { agentClient, modelId };
   }
 
@@ -64,6 +69,11 @@ export function buildAgentClient(
       agentClient: new AnthropicBedrock(),
       modelId: 'us.anthropic.claude-sonnet-4-6',
     };
+  }
+  if (!apiKey) {
+    throw new Error(
+      'ANTHROPIC_API_KEY is required when AWS credentials (AWS_PROFILE or AWS_ACCESS_KEY_ID) are not set',
+    );
   }
   return {
     agentClient: new Anthropic({ apiKey }),

--- a/src/daemon/cortex/session-cortex.ts
+++ b/src/daemon/cortex/session-cortex.ts
@@ -156,8 +156,10 @@ export class SessionCortex {
     // 5. Escalate and inject steer guidance
     if (newCount === 1) {
       if (currentState.status === 'none') {
-        this.stepStates.set(currentStepId, { status: 'hint_injected', failureCount: 1 });
+        // Log before mutating in-memory state: if logEvent fails silently, the in-memory
+        // state should not advance -- crash recovery replays the log to restore state.
         await this.logEvent({ kind: 'hint_injected', stepId: currentStepId, ts: Date.now() });
+        this.stepStates.set(currentStepId, { status: 'hint_injected', failureCount: 1 });
 
         const hint = contractRef
           ? this.buildHintMessage(currentStepId, contractRef)
@@ -167,8 +169,8 @@ export class SessionCortex {
       }
     } else if (newCount === 2) {
       if (currentState.status === 'hint_injected') {
-        this.stepStates.set(currentStepId, { status: 'scaffold_injected', failureCount: 2 });
         await this.logEvent({ kind: 'scaffold_injected', stepId: currentStepId, ts: Date.now() });
+        this.stepStates.set(currentStepId, { status: 'scaffold_injected', failureCount: 2 });
 
         const scaffoldLines = contractRef ? getArtifactBlockedMessage(contractRef) : null;
         const scaffold = (contractRef && scaffoldLines)

--- a/src/daemon/cortex/session-cortex.ts
+++ b/src/daemon/cortex/session-cortex.ts
@@ -48,28 +48,32 @@ export class SessionCortex {
 
       for (const event of events) {
         switch (event.kind) {
-          case 'step_failure_observed': {
-            const current = this.stepStates.get(event.stepId);
-            const status = current?.status ?? 'none';
-            if (status === 'none') {
-              this.stepStates.set(event.stepId, { status: 'none', failureCount: 0 });
-            } else if (status === 'hint_injected') {
-              this.stepStates.set(event.stepId, { status: 'hint_injected', failureCount: 1 });
-            } else {
-              this.stepStates.set(event.stepId, { status: 'scaffold_injected', failureCount: event.failureCount });
+          case 'step_failure_observed':
+            // step_failure_observed is authoritative: its failureCount IS the count at that moment.
+            // Only update if this event's count is higher than current (events are in order,
+            // but be defensive). Status is determined by subsequent hint/scaffold_injected events.
+            {
+              const current = this.stepStates.get(event.stepId);
+              if (!current || event.failureCount > current.failureCount) {
+                // Preserve status if already set by a prior event; default to 'none'.
+                // Cast needed because TypeScript can't prove (status, failureCount) pairing
+                // is valid without the full union check -- the status is set authoritatively
+                // by hint_injected/scaffold_injected events which follow in the log.
+                const status = current?.status ?? 'none';
+                this.stepStates.set(event.stepId, { status, failureCount: event.failureCount } as StepCortexState);
+              }
             }
             break;
-          }
-          case 'hint_injected': {
+          case 'hint_injected':
             this.stepStates.set(event.stepId, { status: 'hint_injected', failureCount: 1 });
             break;
-          }
-          case 'scaffold_injected': {
-            const current = this.stepStates.get(event.stepId);
-            const failureCount = current?.failureCount ?? 2;
-            this.stepStates.set(event.stepId, { status: 'scaffold_injected', failureCount });
+          case 'scaffold_injected':
+            {
+              const current = this.stepStates.get(event.stepId);
+              const failureCount = Math.max(2, current?.failureCount ?? 2);
+              this.stepStates.set(event.stepId, { status: 'scaffold_injected', failureCount });
+            }
             break;
-          }
           case 'step_advanced':
             this.stepStates.delete(event.stepId);
             break;
@@ -104,7 +108,6 @@ export class SessionCortex {
    */
   async handleTurnEnd(
     event: { readonly type: 'turn_end'; readonly toolResults: ReadonlyArray<AgentToolCallResult> },
-    agent: { steer(msg: { role: 'user'; content: string; timestamp: number }): void },
     state: { pendingStepIdAfterAdvance: string | null; pendingSteerParts: string[] },
   ): Promise<void> {
     // 1. Detect step advancement/transition

--- a/src/daemon/cortex/session-cortex.ts
+++ b/src/daemon/cortex/session-cortex.ts
@@ -1,0 +1,222 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { AgentToolResult, AgentToolCallResult } from '../agent-loop.js';
+import { getArtifactBlockedMessage } from '../../v2/durable-core/schemas/artifacts/blocked-messages.js';
+import { V2ContinueWorkflowOutputSchema } from '../../mcp/output-schemas.js';
+import type { z } from 'zod';
+
+export type ContinueWorkflowOutput = z.infer<typeof V2ContinueWorkflowOutputSchema>;
+
+export type CortexEvent =
+  | { kind: 'step_failure_observed'; stepId: string; failureCount: number; errorSummary: string; ts: number }
+  | { kind: 'hint_injected'; stepId: string; ts: number }
+  | { kind: 'scaffold_injected'; stepId: string; ts: number }
+  | { kind: 'step_rewound'; stepId: string; ts: number }
+  | { kind: 'operator_escalated'; stepId: string; ts: number }
+  | { kind: 'step_advanced'; stepId: string; ts: number };
+
+export type StepCortexState =
+  | { readonly status: 'none'; readonly failureCount: 0 }
+  | { readonly status: 'hint_injected'; readonly failureCount: 1 }
+  | { readonly status: 'scaffold_injected'; readonly failureCount: number };
+
+export class SessionCortex {
+  private readonly cortexPath: string;
+  private readonly stepStates = new Map<string, StepCortexState>();
+  private lastStepId: string | null = null;
+
+  constructor(cortexPath: string) {
+    this.cortexPath = cortexPath;
+  }
+
+  /**
+   * Load the event log and replay events to restore state for in-flight sessions.
+   */
+  async load(initialStepId: string | null): Promise<void> {
+    this.lastStepId = initialStepId;
+    try {
+      const data = await fs.readFile(this.cortexPath, 'utf8');
+      const lines = data.split('\n').filter((line) => line.trim().length > 0);
+      const events: CortexEvent[] = [];
+      for (const line of lines) {
+        try {
+          events.push(JSON.parse(line));
+        } catch {
+          // ignore corrupted/incomplete lines (crash safety)
+        }
+      }
+
+      for (const event of events) {
+        switch (event.kind) {
+          case 'step_failure_observed': {
+            const current = this.stepStates.get(event.stepId);
+            const status = current?.status ?? 'none';
+            if (status === 'none') {
+              this.stepStates.set(event.stepId, { status: 'none', failureCount: 0 });
+            } else if (status === 'hint_injected') {
+              this.stepStates.set(event.stepId, { status: 'hint_injected', failureCount: 1 });
+            } else {
+              this.stepStates.set(event.stepId, { status: 'scaffold_injected', failureCount: event.failureCount });
+            }
+            break;
+          }
+          case 'hint_injected': {
+            this.stepStates.set(event.stepId, { status: 'hint_injected', failureCount: 1 });
+            break;
+          }
+          case 'scaffold_injected': {
+            const current = this.stepStates.get(event.stepId);
+            const failureCount = current?.failureCount ?? 2;
+            this.stepStates.set(event.stepId, { status: 'scaffold_injected', failureCount });
+            break;
+          }
+          case 'step_advanced':
+            this.stepStates.delete(event.stepId);
+            break;
+          case 'step_rewound':
+          case 'operator_escalated':
+            break;
+        }
+      }
+    } catch (e: unknown) {
+      if (e && typeof e === 'object' && 'code' in e && e.code !== 'ENOENT') {
+        const message = 'message' in e ? String(e.message) : '';
+        console.error(`[SessionCortex] Error reading event log: ${message}`);
+      }
+    }
+  }
+
+  /**
+   * Log an event to the append-only JSONL log file.
+   */
+  private async logEvent(event: CortexEvent): Promise<void> {
+    try {
+      await fs.mkdir(path.dirname(this.cortexPath), { recursive: true });
+      await fs.appendFile(this.cortexPath, JSON.stringify(event) + '\n', 'utf8');
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.error(`[SessionCortex] Failed to write event to log: ${message}`);
+    }
+  }
+
+  /**
+   * Handle the turn_end event, detecting rejections and injecting steer guidance.
+   */
+  async handleTurnEnd(
+    event: { readonly type: 'turn_end'; readonly toolResults: ReadonlyArray<AgentToolCallResult> },
+    agent: { steer(msg: { role: 'user'; content: string; timestamp: number }): void },
+    state: { pendingStepIdAfterAdvance: string | null; pendingSteerParts: string[] },
+  ): Promise<void> {
+    // 1. Detect step advancement/transition
+    const currentStepId = state.pendingStepIdAfterAdvance;
+    if (currentStepId !== this.lastStepId) {
+      if (this.lastStepId !== null) {
+        await this.logEvent({ kind: 'step_advanced', stepId: this.lastStepId, ts: Date.now() });
+        this.stepStates.delete(this.lastStepId);
+      }
+      this.lastStepId = currentStepId;
+    }
+
+    if (!currentStepId) return;
+
+    // 2. Check if complete_step was called and returned a blocked outcome
+    const completeStepResult = event.toolResults.find((r) => r.toolName === 'complete_step');
+    if (!completeStepResult || completeStepResult.isError) return;
+
+    const result = completeStepResult.result as AgentToolResult<ContinueWorkflowOutput> | null;
+    const details = result?.details;
+    if (!details || details.kind !== 'blocked') return;
+
+    // 3. Extract validation/contract information safely
+    const blockers = details.blockers?.blockers ?? [];
+    let contractRef: string | undefined = undefined;
+    for (const b of blockers) {
+      if (b.pointer.kind === 'output_contract') {
+        contractRef = b.pointer.contractRef;
+        break;
+      }
+    }
+
+    // 4. Update failure count using single StepCortexState discriminated union Map
+    const currentState = this.stepStates.get(currentStepId) ?? { status: 'none', failureCount: 0 };
+    const newCount = currentState.failureCount + 1;
+
+    const errorSummary = blockers.map((b) => b.message).join(' | ').slice(0, 200);
+    await this.logEvent({
+      kind: 'step_failure_observed',
+      stepId: currentStepId,
+      failureCount: newCount,
+      errorSummary,
+      ts: Date.now(),
+    });
+
+    // 5. Escalate and inject steer guidance
+    if (newCount === 1) {
+      if (currentState.status === 'none') {
+        this.stepStates.set(currentStepId, { status: 'hint_injected', failureCount: 1 });
+        await this.logEvent({ kind: 'hint_injected', stepId: currentStepId, ts: Date.now() });
+
+        const hint = contractRef
+          ? this.buildHintMessage(currentStepId, contractRef)
+          : this.buildHintFallback(currentStepId);
+        
+        state.pendingSteerParts.push(hint);
+      }
+    } else if (newCount === 2) {
+      if (currentState.status === 'hint_injected') {
+        this.stepStates.set(currentStepId, { status: 'scaffold_injected', failureCount: 2 });
+        await this.logEvent({ kind: 'scaffold_injected', stepId: currentStepId, ts: Date.now() });
+
+        const scaffoldLines = contractRef ? getArtifactBlockedMessage(contractRef) : null;
+        const scaffold = (contractRef && scaffoldLines)
+          ? this.buildScaffoldMessage(currentStepId, contractRef, scaffoldLines)
+          : this.buildScaffoldFallback(currentStepId);
+
+        state.pendingSteerParts.push(scaffold);
+      }
+    } else {
+      this.stepStates.set(currentStepId, { status: 'scaffold_injected', failureCount: newCount });
+    }
+  }
+
+  private buildHintMessage(stepId: string, contractRef: string): string {
+    const artifactName = contractRef.replace('wr.contracts.', '');
+    return [
+      `**Cortex Interceded (Tier-1 Hint)**`,
+      `Your submission for step '${stepId}' was rejected because it is missing the required output artifact.`,
+      `- **Required Contract**: \`${contractRef}\` (kind: \`${artifactName}\`)`,
+      `- **Action**: You must call \`complete_step\` with a valid \`wr.${artifactName}\` artifact (formatted as JSON) in the \`artifacts\` array parameter.`,
+      `- **Format Guidance**: Make sure your artifact exactly matches the schema. Double-check your parameters and notes.`
+    ].join('\n');
+  }
+
+  private buildScaffoldMessage(stepId: string, contractRef: string, scaffoldLines: readonly string[]): string {
+    return [
+      `**Cortex Interceded (Tier-2 Scaffold)**`,
+      `Your submission for step '${stepId}' was rejected again. To help you proceed, here is a complete copy-pasteable example of a valid artifact for this contract (\`${contractRef}\`):`,
+      ``,
+      `\`\`\`json`,
+      scaffoldLines.join('\n'),
+      `\`\`\``,
+      ``,
+      `Please call \`complete_step\` and include this artifact in the \`artifacts\` parameter, filling in correct values for your task.`,
+      `If you have failed multiple times, stop trying the same unsuccessful approach. Re-read the step prompt and validation criteria, adjust your parameters, and call \`complete_step\` with the corrected artifact.`
+    ].join('\n');
+  }
+
+  private buildHintFallback(stepId: string): string {
+    return [
+      `**Cortex Interceded (Tier-1 Hint)**`,
+      `Your submission for step '${stepId}' was rejected by the engine.`,
+      `Please check the step prompt and validation criteria for the required artifact format, and pass it in \`output.artifacts\` of your next \`complete_step\` call.`
+    ].join('\n');
+  }
+
+  private buildScaffoldFallback(stepId: string): string {
+    return [
+      `**Cortex Interceded (Tier-2 Scaffold)**`,
+      `Your submission for step '${stepId}' was rejected again.`,
+      `Please carefully review the required output schema from the step prompt, ensure all validation criteria are met, and pass the correct artifact in \`output.artifacts\` of your next \`complete_step\` call.`
+    ].join('\n');
+  }
+}

--- a/src/daemon/gate-resume.ts
+++ b/src/daemon/gate-resume.ts
@@ -179,6 +179,7 @@ export async function resumeFromGate(
     firstStepPrompt,
     isComplete: false,
     triggerSource: 'daemon',
+    stepId: rehydrated.pending?.stepId,
     ...(sidecar.worktreePath !== undefined ? { sessionWorkspacePath: sidecar.worktreePath } : {}),
   };
 

--- a/src/daemon/gate-resume.ts
+++ b/src/daemon/gate-resume.ts
@@ -73,7 +73,7 @@ export async function resumeFromGate(
   sessionId: string,
   verdict: GateVerdict,
   ctx: V2ToolContext,
-  apiKey: string,
+  apiKey: string | undefined,
   runWorkflowFn: typeof runWorkflow,
   daemonRegistry?: DaemonRegistry,
   emitter?: DaemonEventEmitter,

--- a/src/daemon/runner/agent-loop-runner.ts
+++ b/src/daemon/runner/agent-loop-runner.ts
@@ -148,7 +148,7 @@ export function buildTurnEndSubscriber(
 
     // Cortex intervention: intercept rejections and inject guidance
     if (ctx.cortex) {
-      await ctx.cortex.handleTurnEnd(event, ctx.agent, ctx.state);
+      await ctx.cortex.handleTurnEnd(event, ctx.state);
     }
 
     // Steer injection: drain pendingSteerParts into the next turn.

--- a/src/daemon/runner/agent-loop-runner.ts
+++ b/src/daemon/runner/agent-loop-runner.ts
@@ -40,7 +40,7 @@ import { injectPendingSteps } from '../turn-end/step-injector.js';
 import { flushConversation } from '../turn-end/conversation-flusher.js';
 import { SessionCortex } from '../cortex/session-cortex.js';
 import type { WorkflowTrigger } from '../types.js';
-import type { PreAgentSession, AgentReadySession, SessionOutcome } from './runner-types.js';
+import type { PreAgentSession, AgentReadySession, SessionOutcome, SessionPaths } from './runner-types.js';
 import { getSchemas } from './tool-schemas.js';
 import { constructTools } from './construct-tools.js';
 import type { runWorkflow } from '../workflow-runner.js';
@@ -408,8 +408,9 @@ export async function buildAgentReadySession(
 export async function runAgentLoop(
   session: AgentReadySession,
   trigger: WorkflowTrigger,
-  conversationPath: string,
+  sessionPaths: SessionPaths,
 ): Promise<SessionOutcome> {
+  const { conversationPath, cortexPath } = sessionPaths;
   const { agent, preAgentSession, sessionCtx, sessionId, handle } = session;
   const { state } = preAgentSession;
   const { emitter } = session.scope;
@@ -426,11 +427,6 @@ export async function runAgentLoop(
 
   const lastFlushedRef = { count: 0 };
 
-  const CONVERSATION_SUFFIX = '-conversation.jsonl';
-  if (!conversationPath.endsWith(CONVERSATION_SUFFIX)) {
-    throw new Error(`Invariant violation: conversationPath must end with '${CONVERSATION_SUFFIX}', got: ${conversationPath}`);
-  }
-  const cortexPath = conversationPath.slice(0, -CONVERSATION_SUFFIX.length) + '-cortex.jsonl';
   const cortex = new SessionCortex(cortexPath);
   await cortex.load(state.pendingStepIdAfterAdvance);
 

--- a/src/daemon/runner/agent-loop-runner.ts
+++ b/src/daemon/runner/agent-loop-runner.ts
@@ -426,7 +426,11 @@ export async function runAgentLoop(
 
   const lastFlushedRef = { count: 0 };
 
-  const cortexPath = conversationPath.replace('-conversation.jsonl', '-cortex.jsonl');
+  const CONVERSATION_SUFFIX = '-conversation.jsonl';
+  if (!conversationPath.endsWith(CONVERSATION_SUFFIX)) {
+    throw new Error(`Invariant violation: conversationPath must end with '${CONVERSATION_SUFFIX}', got: ${conversationPath}`);
+  }
+  const cortexPath = conversationPath.slice(0, -CONVERSATION_SUFFIX.length) + '-cortex.jsonl';
   const cortex = new SessionCortex(cortexPath);
   await cortex.load(state.pendingStepIdAfterAdvance);
 

--- a/src/daemon/runner/agent-loop-runner.ts
+++ b/src/daemon/runner/agent-loop-runner.ts
@@ -38,6 +38,7 @@ import { ActiveSessionSet } from '../active-sessions.js';
 import { withWorkrailSession } from '../tools/_shared.js';
 import { injectPendingSteps } from '../turn-end/step-injector.js';
 import { flushConversation } from '../turn-end/conversation-flusher.js';
+import { SessionCortex } from '../cortex/session-cortex.js';
 import type { WorkflowTrigger } from '../types.js';
 import type { PreAgentSession, AgentReadySession, SessionOutcome } from './runner-types.js';
 import { getSchemas } from './tool-schemas.js';
@@ -73,6 +74,7 @@ export interface TurnEndSubscriberContext {
    */
   readonly lastFlushedRef: { count: number };
   readonly stuckRepeatThreshold: number;
+  readonly cortex?: SessionCortex;
 }
 
 // ---------------------------------------------------------------------------
@@ -143,6 +145,11 @@ export function buildTurnEndSubscriber(
 
     // Conversation history: delta-append after each turn.
     flushConversation(ctx.agent.state.messages, ctx.lastFlushedRef, ctx.conversationPath, appendConversationMessages);
+
+    // Cortex intervention: intercept rejections and inject guidance
+    if (ctx.cortex) {
+      await ctx.cortex.handleTurnEnd(event, ctx.agent, ctx.state);
+    }
 
     // Steer injection: drain pendingSteerParts into the next turn.
     injectPendingSteps(ctx.state, ctx.agent);
@@ -419,6 +426,10 @@ export async function runAgentLoop(
 
   const lastFlushedRef = { count: 0 };
 
+  const cortexPath = conversationPath.replace('-conversation.jsonl', '-cortex.jsonl');
+  const cortex = new SessionCortex(cortexPath);
+  await cortex.load(state.pendingStepIdAfterAdvance);
+
   const unsubscribe = agent.subscribe(buildTurnEndSubscriber({
     agent,
     state,
@@ -429,6 +440,7 @@ export async function runAgentLoop(
     conversationPath,
     lastFlushedRef,
     stuckRepeatThreshold,
+    cortex,
   }));
 
   let stopReason = 'stop';

--- a/src/daemon/runner/agent-loop-runner.ts
+++ b/src/daemon/runner/agent-loop-runner.ts
@@ -251,7 +251,7 @@ export async function buildAgentReadySession(
   preAgentSession: PreAgentSession,
   trigger: WorkflowTrigger,
   ctx: V2ToolContext,
-  apiKey: string,
+  apiKey: string | undefined,
   sessionId: RunId,
   emitter: DaemonEventEmitter | undefined,
   daemonRegistry: DaemonRegistry | undefined,

--- a/src/daemon/runner/construct-tools.ts
+++ b/src/daemon/runner/construct-tools.ts
@@ -40,7 +40,7 @@ import type { runWorkflow } from '../workflow-runner.js';
  */
 export function constructTools(
   ctx: V2ToolContext,
-  apiKey: string,
+  apiKey: string | undefined,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   schemas: Record<string, any>,
   scope: SessionScope,

--- a/src/daemon/runner/index.ts
+++ b/src/daemon/runner/index.ts
@@ -11,13 +11,14 @@
  * type-only, erased at compile time, no runtime circular dependency.
  */
 
-export { WORKTREES_DIR } from './runner-types.js';
+export { WORKTREES_DIR, buildSessionPaths } from './runner-types.js';
 export type {
   PreAgentSession,
   PreAgentSessionResult,
   AgentReadySession,
   SessionOutcome,
   FinalizationContext,
+  SessionPaths,
 } from './runner-types.js';
 export { getSchemas } from './tool-schemas.js';
 export { constructTools } from './construct-tools.js';

--- a/src/daemon/runner/pre-agent-session.ts
+++ b/src/daemon/runner/pre-agent-session.ts
@@ -96,6 +96,7 @@ export async function buildPreAgentSession(
     checkpointToken = s.checkpointToken ?? null;
     firstStepPrompt = s.firstStepPrompt;
     isComplete = s.isComplete;
+    state.pendingStepIdAfterAdvance = s.stepId ?? null;
   } else {
     const startResult = await executeStartWorkflow(
       { workflowId: trigger.workflowId, workspacePath: trigger.workspacePath, goal: trigger.goal },
@@ -120,6 +121,9 @@ export async function buildPreAgentSession(
     checkpointToken = r.checkpointToken ?? null;
     firstStepPrompt = r.pending?.prompt ?? '';
     isComplete = r.isComplete;
+    if (r.pending) {
+      state.pendingStepIdAfterAdvance = r.pending.stepId;
+    }
   }
   updateToken(state, continueToken);
 

--- a/src/daemon/runner/pre-agent-session.ts
+++ b/src/daemon/runner/pre-agent-session.ts
@@ -50,7 +50,7 @@ const execFileAsync = promisify(execFile);
 export async function buildPreAgentSession(
   trigger: WorkflowTrigger,
   ctx: V2ToolContext,
-  apiKey: string,
+  apiKey: string | undefined,
   sessionId: RunId,
   startMs: number,
   statsDir: string,

--- a/src/daemon/runner/runner-types.ts
+++ b/src/daemon/runner/runner-types.ts
@@ -148,6 +148,22 @@ export type SessionOutcome =
 // ---------------------------------------------------------------------------
 
 /** Context for finalizing a completed runWorkflow() session. */
+/**
+ * Typed pair of session-scoped file paths, both derived from sessionId + sessionsDir.
+ * Passed together so neither path can be derived independently via string manipulation.
+ */
+export interface SessionPaths {
+  readonly conversationPath: string;
+  readonly cortexPath: string;
+}
+
+export function buildSessionPaths(sessionsDir: string, sessionId: string): SessionPaths {
+  return {
+    conversationPath: `${sessionsDir}/${sessionId}-conversation.jsonl`,
+    cortexPath: `${sessionsDir}/${sessionId}-cortex.jsonl`,
+  };
+}
+
 export interface FinalizationContext {
   readonly sessionId: RunId;
   readonly workrailSessionId: SessionId | null;

--- a/src/daemon/startup-recovery.ts
+++ b/src/daemon/startup-recovery.ts
@@ -467,6 +467,7 @@ export async function runStartupRecovery(
             firstStepPrompt: rehydrated.pending.prompt ?? '',
             isComplete: rehydrated.isComplete,
             triggerSource: 'daemon',
+            stepId: rehydrated.pending.stepId,
             // Pass the effective workspace path so buildPreAgentSession() can override
             // sessionWorkspacePath for recovered worktree sessions. Without this, the
             // recovery trigger has workspacePath=worktreePath (so the agent uses the

--- a/src/daemon/tools/spawn-agent.ts
+++ b/src/daemon/tools/spawn-agent.ts
@@ -129,7 +129,7 @@ function parseParams(raw: unknown): ParsedParams {
  */
 interface SpawnContext {
   readonly ctx: V2ToolContext;
-  readonly apiKey: string;
+  readonly apiKey: string | undefined;
   readonly sessionId: RunId;
   readonly thisWorkrailSessionId: string;
   readonly currentDepth: number;
@@ -353,7 +353,7 @@ async function spawnOne(spec: SingleSpawnSpec, sc: SpawnContext): Promise<Single
 export function makeSpawnAgentTool(
   sessionId: RunId,
   ctx: V2ToolContext,
-  apiKey: string,
+  apiKey: string | undefined,
   thisWorkrailSessionId: string,
   currentDepth: number,
   maxDepth: number,

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -269,6 +269,7 @@ export interface AllocatedSession {
    * buildPreAgentSession() derives sessionWorkspacePath from trigger as usual.
    */
   readonly sessionWorkspacePath?: string;
+  readonly stepId?: string;
 }
 
 /**

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -147,7 +147,9 @@ import type {
   SessionOutcome,
   FinalizationContext,
   TurnEndSubscriberContext,
+  SessionPaths,
 } from './runner/index.js';
+import { buildSessionPaths } from './runner/index.js';
 export type {
   PreAgentSession,
   PreAgentSessionResult,
@@ -157,6 +159,7 @@ export type {
   TurnEndSubscriberContext,
 } from './runner/index.js';
 export { WORKTREES_DIR } from './runner/runner-types.js';
+export { buildSessionPaths } from './runner/index.js';
 export {
   buildPreAgentSession,
   buildTurnEndSubscriber,
@@ -440,8 +443,8 @@ export async function runWorkflow(
   );
 
   // ---- Agent loop phase: run prompt loop to completion ----
-  const conversationPath = path.join(sessionsDir, `${sessionId}-conversation.jsonl`);
-  const outcome = await runAgentLoop(readySession, trigger, conversationPath);
+  const sessionPaths = buildSessionPaths(sessionsDir, String(sessionId));
+  const outcome = await runAgentLoop(readySession, trigger, sessionPaths);
 
   // Map SessionOutcome back to the raw stopReason/errorMessage that buildSessionResult expects.
   const stopReason = outcome.kind === 'aborted' ? 'error' : outcome.stopReason;
@@ -457,7 +460,7 @@ export async function runWorkflow(
     branchStrategy: trigger.branchStrategy,
     statsDir,
     sessionsDir,
-    conversationPath,
+    conversationPath: sessionPaths.conversationPath,
     emitter,
     daemonRegistry,
     workflowId: trigger.workflowId,

--- a/src/daemon/workflow-runner.ts
+++ b/src/daemon/workflow-runner.ts
@@ -305,7 +305,7 @@ function buildUserMessage(text: string): { role: 'user'; content: string; timest
 export async function runWorkflow(
   trigger: WorkflowTrigger,
   ctx: V2ToolContext,
-  apiKey: string,
+  apiKey: string | undefined,
   daemonRegistry?: DaemonRegistry,
   emitter?: DaemonEventEmitter,
   activeSessionSet?: ActiveSessionSet,

--- a/src/mcp/handlers/v2-advance-core/input-validation.ts
+++ b/src/mcp/handlers/v2-advance-core/input-validation.ts
@@ -170,6 +170,19 @@ export function validateAdvanceInputs(args: {
   const autonomy = rawAutonomy as typeof VALID_AUTONOMY[number];
   const riskPolicy = rawRiskPolicy as typeof VALID_RISK_POLICY[number];
 
+  const rawRc = typedStep?.requireConfirmation;
+  const { requireConfirmation, gateKind } = (() => {
+    if (typeof rawRc === 'object' && rawRc !== null && !Array.isArray(rawRc) && 'kind' in rawRc) {
+      const kindObj = rawRc as { kind: string; condition?: Condition };
+      if (kindObj.kind === 'coordinator_eval' || kindObj.kind === 'human_approval') {
+        const extractedKind = kindObj.kind as import('../../../v2/durable-core/constants.js').GateKind;
+        const condition = 'condition' in kindObj ? kindObj.condition : true;
+        return { requireConfirmation: condition as boolean | Condition | undefined, gateKind: extractedKind };
+      }
+    }
+    return { requireConfirmation: rawRc as boolean | Condition | undefined, gateKind: undefined };
+  })();
+
   return ok({
     pendingStep,
     mergedContext: mergedContextRes.value as Record<string, unknown>,
@@ -185,18 +198,7 @@ export function validateAdvanceInputs(args: {
     riskPolicy,
     effectivePrefs,
     notesOptional,
-    requireConfirmation: typedStep?.requireConfirmation,
-    // Extract gateKind from the object form of requireConfirmation. Must happen here
-    // (boundary) so executeAdvanceCore receives a typed GateKind, not a raw object.
-    gateKind: (() => {
-      const rc = typedStep?.requireConfirmation;
-      if (typeof rc === 'object' && rc !== null && !Array.isArray(rc) && 'kind' in rc) {
-        const k = (rc as { kind: unknown }).kind;
-        if (k === 'coordinator_eval' || k === 'human_approval') {
-          return k as import('../../../v2/durable-core/constants.js').GateKind;
-        }
-      }
-      return undefined;
-    })(),
+    requireConfirmation,
+    gateKind,
   });
 }

--- a/src/trigger/coordinator-deps.ts
+++ b/src/trigger/coordinator-deps.ts
@@ -262,6 +262,9 @@ export class SessionReader {
     const statusResult = await this.deriveSessionStatus(handle);
 
     if (statusResult.kind === 'complete' || statusResult.kind === 'paused_at_gate') {
+      // NOTE: for paused_at_gate, this returns pre-gate artifacts only -- the gated step has not
+      // yet executed. The coordinator can read artifacts produced before the gate fired (e.g.
+      // wr.review_verdict from a prior step), but must not assume the gated step completed.
       const agentResult = await this.fetchAgentResult(handle);
       return { kind: 'success', notes: agentResult.recapMarkdown, artifacts: agentResult.artifacts };
     }

--- a/src/trigger/coordinator-deps.ts
+++ b/src/trigger/coordinator-deps.ts
@@ -261,10 +261,15 @@ export class SessionReader {
   async fetchChildSessionResult(handle: string): Promise<ChildSessionResult> {
     const statusResult = await this.deriveSessionStatus(handle);
 
-    if (statusResult.kind === 'complete' || statusResult.kind === 'paused_at_gate') {
-      // NOTE: for paused_at_gate, this returns pre-gate artifacts only -- the gated step has not
-      // yet executed. The coordinator can read artifacts produced before the gate fired (e.g.
-      // wr.review_verdict from a prior step), but must not assume the gated step completed.
+    if (statusResult.kind === 'complete') {
+      const agentResult = await this.fetchAgentResult(handle);
+      return { kind: 'success', notes: agentResult.recapMarkdown, artifacts: agentResult.artifacts };
+    }
+    if (statusResult.kind === 'paused_at_gate') {
+      // Session is parked at a gate; pre-gate artifacts are available but the gated step has
+      // not executed. Return success so callers can read artifacts (e.g. wr.review_verdict
+      // emitted before the gate). The 'paused_at_gate' outcome in awaitSessions lets callers
+      // distinguish this case if needed.
       const agentResult = await this.fetchAgentResult(handle);
       return { kind: 'success', notes: agentResult.recapMarkdown, artifacts: agentResult.artifacts };
     }
@@ -281,12 +286,12 @@ export class SessionReader {
   }
 
   async awaitSessions(handles: readonly string[], timeoutMs: number): Promise<{
-    results: Array<{ handle: string; outcome: 'success' | 'failed' | 'timeout'; status: string | null; durationMs: number }>;
+    results: Array<{ handle: string; outcome: 'success' | 'paused_at_gate' | 'failed' | 'timeout'; status: string | null; durationMs: number }>;
     allSucceeded: boolean;
   }> {
     const startMs = Date.now();
     const pending = new Set(handles);
-    const results = new Map<string, { handle: string; outcome: 'success' | 'failed' | 'timeout'; status: string | null; durationMs: number }>();
+    const results = new Map<string, { handle: string; outcome: 'success' | 'paused_at_gate' | 'failed' | 'timeout'; status: string | null; durationMs: number }>();
 
     while (pending.size > 0) {
       if (Date.now() - startMs >= timeoutMs) break;
@@ -301,8 +306,9 @@ export class SessionReader {
             results.set(handle, { handle, outcome: 'failed', status: 'blocked', durationMs: Date.now() - startMs });
             pending.delete(handle);
           } else if (statusResult.kind === 'paused_at_gate') {
-            // Gate checkpoint: treat as success so the coordinator can read its artifacts and proceed.
-            results.set(handle, { handle, outcome: 'success', status: 'paused_at_gate', durationMs: Date.now() - startMs });
+            // Gate checkpoint: session is parked waiting for gate evaluation. Artifacts from
+            // pre-gate steps are available, but the gated step has not yet executed.
+            results.set(handle, { handle, outcome: 'paused_at_gate', status: 'paused_at_gate', durationMs: Date.now() - startMs });
             pending.delete(handle);
           } else if (statusResult.kind === 'hard_fail') {
             process.stderr.write(`[WARN coord:reason=store_error handle=${handle.slice(0, 16)}] awaitSessions: ${statusResult.message}\n`);

--- a/src/trigger/coordinator-deps.ts
+++ b/src/trigger/coordinator-deps.ts
@@ -261,20 +261,12 @@ export class SessionReader {
   async fetchChildSessionResult(handle: string): Promise<ChildSessionResult> {
     const statusResult = await this.deriveSessionStatus(handle);
 
-    if (statusResult.kind === 'complete') {
+    if (statusResult.kind === 'complete' || statusResult.kind === 'paused_at_gate') {
       const agentResult = await this.fetchAgentResult(handle);
       return { kind: 'success', notes: agentResult.recapMarkdown, artifacts: agentResult.artifacts };
     }
     if (statusResult.kind === 'blocked') {
       return { kind: 'failed', reason: 'stuck', message: `Child session ${handle.slice(0, 16)} reached blocked state` };
-    }
-    // Gate checkpoint: session paused at a requireConfirmation gate. PR 2 will dispatch
-    // the gate evaluator; for now, treat as failed to unblock the coordinator.
-    if (statusResult.kind === 'paused_at_gate') {
-      // Gate evaluation for child sessions spawned by spawn_agent is not yet wired.
-      // The TriggerRouter handles top-level gate evaluation; child session gates escalate
-      // to the parent as 'stuck' so the parent can report_issue and the operator is notified.
-      return { kind: 'failed', reason: 'stuck', message: `Child session ${handle.slice(0, 16)} paused at gate checkpoint (step '${statusResult.stepId}'). Parent session should report_issue.` };
     }
     if (statusResult.kind === 'hard_fail') {
       process.stderr.write(`[WARN coord:reason=store_error handle=${handle.slice(0, 16)}] fetchChildSessionResult: ${statusResult.message}\n`);
@@ -306,8 +298,8 @@ export class SessionReader {
             results.set(handle, { handle, outcome: 'failed', status: 'blocked', durationMs: Date.now() - startMs });
             pending.delete(handle);
           } else if (statusResult.kind === 'paused_at_gate') {
-            // Gate checkpoint: treat as terminal for now. PR 2 will dispatch the gate evaluator.
-            results.set(handle, { handle, outcome: 'failed', status: 'paused_at_gate', durationMs: Date.now() - startMs });
+            // Gate checkpoint: treat as success so the coordinator can read its artifacts and proceed.
+            results.set(handle, { handle, outcome: 'success', status: 'paused_at_gate', durationMs: Date.now() - startMs });
             pending.delete(handle);
           } else if (statusResult.kind === 'hard_fail') {
             process.stderr.write(`[WARN coord:reason=store_error handle=${handle.slice(0, 16)}] awaitSessions: ${statusResult.message}\n`);
@@ -412,6 +404,7 @@ class CoordinatorDepsImpl implements AdaptiveCoordinatorDeps {
       firstStepPrompt: r.pending?.prompt ?? '',
       isComplete: r.isComplete,
       triggerSource: 'daemon',
+      stepId: r.pending?.stepId,
     };
     const source: SessionSource = { kind: 'pre_allocated', trigger: opts.trigger, session: allocatedSession };
     this.dispatch(opts.trigger, source);

--- a/src/trigger/trigger-listener.ts
+++ b/src/trigger/trigger-listener.ts
@@ -276,9 +276,13 @@ export async function startTriggerListener(
     return null;
   }
 
-  // Resolve API key
+  // Resolve API key.
+  // Optional when AWS credentials (AWS_PROFILE or AWS_ACCESS_KEY_ID) are present --
+  // those sessions use AnthropicBedrock which does not require an Anthropic API key.
+  // buildAgentClient() enforces the key is present when it is actually needed.
   const apiKey = options.apiKey ?? env['ANTHROPIC_API_KEY'];
-  if (!apiKey) {
+  const hasBedrock = !!(env['AWS_PROFILE'] || env['AWS_ACCESS_KEY_ID']);
+  if (!apiKey && !hasBedrock) {
     return { _kind: 'err', error: { kind: 'missing_api_key' } };
   }
 

--- a/src/trigger/trigger-router.ts
+++ b/src/trigger/trigger-router.ts
@@ -97,7 +97,7 @@ export type RouteResult =
 export type RunWorkflowFn = (
   trigger: WorkflowTrigger,
   ctx: V2ToolContext,
-  apiKey: string,
+  apiKey: string | undefined,
   daemonRegistry?: import('../v2/infra/in-memory/daemon-registry/index.js').DaemonRegistry,
   emitter?: DaemonEventEmitter,
   activeSessionSet?: ActiveSessionSet,
@@ -478,7 +478,7 @@ export class TriggerRouter {
   constructor(
     private readonly index: ReadonlyMap<string, TriggerDefinition>,
     private readonly ctx: V2ToolContext,
-    private readonly apiKey: string,
+    private readonly apiKey: string | undefined,
     private readonly runWorkflowFn: RunWorkflowFn,
     opts: TriggerRouterOptions = {},
   ) {

--- a/src/v2/durable-core/domain/prompt-renderer.ts
+++ b/src/v2/durable-core/domain/prompt-renderer.ts
@@ -575,25 +575,37 @@ export function renderPendingPrompt(args: {
   // (e.g. { var: 'taskComplexity', equals: 'Large' }) are evaluated against live session context.
   // Boolean(conditionObject) would always be true -- we need evaluateCondition() here.
   //
-  // Object form { kind: 'coordinator_eval' | 'human_approval' }: extract gateKind FIRST,
-  // then treat the value as boolean true. Must happen before evaluateCondition() since
-  // { kind: '...' } is not a valid condition expression.
-  let rc = step.requireConfirmation;
-  let gateKind: import('../constants.js').GateKind | undefined;
-  if (typeof rc === 'object' && rc !== null && !Array.isArray(rc) && 'kind' in rc) {
-    const kindObj = rc as { kind: string };
-    if (kindObj.kind === 'coordinator_eval' || kindObj.kind === 'human_approval') {
-      gateKind = kindObj.kind as import('../constants.js').GateKind;
-      rc = true; // normalize to boolean for the requireConfirmation evaluation below
+  // Object form { kind: 'coordinator_eval' | 'human_approval', condition?: Condition }: extract gateKind FIRST,
+  // then treat the value as boolean true or evaluate condition since { kind: '...' } is not a valid condition expression.
+  const rawRc = step.requireConfirmation;
+  const { conditionToEvaluate, initialRc, gateKindFromObj } = (() => {
+    if (typeof rawRc === 'object' && rawRc !== null && !Array.isArray(rawRc) && 'kind' in rawRc) {
+      const kindObj = rawRc as { kind: string; condition?: unknown };
+      if (kindObj.kind === 'coordinator_eval' || kindObj.kind === 'human_approval') {
+        const extractedKind = kindObj.kind as import('../constants.js').GateKind;
+        if ('condition' in kindObj) {
+          return { conditionToEvaluate: kindObj.condition, initialRc: rawRc, gateKindFromObj: extractedKind };
+        } else {
+          return { conditionToEvaluate: undefined, initialRc: true, gateKindFromObj: extractedKind };
+        }
+      }
     }
-  }
-  const requireConfirmation = rc === true || rc === false || rc === undefined
-    ? Boolean(rc)
-    : evaluateCondition(rc as Exclude<typeof rc, { kind: string }>, renderContext);
+    return { conditionToEvaluate: undefined, initialRc: rawRc, gateKindFromObj: undefined };
+  })();
+
+  const requireConfirmation = conditionToEvaluate !== undefined
+    ? evaluateCondition(conditionToEvaluate, renderContext)
+    : (initialRc === true || initialRc === false || initialRc === undefined
+        ? Boolean(initialRc)
+        : evaluateCondition(initialRc as Exclude<typeof initialRc, { kind: string }>, renderContext));
+
   // Default gateKind to 'coordinator_eval' when requireConfirmation is true but no kind was specified.
-  if (requireConfirmation && gateKind === undefined) {
-    gateKind = 'coordinator_eval';
-  }
+  const gateKind = (() => {
+    if (requireConfirmation) {
+      return gateKindFromObj ?? 'coordinator_eval';
+    }
+    return undefined;
+  })();
 
   // Resolve both prompt and title — titles are agent-visible (inspect output, UI headers).
   // prompt is optional (steps may use promptBlocks instead); default to '' so the resolver

--- a/tests/unit/session-cortex.test.ts
+++ b/tests/unit/session-cortex.test.ts
@@ -35,7 +35,6 @@ describe('SessionCortex', () => {
     await cortex.load('step-2');
 
     // To verify state, we can run a new handleTurnEnd with step-2 which should trigger a scaffold (failureCount 2)
-    const mockAgent = { steer: () => {} };
     const state = {
       pendingStepIdAfterAdvance: 'step-2',
       pendingSteerParts: [] as string[],
@@ -75,7 +74,6 @@ describe('SessionCortex', () => {
     const cortex = new SessionCortex(cortexLogPath);
     await cortex.load('step-1');
 
-    const mockAgent = { steer: () => {} };
     const state = {
       pendingStepIdAfterAdvance: 'step-1',
       pendingSteerParts: [] as string[],
@@ -127,7 +125,6 @@ describe('SessionCortex', () => {
     const cortex = new SessionCortex(cortexLogPath);
     await cortex.load('step-1');
 
-    const mockAgent = { steer: () => {} };
     const state = {
       pendingStepIdAfterAdvance: 'step-1',
       pendingSteerParts: [] as string[],

--- a/tests/unit/session-cortex.test.ts
+++ b/tests/unit/session-cortex.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { SessionCortex, type CortexEvent } from '../../src/daemon/cortex/session-cortex.js';
+
+describe('SessionCortex', () => {
+  let tmpDir: string;
+  let cortexLogPath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workrail-cortex-test-'));
+    cortexLogPath = path.join(tmpDir, 'test-cortex.jsonl');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('correctly loads and replays events on startup', async () => {
+    const initialEvents = [
+      { kind: 'step_failure_observed', stepId: 'step-1', failureCount: 1, errorSummary: 'missing artifact', ts: Date.now() },
+      { kind: 'hint_injected', stepId: 'step-1', ts: Date.now() },
+      { kind: 'step_failure_observed', stepId: 'step-1', failureCount: 2, errorSummary: 'missing artifact again', ts: Date.now() },
+      { kind: 'scaffold_injected', stepId: 'step-1', ts: Date.now() },
+      { kind: 'step_advanced', stepId: 'step-1', ts: Date.now() },
+      { kind: 'step_failure_observed', stepId: 'step-2', failureCount: 1, errorSummary: 'missing verdict', ts: Date.now() },
+      { kind: 'hint_injected', stepId: 'step-2', ts: Date.now() },
+    ];
+
+    const lines = initialEvents.map(e => JSON.stringify(eventWithTs(e))).join('\n') + '\n';
+    await fs.writeFile(cortexLogPath, lines, 'utf8');
+
+    const cortex = new SessionCortex(cortexLogPath);
+    await cortex.load('step-2');
+
+    // To verify state, we can run a new handleTurnEnd with step-2 which should trigger a scaffold (failureCount 2)
+    const mockAgent = { steer: () => {} };
+    const state = {
+      pendingStepIdAfterAdvance: 'step-2',
+      pendingSteerParts: [] as string[],
+    };
+
+    const blockEvent = {
+      type: 'turn_end' as const,
+      toolResults: [
+        {
+          toolName: 'complete_step',
+          isError: false,
+          result: {
+            details: {
+              kind: 'blocked',
+              blockers: {
+                blockers: [
+                  {
+                    message: 'Missing review verdict',
+                    pointer: { kind: 'output_contract', contractRef: 'wr.contracts.review_verdict' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    await cortex.handleTurnEnd(blockEvent, mockAgent, state);
+
+    expect(state.pendingSteerParts).toHaveLength(1);
+    expect(state.pendingSteerParts[0]).toContain('Cortex Interceded (Tier-2 Scaffold)');
+    expect(state.pendingSteerParts[0]).toContain('wr.review_verdict');
+  });
+
+  it('triggers Tier-1 Hint on first failure, and Tier-2 Scaffold on second failure', async () => {
+    const cortex = new SessionCortex(cortexLogPath);
+    await cortex.load('step-1');
+
+    const mockAgent = { steer: () => {} };
+    const state = {
+      pendingStepIdAfterAdvance: 'step-1',
+      pendingSteerParts: [] as string[],
+    };
+
+    const blockEvent = {
+      type: 'turn_end' as const,
+      toolResults: [
+        {
+          toolName: 'complete_step',
+          isError: false,
+          result: {
+            details: {
+              kind: 'blocked',
+              blockers: {
+                blockers: [
+                  {
+                    message: 'Missing loop control',
+                    pointer: { kind: 'output_contract', contractRef: 'wr.contracts.loop_control' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    // First failure: Hint
+    await cortex.handleTurnEnd(blockEvent, mockAgent, state);
+    expect(state.pendingSteerParts).toHaveLength(1);
+    expect(state.pendingSteerParts[0]).toContain('Cortex Interceded (Tier-1 Hint)');
+    expect(state.pendingSteerParts[0]).toContain('wr.contracts.loop_control');
+
+    // Second failure: Scaffold
+    state.pendingSteerParts = [];
+    await cortex.handleTurnEnd(blockEvent, mockAgent, state);
+    expect(state.pendingSteerParts).toHaveLength(1);
+    expect(state.pendingSteerParts[0]).toContain('Cortex Interceded (Tier-2 Scaffold)');
+    expect(state.pendingSteerParts[0]).toContain('wr.contracts.loop_control');
+
+    // Third failure: No-op (exceeded Phase 2 maximum of tier 2)
+    state.pendingSteerParts = [];
+    await cortex.handleTurnEnd(blockEvent, mockAgent, state);
+    expect(state.pendingSteerParts).toHaveLength(0);
+  });
+
+  it('resets failure counts when step advances', async () => {
+    const cortex = new SessionCortex(cortexLogPath);
+    await cortex.load('step-1');
+
+    const mockAgent = { steer: () => {} };
+    const state = {
+      pendingStepIdAfterAdvance: 'step-1',
+      pendingSteerParts: [] as string[],
+    };
+
+    const blockEvent = {
+      type: 'turn_end' as const,
+      toolResults: [
+        {
+          toolName: 'complete_step',
+          isError: false,
+          result: {
+            details: {
+              kind: 'blocked',
+              blockers: {
+                blockers: [
+                  {
+                    message: 'Missing loop control',
+                    pointer: { kind: 'output_contract', contractRef: 'wr.contracts.loop_control' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    // First failure on step-1: Hint
+    await cortex.handleTurnEnd(blockEvent, mockAgent, state);
+    expect(state.pendingSteerParts).toHaveLength(1);
+    expect(state.pendingSteerParts[0]).toContain('Tier-1 Hint');
+
+    // Step advances! We transition to step-2
+    state.pendingStepIdAfterAdvance = 'step-2';
+    state.pendingSteerParts = [];
+
+    // Success or other non-blocked turn_end on step-2
+    const successEvent = {
+      type: 'turn_end' as const,
+      toolResults: [],
+    };
+    await cortex.handleTurnEnd(successEvent, mockAgent, state);
+    expect(state.pendingSteerParts).toHaveLength(0);
+
+    // Now step-2 fails: should trigger Tier-1 Hint, NOT Tier-2 Scaffold
+    await cortex.handleTurnEnd(blockEvent, mockAgent, state);
+    expect(state.pendingSteerParts).toHaveLength(1);
+    expect(state.pendingSteerParts[0]).toContain('Tier-1 Hint');
+  });
+});
+
+function eventWithTs(e: Omit<CortexEvent, 'ts'> & { ts?: number }): CortexEvent {
+  return { ...e, ts: e.ts ?? Date.now() } as CortexEvent;
+}

--- a/tests/unit/session-cortex.test.ts
+++ b/tests/unit/session-cortex.test.ts
@@ -64,7 +64,7 @@ describe('SessionCortex', () => {
       ],
     };
 
-    await cortex.handleTurnEnd(blockEvent, mockAgent, state);
+    await cortex.handleTurnEnd(blockEvent, state);
 
     expect(state.pendingSteerParts).toHaveLength(1);
     expect(state.pendingSteerParts[0]).toContain('Cortex Interceded (Tier-2 Scaffold)');
@@ -105,21 +105,21 @@ describe('SessionCortex', () => {
     };
 
     // First failure: Hint
-    await cortex.handleTurnEnd(blockEvent, mockAgent, state);
+    await cortex.handleTurnEnd(blockEvent, state);
     expect(state.pendingSteerParts).toHaveLength(1);
     expect(state.pendingSteerParts[0]).toContain('Cortex Interceded (Tier-1 Hint)');
     expect(state.pendingSteerParts[0]).toContain('wr.contracts.loop_control');
 
     // Second failure: Scaffold
     state.pendingSteerParts = [];
-    await cortex.handleTurnEnd(blockEvent, mockAgent, state);
+    await cortex.handleTurnEnd(blockEvent, state);
     expect(state.pendingSteerParts).toHaveLength(1);
     expect(state.pendingSteerParts[0]).toContain('Cortex Interceded (Tier-2 Scaffold)');
     expect(state.pendingSteerParts[0]).toContain('wr.contracts.loop_control');
 
     // Third failure: No-op (exceeded Phase 2 maximum of tier 2)
     state.pendingSteerParts = [];
-    await cortex.handleTurnEnd(blockEvent, mockAgent, state);
+    await cortex.handleTurnEnd(blockEvent, state);
     expect(state.pendingSteerParts).toHaveLength(0);
   });
 
@@ -157,7 +157,7 @@ describe('SessionCortex', () => {
     };
 
     // First failure on step-1: Hint
-    await cortex.handleTurnEnd(blockEvent, mockAgent, state);
+    await cortex.handleTurnEnd(blockEvent, state);
     expect(state.pendingSteerParts).toHaveLength(1);
     expect(state.pendingSteerParts[0]).toContain('Tier-1 Hint');
 
@@ -170,11 +170,11 @@ describe('SessionCortex', () => {
       type: 'turn_end' as const,
       toolResults: [],
     };
-    await cortex.handleTurnEnd(successEvent, mockAgent, state);
+    await cortex.handleTurnEnd(successEvent, state);
     expect(state.pendingSteerParts).toHaveLength(0);
 
     // Now step-2 fails: should trigger Tier-1 Hint, NOT Tier-2 Scaffold
-    await cortex.handleTurnEnd(blockEvent, mockAgent, state);
+    await cortex.handleTurnEnd(blockEvent, state);
     expect(state.pendingSteerParts).toHaveLength(1);
     expect(state.pendingSteerParts[0]).toContain('Tier-1 Hint');
   });

--- a/tests/unit/v2/prompt-renderer.test.ts
+++ b/tests/unit/v2/prompt-renderer.test.ts
@@ -947,4 +947,76 @@ describe('buildMetricsSection', () => {
       expect(result.value.prompt).not.toContain('final step');
     }
   });
+
+  describe('nested conditional requireConfirmation', () => {
+    const conditionalWorkflow = createWorkflow(
+      {
+        id: 'conditional-test',
+        name: 'Conditional Test',
+        description: 'Test nested conditional gates',
+        version: '1.0.0',
+        steps: [
+          {
+            id: 'step1',
+            title: 'Step 1',
+            prompt: 'Do step 1',
+            notesOptional: true,
+            requireConfirmation: {
+              kind: 'human_approval',
+              condition: {
+                not: { var: 'verdict', equals: 'clean' }
+              }
+            }
+          }
+        ],
+      } as any,
+      createBundledSource()
+    );
+
+    it('requires confirmation with human_approval when condition is met (verdict = blocking)', () => {
+      const indexWithBlocking = {
+        runContextByRunId: new Map([['run_1', { verdict: 'blocking' }]])
+      } as any;
+
+      const result = renderPendingPrompt({
+        workflow: conditionalWorkflow,
+        stepId: 'step1',
+        loopPath: [],
+        truth: { events: [], manifest: [] },
+        runId: 'run_1',
+        nodeId: 'node_1',
+        rehydrateOnly: false,
+        precomputedIndex: indexWithBlocking,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.requireConfirmation).toBe(true);
+        expect((result.value as any).gateKind).toBe('human_approval');
+      }
+    });
+
+    it('does not require confirmation when condition is not met (verdict = clean)', () => {
+      const indexWithClean = {
+        runContextByRunId: new Map([['run_1', { verdict: 'clean' }]])
+      } as any;
+
+      const result = renderPendingPrompt({
+        workflow: conditionalWorkflow,
+        stepId: 'step1',
+        loopPath: [],
+        truth: { events: [], manifest: [] },
+        runId: 'run_1',
+        nodeId: 'node_1',
+        rehydrateOnly: false,
+        precomputedIndex: indexWithClean,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.requireConfirmation).toBe(false);
+        expect((result.value as any).gateKind).toBeUndefined();
+      }
+    });
+  });
 });

--- a/tests/unit/v2/validate-advance-inputs-precomputed.test.ts
+++ b/tests/unit/v2/validate-advance-inputs-precomputed.test.ts
@@ -141,4 +141,46 @@ describe('validateAdvanceInputs with precomputedIndex', () => {
     expect(result.isErr()).toBe(true);
     expect(result._unsafeUnwrapErr().kind).toBe('invariant_violation');
   });
+
+  it('correctly normalizes nested conditional requireConfirmation and extracts gateKind', () => {
+    const conditionalWorkflowDef = {
+      id: 'test-wf-conditional',
+      name: 'Test',
+      description: 'Test workflow',
+      version: '1',
+      steps: [
+        {
+          id: 'step-1',
+          label: 'Step 1',
+          prompt: 'Do step 1',
+          requireConfirmation: {
+            kind: 'human_approval',
+            condition: {
+              not: { var: 'verdict', equals: 'clean' }
+            }
+          }
+        },
+      ],
+    };
+    const condWorkflow = createWorkflow(conditionalWorkflowDef as any, createBundledSource());
+
+    const sorted = asSortedEventLog([makeRunStarted(0, 'run_1'), makeNodeCreated(1, 'run_1', 'node_1')]);
+    const index = buildSessionIndex(sorted._unsafeUnwrap());
+
+    const result = validateAdvanceInputs({
+      truth: { events: [], manifest: [] },
+      runId,
+      currentNodeId: nodeId,
+      inputContext: undefined,
+      inputOutput: undefined,
+      pinnedWorkflow: condWorkflow,
+      pendingStep,
+      precomputedIndex: index,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const val = result._unsafeUnwrap();
+    expect(val.gateKind).toBe('human_approval');
+    expect(val.requireConfirmation).toEqual({ not: { var: 'verdict', equals: 'clean' } });
+  });
 });

--- a/workflows/mr-review-workflow.agentic.v2.json
+++ b/workflows/mr-review-workflow.agentic.v2.json
@@ -300,7 +300,7 @@
       "requireConfirmation": {
         "kind": "human_approval",
         "condition": {
-          "not": { "var": "verdict", "equals": "clean" }
+          "not": { "var": "recommendation", "equals": "clean" }
         }
       }
     }

--- a/workflows/mr-review-workflow.agentic.v2.json
+++ b/workflows/mr-review-workflow.agentic.v2.json
@@ -297,7 +297,12 @@
       "outputContract": {
         "contractRef": "wr.contracts.review_verdict"
       },
-      "requireConfirmation": { "kind": "human_approval" }
+      "requireConfirmation": {
+        "kind": "human_approval",
+        "condition": {
+          "not": { "var": "verdict", "equals": "clean" }
+        }
+      }
     }
   ]
 }

--- a/workflows/mr-review-workflow.agentic.v2.json
+++ b/workflows/mr-review-workflow.agentic.v2.json
@@ -27,7 +27,10 @@
         {
           "id": "evidence_quality",
           "purpose": "Each finding cites a specific file, function, or line. No finding relies on intuition or pattern-matching without concrete grounding.",
-          "levels": ["low", "high"]
+          "levels": [
+            "low",
+            "high"
+          ]
         }
       ]
     },
@@ -38,7 +41,10 @@
         {
           "id": "coverage_completeness",
           "purpose": "All material review domains are checked or explicitly acknowledged as gaps in the coverage ledger.",
-          "levels": ["low", "high"]
+          "levels": [
+            "low",
+            "high"
+          ]
         }
       ]
     },
@@ -49,7 +55,10 @@
         {
           "id": "contradiction_resolution",
           "purpose": "Every material contradiction is resolved by evidence or explicitly acknowledged with a stated position and rationale.",
-          "levels": ["low", "high"]
+          "levels": [
+            "low",
+            "high"
+          ]
         }
       ]
     },
@@ -60,7 +69,10 @@
         {
           "id": "finding_schema_compliance",
           "purpose": "Every Critical/Major finding has: specific file+line, causal link explaining why this PR introduced or worsened it, and a concrete remediation or verification step. Findings without all three are flags, not actionable review comments.",
-          "levels": ["low", "high"]
+          "levels": [
+            "low",
+            "high"
+          ]
         }
       ]
     }
@@ -97,8 +109,14 @@
       "prompt": "Build the review foundation in one pass, including transitive impact discovery.\n\n**Step 1 -- Early exit / minimum inputs:**\nBefore exploring, verify that the review target is real and inspectable. If the diff, changed files, or equivalent review material are completely absent and cannot be inferred with tools, ask for the minimum missing artifact and stop. Do NOT ask questions you can resolve with tools.\n\n**Step 2 -- Locate and bound the review target:**\nAttempt to determine the strongest available review target and boundary.\n\nAttempt to establish:\n- `reviewTargetKind` from the strongest available source (PR/MR, branch, patch, diff, or local working tree changes)\n- `reviewTargetSource` describing where the target came from\n- likely PR/MR identity when available (`prUrl`, `prNumber`)\n- likely base / ancestor reference (`baseCandidate`, `mergeBaseRef`) when available\n- whether the branch may include inherited or out-of-scope changes\n- `boundaryConfidence`: High / Medium / Low\n\nDo not over-prescribe your own investigation path. Use the strongest available evidence and record uncertainty honestly.\n\n**Step 3 -- Enrich with context:**\nRecover the strongest available intent and policy context.\n\nAttempt to recover:\n- MR title, purpose, and PR description\n- ticket / issue / acceptance context (`ticketRefs`, `ticketContext`)\n- supporting docs / specs / rollout context (`supportingDocsFound`)\n- repo or user policy/convention context (`policySourcesFound`) -- check AGENTS.md, CLAUDE.md, .workrail/review-rules.md, or equivalent\n- `contextConfidence`: High / Medium / Low\n\n**Step 4 -- Review-surface hygiene:**\nClassify the visible change into a minimal review surface.\n\nSet:\n- `coreReviewSurface`\n- `likelyNoiseOrMechanicalChurn`\n- `likelyInheritedOrOutOfScopeChanges`\n- `reviewSurfaceSummary`\n- `reviewScopeWarnings`\n\n**Step 5 -- Classify the review:**\nAfter exploration, classify the work.\n\nSet:\n- `reviewMode`: QUICK / STANDARD / THOROUGH\n- `riskLevel`: Low / Medium / High\n- `shapeProfile`: `isolated_change`, `crosscutting_change`, `mechanically_noisy_change`, or `ambiguous_boundary`\n- `changeTypeProfile`: `general_code_change`, `api_contract_change`, `data_model_or_migration`, `security_sensitive`, or `test_only`\n- `maxParallelism`: 0 / 3 / 5\n- `criticalSurfaceTouched`: true / false\n- `needsSimulation`: true / false\n- `needsBoundaryFollowup`: true / false\n- `needsContextFollowup`: true / false\n- `needsReviewerBundle`: true / false\n\nDecision guidance:\n- QUICK: very small, isolated, low-risk changes with little ambiguity\n- STANDARD: typical feature or bug-fix reviews with moderate ambiguity or moderate risk\n- THOROUGH: critical surfaces, architectural novelty, high risk, broad change sets, or strong need for independent reviewer perspectives\n\nRouting guidance:\n- `api_contract_change` -> bias toward contract/consumer/backward-compatibility scrutiny\n- `data_model_or_migration` -> bias toward rollout/compatibility/simulation scrutiny\n- `security_sensitive` -> bias toward adversarial/runtime-risk scrutiny, lower tolerance for weak evidence\n- `test_only` -> bias toward stronger false-positive suppression\n- `mechanically_noisy_change` -> bias toward stronger noise filtering\n\n**Step 6 -- Caller enumeration (transitive impact discovery):**\nThis step discovers regressions that diff-anchoring alone cannot catch.\n\nFor each changed function, method, or exported symbol in the diff:\n1. Extract the name from the changed lines\n2. Run `git grep -n \"<name>\"` (or ripgrep) across the repository, excluding the changed files themselves\n3. Collect results: unchanged files that call, import, or reference the changed symbol\n4. For each caller found, note: file path, line number, and how it uses the symbol\n5. Assess whether the change's contract (signature, return type, behavior) could affect each caller\n\nSet:\n- `callerEnumerationResults`: array of `{ changedSymbol, callers: [{ file, line, usage }], contractChangeRisk: 'high'|'medium'|'low'|'none' }`\n- `callerEnumerationCount`: total number of external callers found\n- `callerEnumerationHighRiskCount`: callers where contractChangeRisk is 'high'\n- `callerEnumerationConfidence`: High / Medium / Low\n\nFallback: if grep/ripgrep is unavailable or the codebase is too large to enumerate, set `callerEnumerationConfidence: Low` and record the limitation. Do not block the review.\n\nHigh-risk callers feed directly into the `correctness_invariants` reviewer family in Phase 3.\n\n**Step 7 -- Optional deeper context:**\nIf `reviewMode` is STANDARD or THOROUGH and context remains incomplete, spawn TWO WorkRail Executors SIMULTANEOUSLY running `routine-context-gathering` with focus=COMPLETENESS and focus=DEPTH. Synthesize both outputs before finishing this step.\n\n**Step 8 -- Human-facing artifact:**\nChoose `reviewDocPath` only if a live artifact will materially improve human readability. Default: `mr-review.md` at project root. Optional, never canonical workflow state.\n\nFallback behavior:\n- PR/MR not found but branch/diff is inspectable -> continue with downgraded context confidence\n- merge-base / ancestor ambiguous -> continue, set `needsBoundaryFollowup = true`, disclose\n- ticket or supporting docs missing -> continue with downgraded context confidence\n- only a patch/diff available -> continue if inspectable, lower confidence on intent-dependent conclusions\n- review target itself missing -> ask only for that missing artifact and stop\n\nSet these context keys:\n`reviewTargetKind`, `reviewTargetSource`, `prUrl`, `prNumber`, `baseCandidate`, `mergeBaseRef`, `boundaryConfidence`, `contextConfidence`, `mrTitle`, `mrPurpose`, `ticketRefs`, `ticketContext`, `supportingDocsFound`, `policySourcesFound`, `accessibleContextSources`, `missingContextSources`, `focusAreas`, `changedFileCount`, `criticalSurfaceTouched`, `reviewMode`, `riskLevel`, `shapeProfile`, `changeTypeProfile`, `maxParallelism`, `reviewDocPath`, `contextSummary`, `candidateFiles`, `moduleRoots`, `contextUnknownCount`, `coverageGapCount`, `authorIntentUnclear`, `needsSimulation`, `needsBoundaryFollowup`, `needsContextFollowup`, `needsReviewerBundle`, `coreReviewSurface`, `likelyNoiseOrMechanicalChurn`, `likelyInheritedOrOutOfScopeChanges`, `reviewSurfaceSummary`, `reviewScopeWarnings`, `openQuestions`, `callerEnumerationResults`, `callerEnumerationCount`, `callerEnumerationHighRiskCount`, `callerEnumerationConfidence`\n\nAlso set a one-sentence goal in context (e.g. 'review PR #47 before merge') to populate the session title.\n\nRules:\n- answer your own questions with tools whenever possible\n- only keep true human-decision questions in `openQuestions`\n- classify AFTER exploring, not before\n- caller enumeration runs even for QUICK mode -- it is cheap and catches the most important regression class",
       "requireConfirmation": {
         "or": [
-          { "var": "reviewMode", "equals": "THOROUGH" },
-          { "var": "riskLevel", "equals": "High" }
+          {
+            "var": "reviewMode",
+            "equals": "THOROUGH"
+          },
+          {
+            "var": "riskLevel",
+            "equals": "High"
+          }
         ]
       }
     },
@@ -120,7 +138,12 @@
       "promptBlocks": {
         "goal": "Freeze a shared factual basis for review and decide how much reviewer-family parallelism is warranted.",
         "constraints": [
-          [{ "kind": "ref", "refId": "wr.refs.notes_first_durability" }],
+          [
+            {
+              "kind": "ref",
+              "refId": "wr.refs.notes_first_durability"
+            }
+          ],
           "The fact packet is the primary truth for downstream reviewer families.",
           "Keep `recommendationHypothesis` as a secondary hypothesis to challenge, not a frame to defend.",
           "Include the full bodies of changed functions with [NEW]/[UNCHANGED] line markers when the PR is not large (fewer than 10 changed functions). For larger PRs, include at minimum the function signature and the changed hunk with 8 lines of context before the change and 2 lines after."
@@ -146,12 +169,25 @@
     {
       "id": "phase-3-reviewer-family-bundle",
       "title": "Phase 3: Parallel Reviewer Family Bundle",
-      "runCondition": { "var": "needsReviewerBundle", "equals": true },
+      "runCondition": {
+        "var": "needsReviewerBundle",
+        "equals": true
+      },
       "promptBlocks": {
         "goal": "Run the selected reviewer families in parallel from the same fact packet, then synthesize their output as evidence rather than conclusions.",
         "constraints": [
-          [{ "kind": "ref", "refId": "wr.refs.notes_first_durability" }],
-          [{ "kind": "ref", "refId": "wr.refs.synthesis_under_disagreement" }],
+          [
+            {
+              "kind": "ref",
+              "refId": "wr.refs.notes_first_durability"
+            }
+          ],
+          [
+            {
+              "kind": "ref",
+              "refId": "wr.refs.synthesis_under_disagreement"
+            }
+          ],
           "Each reviewer family must use `reviewFactPacket` as primary truth.",
           "Use `recommendationHypothesis` only as secondary comparison context.",
           "Reviewer-family outputs are raw evidence, not canonical review state.",
@@ -162,7 +198,7 @@
         "procedure": [
           "Before delegating, restate the current `recommendationHypothesis` and say which reviewer family is most likely to challenge it.",
           "Family missions and checklists:\n\n`correctness_invariants` -- logic errors, invariant violations, API contract breaks, transitive caller impact.\nCHECKLIST: (1) Does the changed logic handle all branches including error paths and edge cases? (2) Do the callerEnumerationResults show any caller whose contract assumptions are now violated? (3) Are all invariants that callers depend on still upheld? (4) Are there null/undefined/empty cases the change doesn't handle? (5) Does the change break any existing tests or cause them to test the wrong thing?\n\n`patterns_architecture` -- pattern fit, design consistency, architectural concerns, scope creep.\nCHECKLIST: (1) Does the change belong in the layer/module where it was placed? (2) Does it introduce unnecessary complexity or duplicate existing solutions? (3) Does it respect the module's existing abstractions without adding leaky ones? (4) Is scope creep present -- changes beyond what the ticket requires? (5) Would a future maintainer understand why this was placed here?\n\n`runtime_production_risk` -- runtime behavior, production impact, performance, state-flow, rollout safety.\nCHECKLIST: (1) Are there performance implications (N+1, blocking calls, memory retention)? (2) Is the change safe under concurrent access? (3) Does it affect rollout safety (feature flags, migrations, backward compatibility)? (4) Are error cases handled in a way that degrades gracefully? (5) Is the change observable -- are there logs/metrics to detect if it breaks in production?\n\n`security` -- adversarial analysis: trust boundaries, attacker-controlled inputs, privilege escalation, injection risks.\nCHECKLIST: (1) What inputs in the changed code path are attacker-controlled? Trace each. (2) Does the change cross a trust boundary -- does it pass attacker-controlled data to a privileged operation? (3) Are there injection risks (SQL, command, path traversal, template)? (4) Does the change affect auth, session handling, permissions, or crypto? If yes, what could an attacker do with the change? (5) Are secrets, tokens, or credentials handled correctly?\nNOTE: approach this as an attacker, not a code auditor. Start by identifying what an attacker controls, then ask how the change could be exploited.\n\n`test_docs_rollout` -- test adequacy, documentation, migration, rollout, affected consumers.\nCHECKLIST: (1) Do the new/changed tests actually exercise the new behavior, or do they test implementation details? (2) Are error paths and edge cases tested? (3) Is the public API or behavior change documented? (4) If there is a migration or schema change, is the rollout sequence safe? (5) Are downstream consumers or dependents identified and accounted for?\n\n`philosophy_alignment` -- implementation approach vs. coding philosophy, alternative approaches.\nCHECKLIST: (1) For each relevant principle from the fact packet, does the implementation follow it, violate it, or is neutral? Name violations by principle and cite specific code. (2) Generate 2-3 alternative approaches that would also satisfy the acceptance criteria -- for each, state what it looks like in one sentence, which philosophy principles it scores better/worse on, and why it was or was not the right choice here. (3) Is the chosen approach the best one given the philosophy, or merely a correct one? (4) Are there abstractions that would make illegal states unrepresentable that the author missed? (5) Does the change handle errors as data (Result types) rather than exceptions?\n\n`false_positive_skeptic` -- challenge overreaches, weak evidence, severity inflation.\nMISSION: find the strongest case that other families are wrong. For each Major or Critical finding from other families: (1) Is the evidence strong enough to justify the severity? (2) Could this issue have pre-existed before this PR? (3) Is the affected code path actually reachable? (4) Does the suggested fix actually address the root cause? (5) Is the reviewer demonstrating codebase knowledge or pattern-matching on surface appearance?\n\n`ticket_compliance` -- verify the PR delivers what the ticket required.\nCHECKLIST: (1) For each acceptance criterion from `acceptanceCriteria` with status `missing` or `partial`, confirm whether it is truly absent from the diff or whether Phase 0b assessment was wrong. (2) For each `scopeCreepFlag`, assess severity: is this a necessary implementation detail or genuine unasked-for scope? (3) Does the PR description accurately describe what the diff does? (4) Are there acceptance criteria that are `met` on paper but implemented in a way that misses the spirit of the requirement? (5) Would the ticket author consider this PR done?\n\n`missed_issue_hunter` -- search for an important issue category the other families may have missed.\nMISSION: identify one class of issue the other families are structurally blind to. Consider: (1) Cross-cutting concerns that span multiple changed files (2) Second-order effects of caller contract changes not yet enumerated (3) Security concerns outside the explicit security domain (timing attacks, resource exhaustion, SSRF) (4) Operational concerns (config drift, deployment dependencies, secret rotation) (5) Long-term maintainability issues the current reviewers didn't flag",
-          "Mode-adaptive parallelism: STANDARD = spawn THREE WorkRail Executors SIMULTANEOUSLY for the selected families; THOROUGH = spawn FIVE WorkRail Executors SIMULTANEOUSLY for the selected families.",
+          "Mode-adaptive parallelism: STANDARD = spawn THREE WorkRail Executors SIMULTANEOUSLY, one per selected family; THOROUGH = spawn FIVE WorkRail Executors SIMULTANEOUSLY. For each executor use workflowId='wr.routine-reviewer-family' and pass context: { familyName: '<name>', familyMission: '<mission>', familyChecklist: '<checklist items>', reviewFactPacket: { prTitle, prNumber, diffStat, changedFiles, intentAlignmentStatus, acceptanceCriteria, callerEnumerationResults, recommendationHypothesis } }. Each executor receives ONLY its family context -- do NOT pass your full session context, synthesis notes, or other families' outputs. Fresh perspective is the point.",
           "After receiving outputs, explicitly synthesize: what reviewer families confirmed, what was genuinely new, what appeared weak or overreached, and what changed your mind or did not.",
           "Set these context keys: `familyFindingsSummary`, `familyRecommendationSpread`, `contradictionCount`, `blindSpotCount`, `falsePositiveRiskCount`, `needsSimulation`, `rawFamilyFindings` (all findings before reflection scoring, for Phase 3b).",
           "Compute `contradictionCount` as material disagreements across families about issue validity, severity, or recommendation.",
@@ -181,7 +217,10 @@
     {
       "id": "phase-3b-hidden-reflection-scoring",
       "title": "Phase 3b: Hidden Reflection Scoring",
-      "runCondition": { "var": "needsReviewerBundle", "equals": true },
+      "runCondition": {
+        "var": "needsReviewerBundle",
+        "equals": true
+      },
       "prompt": "Score and filter the raw reviewer-family findings before synthesis. This pass is internal only -- scores and suppression rationale are never shown to reviewers or included in the final output.\n\nFor each finding in `rawFamilyFindings`:\n\n1. Score it 0-10 on confidence x actionability:\n   - Confidence (0-5): How certain are you that the issue is real and caused by this PR? 0 = speculation, 5 = directly observed in changed lines with clear causal path.\n   - Actionability (0-5): How clearly does the finding tell the reviewer what to do? 0 = vague flag, 5 = specific file+line+remediation step.\n   - Score = Confidence + Actionability (max 10)\n\n2. Apply the finding contract check:\n   - Does it have a specific file and line? If not, -3.\n   - Does it articulate why this PR introduced or worsened the issue? If not, -3.\n   - Does it have a concrete remediation step? If not, -2.\n\n3. Keep findings scoring 5 or above. Convert findings scoring 3-4 to clarification questions. Suppress findings scoring 0-2.\n\n4. For Critical findings: the threshold is 4 (lower bar -- don't suppress potential critical issues).\n\nSet these context keys:\n- `scoredFindings`: array of `{ finding, score, disposition: 'keep'|'clarify'|'suppress' }`\n- `reflectionScoredFindingsCount`: total findings scored\n- `filteredFindingsCount`: findings suppressed (score < 5 for non-critical, score < 4 for critical)\n- `clarificationQuestionsCount`: findings converted to clarification questions\n- `postReflectionCriticalCount`: critical findings remaining after scoring\n- `postReflectionMajorCount`: major findings remaining after scoring\n\nRules:\n- never include scores, thresholds, or suppression rationale in any reviewer-facing output\n- the purpose of this step is to improve signal-to-noise, not to reduce finding count for its own sake\n- a finding that fails the contract check but is clearly important should be rewritten to satisfy the contract rather than suppressed",
       "requireConfirmation": false
     },
@@ -205,7 +244,12 @@
           "promptBlocks": {
             "goal": "If contradictions, blind spots, or important coverage gaps remain, run only the smallest targeted follow-up needed.",
             "constraints": [
-              [{ "kind": "ref", "refId": "wr.refs.parallelize_cognition_serialize_synthesis" }],
+              [
+                {
+                  "kind": "ref",
+                  "refId": "wr.refs.parallelize_cognition_serialize_synthesis"
+                }
+              ],
               "Prefer one compact targeted bundle over repeated broad delegation moments.",
               "Do not regather broad context unless a contradiction proves the original fact packet is insufficient.",
               "Targeted follow-up output is evidence only and must still be synthesized by the main agent."
@@ -249,8 +293,18 @@
       "promptBlocks": {
         "goal": "Stress-test the current recommendation before final handoff.",
         "constraints": [
-          [{ "kind": "ref", "refId": "wr.refs.adversarial_challenge_rules" }],
-          [{ "kind": "ref", "refId": "wr.refs.synthesis_under_disagreement" }],
+          [
+            {
+              "kind": "ref",
+              "refId": "wr.refs.adversarial_challenge_rules"
+            }
+          ],
+          [
+            {
+              "kind": "ref",
+              "refId": "wr.refs.synthesis_under_disagreement"
+            }
+          ],
           "Validation output is evidence to synthesize, not an automatic reopen signal."
         ],
         "procedure": [
@@ -276,7 +330,9 @@
       ],
       "assessmentConsequences": [
         {
-          "when": { "anyEqualsLevel": "low" },
+          "when": {
+            "anyEqualsLevel": "low"
+          },
           "effect": {
             "kind": "require_followup",
             "guidance": "evidence_quality low: anchor each finding to a specific file/line; remove findings without concrete grounding. coverage_completeness low: investigate uncovered domains or acknowledge gaps in the ledger. contradiction_resolution low: resolve each contradiction or state your position with rationale. finding_schema_compliance low: for every Critical/Major finding, add file+line, causal link to PR changes, and a concrete remediation step."
@@ -285,22 +341,31 @@
       ],
       "requireConfirmation": {
         "or": [
-          { "var": "validatorConsensusLevel", "equals": "Low" },
-          { "var": "recommendationConfidenceBand", "equals": "Low" }
+          {
+            "var": "validatorConsensusLevel",
+            "equals": "Low"
+          },
+          {
+            "var": "recommendationConfidenceBand",
+            "equals": "Low"
+          }
         ]
       }
     },
     {
       "id": "phase-6-final-handoff",
       "title": "Phase 6: Final Handoff",
-      "prompt": "Provide the final MR review handoff.\n\nInclude:\n- MR title and purpose\n- intent alignment status and any misalignment finding\n- review mode used\n- final recommendation and confidence band\n- confidence assessment summary, including the most important reason confidence was capped if it was not High\n- counts of Critical / Major / Minor / Nit findings (post-reflection)\n- top findings with rationale -- each must include file, line, causal link to PR changes, and remediation step\n- caller enumeration summary: how many external callers were found, how many were high-risk, and what was assessed\n- strongest remaining areas of uncertainty, if any\n- summary of the coverage ledger, especially any still-uncertain domains\n- ready-to-post MR comments summary\n- any validation outcomes a human reviewer should see\n- review environment status: sources used, sources missing, boundary and context confidence, how limits affected the review\n- path to the full human-facing review artifact (`reviewDocPath`) only if one was created\n\nRules:\n- the final recommendation assists a human reviewer; it does not replace them\n- if `reviewDocPath` exists, treat it as a human-facing companion artifact only\n- be explicit when missing PR/ticket/doc/boundary context limited confidence\n- do not post comments, approve, reject, or merge unless the user explicitly asks\n- if reflection scoring suppressed findings, do NOT mention the count or rationale -- only present the final kept findings\n\nIMPORTANT: Emit a structured verdict via complete_step's artifacts[] parameter. Required fields on the outer object; enrichment fields are optional on each finding:\n{\n  \"kind\": \"wr.review_verdict\",\n  \"verdict\": \"clean\" | \"minor\" | \"blocking\",\n  \"confidence\": \"high\" | \"medium\" | \"low\",\n  \"findings\": [\n    {\n      \"severity\": \"critical\" | \"major\" | \"minor\" | \"nit\",\n      \"summary\": \"one-line description\",\n      \"findingCategory\": \"correctness\" | \"security\" | \"architecture\" | \"ux\" | \"performance\" | \"testing\" | \"style\",\n      \"file\": \"path/to/file.ts\",\n      \"startLine\": 42,\n      \"endLine\": 47,\n      \"causalLink\": \"one sentence: why this PR introduced or worsened this issue\",\n      \"remediation\": \"one sentence: the smallest credible fix or verification step\"\n    }\n  ],\n  \"summary\": \"one-line overall verdict summary\"\n}\nFor a clean review: findings: []. verdict: clean = no blocking issues, minor = small issues only, blocking = critical or major issues found. file/startLine/endLine/causalLink/remediation are optional enrichment fields -- include them for Critical and Major findings. omit endLine if single-line.",
+      "prompt": "Provide the final MR review handoff.\n\nInclude:\n- MR title and purpose\n- intent alignment status and any misalignment finding\n- review mode used\n- final recommendation and confidence band\n- confidence assessment summary, including the most important reason confidence was capped if it was not High\n- counts of Critical / Major / Minor / Nit findings (post-reflection)\n- top findings with rationale -- each must include file, line, causal link to PR changes, and remediation step\n- caller enumeration summary: how many external callers were found, how many were high-risk, and what was assessed\n- strongest remaining areas of uncertainty, if any\n- summary of the coverage ledger, especially any still-uncertain domains\n- ready-to-post MR comments summary\n- any validation outcomes a human reviewer should see\n- review environment status: sources used, sources missing, boundary and context confidence, how limits affected the review\n- path to the full human-facing review artifact (`reviewDocPath`) only if one was created\n\nRules:\n- the final recommendation assists a human reviewer; it does not replace them\n- if `reviewDocPath` exists, treat it as a human-facing companion artifact only\n- be explicit when missing PR/ticket/doc/boundary context limited confidence\n- do not post comments, approve, reject, or merge unless the user explicitly asks\n- if reflection scoring suppressed findings, do NOT mention the count or rationale -- only present the final kept findings\n\nIMPORTANT: Emit a structured verdict via your advance call's output.artifacts[] parameter (complete_step in daemon sessions, continue_workflow in MCP sessions). Required fields on the outer object; enrichment fields are optional on each finding:\n{\n  \"kind\": \"wr.review_verdict\",\n  \"verdict\": \"clean\" | \"minor\" | \"blocking\",\n  \"confidence\": \"high\" | \"medium\" | \"low\",\n  \"findings\": [\n    {\n      \"severity\": \"critical\" | \"major\" | \"minor\" | \"nit\",\n      \"summary\": \"one-line description\",\n      \"findingCategory\": \"correctness\" | \"security\" | \"architecture\" | \"ux\" | \"performance\" | \"testing\" | \"style\",\n      \"file\": \"path/to/file.ts\",\n      \"startLine\": 42,\n      \"endLine\": 47,\n      \"causalLink\": \"one sentence: why this PR introduced or worsened this issue\",\n      \"remediation\": \"one sentence: the smallest credible fix or verification step\"\n    }\n  ],\n  \"summary\": \"one-line overall verdict summary\"\n}\nFor a clean review: findings: []. verdict: clean = no blocking issues, minor = small issues only, blocking = critical or major issues found. file/startLine/endLine/causalLink/remediation are optional enrichment fields -- include them for Critical and Major findings. omit endLine if single-line.",
       "outputContract": {
         "contractRef": "wr.contracts.review_verdict"
       },
       "requireConfirmation": {
         "kind": "human_approval",
         "condition": {
-          "not": { "var": "recommendation", "equals": "clean" }
+          "not": {
+            "var": "recommendation",
+            "equals": "clean"
+          }
         }
       }
     }

--- a/workflows/routines/reviewer-family.json
+++ b/workflows/routines/reviewer-family.json
@@ -1,0 +1,17 @@
+{
+  "id": "wr.routine-reviewer-family",
+  "name": "Reviewer Family Audit",
+  "description": "Bounded single-step code review auditor. Receives a specific reviewer family mission, checklist, and frozen fact packet. Runs the checklist directly against the diff using tools and delivers structured findings. Designed to be spawned in parallel by wr.mr-review phase-3 -- each instance gets a distinct family mission and fresh context with no cross-contamination from sibling families or the parent session.",
+  "version": "1.0.0",
+  "metricsProfile": "none",
+  "recommendedPreferences": {
+    "recommendedAutonomy": "full_auto_never_stop"
+  },
+  "steps": [
+    {
+      "id": "audit-and-deliver",
+      "title": "Run Checklist and Deliver Findings",
+      "prompt": "You are a specialized code reviewer. Your mission and checklist are in the context variables `familyMission`, `familyChecklist`, and `familyName`. The frozen fact packet (PR diff summary, changed files, intent alignment, caller enumeration results, acceptance criteria) is in `reviewFactPacket`.\n\nRun through your checklist directly:\n1. Read the relevant diff sections and code using your tools\n2. For each checklist item, make a concrete determination -- do not speculate\n3. Any finding must satisfy the FINDING CONTRACT:\n   - Specific file and line number\n   - Affected code path or trust boundary\n   - Concrete failure mode or risk\n   - Why THIS PR introduced or worsened it (not just that the issue exists)\n   - Smallest credible remediation or verification step\n4. Cap at 3 findings for STANDARD, 5 for THOROUGH. Rank by severity × confidence × actionability. Extras are noise.\n5. When context is insufficient for a confident finding, emit 'Clarification needed: [specific question]' instead of a low-confidence finding.\n\nDeliver your findings in notes. Use this structure:\n\n## Family: {{familyName}}\n\n### Checklist Results\n[For each checklist item: checked / not checked / clarification needed]\n\n### Findings\n[Each finding with file, line, failure mode, causal link, remediation]\n\n### Recommendation Contribution\n[clean | minor | blocking] -- one word + one sentence rationale"
+    }
+  ]
+}

--- a/workflows/routines/reviewer-family.json
+++ b/workflows/routines/reviewer-family.json
@@ -1,7 +1,7 @@
 {
   "id": "wr.routine-reviewer-family",
   "name": "Reviewer Family Audit",
-  "description": "Bounded single-step code review auditor. Receives a specific reviewer family mission, checklist, and frozen fact packet. Runs the checklist directly against the diff using tools and delivers structured findings. Designed to be spawned in parallel by wr.mr-review phase-3 -- each instance gets a distinct family mission and fresh context with no cross-contamination from sibling families or the parent session.",
+  "description": "TEMPORARY SHIM -- replace when spawn_agent supports workflowId-less task worker spawning. The proper architecture is a bare agent session (goal + tools + end_turn) with a typed ReviewerFamilyContext contract enforced at spawn time. This 1-step routine exists because spawn_agent currently requires a workflowId. See backlog: 'spawn_agent task worker mode'.\n\nBounded single-step code review auditor. Receives a specific reviewer family mission, checklist, and frozen fact packet. Runs the checklist directly against the diff using tools and delivers structured findings. Designed to be spawned in parallel by wr.mr-review phase-3 -- each instance gets a distinct family mission and fresh context with no cross-contamination from sibling families or the parent session.",
   "version": "1.0.0",
   "metricsProfile": "none",
   "recommendedPreferences": {


### PR DESCRIPTION
Closes #1075 (SessionCortex Phase 1+2)
Closes #1078 (remove redundant human_approval gate)

## Summary

- **SessionCortex Phase 1+2** (`src/daemon/cortex/session-cortex.ts`): subscribes to `turn_end`, counts per-step engine rejection failures, injects tier-1 hint (failure 1) and tier-2 scaffold (failure 2) before the next LLM turn. State tracked as `Map<string, StepCortexState>` discriminated union. Crash-safe JSONL event log at `~/.workrail/daemon-sessions/cortex-<sessionId>.jsonl` enables recovery on daemon restart.
- **Conditional gate support**: `requireConfirmation` object form now accepts optional `condition` field -- gate only fires when the condition evaluates true against session context. Applied to `wr.mr-review` phase-6: gate fires only when `recommendation != 'clean'` (set by prior synthesis step). Schema, input-validation, and prompt-renderer all updated.
- **Coordinator fix**: `paused_at_gate` in `awaitSessions()` now maps to `outcome: 'success'` so coordinator child sessions at a gate can return their artifacts to the parent coordinator.
- **Bedrock-only daemon startup**: daemon now starts when only AWS credentials are present (`AWS_PROFILE` or `AWS_ACCESS_KEY_ID`) -- no `ANTHROPIC_API_KEY` required. `RunWorkflowFn` type updated to `apiKey: string | undefined` throughout.
- **`dev:daemon` script**: isolated daemon dev loop using `~/.workrail/dev/` as the data dir -- no contamination of production sessions. Every existing `worktrain` command works against it. Documented in AGENTS.md.
- **Backlog**: added ProviderConfig DU item (proper architectural fix for credential threading) and operator-facing capability toggles item.
- **Authoring spec**: added `conditional-gate-context-timing` rule documenting the invariant that `requireConfirmation` condition vars must be set by prior steps.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run` 401 files, 6268 tests passing
- [x] `npm run validate:authoring-spec` passes
- [x] `npm run validate:authoring-docs` passes
- [x] New tests: `tests/unit/session-cortex.test.ts` (3 tests), `tests/unit/v2/prompt-renderer.test.ts` (new conditional gate cases), `tests/unit/v2/validate-advance-inputs-precomputed.test.ts`
- [ ] Live e2e: start dev daemon with `npm run build && npm run dev:daemon`, fire `worktrain dispatch --pr <n> -w .`, verify session completes and draft review posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)