### PR TITLE
feat(mcp): add modular ClientUsageReader with Claude Code support

### DIFF
--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -82,6 +82,17 @@ export type ConsoleSessionHealth = 'healthy' | 'corrupt';
  * Mirror of SessionMetricsV2 in src/v2/projections/session-metrics.ts.
  * Keep in sync with the backend definition.
  */
+
+export type ClientUsage = {
+  readonly client: string;
+  readonly model: string | null;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheWriteTokens: number;
+  readonly turns: number;
+};
+
 export interface SessionMetricsV2 {
   // From run_completed event (engine-authoritative)
   readonly startGitSha: string | null;
@@ -96,6 +107,8 @@ export interface SessionMetricsV2 {
   readonly filesChanged: number | null;
   readonly linesAdded: number | null;
   readonly linesRemoved: number | null;
+  // From usage_recorded events (one entry per MCP client detected)
+  readonly usageEvents: readonly ClientUsage[];
 }
 
 export interface ConsoleSessionSummary {

--- a/src/mcp/client-usage/claude-code.ts
+++ b/src/mcp/client-usage/claude-code.ts
@@ -1,0 +1,169 @@
+/**
+ * Claude Code usage reader.
+ *
+ * Claude Code writes per-conversation JSONL files to:
+ *   ~/.claude/projects/<encoded-workspace-path>/<conversation-uuid>.jsonl
+ *
+ * Each line is a JSON object. Lines with type='assistant' contain a message.usage
+ * object with input_tokens, output_tokens, cache_creation_input_tokens,
+ * cache_read_input_tokens, and a message.model field.
+ *
+ * Detection strategy: grep each candidate file for the WorkRail session ID.
+ * The session ID (sess_...) appears in tool call inputs (e.g. in continueToken
+ * parameters passed to mcp__workrail__* tools). Files that contain the session ID
+ * are the conversation files for this WorkRail session.
+ *
+ * WHY grep for session ID (not timestamp-only matching): a JSONL file covers one
+ * Claude Code conversation. A single conversation may span multiple WorkRail sessions.
+ * Timestamp filtering narrows candidates; session ID grep confirms membership.
+ */
+
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { ClientUsage, ClientUsageReader } from './types.js';
+
+/**
+ * Shape of an assistant message in Claude Code's JSONL format.
+ * Only the fields we care about are declared; unknown fields are ignored (strip mode).
+ */
+interface ClaudeCodeAssistantEntry {
+  readonly type: 'assistant';
+  readonly message: {
+    readonly model?: string;
+    readonly usage?: {
+      readonly input_tokens?: number;
+      readonly output_tokens?: number;
+      readonly cache_creation_input_tokens?: number;
+      readonly cache_read_input_tokens?: number;
+    };
+  };
+}
+
+/**
+ * Encode a workspace path to a Claude Code project directory name.
+ *
+ * Claude Code replaces each path separator with a hyphen.
+ * Example: /Users/etienneb/git/personal/workrail
+ *       -> -Users-etienneb-git-personal-workrail
+ */
+function encodeWorkspacePath(workspacePath: string): string {
+  return workspacePath.replace(/\//g, '-');
+}
+
+/**
+ * Check whether a raw JSONL line is an assistant entry.
+ * Returns the typed entry or null if it does not match.
+ *
+ * Pure function: no I/O, validates structure at the boundary.
+ */
+function parseAssistantEntry(raw: unknown): ClaudeCodeAssistantEntry | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+  if (obj['type'] !== 'assistant') return null;
+  const message = obj['message'];
+  if (typeof message !== 'object' || message === null) return null;
+  return { type: 'assistant', message: message as ClaudeCodeAssistantEntry['message'] };
+}
+
+/**
+ * Sum all assistant entry usage fields from a JSONL file.
+ * Returns null if no assistant entries with usage data were found.
+ *
+ * Pure function over the parsed lines: no I/O once the content is provided.
+ */
+function sumUsageFromLines(lines: string[], clientName: string): ClientUsage | null {
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cacheReadTokens = 0;
+  let cacheWriteTokens = 0;
+  let turns = 0;
+  let model: string | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      // Malformed line -- skip and continue
+      continue;
+    }
+
+    const entry = parseAssistantEntry(parsed);
+    if (!entry) continue;
+
+    const usage = entry.message.usage;
+    if (!usage) continue;
+
+    inputTokens += usage.input_tokens ?? 0;
+    outputTokens += usage.output_tokens ?? 0;
+    cacheReadTokens += usage.cache_read_input_tokens ?? 0;
+    cacheWriteTokens += usage.cache_creation_input_tokens ?? 0;
+    turns += 1;
+
+    // Use the last non-null model seen (most recent model wins)
+    if (entry.message.model) {
+      model = entry.message.model;
+    }
+  }
+
+  if (turns === 0) return null;
+
+  return {
+    client: clientName,
+    model,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    turns,
+  };
+}
+
+export class ClaudeCodeUsageReader implements ClientUsageReader {
+  readonly clientName = 'claude-code';
+
+  constructor(
+    // Allows injecting a custom home directory in tests.
+    private readonly homeDir: string = homedir(),
+  ) {}
+
+  searchDirs(workspacePath: string): string[] {
+    const encoded = encodeWorkspacePath(workspacePath);
+    const dir = join(this.homeDir, '.claude', 'projects', encoded);
+    return [dir];
+  }
+
+  async parseUsage(filePath: string, sessionId: string, startMs: number): Promise<ClientUsage | null> {
+    let content: string;
+    try {
+      // Check modification time: skip files not modified since session start.
+      // WHY: narrows candidates cheaply before doing a full file read.
+      const stat = await fs.stat(filePath);
+      if (stat.mtimeMs < startMs) return null;
+
+      content = await fs.readFile(filePath, 'utf-8');
+    } catch {
+      // File missing or unreadable -- not an error condition (another client may have
+      // deleted or rotated the file). Return null to skip.
+      return null;
+    }
+
+    // Check for session ID presence (fast string search before line parsing).
+    // WHY: the session ID appears in tool call inputs in the JSONL content.
+    // Files that do not contain the session ID do not belong to this session.
+    if (!content.includes(sessionId)) return null;
+
+    const lines = content.split('\n');
+    return sumUsageFromLines(lines, this.clientName);
+  }
+}
+
+/**
+ * Default singleton for use in production.
+ * Created once at module load time; no mutable state.
+ */
+export const claudeCodeUsageReader = new ClaudeCodeUsageReader();

--- a/src/mcp/client-usage/claude-code.ts
+++ b/src/mcp/client-usage/claude-code.ts
@@ -46,9 +46,15 @@ interface ClaudeCodeAssistantEntry {
  * Claude Code replaces each path separator with a hyphen.
  * Example: /Users/etienneb/git/personal/workrail
  *       -> -Users-etienneb-git-personal-workrail
+ * Example (Windows):   C:\Users\etienneb\git\workrail
+ *                   -> C:-Users-etienneb-git-workrail
+ *
+ * WHY both separators: Claude Code runs on macOS and Windows. On Windows, Node.js
+ * path functions return backslash-separated paths. Claude Code uses the same
+ * replace-separators-with-hyphens encoding on all platforms.
  */
 function encodeWorkspacePath(workspacePath: string): string {
-  return workspacePath.replace(/\//g, '-');
+  return workspacePath.replace(/[/\\]/g, '-');
 }
 
 /**

--- a/src/mcp/client-usage/index.ts
+++ b/src/mcp/client-usage/index.ts
@@ -1,0 +1,75 @@
+/**
+ * collect() -- entry point for usage collection.
+ *
+ * Scans all registered ClientUsageReaders for usage data belonging to a session.
+ * Called fire-and-forget after run_completed is written; must never throw or block.
+ *
+ * Design:
+ * - For each reader, enumerate files in searchDirs()
+ * - For each candidate file (modified within session window), call parseUsage()
+ * - Collect and return all non-null ClientUsage results
+ * - All I/O errors are caught and discarded -- this is observability data, not correctness
+ */
+
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import type { ClientUsage, ClientUsageReader } from './types.js';
+import { USAGE_READERS } from './registry.js';
+
+export type { ClientUsage, ClientUsageReader } from './types.js';
+
+/**
+ * Collect token usage for a session from all registered readers.
+ *
+ * @param sessionId - The WorkRail session ID (used for session ID grep in files)
+ * @param workspacePath - Workspace root path (null-safe: returns [] if null/empty)
+ * @param startMs - Session start timestamp in milliseconds (used to filter files by mtime)
+ * @param readers - Readers to use (defaults to USAGE_READERS registry)
+ *
+ * @returns Array of ClientUsage objects, one per client that had matching data.
+ *   Returns an empty array if no usage was found (not an error condition).
+ *   Never throws.
+ */
+export async function collect(
+  sessionId: string,
+  workspacePath: string | null,
+  startMs: number,
+  readers: readonly ClientUsageReader[] = USAGE_READERS,
+): Promise<readonly ClientUsage[]> {
+  // Guard: workspacePath is required for directory enumeration.
+  // When absent (e.g. no repo_root observation recorded), skip collection silently.
+  if (!workspacePath) return [];
+
+  const results: ClientUsage[] = [];
+
+  for (const reader of readers) {
+    const dirs = reader.searchDirs(workspacePath);
+
+    for (const dir of dirs) {
+      let entries: string[];
+      try {
+        entries = await fs.readdir(dir);
+      } catch {
+        // Directory doesn't exist or is unreadable -- skip this reader silently.
+        continue;
+      }
+
+      for (const entry of entries) {
+        if (!entry.endsWith('.jsonl')) continue;
+
+        const filePath = join(dir, entry);
+        try {
+          const usage = await reader.parseUsage(filePath, sessionId, startMs);
+          if (usage !== null) {
+            results.push(usage);
+          }
+        } catch {
+          // parseUsage should not throw (it catches internally), but guard here too.
+          continue;
+        }
+      }
+    }
+  }
+
+  return results;
+}

--- a/src/mcp/client-usage/registry.ts
+++ b/src/mcp/client-usage/registry.ts
@@ -1,0 +1,24 @@
+/**
+ * Registry of ClientUsageReader implementations.
+ *
+ * WHY a registry (not a hardcoded call): adding a new MCP client reader requires
+ * only writing one new file and adding one entry here. The collect() entry point
+ * is unchanged.
+ *
+ * Ordering: readers are tried in order. All readers that match are collected --
+ * multiple clients can produce usage events for the same session.
+ */
+
+import type { ClientUsageReader } from './types.js';
+import { claudeCodeUsageReader } from './claude-code.js';
+
+/**
+ * Ordered list of all registered ClientUsageReader implementations.
+ *
+ * To add a new reader: implement ClientUsageReader, export a singleton,
+ * and add it here.
+ */
+export const USAGE_READERS: readonly ClientUsageReader[] = [
+  claudeCodeUsageReader,
+  // Future: cursorUsageReader, antigravityUsageReader, etc.
+];

--- a/src/mcp/client-usage/types.ts
+++ b/src/mcp/client-usage/types.ts
@@ -1,0 +1,62 @@
+/**
+ * ClientUsageReader interface for the usage collection system.
+ *
+ * WHY modular interface: different MCP clients (Claude Code, Cursor, Antigravity, etc.)
+ * store usage data in different formats and locations. A registry of readers allows
+ * adding new clients by writing one file and adding one registry entry, with no changes
+ * to the collection machinery.
+ *
+ * WHY separate from the engine: usage collection is best-effort observability.
+ * It must never affect session correctness -- it is collected fire-and-forget after
+ * run_completed is written.
+ *
+ * WHY ClientUsage is defined in durable-core: the projections layer must not import
+ * from the MCP layer (architecture lock). Defining the shared type in durable-core
+ * allows both layers to reference it without cross-boundary imports.
+ */
+
+// ClientUsage is defined in durable-core to avoid a mcp -> v2/projections import cycle.
+import type { ClientUsage } from '../../v2/durable-core/schemas/session/usage.js';
+export type { ClientUsage };
+
+/**
+ * Interface for an MCP client that writes local usage logs.
+ *
+ * Responsibility: given a workspace path, return candidate directories to scan;
+ * given a candidate file, session ID, and session start time, return summed usage or null.
+ *
+ * Implementors:
+ * - ClaudeCodeUsageReader (src/mcp/client-usage/claude-code.ts)
+ * - Future: CursorUsageReader, AntigravityUsageReader, etc.
+ */
+export interface ClientUsageReader {
+  readonly clientName: string;
+
+  /**
+   * Return directories to scan for usage log files.
+   *
+   * WHY takes workspacePath: each client encodes the workspace into the directory path
+   * differently. The reader knows how to derive the correct search directory.
+   *
+   * Returns an empty array if the client's log directory does not exist or is not applicable
+   * for the given workspace path. Callers must handle empty arrays gracefully.
+   */
+  searchDirs(workspacePath: string): string[];
+
+  /**
+   * Parse a single log file and return summed usage for the given session, or null if
+   * the session is not found in the file.
+   *
+   * WHY sessionId: the reader must confirm the file belongs to this session (e.g. by
+   * grepping for the session ID in tool call payloads) before summing usage.
+   *
+   * WHY startMs: used to filter files by modification time -- only files modified after
+   * session start are candidates. The reader may also use it to filter individual entries.
+   *
+   * Returns null if:
+   * - The session ID is not found in the file
+   * - The file cannot be parsed
+   * - No assistant entries with usage data are present
+   */
+  parseUsage(filePath: string, sessionId: string, startMs: number): Promise<ClientUsage | null>;
+}

--- a/src/mcp/handlers/v2-execution/index.ts
+++ b/src/mcp/handlers/v2-execution/index.ts
@@ -255,7 +255,7 @@ async function collectAndRecordUsage(
           timestampMs: Date.now(),
         }));
 
-        return sessionStore.append(lock, { events: eventsToAppend, snapshotPins: [] });
+        return sessionStore.append(lock, { events: eventsToAppend, snapshotPins: [] }, truth);
       })
     ).match(
       () => {

--- a/src/mcp/handlers/v2-execution/index.ts
+++ b/src/mcp/handlers/v2-execution/index.ts
@@ -14,7 +14,7 @@ import {
   type RunId,
   type NodeId,
 } from '../../../v2/durable-core/ids/index.js';
-import { ResultAsync as RA, errAsync as neErrorAsync } from 'neverthrow';
+import { ResultAsync as RA, errAsync as neErrorAsync, okAsync } from 'neverthrow';
 import {
   mapStartWorkflowErrorToToolError,
   mapContinueWorkflowErrorToToolError,
@@ -30,6 +30,10 @@ import { handleAdvanceIntent } from './continue-advance.js';
 import { attachV2ExecutionRenderMetadata } from '../../render-envelope.js';
 import type { StepContentEnvelope } from '../../step-content-envelope.js';
 import { rememberExplicitWorkspaceRoot } from '../shared/remembered-roots.js';
+import { collect } from '../../client-usage/index.js';
+import { EVENT_KIND } from '../../../v2/durable-core/constants.js';
+import { buildSessionIndex } from '../../../v2/durable-core/session-index.js';
+import { asSortedEventLog } from '../../../v2/durable-core/sorted-event-log.js';
 
 /** Unified result for continue_workflow — envelope present on rehydrate with pending step. */
 interface ContinueWorkflowResult {
@@ -164,6 +168,108 @@ function loadAndRehydrate(
     }));
 }
 
+// ── Usage collection (fire-and-forget) ───────────────────────────────────
+
+/**
+ * Collect MCP client token usage and write usage_recorded events to the session store.
+ *
+ * Called fire-and-forget after a session completes (isComplete === true).
+ * Must never throw or reject -- all errors are caught and logged.
+ *
+ * WHY standalone function (not inside the lock chain): the session lock is held
+ * throughout handleAdvanceIntent. This function runs after the lock is released,
+ * acquiring its own fresh lock for the append. This is the same pattern as
+ * delivery_recorded in the daemon delivery pipeline.
+ *
+ * WHY re-reads the session store: the post-advance truth is not accessible at
+ * the index.ts call site without threading it through the response. The extra
+ * read is fire-and-forget and does not affect response latency.
+ */
+async function collectAndRecordUsage(
+  sessionId: SessionId,
+  sessionStore: V2ToolContext['v2']['sessionStore'],
+  gate: V2ToolContext['v2']['gate'],
+  idFactory: V2ToolContext['v2']['idFactory'],
+): Promise<void> {
+  try {
+    // Re-read session events to extract workspacePath, startMs, and runId.
+    const loadResult = await sessionStore.load(sessionId);
+    if (loadResult.isErr()) return;
+
+    const events = loadResult.value.events;
+    if (events.length === 0) return;
+
+    // workspacePath: from repo_root observation event
+    let workspacePath: string | null = null;
+    for (const e of events) {
+      if (e.kind === 'observation_recorded' && e.data.key === 'repo_root') {
+        workspacePath = e.data.value.value;
+        break;
+      }
+    }
+
+    // startMs: from the first event's timestampMs
+    const startMs = events[0]?.timestampMs ?? Date.now();
+
+    // runId: from the run_completed event's scope
+    let runId: string | null = null;
+    for (const e of events) {
+      if (e.kind === EVENT_KIND.RUN_COMPLETED) {
+        runId = e.scope.runId;
+        break;
+      }
+    }
+    if (!runId) return;
+
+    // Collect usage from all registered readers
+    const usageResults = await collect(String(sessionId), workspacePath, startMs);
+    if (usageResults.length === 0) return;
+
+    // Append one usage_recorded event per client that was detected.
+    // Each append uses a fresh session lock to avoid lock re-entrancy.
+    await gate.withHealthySessionLock(sessionId, (lock) =>
+      sessionStore.load(sessionId).andThen((truth) => {
+        const sortedResult = asSortedEventLog(truth.events);
+        if (sortedResult.isErr()) return okAsync(undefined as void);
+        const index = buildSessionIndex(sortedResult.value);
+
+        // Build one event per usage result, chaining the appends.
+        // Each event gets a sequential eventIndex derived from the post-append index.
+        const eventsToAppend = usageResults.map((usage, i) => ({
+          v: 1 as const,
+          eventId: idFactory.mintEventId(),
+          eventIndex: index.nextEventIndex + i,
+          sessionId: String(sessionId),
+          kind: EVENT_KIND.USAGE_RECORDED,
+          dedupeKey: `usage-recorded:${String(sessionId)}:${usage.client}`,
+          scope: { runId: runId! },
+          data: {
+            client: usage.client,
+            model: usage.model,
+            inputTokens: usage.inputTokens,
+            outputTokens: usage.outputTokens,
+            cacheReadTokens: usage.cacheReadTokens,
+            cacheWriteTokens: usage.cacheWriteTokens,
+            turns: usage.turns,
+          },
+          timestampMs: Date.now(),
+        }));
+
+        return sessionStore.append(lock, { events: eventsToAppend, snapshotPins: [] });
+      })
+    ).match(
+      () => {
+        // Success -- usage recorded
+      },
+      (err) => {
+        console.warn(`[workrail:usage] Could not record usage for session ${String(sessionId)}: ${JSON.stringify(err)}`);
+      }
+    );
+  } catch (err: unknown) {
+    console.warn(`[workrail:usage] Unexpected error collecting usage for session ${String(sessionId)}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 // ── Main handler ─────────────────────────────────────────────────────────
 
 export function executeContinueWorkflow(
@@ -248,7 +354,16 @@ export function executeContinueWorkflow(
               entropy,
               cleanResponseFormat: ctx.featureFlags?.isEnabled('cleanResponseFormat') ?? false,
             }))
-            .map((response) => ({ response }));
+            .map((response) => {
+              // Fire-and-forget: collect MCP client usage after session completion.
+              // WHY void (no await): usage collection must never block the session response.
+              // WHY kind check + isComplete: gate_checkpoint has no isComplete field;
+              // only ok/blocked variants with isComplete=true represent a finished session.
+              if (response.kind !== 'gate_checkpoint' && response.isComplete) {
+                void collectAndRecordUsage(sessionId, sessionStore, gate, idFactory);
+              }
+              return { response };
+            });
         });
     }
   }

--- a/src/v2/durable-core/constants.ts
+++ b/src/v2/durable-core/constants.ts
@@ -276,6 +276,7 @@ export const EVENT_KIND = {
   RUN_COMPLETED: 'run_completed',
   DELIVERY_RECORDED: 'delivery_recorded',
   REVIEW_DRAFT_SUBMITTED: 'review_draft_submitted',
+  USAGE_RECORDED: 'usage_recorded',
 } as const;
 
 export type EventKindV1 = typeof EVENT_KIND[keyof typeof EVENT_KIND];

--- a/src/v2/durable-core/schemas/session/events.ts
+++ b/src/v2/durable-core/schemas/session/events.ts
@@ -377,6 +377,33 @@ export const DomainEventV1Schema = z.discriminatedUnion('kind', [
       submittedAt: z.string(),
     }),
   }),
+  /**
+   * usage_recorded: appended fire-and-forget after run_completed by the
+   * ClientUsageReader pipeline (src/mcp/client-usage/).
+   *
+   * WHY a separate event (not part of run_completed): usage data is collected
+   * asynchronously after the session lock is released. run_completed fires
+   * inside the lock; usage_recorded fires after it.
+   *
+   * WHY per-client: multiple MCP clients (Claude Code, Cursor, etc.) may run
+   * the same session. One event per client that was detected.
+   *
+   * WHY model is nullable: the client log may not record the model for every turn.
+   * null means 'model not recorded', not 'no model was used'.
+   */
+  DomainEventEnvelopeV1Schema.extend({
+    kind: z.literal('usage_recorded'),
+    scope: z.object({ runId: z.string().min(1) }),
+    data: z.object({
+      client: z.string().min(1),
+      model: z.string().nullable(),
+      inputTokens: z.number().int().nonnegative(),
+      outputTokens: z.number().int().nonnegative(),
+      cacheReadTokens: z.number().int().nonnegative(),
+      cacheWriteTokens: z.number().int().nonnegative(),
+      turns: z.number().int().nonnegative(),
+    }),
+  }),
 ]);
 
 export type DomainEventV1 = z.infer<typeof DomainEventV1Schema>;

--- a/src/v2/durable-core/schemas/session/usage.ts
+++ b/src/v2/durable-core/schemas/session/usage.ts
@@ -1,0 +1,27 @@
+/**
+ * ClientUsage: summed token usage for a single MCP session as reported by one client.
+ *
+ * This type is the domain-level representation of the data in `usage_recorded` events.
+ * It is defined here (in durable-core) so that both the projections layer and the MCP
+ * client-usage module can reference it without creating cross-boundary imports.
+ *
+ * WHY here and not in mcp/client-usage/: projections/session-metrics.ts must not import
+ * from the MCP layer (architecture lock: projections are internal-only). Defining the
+ * shared type in durable-core makes it accessible to both sides.
+ */
+
+/**
+ * Summed token usage for a single MCP session as reported by one MCP client.
+ *
+ * All token counts are non-negative integers. model is nullable because
+ * client logs may not record the model for every turn.
+ */
+export type ClientUsage = {
+  readonly client: string;
+  readonly model: string | null;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheWriteTokens: number;
+  readonly turns: number;
+};

--- a/src/v2/projections/session-metrics.ts
+++ b/src/v2/projections/session-metrics.ts
@@ -1,6 +1,7 @@
 import type { DomainEventV1 } from '../durable-core/schemas/session/index.js';
 import { EVENT_KIND, VALID_METRICS_OUTCOME } from '../durable-core/constants.js';
 import type { MetricsOutcome } from '../durable-core/constants.js';
+import type { ClientUsage } from '../durable-core/schemas/session/usage.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -37,6 +38,14 @@ export interface SessionMetricsV2 {
   readonly filesChanged: number | null;
   readonly linesAdded: number | null;
   readonly linesRemoved: number | null;
+  /**
+   * Token usage per MCP client, derived from usage_recorded events.
+   *
+   * Empty array when no usage was recorded (e.g. session completed before the
+   * ClientUsageReader pipeline was deployed, or no client log was found).
+   * One element per client that reported usage (typically just claude-code).
+   */
+  readonly usageEvents: readonly ClientUsage[];
 }
 
 // ---------------------------------------------------------------------------
@@ -179,6 +188,24 @@ export function projectSessionMetricsV2(
   const finalCaptureConfidence: 'high' | 'none' =
     deliveryShas.length > 0 ? 'high' : captureConfidence;
 
+  // Collect usage_recorded events for the matching runId.
+  // One element per client that reported usage. Order follows event log order.
+  const usageEvents: ClientUsage[] = [];
+  for (const e of events) {
+    if (e.kind !== EVENT_KIND.USAGE_RECORDED) continue;
+    if (e.scope?.runId !== runCompletedRunId) continue;
+    const d = e.data;
+    usageEvents.push({
+      client: typeof d.client === 'string' ? d.client : '',
+      model: typeof d.model === 'string' ? d.model : null,
+      inputTokens: typeof d.inputTokens === 'number' ? d.inputTokens : 0,
+      outputTokens: typeof d.outputTokens === 'number' ? d.outputTokens : 0,
+      cacheReadTokens: typeof d.cacheReadTokens === 'number' ? d.cacheReadTokens : 0,
+      cacheWriteTokens: typeof d.cacheWriteTokens === 'number' ? d.cacheWriteTokens : 0,
+      turns: typeof d.turns === 'number' ? d.turns : 0,
+    });
+  }
+
   return {
     startGitSha,
     endGitSha,
@@ -191,5 +218,6 @@ export function projectSessionMetricsV2(
     filesChanged,
     linesAdded,
     linesRemoved,
+    usageEvents,
   };
 }

--- a/tests/unit/client-usage-claude-code.test.ts
+++ b/tests/unit/client-usage-claude-code.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for ClaudeCodeUsageReader.
+ *
+ * Tests the JSONL parsing logic, session ID detection, and token summing.
+ * Uses a temporary directory with fixture JSONL files for I/O tests.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+
+import { ClaudeCodeUsageReader } from '../../src/mcp/client-usage/claude-code.js';
+
+// ── Fixture helpers ────────────────────────────────────────────────────────────
+
+function makeAssistantLine(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+  cacheRead: number,
+  cacheWrite: number,
+): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: {
+      model,
+      usage: {
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        cache_read_input_tokens: cacheRead,
+        cache_creation_input_tokens: cacheWrite,
+      },
+    },
+  });
+}
+
+function makeToolUseLine(sessionId: string): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: {
+      model: 'claude-sonnet-4-6',
+      content: [
+        {
+          type: 'tool_use',
+          name: 'mcp__workrail__continue_workflow',
+          input: { continueToken: 'ct_test', sessionId },
+        },
+      ],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    },
+  });
+}
+
+// ── Test setup ─────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workrail-client-usage-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+// ── searchDirs ─────────────────────────────────────────────────────────────────
+
+describe('ClaudeCodeUsageReader.searchDirs', () => {
+  it('encodes workspace path by replacing slashes with hyphens', () => {
+    const reader = new ClaudeCodeUsageReader('/fake/home');
+    const dirs = reader.searchDirs('/Users/etienneb/git/personal/workrail');
+    expect(dirs).toHaveLength(1);
+    expect(dirs[0]).toContain('-Users-etienneb-git-personal-workrail');
+    expect(dirs[0]).toContain('.claude');
+    expect(dirs[0]).toContain('projects');
+  });
+
+  it('uses the injected homeDir', () => {
+    const reader = new ClaudeCodeUsageReader('/custom/home');
+    const dirs = reader.searchDirs('/my/project');
+    expect(dirs[0]).toContain('/custom/home');
+  });
+});
+
+// ── parseUsage ─────────────────────────────────────────────────────────────────
+
+describe('ClaudeCodeUsageReader.parseUsage', () => {
+  it('returns null for a file not modified since startMs', async () => {
+    const reader = new ClaudeCodeUsageReader(tmpDir);
+    const filePath = path.join(tmpDir, 'old.jsonl');
+    await fs.writeFile(filePath, makeAssistantLine('model-1', 100, 50, 200, 300) + '\n');
+
+    // Use a startMs far in the future so the file's mtime is before it
+    const futureMs = Date.now() + 1_000_000;
+    const result = await reader.parseUsage(filePath, 'sess_test', futureMs);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when session ID is not found in the file', async () => {
+    const reader = new ClaudeCodeUsageReader(tmpDir);
+    const filePath = path.join(tmpDir, 'no-session.jsonl');
+    await fs.writeFile(
+      filePath,
+      makeAssistantLine('claude-sonnet-4-6', 100, 50, 200, 300) + '\n' +
+      makeToolUseLine('sess_other_session') + '\n',
+    );
+
+    const result = await reader.parseUsage(filePath, 'sess_target_session', 0);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a non-existent file', async () => {
+    const reader = new ClaudeCodeUsageReader(tmpDir);
+    const result = await reader.parseUsage(path.join(tmpDir, 'nonexistent.jsonl'), 'sess_test', 0);
+    expect(result).toBeNull();
+  });
+
+  it('sums usage fields from all assistant entries when session ID found', async () => {
+    const reader = new ClaudeCodeUsageReader(tmpDir);
+    const filePath = path.join(tmpDir, 'session.jsonl');
+
+    const content = [
+      makeToolUseLine('sess_myworkrailsession'),  // contains session ID
+      makeAssistantLine('claude-sonnet-4-6', 100, 50, 200, 300),
+      makeAssistantLine('claude-sonnet-4-6', 150, 75, 100, 50),
+      JSON.stringify({ type: 'user', message: { text: 'hello' } }),  // non-assistant line
+    ].join('\n');
+
+    await fs.writeFile(filePath, content);
+
+    const result = await reader.parseUsage(filePath, 'sess_myworkrailsession', 0);
+
+    expect(result).not.toBeNull();
+    expect(result!.client).toBe('claude-code');
+    // The tool_use line has usage too (input_tokens: 10, output_tokens: 5)
+    expect(result!.inputTokens).toBe(100 + 150 + 10);
+    expect(result!.outputTokens).toBe(50 + 75 + 5);
+    expect(result!.cacheReadTokens).toBe(200 + 100 + 0);
+    expect(result!.cacheWriteTokens).toBe(300 + 50 + 0);
+    expect(result!.turns).toBe(3); // 3 assistant entries
+  });
+
+  it('returns the last non-null model seen', async () => {
+    const reader = new ClaudeCodeUsageReader(tmpDir);
+    const filePath = path.join(tmpDir, 'models.jsonl');
+
+    const content = [
+      'sess_abc' + ' something',  // session ID marker (just string presence)
+      makeAssistantLine('claude-sonnet-3-7', 10, 5, 0, 0),
+      makeAssistantLine('claude-sonnet-4-6', 20, 10, 0, 0),
+    ].join('\n');
+
+    await fs.writeFile(filePath, content);
+
+    const result = await reader.parseUsage(filePath, 'sess_abc', 0);
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('skips malformed JSON lines without throwing', async () => {
+    const reader = new ClaudeCodeUsageReader(tmpDir);
+    const filePath = path.join(tmpDir, 'malformed.jsonl');
+
+    const content = [
+      'sess_xyz is here',
+      makeAssistantLine('claude-sonnet-4-6', 100, 50, 0, 0),
+      '{ bad json',
+      makeAssistantLine('claude-sonnet-4-6', 50, 25, 0, 0),
+    ].join('\n');
+
+    await fs.writeFile(filePath, content);
+
+    const result = await reader.parseUsage(filePath, 'sess_xyz', 0);
+    expect(result).not.toBeNull();
+    expect(result!.inputTokens).toBe(150);
+    expect(result!.turns).toBe(2);
+  });
+
+  it('returns null when file has session ID but no assistant entries with usage', async () => {
+    const reader = new ClaudeCodeUsageReader(tmpDir);
+    const filePath = path.join(tmpDir, 'no-usage.jsonl');
+
+    const content = [
+      'sess_target is here',
+      JSON.stringify({ type: 'user', message: 'hello' }),
+      JSON.stringify({ type: 'system', content: 'system prompt' }),
+    ].join('\n');
+
+    await fs.writeFile(filePath, content);
+
+    const result = await reader.parseUsage(filePath, 'sess_target', 0);
+    expect(result).toBeNull();
+  });
+});

--- a/tests/unit/client-usage-claude-code.test.ts
+++ b/tests/unit/client-usage-claude-code.test.ts
@@ -73,8 +73,8 @@ afterEach(async () => {
 
 describe('ClaudeCodeUsageReader.searchDirs', () => {
   it('encodes workspace path by replacing slashes with hyphens', () => {
-    const reader = new ClaudeCodeUsageReader('/fake/home');
-    const dirs = reader.searchDirs('/Users/etienneb/git/personal/workrail');
+    const reader = new ClaudeCodeUsageReader(path.join('/fake', 'home'));
+    const dirs = reader.searchDirs(path.join('/Users', 'etienneb', 'git', 'personal', 'workrail'));
     expect(dirs).toHaveLength(1);
     expect(dirs[0]).toContain('-Users-etienneb-git-personal-workrail');
     expect(dirs[0]).toContain('.claude');
@@ -82,9 +82,11 @@ describe('ClaudeCodeUsageReader.searchDirs', () => {
   });
 
   it('uses the injected homeDir', () => {
-    const reader = new ClaudeCodeUsageReader('/custom/home');
-    const dirs = reader.searchDirs('/my/project');
-    expect(dirs[0]).toContain('/custom/home');
+    const customHome = path.join('/custom', 'home');
+    const reader = new ClaudeCodeUsageReader(customHome);
+    const dirs = reader.searchDirs(path.join('/my', 'project'));
+    // Use path.join segment check so it passes on both Unix (/) and Windows (\)
+    expect(dirs[0]).toContain(path.join('custom', 'home'));
   });
 });
 

--- a/tests/unit/client-usage-collect.test.ts
+++ b/tests/unit/client-usage-collect.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for collect() from src/mcp/client-usage/index.ts.
+ *
+ * Tests the collection orchestration: reader enumeration, directory scanning,
+ * file filtering, and result aggregation.
+ * Uses mock readers to avoid I/O.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+
+import { collect } from '../../src/mcp/client-usage/index.js';
+import type { ClientUsage, ClientUsageReader } from '../../src/mcp/client-usage/types.js';
+
+// ── Mock reader helpers ────────────────────────────────────────────────────────
+
+function makeFixedReader(
+  name: string,
+  dirs: string[],
+  parseResult: ClientUsage | null,
+): ClientUsageReader {
+  return {
+    clientName: name,
+    searchDirs: () => dirs,
+    parseUsage: async () => parseResult,
+  };
+}
+
+function makeSelectiveReader(
+  name: string,
+  dirs: string[],
+  // Map from filename to result
+  results: Record<string, ClientUsage | null>,
+): ClientUsageReader {
+  return {
+    clientName: name,
+    searchDirs: () => dirs,
+    parseUsage: async (filePath: string) => {
+      const filename = path.basename(filePath);
+      return results[filename] ?? null;
+    },
+  };
+}
+
+function makeFixedUsage(client: string): ClientUsage {
+  return {
+    client,
+    model: 'test-model',
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheReadTokens: 200,
+    cacheWriteTokens: 300,
+    turns: 5,
+  };
+}
+
+// ── collect() ─────────────────────────────────────────────────────────────────
+
+describe('collect()', () => {
+  it('returns empty array when workspacePath is null', async () => {
+    const reader = makeFixedReader('test', ['/any/dir'], makeFixedUsage('test'));
+    const results = await collect('sess_test', null, 0, [reader]);
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns empty array when workspacePath is empty string', async () => {
+    const reader = makeFixedReader('test', ['/any/dir'], makeFixedUsage('test'));
+    const results = await collect('sess_test', '', 0, [reader]);
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns empty array when no readers are registered', async () => {
+    const results = await collect('sess_test', '/my/project', 0, []);
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns empty array when reader searchDirs returns non-existent directory', async () => {
+    const reader = makeFixedReader('test', ['/does/not/exist/xyz'], makeFixedUsage('test'));
+    const results = await collect('sess_test', '/my/project', 0, [reader]);
+    expect(results).toHaveLength(0);
+  });
+
+  it('collects results from a reader that matches files', async () => {
+    // Create a temp directory with JSONL files
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workrail-collect-test-'));
+    try {
+      await fs.writeFile(path.join(tmpDir, 'conv1.jsonl'), 'dummy\n');
+      await fs.writeFile(path.join(tmpDir, 'conv2.jsonl'), 'dummy\n');
+      await fs.writeFile(path.join(tmpDir, 'not-a-jsonl.txt'), 'ignored\n');
+
+      const usage = makeFixedUsage('test-client');
+      const reader: ClientUsageReader = {
+        clientName: 'test-client',
+        searchDirs: () => [tmpDir],
+        parseUsage: async (filePath: string) => {
+          // Only match conv1.jsonl
+          if (path.basename(filePath) === 'conv1.jsonl') return usage;
+          return null;
+        },
+      };
+
+      const results = await collect('sess_test', '/my/project', 0, [reader]);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toBe(usage);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('aggregates results from multiple readers', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workrail-collect-multi-'));
+    try {
+      await fs.writeFile(path.join(tmpDir, 'file.jsonl'), 'dummy\n');
+
+      const usageA = makeFixedUsage('client-a');
+      const usageB = makeFixedUsage('client-b');
+      const readerA = makeFixedReader('client-a', [tmpDir], usageA);
+      const readerB = makeFixedReader('client-b', [tmpDir], usageB);
+
+      const results = await collect('sess_test', '/my/project', 0, [readerA, readerB]);
+      expect(results).toHaveLength(2);
+      expect(results.map(r => r.client)).toContain('client-a');
+      expect(results.map(r => r.client)).toContain('client-b');
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips non-jsonl files', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workrail-collect-skip-'));
+    try {
+      await fs.writeFile(path.join(tmpDir, 'file.txt'), 'ignored\n');
+      await fs.writeFile(path.join(tmpDir, 'file.json'), 'ignored\n');
+      await fs.writeFile(path.join(tmpDir, 'file.jsonl'), 'will-be-checked\n');
+
+      const parsedFiles: string[] = [];
+      const reader: ClientUsageReader = {
+        clientName: 'test',
+        searchDirs: () => [tmpDir],
+        parseUsage: async (filePath: string) => {
+          parsedFiles.push(path.basename(filePath));
+          return null;
+        },
+      };
+
+      await collect('sess_test', '/project', 0, [reader]);
+      expect(parsedFiles).toHaveLength(1);
+      expect(parsedFiles[0]).toBe('file.jsonl');
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('handles reader parseUsage errors without throwing', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workrail-collect-err-'));
+    try {
+      await fs.writeFile(path.join(tmpDir, 'file.jsonl'), 'dummy\n');
+
+      const reader: ClientUsageReader = {
+        clientName: 'broken',
+        searchDirs: () => [tmpDir],
+        parseUsage: async () => {
+          throw new Error('simulated reader error');
+        },
+      };
+
+      // Should not throw
+      const results = await collect('sess_test', '/project', 0, [reader]);
+      expect(results).toHaveLength(0);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses default USAGE_READERS registry when no readers are passed', async () => {
+    // Should not throw and should return an array (empty in test env)
+    const results = await collect('sess_nonexistent', '/some/workspace', 0);
+    expect(Array.isArray(results)).toBe(true);
+  });
+});

--- a/tests/unit/v2/session-metrics-projection.test.ts
+++ b/tests/unit/v2/session-metrics-projection.test.ts
@@ -426,4 +426,90 @@ describe('projectSessionMetricsV2', () => {
     expect(result.agentCommitShas).toEqual([]);
     expect(result.captureConfidence).toBe('none');
   });
+
+  it('usageEvents is empty when no usage_recorded events present', () => {
+    const events: DomainEventV1[] = [
+      makeSessionCreatedEvent(0),
+      makeRunStartedEvent('run_1', 1),
+      makeRunCompletedEvent({ runId: 'run_1', eventIndex: 2 }),
+    ];
+
+    const result = projectSessionMetricsV2(events);
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.usageEvents).toEqual([]);
+  });
+
+  it('usageEvents contains entries from usage_recorded events for the matching runId', () => {
+    const events: DomainEventV1[] = [
+      makeSessionCreatedEvent(0),
+      makeRunStartedEvent('run_1', 1),
+      makeRunCompletedEvent({ runId: 'run_1', eventIndex: 2 }),
+      {
+        v: 1,
+        eventId: 'evt_usage',
+        eventIndex: 3,
+        sessionId: 'sess_1',
+        kind: 'usage_recorded',
+        dedupeKey: 'usage-recorded:sess_1:claude-code',
+        scope: { runId: 'run_1' },
+        data: {
+          client: 'claude-code',
+          model: 'claude-sonnet-4-6',
+          inputTokens: 286,
+          outputTokens: 1234,
+          cacheReadTokens: 50000,
+          cacheWriteTokens: 2000,
+          turns: 10,
+        },
+        timestampMs: 0,
+      } as unknown as DomainEventV1,
+    ];
+
+    const result = projectSessionMetricsV2(events);
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.usageEvents).toHaveLength(1);
+    expect(result.usageEvents[0]).toMatchObject({
+      client: 'claude-code',
+      model: 'claude-sonnet-4-6',
+      inputTokens: 286,
+      outputTokens: 1234,
+      cacheReadTokens: 50000,
+      cacheWriteTokens: 2000,
+      turns: 10,
+    });
+  });
+
+  it('usageEvents ignores usage_recorded events from a different runId', () => {
+    const events: DomainEventV1[] = [
+      makeSessionCreatedEvent(0),
+      makeRunStartedEvent('run_1', 1),
+      makeRunCompletedEvent({ runId: 'run_1', eventIndex: 2 }),
+      {
+        v: 1,
+        eventId: 'evt_usage_other',
+        eventIndex: 3,
+        sessionId: 'sess_1',
+        kind: 'usage_recorded',
+        dedupeKey: 'usage-recorded:sess_1:claude-code',
+        scope: { runId: 'run_2' }, // different runId -- should be ignored
+        data: {
+          client: 'claude-code',
+          model: 'claude-sonnet-4-6',
+          inputTokens: 999,
+          outputTokens: 999,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          turns: 5,
+        },
+        timestampMs: 0,
+      } as unknown as DomainEventV1,
+    ];
+
+    const result = projectSessionMetricsV2(events);
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.usageEvents).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Implements the ClientUsageReader system from issue #1116. After each session completes (when `run_completed` is written), the system fire-and-forgets a usage collection pass that:

1. Scans `~/.claude/projects/<encoded-workspace>/` JSONL files for the WorkRail session ID
2. Sums token usage from all matched `assistant` entries
3. Writes one `usage_recorded` event per matched client to the session store
4. Surfaces the data via `projectSessionMetricsV2` as `usageEvents: readonly ClientUsage[]`

**New files:**
- `src/mcp/client-usage/types.ts` -- `ClientUsageReader` interface
- `src/mcp/client-usage/claude-code.ts` -- `ClaudeCodeUsageReader` implementation
- `src/mcp/client-usage/registry.ts` -- `USAGE_READERS` ordered registry
- `src/mcp/client-usage/index.ts` -- `collect()` entry point
- `src/v2/durable-core/schemas/session/usage.ts` -- `ClientUsage` shared type

**Modified files:**
- `src/v2/durable-core/schemas/session/events.ts` -- `usage_recorded` event in `DomainEventV1Schema`
- `src/v2/durable-core/constants.ts` -- `USAGE_RECORDED` in `EVENT_KIND`
- `src/v2/projections/session-metrics.ts` -- `usageEvents` in `SessionMetricsV2`
- `src/mcp/handlers/v2-execution/index.ts` -- `collectAndRecordUsage()` fire-and-forget injection

## Architecture notes

- `ClientUsage` type lives in `durable-core` to avoid a MCP-to-projections import cycle
- `collectAndRecordUsage()` runs after the session lock is released (post-`handleAdvanceIntent`), acquiring its own fresh lock for the append -- same pattern as `delivery_recorded`
- `dedupeKey: usage-recorded:{sessionId}:{client}` ensures idempotency on replay
- `usageEvents: readonly ClientUsage[]` (empty array) instead of nullable to avoid nullable-as-state-machine
- Known limitation: JSONL may not be fully flushed for the final turn at collection time. Acceptable for v1 observational data.

## Related issues

- Closes #1116
- Follow-up: #1117 (Cursor reader), #1118 (Antigravity reader), #1119 (survey MCP clients)

## Test plan

- [x] `npx vitest run tests/unit/client-usage-claude-code.test.ts` -- 9 tests pass
- [x] `npx vitest run tests/unit/client-usage-collect.test.ts` -- 9 tests pass
- [x] `npx vitest run` -- 405 test files, 6318 tests pass
- [x] `npm run build` -- TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)