### PR TITLE
docs: update README to reflect v2 capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,18 @@ Ask one to fix a bug and it starts editing code immediately - before understandi
 considering alternatives, before verifying assumptions. It's not stupid; it's a predictive model
 doing what predictive models do: fill in gaps and race to an answer.
 
-You can add system prompts: "plan before coding," "gather context first." But as conversations grow,
-those instructions fade into the background. The agent reverts to its default: assume, predict, jump
-to conclusions.
+You can add system prompts or skills: "plan before coding," "gather context first," "follow our
+architecture guidelines." But system prompts fade as conversations grow. Skills front-load all
+guidance at once - which works for simple tasks but breaks down when the task is long and the
+guidance is complex. The agent reverts to its default: assume, predict, jump to conclusions.
+
+The deeper problems compound from there:
+
+- **Tasks left incomplete** - the agent ships something that looks done but skips the hard parts
+- **Guidelines ignored** - your architecture rules, best practices, and team conventions aren't enforced; the agent knows them but doesn't apply them
+- **No audit trail** - when AI work goes wrong, there's no record of what decisions were made or why
+- **Context lost between sessions** - every new conversation starts from zero; prior work, decisions, and context vanish
+- **Parallelism is chaos** - running multiple AI tasks simultaneously means constant context-switching and re-explaining; there's no shared structure
 
 **The result: inconsistent quality that depends on how much you babysit the agent.**
 
@@ -35,6 +44,9 @@ the [Model Context Protocol](https://modelcontextprotocol.org). The agent calls 
 gets the first step, completes it, calls `continue_workflow`. Future steps stay hidden until previous ones are done.
 
 **The agent can't skip to implementation because it doesn't know those steps exist yet.**
+
+Sessions are durable. Work is saved to disk at every step and can be resumed across conversations
+with `resume_session` — pick up exactly where you left off, even days later or in a fresh chat.
 
 ### The Mechanism
 
@@ -118,14 +130,50 @@ Each step follows a pattern that prevents common AI failure modes:
 
 This isn't arbitrary structure. It's how experienced developers actually work.
 
+### Durable Sessions
+
+Sessions persist to disk at every step. Close the chat, come back tomorrow, pick up exactly where
+you left off:
+
+```
+# New conversation, days later
+> "Resume the auth refactor I was working on"
+
+Agent: → resume_session()
+
+WorkRail: Found your session from 3 days ago.
+          You were on Step 4: Implement token rotation.
+          Here's what you had documented so far...
+```
+
+Each step's output — notes, decisions, artifacts — is saved and concatenated automatically. No
+context re-setup. No re-explaining what was already done.
+
+### Visibility and Audit Trail
+
+The WorkRail Console is a browser dashboard that shows every active and completed session. It
+auto-boots when you use WorkRail and gives you a live view of what the agent is doing, what it has
+done, and what decisions it made at each step.
+
+Open it anytime with `worktrain console`.
+
+### Running Tasks in Parallel
+
+Because sessions are independent and durable, you can run multiple AI tasks simultaneously without
+babysitting any of them. Start five workflows, let each agent work through its steps, check in when
+they checkpoint. No context-switching overhead — each session has its own complete state.
+
 ### Why This Beats System Prompts
 
-| System Prompt | WorkRail |
-|---------------|----------|
+| System Prompt / Skill | WorkRail |
+|-----------------------|----------|
 | "Plan first" fades as context grows | Each step is fresh and immediate |
 | Agent decides what to follow | Agent can't skip - next step is hidden |
-| One-size-fits-all instructions | Workflows adapt to task complexity |
+| Skills front-load all guidance at once | Guidance is delivered one step at a time, in context |
+| One-size-fits-all instructions | Workflows encode your team's rules and best practices |
 | Inconsistent results | Repeatable, consistent quality |
+| Stateless — context lost when chat ends | Durable sessions — resume exactly where you left off |
+| One task at a time or constant context-switching | Independent sessions run in parallel without babysitting |
 
 ---
 
@@ -186,10 +234,12 @@ chmod +x $(npm root -g)/@exaudeus/workrail/dist/mcp-server.js
 | Workflow | When to Use |
 |----------|-------------|
 | `coding-task-workflow-agentic` | Feature development with notes-first durability and audit loops |
-| `bug-investigation-agentic` | Systematic debugging with evidence-based analysis |
-| `mr-review-workflow-agentic` | Code review with parallel reviewer families |
+| `bug-investigation.agentic.v2` | Systematic debugging with evidence-based analysis |
+| `mr-review-workflow.agentic.v2` | Code review with parallel reviewer families |
 | `wr.discovery` | Upstream exploration, framing, and design synthesis |
+| `wr.shaping` | Shape a fuzzy problem into an implementation-ready pitch |
 | `document-creation-workflow` | Technical documentation with structure |
+| `architecture-scalability-audit` | Audit a service for production readiness and scalability |
 
 Workflows adapt to complexity - simple tasks get fast-tracked, complex tasks get full rigor.
 
@@ -218,6 +268,14 @@ check X?" "What about edge case Y?" "Show me your reasoning."
 
 WorkRail does this automatically. The workflow asks the questions a senior dev would ask, at the
 moments they'd ask them.
+
+### Team Knowledge, Shared
+
+Workflows are JSON files you can version-control and share with your team. Encode your architectural
+rules, review checklists, and best practices directly into the execution path — so every AI task on
+your team follows the same standards, automatically.
+
+A workflow you write for your own team is a workflow that runs the same way for every engineer on it.
 
 ---
 
@@ -265,6 +323,9 @@ support [conditions, loops, validation criteria](docs/authoring.md), and more.
 - **Integrations**
   - [Claude Code Setup](docs/integrations/claude-code.md) – Complete guide for Desktop & CLI
   - [Firebender Setup](docs/integrations/firebender.md) – Firebender integration
+- **Console & Sessions**
+  - Run `worktrain console` to open the browser dashboard
+  - Use `resume_session` in any conversation to reconnect to an existing session
 
 ---
 


### PR DESCRIPTION
## Summary

- Expands The Problem with the complete failure-mode picture: incomplete tasks, guidelines ignored, no audit trail, context lost between sessions, parallelism chaos
- Adds three new sections: Durable Sessions, Visibility and Audit Trail (console), Running Tasks in Parallel
- Expands comparison table to include skills front-loading, durable sessions, and parallelism rows
- Adds Team Knowledge Shared philosophy subsection
- Fixes two incorrect workflow IDs in the Included Workflows table
- Adds Console & Sessions to Documentation links

The README was describing v1-era WorkRail. These changes bring it up to date with what v2 actually delivers.

## Test plan

- [ ] Read through the full README and confirm it flows correctly
- [ ] Verify all workflow IDs in the table exist in `workflows/`
- [ ] Confirm `worktrain console` and `resume_session` are accurately described

🤖 Generated with [Claude Code](https://claude.com/claude-code)