### PR TITLE
feat(mcp): align tools and formatters for environment compatibility

### DIFF
--- a/src/daemon/gate-resume.ts
+++ b/src/daemon/gate-resume.ts
@@ -90,9 +90,10 @@ export async function resumeFromGate(
     workflowId?: string;
     goal?: string;
     workspacePath?: string;
-    branchStrategy?: 'worktree' | 'none';
+    branchStrategy?: 'worktree' | 'none' | 'read-only';
     worktreePath?: string;
     continueToken?: string;
+    context?: Record<string, unknown>;
   };
   try {
     const raw = await fs.readFile(sidecarPath, 'utf8');
@@ -188,6 +189,7 @@ export async function resumeFromGate(
     goal,
     workspacePath,
     branchStrategy: sidecar.branchStrategy ?? 'none',
+    context: sidecar.context,
   };
 
   const source: SessionSource = {

--- a/src/daemon/runner/agent-loop-runner.ts
+++ b/src/daemon/runner/agent-loop-runner.ts
@@ -334,6 +334,7 @@ export async function buildAgentReadySession(
     triggerWorkspacePath: trigger.workspacePath,
     triggerGoal: trigger.goal ?? '',
     triggerBranchStrategy: trigger.branchStrategy,
+    triggerContext: trigger.context,
     activeSessionSet,
     // C2: pass the parent activity notifier through scope so constructTools can
     // forward it to makeSpawnAgentTool. When a grandchild spawns further children,

--- a/src/daemon/runner/construct-tools.ts
+++ b/src/daemon/runner/construct-tools.ts
@@ -55,7 +55,7 @@ export function constructTools(
     fileTracker, onAdvance, onComplete, onTokenUpdate, onIssueReported, onGateParked,
     getCurrentToken, sessionWorkspacePath, spawnCurrentDepth, spawnMaxDepth,
     emitter, activeSessionSet, workflowId: scopeWorkflowId,
-    triggerWorkspacePath, triggerGoal, triggerBranchStrategy,
+    triggerWorkspacePath, triggerGoal, triggerBranchStrategy, triggerContext,
     onChildStepAdvance,
   } = scope;
   const sid = scope.sessionId;
@@ -79,9 +79,9 @@ export function constructTools(
       emitter,
       workrailSid,
       onGateParked,
-      { workflowId: scopeWorkflowId, goal: triggerGoal, workspacePath: triggerWorkspacePath, branchStrategy: triggerBranchStrategy },
+      { workflowId: scopeWorkflowId, goal: triggerGoal, workspacePath: triggerWorkspacePath, branchStrategy: triggerBranchStrategy, context: triggerContext },
     ),
-    makeContinueWorkflowTool(sid, ctx, onAdvance, onComplete, schemas, executeContinueWorkflow, emitter, workrailSid, onGateParked, { workflowId: scopeWorkflowId, goal: triggerGoal, workspacePath: triggerWorkspacePath, branchStrategy: triggerBranchStrategy }),
+    makeContinueWorkflowTool(sid, ctx, onAdvance, onComplete, schemas, executeContinueWorkflow, emitter, workrailSid, onGateParked, { workflowId: scopeWorkflowId, goal: triggerGoal, workspacePath: triggerWorkspacePath, branchStrategy: triggerBranchStrategy, context: triggerContext }),
     // WHY sessionWorkspacePath: when branchStrategy === 'worktree', all agent file operations
     // must target the isolated worktree, not the main checkout.
     makeBashTool(sessionWorkspacePath, schemas, sid, emitter, workrailSid),

--- a/src/daemon/runner/pre-agent-session.ts
+++ b/src/daemon/runner/pre-agent-session.ts
@@ -145,6 +145,7 @@ export async function buildPreAgentSession(
       workflowId: trigger.workflowId,
       goal: trigger.goal,
       workspacePath: trigger.workspacePath,
+      context: trigger.context,
     });
     if (persistResult.kind === 'err') {
       return {
@@ -189,7 +190,7 @@ export async function buildPreAgentSession(
 
       const worktreePersistResult = await persistTokens(
         sessionId, continueToken ?? state.currentContinueToken, checkpointToken, sessionWorktreePath,
-        { workflowId: trigger.workflowId, goal: trigger.goal, workspacePath: trigger.workspacePath },
+        { workflowId: trigger.workflowId, goal: trigger.goal, workspacePath: trigger.workspacePath, context: trigger.context },
       );
       if (worktreePersistResult.kind === 'err') {
         console.error(`[WorkflowRunner] Worktree sidecar persist failed: ${worktreePersistResult.error.code} -- ${worktreePersistResult.error.message}`);
@@ -252,7 +253,7 @@ export async function buildPreAgentSession(
 
       const worktreePersistResult = await persistTokens(
         sessionId, continueToken ?? state.currentContinueToken, checkpointToken, sessionWorktreePath,
-        { workflowId: trigger.workflowId, goal: trigger.goal, workspacePath: trigger.workspacePath, branchStrategy: 'read-only' },
+        { workflowId: trigger.workflowId, goal: trigger.goal, workspacePath: trigger.workspacePath, branchStrategy: 'read-only', context: trigger.context },
       );
       if (worktreePersistResult.kind === 'err') {
         console.error(`[WorkflowRunner] Read-only worktree sidecar persist failed: ${worktreePersistResult.error.code} -- ${worktreePersistResult.error.message}`);

--- a/src/daemon/session-scope.ts
+++ b/src/daemon/session-scope.ts
@@ -272,6 +272,12 @@ export interface SessionScope {
   readonly triggerBranchStrategy: import('./types.js').BranchStrategy | undefined;
 
   /**
+   * The trigger's context variables. Stored in the gate sidecar so resumeFromGate()
+   * can reconstruct the WorkflowTrigger with the original context.
+   */
+  readonly triggerContext?: Readonly<Record<string, unknown>>;
+
+  /**
    * Registry mapping workrailSessionId -> abort callback.
    * Used by `spawn_agent` to register/deregister child sessions.
    * May be undefined if graceful shutdown is not enabled.

--- a/src/daemon/tools/_shared.ts
+++ b/src/daemon/tools/_shared.ts
@@ -89,6 +89,7 @@ export async function persistTokens(
     readonly goal: string;
     readonly workspacePath: string;
     readonly branchStrategy?: import('../types.js').BranchStrategy;
+    readonly context?: Readonly<Record<string, unknown>>;
   },
   gateState?: {
     readonly kind: 'gate_checkpoint';
@@ -112,6 +113,7 @@ export async function persistTokens(
           goal: recoveryContext.goal,
           workspacePath: recoveryContext.workspacePath,
           ...(recoveryContext.branchStrategy !== undefined ? { branchStrategy: recoveryContext.branchStrategy } : {}),
+          ...(recoveryContext.context !== undefined ? { context: recoveryContext.context } : {}),
         } : {}),
         ...(gateState !== undefined ? { gateState } : {}),
         ...(workrailSessionId != null ? { workrailSessionId } : {}),

--- a/src/daemon/tools/continue-workflow.ts
+++ b/src/daemon/tools/continue-workflow.ts
@@ -24,7 +24,7 @@ export function makeContinueWorkflowTool(
   emitter?: DaemonEventEmitter,
   workrailSessionId?: SessionId | null,
   onGateParked: (gateToken: string, stepId: string, gateKind: import('../../v2/durable-core/constants.js').GateKind) => void = () => { /* no-op for callers that predate gate support */ },
-  gateRecoveryContext?: { readonly workflowId: string; readonly goal: string; readonly workspacePath: string; readonly branchStrategy?: import('../types.js').BranchStrategy },
+  gateRecoveryContext?: { readonly workflowId: string; readonly goal: string; readonly workspacePath: string; readonly branchStrategy?: import('../types.js').BranchStrategy; readonly context?: Readonly<Record<string, unknown>> },
 ): AgentTool {
   return {
     name: 'continue_workflow',
@@ -240,7 +240,7 @@ export function makeCompleteStepTool(
   emitter?: DaemonEventEmitter,
   workrailSessionId?: SessionId | null,
   onGateParked: (gateToken: string, stepId: string, gateKind: import('../../v2/durable-core/constants.js').GateKind) => void = () => { /* no-op for callers that predate gate support */ },
-  gateRecoveryContext?: { readonly workflowId: string; readonly goal: string; readonly workspacePath: string; readonly branchStrategy?: import('../types.js').BranchStrategy },
+  gateRecoveryContext?: { readonly workflowId: string; readonly goal: string; readonly workspacePath: string; readonly branchStrategy?: import('../types.js').BranchStrategy; readonly context?: Readonly<Record<string, unknown>> },
 ): AgentTool {
   return {
     name: 'complete_step',

--- a/src/mcp/response-supplements.ts
+++ b/src/mcp/response-supplements.ts
@@ -34,7 +34,13 @@ const NOTES_GUIDANCE = [
   '- Omitting notes will block the step.',
 ].join('\n');
 
-export type SupplementKind = 'authority_context' | 'notes_guidance';
+const SUBAGENT_GUIDANCE = [
+  'Interactive Session Advancement & Subagent Guidance:',
+  '- **Advancement**: When you have completed all work for this step, call `continue_workflow` with the provided `continueToken`. You can pass `notes` and `artifacts` directly at the top level or nested inside `output` — both formats are fully supported.',
+  '- **Spawning Routines / Executors**: If a step instructs you to "spawn a WorkRail Executor" or execute a parallel routine (e.g. `wr.routine-philosophy-alignment`), you should delegate it to a subagent using your native client capabilities (e.g. `invoke_subagent` to start a child agent running the routine with `start_workflow`) or execute it inline if client-side subagent tools are unavailable.',
+].join('\n');
+
+export type SupplementKind = 'authority_context' | 'notes_guidance' | 'subagent_guidance';
 
 export interface FormattedSupplement {
   readonly kind: SupplementKind;
@@ -93,6 +99,13 @@ const CLEAN_RESPONSE_SUPPLEMENTS: readonly ResponseSupplementSpec[] = [
     lifecycles: ['start', 'rehydrate'],
     delivery: { mode: 'once_per_session', emitOn: 'start' },
     renderText: () => NOTES_GUIDANCE,
+  }),
+  defineResponseSupplement({
+    kind: 'subagent_guidance',
+    order: 30,
+    lifecycles: ['start', 'rehydrate'],
+    delivery: { mode: 'per_lifecycle' },
+    renderText: () => SUBAGENT_GUIDANCE,
   }),
 ];
 

--- a/src/mcp/v2-response-formatter.ts
+++ b/src/mcp/v2-response-formatter.ts
@@ -362,6 +362,10 @@ function formatRehydrate(data: V2ExecutionResponse): string {
   }
 
   lines.push('Continue working on this step. When done, call `continue_workflow` to advance.');
+  lines.push('');
+  lines.push('**Interactive Session Tips:**');
+  lines.push('- **Advancement:** You can call `continue_workflow` and pass `notes` and `artifacts` directly as top-level parameters (or nested under `output`).');
+  lines.push('- **Routines / Subagents:** If instructed to "spawn a WorkRail Executor" or execute a routine, use your client-side subagent spawning capabilities (e.g. `invoke_subagent` starting `start_workflow` for the routine) or run the steps inline yourself.');
 
   return lines.join('\n');
 }
@@ -387,7 +391,10 @@ function formatSuccess(data: V2ExecutionResponse): string {
   lines.push('');
   lines.push('Execute this step, then call `continue_workflow` to advance.');
   lines.push('');
-  lines.push('Include `output.notesMarkdown` documenting your work — what you did, key decisions, what you produced, and anything notable.');
+  lines.push('Include `output.notesMarkdown` documenting your work — what you did, key decisions, what you produced, and anything notable. (Providing flat top-level `notes` and `artifacts` is also fully supported as a compatibility alias).');
+  lines.push('');
+  lines.push('**Subagent & Routine Guidance:**');
+  lines.push('If this step instructs you to "spawn a WorkRail Executor" or run a parallel routine (e.g. `wr.routine-philosophy-alignment`), delegate it to a subagent using your native client-side tools (e.g. `invoke_subagent` running `start_workflow` for that routine) or execute it inline yourself if client-side subagent tools are unavailable.');
   lines.push('');
   lines.push(formatPreferences(data.preferences));
 

--- a/src/mcp/v2/tools.ts
+++ b/src/mcp/v2/tools.ts
@@ -93,6 +93,14 @@ const continueWorkflowContextAliasField = z.record(z.unknown()).optional().descr
   'Compatibility alias for context. Canonical field name: "context".'
 );
 
+const continueWorkflowNotesAliasField = z.string().optional().describe(
+  'Compatibility alias for output.notesMarkdown. Provide your step notes here directly.'
+);
+
+const continueWorkflowArtifactsAliasField = z.array(z.unknown()).optional().describe(
+  'Compatibility alias for output.artifacts. Provide structured step artifacts here directly.'
+);
+
 /**
  * Validation schema for continue_workflow (runtime contract).
  *
@@ -105,6 +113,8 @@ const continueWorkflowContextAliasField = z.record(z.unknown()).optional().descr
 export const V2ContinueWorkflowInput = V2ContinueWorkflowInputShape
   .extend({
     contextVariables: continueWorkflowContextAliasField,
+    notes: continueWorkflowNotesAliasField,
+    artifacts: continueWorkflowArtifactsAliasField,
   })
   .superRefine((data, ctx) => {
     const aliasMap = CONTINUE_WORKFLOW_PROTOCOL.aliasMap;
@@ -118,7 +128,21 @@ export const V2ContinueWorkflowInput = V2ContinueWorkflowInputShape
         message: `Provide either "${canonical}" or "${alias}", not both. Canonical field: "${canonical}".`,
       });
     }
-    if (data.intent === 'rehydrate' && data.output) {
+    if (data.notes !== undefined && data.output?.notesMarkdown !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['notes'],
+        message: 'Provide either "notes" or "output.notesMarkdown", not both.',
+      });
+    }
+    if (data.artifacts !== undefined && data.output?.artifacts !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['artifacts'],
+        message: 'Provide either "artifacts" or "output.artifacts", not both.',
+      });
+    }
+    if (data.intent === 'rehydrate' && (data.output || data.notes !== undefined || data.artifacts !== undefined)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['output'],
@@ -140,12 +164,18 @@ export const V2ContinueWorkflowInput = V2ContinueWorkflowInputShape
     const normalized = CONTINUE_WORKFLOW_PROTOCOL.aliasMap
       ? normalizeAliasedFields(data as Readonly<Record<string, unknown>>, CONTINUE_WORKFLOW_PROTOCOL.aliasMap)
       : (data as Record<string, unknown>);
-    const intent = data.intent ?? (data.output ? 'advance' : 'rehydrate');
+    const notesMarkdown = data.notes ?? data.output?.notesMarkdown;
+    const artifacts = data.artifacts ?? data.output?.artifacts;
+    const output = (notesMarkdown !== undefined || artifacts !== undefined) ? {
+      ...(notesMarkdown !== undefined ? { notesMarkdown } : {}),
+      ...(artifacts !== undefined ? { artifacts } : {}),
+    } : undefined;
+    const intent = data.intent ?? (output ? 'advance' : 'rehydrate');
     return {
       intent,
       continueToken: data.continueToken,
       ...(normalized.context ? { context: normalized.context } : {}),
-      ...(data.output ? { output: data.output } : {}),
+      ...(output ? { output } : {}),
       ...(data.workspacePath !== undefined ? { workspacePath: data.workspacePath } : {}),
     };
   });

--- a/src/trigger/coordinator-deps.ts
+++ b/src/trigger/coordinator-deps.ts
@@ -375,15 +375,25 @@ class CoordinatorDepsImpl implements AdaptiveCoordinatorDeps {
     trigger: WorkflowTrigger;
     parentSessionId?: string;
   }): Promise<{ kind: 'ok'; handle: string } | { kind: 'err'; error: string }> {
+    const startContext: Record<string, string> = {
+      is_autonomous: 'true',
+      workspacePath: opts.workspace,
+      triggerSource: 'daemon',
+      ...(opts.parentSessionId !== undefined ? { parentSessionId: opts.parentSessionId } : {}),
+    };
+
+    if (opts.trigger.context) {
+      for (const [k, v] of Object.entries(opts.trigger.context)) {
+        if (v !== undefined && v !== null) {
+          startContext[k] = typeof v === 'string' ? v : JSON.stringify(v);
+        }
+      }
+    }
+
     const startResult = await executeStartWorkflow(
       { workflowId: opts.workflowId, workspacePath: opts.workspace, goal: opts.goal },
       this.ctx,
-      {
-        is_autonomous: 'true',
-        workspacePath: opts.workspace,
-        triggerSource: 'daemon',
-        ...(opts.parentSessionId !== undefined ? { parentSessionId: opts.parentSessionId } : {}),
-      },
+      startContext,
     );
     if (startResult.isErr()) {
       const detail = `${startResult.error.kind}${'message' in startResult.error ? ': ' + (startResult.error as { message: string }).message : ''}`;

--- a/tests/architecture/v2-tool-schema-snapshot.test.ts
+++ b/tests/architecture/v2-tool-schema-snapshot.test.ts
@@ -92,10 +92,12 @@ describe('v2 tool schema field snapshots (anti-drift)', () => {
 
   it('continue_workflow validation boundary: exact field set', () => {
     expect(extractFieldNames(V2ContinueWorkflowInput)).toEqual([
+      'artifacts',
       'context',
       'contextVariables',
       'continueToken',
       'intent',
+      'notes',
       'output',
       'workspacePath',
     ]);

--- a/tests/unit/mcp-alias.test.ts
+++ b/tests/unit/mcp-alias.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { V2ContinueWorkflowInputShape, V2ContinueWorkflowInput } from '../../src/mcp/v2/tools.js';
+
+describe('MCP continue_workflow schema compatibility aliases', () => {
+  describe('Static disjointness verification', () => {
+    it('asserts flat alias keys do not exist in the canonical input shape', () => {
+      const canonicalKeys = Object.keys(V2ContinueWorkflowInputShape.shape);
+      
+      // The canonical shape should not contain our flat compatibility aliases directly.
+      // This guarantees they are boundary-only additions and don't silently shadow future fields.
+      expect(canonicalKeys).not.toContain('notes');
+      expect(canonicalKeys).not.toContain('artifacts');
+    });
+  });
+
+  describe('Transform and normalisation', () => {
+    const continueToken = 'ct_mockToken12345';
+    const workspacePath = '/Users/mock/git/project';
+
+    it('successfully parses and normalizes pure flat aliased payloads', () => {
+      const payload = {
+        continueToken,
+        workspacePath,
+        notes: 'Substantive step notes with more than 50 characters required for step completions.',
+        artifacts: [{ kind: 'wr.mock_artifact', data: 42 }],
+      };
+
+      const result = V2ContinueWorkflowInput.safeParse(payload);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.output).toBeDefined();
+        expect(result.data.output?.notesMarkdown).toBe(payload.notes);
+        expect(result.data.output?.artifacts).toEqual(payload.artifacts);
+        expect(result.data.intent).toBe('advance');
+      }
+    });
+
+    it('successfully parses pure canonical nested output payloads', () => {
+      const payload = {
+        continueToken,
+        workspacePath,
+        output: {
+          notesMarkdown: 'Substantive step notes with more than 50 characters required for step completions.',
+          artifacts: [{ kind: 'wr.mock_artifact', data: 42 }],
+        },
+      };
+
+      const result = V2ContinueWorkflowInput.safeParse(payload);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.output).toBeDefined();
+        expect(result.data.output?.notesMarkdown).toBe(payload.output.notesMarkdown);
+        expect(result.data.output?.artifacts).toEqual(payload.output.artifacts);
+        expect(result.data.intent).toBe('advance');
+      }
+    });
+
+    it('successfully normalizes hybrid payloads (e.g. flat notes, nested artifacts)', () => {
+      const payload = {
+        continueToken,
+        workspacePath,
+        notes: 'Substantive step notes with more than 50 characters required for step completions.',
+        output: {
+          artifacts: [{ kind: 'wr.mock_artifact', data: 42 }],
+        },
+      };
+
+      const result = V2ContinueWorkflowInput.safeParse(payload);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.output).toBeDefined();
+        expect(result.data.output?.notesMarkdown).toBe(payload.notes);
+        expect(result.data.output?.artifacts).toEqual(payload.output.artifacts);
+        expect(result.data.intent).toBe('advance');
+      }
+    });
+
+    it('infers intent as rehydrate when no output or aliases are present', () => {
+      const payload = {
+        continueToken,
+        workspacePath,
+      };
+
+      const result = V2ContinueWorkflowInput.safeParse(payload);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.output).toBeUndefined();
+        expect(result.data.intent).toBe('rehydrate');
+      }
+    });
+  });
+
+  describe('Validation conflict guards', () => {
+    const continueToken = 'ct_mockToken12345';
+    const workspacePath = '/Users/mock/git/project';
+
+    it('rejects payload containing both flat notes and nested notesMarkdown', () => {
+      const payload = {
+        continueToken,
+        workspacePath,
+        notes: 'Flat notes',
+        output: {
+          notesMarkdown: 'Nested notes',
+        },
+      };
+
+      const result = V2ContinueWorkflowInput.safeParse(payload);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = result.error.issues;
+        expect(issues.some(i => i.path.includes('notes') && i.message.includes('Provide either "notes" or "output.notesMarkdown"'))).toBe(true);
+      }
+    });
+
+    it('rejects payload containing both flat artifacts and nested artifacts', () => {
+      const payload = {
+        continueToken,
+        workspacePath,
+        artifacts: [{ kind: 'flat' }],
+        output: {
+          artifacts: [{ kind: 'nested' }],
+        },
+      };
+
+      const result = V2ContinueWorkflowInput.safeParse(payload);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = result.error.issues;
+        expect(issues.some(i => i.path.includes('artifacts') && i.message.includes('Provide either "artifacts" or "output.artifacts"'))).toBe(true);
+      }
+    });
+
+    it('rejects rehydrate intent when flat notes are supplied', () => {
+      const payload = {
+        continueToken,
+        workspacePath,
+        intent: 'rehydrate',
+        notes: 'Some notes',
+      };
+
+      const result = V2ContinueWorkflowInput.safeParse(payload);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issues = result.error.issues;
+        expect(issues.some(i => i.path.includes('output') && i.message.includes('intent is "rehydrate" but output was provided'))).toBe(true);
+      }
+    });
+  });
+});

--- a/tests/unit/mcp/response-supplements.test.ts
+++ b/tests/unit/mcp/response-supplements.test.ts
@@ -11,10 +11,12 @@ describe('buildResponseSupplements', () => {
     expect(supplements.map((supplement) => supplement.kind)).toEqual([
       'authority_context',
       'notes_guidance',
+      'subagent_guidance',
     ]);
-    expect(supplements.map((supplement) => supplement.order)).toEqual([10, 20]);
+    expect(supplements.map((supplement) => supplement.order)).toEqual([10, 20, 30]);
     expect(supplements[0]!.text).toContain('WorkRail is a separate live system');
     expect(supplements[1]!.text).toContain('How to write good notes');
+    expect(supplements[2]!.text).toContain('Interactive Session Advancement');
   });
 
   it('returns only authority context for rehydrate', () => {
@@ -25,8 +27,10 @@ describe('buildResponseSupplements', () => {
 
     expect(supplements.map((supplement) => supplement.kind)).toEqual([
       'authority_context',
+      'subagent_guidance',
     ]);
     expect(supplements[0]!.text).not.toContain('How to write good notes');
+    expect(supplements[1]!.text).toContain('Interactive Session Advancement');
   });
 
   it('supports once-per-session supplements without durable tracking', () => {

--- a/tests/unit/v2/v2-response-formatter-integration.test.ts
+++ b/tests/unit/v2/v2-response-formatter-integration.test.ts
@@ -117,10 +117,11 @@ describe('toMcpResult — clean response supplements', () => {
       }),
     }, ctx);
 
-    expect(result.content).toHaveLength(3);
+    expect(result.content).toHaveLength(4);
     expect((result.content[0] as { text: string }).text).toContain('Execute the first task.');
     expect((result.content[1] as { text: string }).text).toContain('WorkRail is a separate live system');
     expect((result.content[2] as { text: string }).text).toContain('How to write good notes');
+    expect((result.content[3] as { text: string }).text).toContain('Interactive Session Advancement');
   });
 
   it('rehydrate responses include authority context but not notes guidance', () => {
@@ -136,9 +137,10 @@ describe('toMcpResult — clean response supplements', () => {
       }),
     }, ctx);
 
-    expect(result.content).toHaveLength(2);
+    expect(result.content).toHaveLength(3);
     expect((result.content[1] as { text: string }).text).toContain('WorkRail is a separate live system');
     expect((result.content[1] as { text: string }).text).not.toContain('How to write good notes');
+    expect((result.content[2] as { text: string }).text).toContain('Interactive Session Advancement');
   });
 
   it('advance responses do not include supplemental content items', () => {


### PR DESCRIPTION
## Summary
Resolves mismatches in the interactive MCP server execution environment regarding subagent routine spawning and strict continue_workflow handoff validation:
- Exposes optional flat `notes` and `artifacts` parameters at the validation boundary.
- Normalizes compatibility aliases in schema transforms with strict superRefine mutual exclusivity conflict validation.
- Enriches natural language formatters and supplements to guide agents on flat payloads and native routine subagent spawning.
- Writes a static disjointness unit test suite protecting against schema collisions.
- Integrates context propagation for spawned autonomous daemon sessions.

Closes #1097

## Test plan
- [x] npx vitest run tests/unit/mcp-alias.test.ts (8/8 passed)
- [x] npx vitest run tests/unit/mcp/response-supplements.test.ts tests/unit/v2/v2-response-formatter-integration.test.ts (12/12 passed)
- [x] npx vitest run (all 6,280+ tests passed successfully)
- [x] npm run build