### PR TITLE
feat(engine): add engine-side git diff metrics via two new domain events

### DIFF
--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -105,12 +105,50 @@ export type TokenSnapshot = {
   readonly turns: number;
 };
 
+/**
+ * Mirror of GitCommittedDiff in src/mcp/git-metrics/types.ts.
+ * Keep in sync with the backend definition.
+ */
+export type GitCommittedDiff = {
+  readonly filesChanged: number;
+  readonly linesAdded: number;
+  readonly linesRemoved: number;
+  readonly truncated: boolean;
+};
+
+/**
+ * Mirror of GitWorkingTreeState in src/mcp/git-metrics/types.ts.
+ * Keep in sync with the backend definition.
+ */
+export type GitWorkingTreeState = {
+  readonly stagedFiles: number;
+  readonly unstagedFiles: number;
+};
+
+/**
+ * Mirror of GitEvidence in src/mcp/git-metrics/types.ts.
+ * Authoritative engine-side git diff evidence for a completed session.
+ * Keep in sync with the backend definition.
+ */
+export type GitEvidence = {
+  readonly startSha: string | null;
+  readonly endSha: string | null;
+  readonly commitShas: readonly string[];
+  readonly prRefs: readonly number[];
+  /** null means the diff command failed or timed out. */
+  readonly committedDiff: GitCommittedDiff | null;
+  /** null means the status command failed or timed out. */
+  readonly workingTree: GitWorkingTreeState | null;
+  readonly captureConfidence: 'high' | 'partial' | 'none';
+};
+
 export interface SessionMetricsV2 {
   // From run_completed event (engine-authoritative)
   readonly startGitSha: string | null;
   readonly endGitSha: string | null;
   readonly gitBranch: string | null;
   readonly agentCommitShas: readonly string[];
+  /** @deprecated Always 'none' since PR #903. Use gitEvidence.captureConfidence. */
   readonly captureConfidence: 'high' | 'none';
   readonly durationMs: number | undefined;
   // From context_set metrics_* keys (agent-reported, each independently nullable)
@@ -123,6 +161,8 @@ export interface SessionMetricsV2 {
   readonly usageEvents: readonly ClientUsage[];
   // From token_checkpoint events (start/end delta for this workflow run)
   readonly tokenDelta: TokenSnapshot | null;
+  // From git_metrics_recorded event (engine-authoritative git diff, null for old sessions)
+  readonly gitEvidence: GitEvidence | null;
 }
 
 export interface ConsoleSessionSummary {

--- a/docs/design/git-metrics-candidates.md
+++ b/docs/design/git-metrics-candidates.md
@@ -1,0 +1,126 @@
+# Git Metrics Collection -- Design Candidates
+
+*Pre-registered before implementation. Main agent synthesis.*
+
+---
+
+## Constraint Orientation
+
+Before candidates, each [TEAM_RULE] and [CONVENTION] constraint is applied:
+
+- [TEAM_RULE] run_completed schema must NOT change -- **rules out** any candidate that adds `captureConfidence: 'partial'` to the run_completed event; partial stays in git_metrics_recorded only.
+- [TEAM_RULE] Git diff must be fire-and-forget AFTER lock release -- **rules out** any candidate that reads the diff inside outcome-success.ts (inside the session lock).
+- [TEAM_RULE] All git commands need explicit timeouts -- **all candidates** must pass timeout arguments to execFile calls.
+- [TEAM_RULE] Diff output truncated at ~10k lines with `truncated: true` -- **all candidates** must implement line-count truncation.
+- [CONVENTION] New events follow `DomainEventEnvelopeV1Schema.extend({ kind: z.literal('...'), ... })` pattern -- **all candidates** must register events this way.
+- [CONVENTION] New EVENT_KIND constants added to the EVENT_KIND object (SCREAMING_SNAKE_CASE key, snake_case value) -- **all candidates** must add GIT_START_RECORDED and GIT_METRICS_RECORDED.
+- [CONVENTION] Fire-and-forget appended to the sequential async IIFE using `await` (not concurrent void calls) -- **all candidates** must chain `await recordGitMetrics(...)` after the existing await calls.
+- [CONVENTION] Git reader uses execFile not exec for commands with user-controlled content -- **all candidates** must use execFile.
+- [CONVENTION] Reader placed in `src/mcp/git-metrics/reader.ts` (sibling to `src/mcp/client-usage/reader.ts`) -- **all candidates** share this location.
+
+---
+
+## Real Tensions
+
+1. **Additive schema purity vs. data consolidation.** The cleanest data model would put all git info in one event (`git_metrics_recorded` only, capturing both start and end state). But start-time dirty state is only available at workflow start, not completion. Splitting into two events (`git_start_recorded` for baseline, `git_metrics_recorded` for diffs) is architecturally correct but adds event registration overhead.
+
+2. **captureConfidence type scope vs. backward compat.** Adding `'partial'` to captureConfidence on `run_completed` would fix the existing bug site most directly. But it requires changing the `run_completed` schema (a [TEAM_RULE] violation) and adding a superRefine for partial. Keeping the fix confined to `git_metrics_recorded` (a new event) preserves backward compat but leaves the `outcome-success.ts` captureConfidence bug still present (permanently `'none'`).
+
+3. **Projection complexity vs. backward compat.** `SessionMetricsV2` could get a clean unified `gitEvidence` field (preferred) or the projection could try to synthesize from old `run_completed` fields + new events simultaneously, increasing complexity.
+
+4. **Reader purity vs. testability.** Pure async functions with execFile are easy to unit-test (mock execFile). A class-based reader with injected shell adapter is more testable with fakes but adds ceremony that violates YAGNI for this size of module.
+
+---
+
+## Candidates
+
+### Candidate A: Minimal patch (no new events)
+
+**Summary:** Fix the `captureConfidence` bug in `outcome-success.ts`, extend `git diff` to run fire-and-forget by adding it after the session lock, store results directly in `context_set` (like agent-reported metrics), and extend `SessionMetricsV2` to read them.
+
+**Tensions resolved:** Simplest change. No new event schema registration.
+
+**Tensions accepted:** Uses `context_set` (untyped JsonValue) as git metrics carrier -- violates "prefer explicit domain types". Conflicts with PHILOSOPHY constraint 2 (GitEvidence must be explicit domain type). Projection boundary is still untyped at storage.
+
+**Constraint satisfaction:**
+- [TEAM_RULE] run_completed unchanged: YES
+- [TEAM_RULE] fire-and-forget after lock: YES
+- [PHILOSOPHY] explicit domain types: NO -- context_set carries JsonValue
+
+**VERDICT: Disqualified.** Violates PHILOSOPHY constraint 2 (explicit domain types). context_set is the wrong carrier for engine-authoritative structured data.
+
+---
+
+### Candidate B: Two new events, gitEvidence projection (RECOMMENDED)
+
+**Summary:** Add `git_start_recorded` and `git_metrics_recorded` as new event schema members in `DomainEventV1Schema`. Add `GIT_START_RECORDED` and `GIT_METRICS_RECORDED` to EVENT_KIND. Build `src/mcp/git-metrics/` with `types.ts`, `reader.ts`, `record.ts`, `index.ts`. Wire `recordGitStart` fire-and-forget in `handleV2StartWorkflow`. Wire `recordGitMetrics` appended to the existing sequential async IIFE in `handleV2ContinueWorkflow`. Extend `SessionMetricsV2` with `gitEvidence: GitEvidence | null`. Fix captureConfidence in `outcome-success.ts` to produce correct 'high'/'none' even without changing the schema (endSha !== null && commitShas.length > 0 check). Add `'partial'` only to the new `git_metrics_recorded` event schema's captureConfidence field.
+
+**Tensions resolved:** Type safety (explicit GitEvidence domain type), backward compat (no run_completed schema change), deterministic fire-and-forget (established pattern), reader purity (pure async functions).
+
+**Tensions accepted:** Two event registrations (minor overhead). captureConfidence enum is now diverged between run_completed ('high'|'none') and git_metrics_recorded ('high'|'partial'|'none') -- slight inconsistency but necessary for backward compat.
+
+**Constraint satisfaction:**
+- [TEAM_RULE] run_completed unchanged: YES -- schema untouched
+- [TEAM_RULE] fire-and-forget after lock: YES -- both record calls are outside the session lock
+- [TEAM_RULE] explicit timeouts: YES -- 10000ms for diff, 5000ms for status/log
+- [TEAM_RULE] truncation at ~10k lines: YES -- reader checks line count
+- [CONVENTION] DomainEventEnvelopeV1Schema.extend pattern: YES
+- [CONVENTION] EVENT_KIND constant: YES
+- [CONVENTION] sequential async IIFE await: YES
+- [CONVENTION] execFile not exec: YES
+- [CONVENTION] reader placement: YES
+- [PHILOSOPHY] explicit domain types: YES -- GitEvidence is a named typed interface
+- [PHILOSOPHY] errors are data: YES -- readers return null on failure, never throw
+- [PHILOSOPHY] pure functions: YES -- reader.ts is pure async, no class
+
+**VERDICT: Recommended.** Fully satisfies all constraints with the smallest surface area expansion.
+
+---
+
+### Candidate C: Single event (`git_session_recorded`), start state embedded
+
+**Summary:** Capture start dirty state synchronously inside `executeStartWorkflow` (before returning), store it in the session as a single `git_session_recorded` event that is updated at completion using an event amendment pattern.
+
+**Tensions resolved:** One event registration instead of two.
+
+**Tensions accepted:** Events in the session store are append-only -- "amending" an event requires a new event with a reference to the original, adding complexity. Capturing synchronously at start potentially slows the start response (violates fire-and-forget requirement). Start state capture inside the session lock is a [TEAM_RULE] violation.
+
+**Constraint satisfaction:**
+- [TEAM_RULE] fire-and-forget after lock: NO -- synchronous start capture is inside the lock
+- [TEAM_RULE] run_completed unchanged: YES
+
+**VERDICT: Disqualified.** Violates [TEAM_RULE] for fire-and-forget (synchronous git I/O at session start would block the response).
+
+---
+
+### Candidate D: Candidate B + captureConfidence fix on run_completed schema
+
+**Summary:** Same as Candidate B, but also extends run_completed schema to allow `'partial'` in captureConfidence, updating the superRefine accordingly.
+
+**Tensions resolved:** Unifies captureConfidence semantics across both events; fixes the bug at its root site in outcome-success.ts with full type support.
+
+**Tensions accepted:** Requires modifying run_completed schema -- a [TEAM_RULE] violation.
+
+**Constraint satisfaction:**
+- [TEAM_RULE] run_completed unchanged: NO -- schema extended with 'partial'
+
+**VERDICT: Rejected.** The schema change has downstream consequences (any parser that parses old events with 'partial' must handle the new enum value). AGENTS.md explicitly states run_completed schema must not change. The fix is better done in the new event only.
+
+---
+
+## Constraint Satisfaction Matrix
+
+| Constraint | Candidate A | Candidate B | Candidate C | Candidate D |
+|---|---|---|---|---|
+| run_completed unchanged [TEAM_RULE] | YES | YES | YES | NO |
+| fire-and-forget [TEAM_RULE] | YES | YES | NO | YES |
+| explicit domain types [PHILOSOPHY] | NO | YES | YES | YES |
+| errors are data [PHILOSOPHY] | YES | YES | YES | YES |
+| DomainEventEnvelopeV1Schema.extend [CONVENTION] | N/A | YES | YES | YES |
+| execFile not exec [CONVENTION] | YES | YES | YES | YES |
+
+---
+
+## Recommendation
+
+**Candidate B** is the only candidate that satisfies all constraints without violating any [TEAM_RULE] or [CONVENTION]. Candidates A, C, and D each have a disqualifying violation. Candidate B resolves the captureConfidence bug at the correct scope (new event only), preserves backward compat for old sessions, and follows the established fire-and-forget pattern exactly.

--- a/docs/design/git-metrics-design-review.md
+++ b/docs/design/git-metrics-design-review.md
@@ -1,0 +1,82 @@
+# Git Metrics Collection -- Design Review Findings
+
+*Review of Candidate B (selected). Main agent synthesis.*
+
+---
+
+## Tradeoff Review
+
+**T1: captureConfidence enum divergence**
+`run_completed` retains `'high'|'none'` (schema locked). `git_metrics_recorded` uses `'high'|'partial'|'none'`. Two fields encoding similar concepts exist on SessionMetricsV2. Acceptable because the old field is documented as legacy/broken and gitEvidence is the authoritative replacement. Fails to be unacceptable only if a consumer starts reading the old run_completed captureConfidence and expecting 'partial' -- no current consumer does.
+
+**T2: Two new event union members**
+Both are standard DomainEventEnvelopeV1Schema.extend() registrations. TypeScript exhaustive switches will catch any unhandled cases at compile time. Projection loops skip unknown events, so backward compat holds. Acceptable.
+
+**T3: Post-completion appendEvent window**
+Confirmed by code inspection: gate.withHealthySessionLock acquires a fresh lock after session completion for usage_recorded and token_checkpoint. Same window is open for git_metrics_recorded. Appends are sequential (not concurrent) to avoid SESSION_LOCK_REENTRANT. Acceptable.
+
+---
+
+## Failure Mode Review
+
+**FM-1 (git not installed / not a git repo):** Reader returns null, captureConfidence='none'. Handled.
+
+**FM-2 (enormous git diff output):** CRITICAL -- execFile buffers all output before return. Without `maxBuffer` set, pathological repos could OOM the process. Required fix: set `maxBuffer: 5 * 1024 * 1024` on the execFile call AND implement line-count truncation. Both required.
+
+**FM-3 (SESSION_LOCK_REENTRANT on concurrent calls):** Handled by sequential await in async IIFE.
+
+**FM-4 (git diff timeout):** 10000ms timeout. On timeout, execFile throws, reader returns null, captureConfidence='partial'. Handled.
+
+**FM-5 (post-completion appendEvent silent failure):** Consistent with existing pattern (usage_recorded, token_checkpoint). No observable signal but does not affect session correctness. Handled.
+
+---
+
+## Runner-Up / Simpler Alternative Review
+
+**Runner-up (Candidate D):** Extends run_completed captureConfidence to include 'partial'. Rejected -- violates [TEAM_RULE] run_completed schema unchanged. No elements worth borrowing except the insight that outcome-success.ts captureConfidence condition can be fixed within the existing type constraint.
+
+**Simpler alternative (skip git_start_recorded):** Fails AC-1. Start dirty state is useful (baseline for 'did the agent clean up staged changes'). Not worth skipping.
+
+**Hybrid (one consolidated event):** Aesthetic only -- no architectural benefit. Not pursued.
+
+---
+
+## Philosophy Alignment
+
+**Satisfied:** explicit domain types, errors as data, pure functions, determinism, timeouts as first-class, validate at boundaries, functional core / imperative shell.
+
+**Tensions:**
+- Make illegal states unrepresentable: `committedDiff: GitCommittedDiff | null` inside GitEvidence. Resolved by invariant: null = command failed (never zero-changes).
+- Single source of state truth: dual captureConfidence fields (legacy run_completed + new gitEvidence). Resolved by documenting old field as legacy.
+
+Both tensions are acceptable.
+
+---
+
+## Findings
+
+### Red (blocking)
+None.
+
+### Orange (must fix in implementation)
+**O-1:** `execFile` calls must set `maxBuffer: 5 * 1024 * 1024` (5MB). Without this, Node.js default maxBuffer (~1MB for older versions) or unlimited buffering before OOM could cause issues on large diffs. Required for FM-2 mitigation.
+
+### Yellow (should address)
+**Y-1:** `SessionMetricsV2.captureConfidence` (from run_completed) is now permanently broken ('none' for all sessions) but still exposed as a top-level field. Should add a `@deprecated` JSDoc comment directing consumers to use `gitEvidence.captureConfidence` instead.
+
+**Y-2:** The `null = command failed` invariant for `committedDiff` and `workingTree` in `GitEvidence` must be documented in the type definition (JSDoc), not just in design docs.
+
+---
+
+## Recommended Revisions
+
+1. **In reader.ts:** Add `maxBuffer: 5 * 1024 * 1024` to all execFile calls (addresses O-1).
+2. **In session-metrics.ts:** Add `@deprecated` JSDoc on `captureConfidence` field directing to `gitEvidence.captureConfidence` (addresses Y-1).
+3. **In types.ts:** Add JSDoc on `committedDiff` and `workingTree` nullable fields: 'null means the command failed or timed out; zero-change results return a zero-valued struct, not null' (addresses Y-2).
+
+---
+
+## Residual Concerns
+
+- **Silent git event loss:** If recordGitMetrics fails silently (FM-5), there is no observable signal. Acceptable by established convention, but means the feature's effectiveness cannot be monitored from outside. Future work: a periodic audit of sessions without git_metrics_recorded events.
+- **maxBuffer adequacy:** 5MB covers most repos, but a truly pathological diff (e.g. adding a generated file with millions of lines) could still exceed it. The truncation logic is a secondary defense -- the maxBuffer is the primary defense against unbounded memory use.

--- a/docs/design/git-metrics-implementation-plan.md
+++ b/docs/design/git-metrics-implementation-plan.md
@@ -1,0 +1,205 @@
+# Implementation Plan: Engine-Side Git Metrics Collection
+
+## 1. Problem Statement
+
+WorkRail sessions capture git state (startSha, endSha, captureConfidence) in `run_completed` but two bugs prevent useful data from reaching consumers:
+1. `captureConfidence` is permanently `'none'` for all sessions -- the condition `agentCommitShas.length > 0` is always false since PR #903 (agentCommitShas was deprecated to empty).
+2. The committed diff (lines added/removed, files changed) is never captured -- only agent-reported context_set metrics_* values exist, which are unreliable.
+3. No baseline dirty-state is captured at session start -- there is no record of whether the working tree was clean when the agent began.
+
+## 2. Acceptance Criteria
+
+All IDs trace to pre-registered criteria from Phase 5.
+
+- [ ] **AC-1:** `git_start_recorded` event written fire-and-forget after `start_workflow` succeeds (when workspace path is provided).
+- [ ] **AC-2:** `git_metrics_recorded` event written fire-and-forget after session completion (isComplete=true), containing committed diff stat between startSha and endSha, captureConfidence, and commit SHAs.
+- [ ] **AC-3:** `captureConfidence` in `git_metrics_recorded` is `'high'` when endSha differs from startSha, `'partial'` when endSha present but equals startSha or diff failed, `'none'` when no git info available.
+- [ ] **AC-4:** `projectSessionMetricsV2` returns non-null `gitEvidence` when `git_metrics_recorded` event is in the log; returns null gitEvidence when that event is absent (backward compat for old sessions).
+- [ ] **AC-5:** Git operation failures and timeouts do not propagate as MCP tool errors; they are caught and produce null/partial results silently.
+- [ ] **AC-6:** `run_completed` event schema is unchanged -- existing session logs parse correctly after the change.
+- [ ] **[NEW-1]** All execFile calls set `maxBuffer: 5 * 1024 * 1024`. Rationale: without maxBuffer, pathological diffs could exhaust process memory before truncation (discovered in design review O-1).
+- [ ] `npx vitest run` passes.
+- [ ] `npm run build` clean.
+
+## 3. Non-Goals
+
+- No changes to the `run_completed` event schema.
+- No changes to `captureConfidence` type on `run_completed` (remains `'high'|'none'`).
+- No changes to `outcome-success.ts` beyond the captureConfidence condition fix.
+- No new MCP tools or API endpoints.
+- No console UI changes (gitEvidence will be available in SessionMetricsV2 but console rendering is out of scope).
+- No git operations inside the session lock.
+
+## 4. Philosophy-Driven Constraints
+
+- **[PHILOSOPHY]** `GitEvidence` is an explicit domain type with named fields -- no `Record<string, unknown>` or `JsonValue` carriers.
+- **[PHILOSOPHY]** Reader functions return null on failure, never throw -- errors are data.
+- **[PHILOSOPHY]** Reader functions are pure async functions, not classes -- compose with small pure functions.
+- **[PHILOSOPHY]** null on `committedDiff` and `workingTree` fields means command failed; zero-change result returns a zero-valued struct (not null).
+- **[CONVENTION]** New events registered via `DomainEventEnvelopeV1Schema.extend({ kind: z.literal('...'), data: ... })` pattern.
+- **[CONVENTION]** execFile not exec for all git commands (user-controlled repoRoot path).
+- **[CONVENTION]** recordGitMetrics appended as await in the sequential async IIFE -- not a concurrent void call.
+- **[TEAM_RULE]** Git operations fire-and-forget, NEVER inside outcome-success.ts lock chain.
+
+## 5. Invariants
+
+- **I-1:** `git_start_recorded` is written once per session (at session start) or not at all. Duplicate writes are prevented because the fire-and-forget only runs in the handleV2StartWorkflow success path.
+- **I-2:** `git_metrics_recorded` is written once per session (at session completion) or not at all. Fires only when `isComplete=true` in the async IIFE.
+- **I-3:** `run_completed` schema is unchanged -- any event log valid before this change is valid after.
+- **I-4:** `null` on `GitEvidence.committedDiff` means the git diff command failed or timed out. `{ filesChanged: 0, linesAdded: 0, linesRemoved: 0, truncated: false }` means the command ran and found no changes.
+- **I-5:** All git execFile calls set `maxBuffer: 5 * 1024 * 1024` to prevent unbounded memory use on large diffs.
+- **I-6:** All git execFile calls set explicit timeouts: 10000ms for diff, 5000ms for status/log.
+
+## 6. Selected Approach
+
+**Candidate B:** Two new events (`git_start_recorded`, `git_metrics_recorded`), new `src/mcp/git-metrics/` module (types/reader/record/index), wired fire-and-forget in `handleV2StartWorkflow` and the completion async IIFE. `SessionMetricsV2` extended with `gitEvidence: GitEvidence | null`.
+
+See `/Users/etienneb/git/personal/workrail/docs/design/git-metrics-candidates.md` for full design candidate rationale.
+
+## 7. Slices
+
+### Slice 1: Event schemas + constants (no behavior change)
+
+**Files:**
+- `src/v2/durable-core/constants.ts` -- add `GIT_START_RECORDED: 'git_start_recorded'` and `GIT_METRICS_RECORDED: 'git_metrics_recorded'` to `EVENT_KIND`
+- `src/v2/durable-core/schemas/session/events.ts` -- add `git_start_recorded` and `git_metrics_recorded` to `DomainEventV1Schema` discriminated union
+
+**Done when:** `npm run build` clean with new event kinds. TypeScript discriminated union updated.
+
+**AC traced:** AC-6 (run_completed schema unchanged), AC-2 (event exists).
+
+**Implementation notes:**
+- `git_start_recorded` data: `{ stagedFiles: number, unstagedFiles: number, repoRoot: string }`
+- `git_metrics_recorded` data: `{ startSha: string | null, endSha: string | null, commitShas: readonly string[], filesChanged: number | null, linesAdded: number | null, linesRemoved: number | null, truncated: boolean, stagedFiles: number | null, unstagedFiles: number | null, captureConfidence: z.enum(['high', 'partial', 'none']), prRefs: readonly number[] }`
+
+### Slice 2: src/mcp/git-metrics/ module
+
+**Files (new):**
+- `src/mcp/git-metrics/types.ts`
+- `src/mcp/git-metrics/reader.ts`
+- `src/mcp/git-metrics/record.ts`
+- `src/mcp/git-metrics/index.ts`
+
+**Done when:** Module exports `recordGitStart` and `recordGitMetrics`, reader functions return correct types, all functions are covered by unit tests.
+
+**AC traced:** AC-1, AC-2, AC-3, AC-5, NEW-1.
+
+**Implementation notes:**
+- `readWorkingTreeState(repoRoot, timeoutMs)`: runs `git diff --cached --numstat` and `git diff --numstat`, returns `{ stagedFiles, unstagedFiles }` or null on failure.
+- `readCommittedDiff(repoRoot, startSha, timeoutMs)`: runs `git diff startSha..HEAD --numstat --no-renames`, returns `{ filesChanged, linesAdded, linesRemoved, truncated }` or null on failure. Truncates at 10000 lines.
+- `parseCommitMessages(repoRoot, startSha, timeoutMs)`: runs `git log --pretty=format:%s%n%b --no-merges --first-parent startSha..HEAD`, returns commit SHAs and PR refs parsed from message body.
+- `readCommitShas(repoRoot, startSha, timeoutMs)`: runs `git log --no-merges --first-parent --format=%H startSha..HEAD`.
+- All execFile calls: `maxBuffer: 5 * 1024 * 1024`, explicit timeout.
+- `recordGitStart(sessionId, repoRoot, sessionStore, gate, idFactory)`: calls readWorkingTreeState, appends git_start_recorded event.
+- `recordGitMetrics(sessionId, repoRoot, startSha, sessionStore, gate, idFactory)`: runs all reader functions, computes captureConfidence, appends git_metrics_recorded event.
+- PR ref parsing: match `#\d+`, `Closes #\d+`, `Fixes #\d+`, `Refs #\d+` in commit message bodies.
+
+### Slice 3: captureConfidence bug fix in outcome-success.ts
+
+**Files:**
+- `src/mcp/handlers/v2-advance-core/outcome-success.ts` -- change line ~272 condition
+
+**Done when:** Condition reads `endSha !== null && commitShas.length > 0 ? 'high' : 'none'`.
+
+**AC traced:** AC-3 (indirect -- git_metrics_recorded uses its own captureConfidence, but this fix prevents the run_completed value from being further misleading).
+
+**Note:** This is a minimal correctness fix. It does NOT add 'partial' to the run_completed captureConfidence (schema unchanged per I-3).
+
+### Slice 4: Wiring in handleV2StartWorkflow and handleV2ContinueWorkflow
+
+**Files:**
+- `src/mcp/handlers/v2-execution/index.ts`
+
+**Done when:** `recordGitStart` fires after handleV2StartWorkflow success. `recordGitMetrics` is the third await in the completion async IIFE.
+
+**AC traced:** AC-1, AC-2, AC-5.
+
+**Implementation notes:**
+```typescript
+// In handleV2StartWorkflow success branch (after recordTokenCheckpoint):
+void recordGitStart(result.sessionId, input.workspacePath, guard.ctx.v2.sessionStore, guard.ctx.v2.gate, guard.ctx.v2.idFactory);
+
+// In the completion async IIFE:
+void (async () => {
+  await collectAndRecordUsage(sessionId, sessionStore, gate, idFactory);
+  await recordTokenCheckpoint(sessionId, 'end', undefined, sessionStore, gate, idFactory);
+  await recordGitMetrics(sessionId, sessionStore, gate, idFactory);
+})();
+```
+
+Note: `recordGitMetrics` must re-read the session store to find the repoRoot and startSha (same pattern as collectAndRecordUsage re-reading for workspacePath).
+
+### Slice 5: SessionMetricsV2 projection extension
+
+**Files:**
+- `src/v2/projections/session-metrics.ts` -- add `gitEvidence: GitEvidence | null` field, read from `git_metrics_recorded` event
+
+**Done when:** `projectSessionMetricsV2` returns `gitEvidence` populated from `git_metrics_recorded` when present, null when absent.
+
+**AC traced:** AC-4.
+
+**Implementation notes:**
+- Add `@deprecated` JSDoc on existing `captureConfidence` field (Y-1 from design review).
+- gitEvidence projection reads git_metrics_recorded event and maps to GitEvidence type.
+- Backward compat: sessions without git_metrics_recorded return `gitEvidence: null`.
+
+### Slice 6: console/src/api/types.ts mirror type
+
+**Files:**
+- `console/src/api/types.ts` -- add `GitEvidence` type matching the projection output
+
+**Done when:** Console API type mirrors GitEvidence.
+
+**AC traced:** (infrastructure for future console rendering -- no dedicated AC, but required for type consistency).
+
+### Slice 7: Tests
+
+**Files (new):**
+- `tests/unit/git-metrics-reader.test.ts` -- reader unit tests with mocked execFile
+- `tests/unit/git-metrics-projection.test.ts` -- projection tests for gitEvidence field
+
+**Done when:** Tests pass for: reader returns null on execFile failure; reader truncates at 10000 lines; captureConfidence='high' when commitShas.length > 0; captureConfidence='partial' when endSha != startSha but diff failed; gitEvidence=null when git_metrics_recorded absent; gitEvidence populated when event present.
+
+**AC traced:** AC-1 through AC-6.
+
+## 8. Test Design
+
+**Unit tests (automated):**
+- Reader functions with mocked execFile: success case, failure case, timeout case, truncation case.
+- `parseCommitMessages` with PR ref patterns: `#123`, `Closes #456`, `Fixes #789`, none.
+- `captureConfidence` computation: all three cases.
+- `projectSessionMetricsV2` with and without `git_metrics_recorded` event in event log.
+
+**Integration tests:**
+- Not required for this PR -- the fire-and-forget pattern is tested by existing integration tests for collectAndRecordUsage and recordTokenCheckpoint.
+
+**Regression:**
+- Existing `tests/lifecycle/bundled-workflow-smoke.test.ts` and `tests/unit/session-metrics.test.ts` must continue to pass without modification (AC-4 backward compat).
+
+## 9. Risk Register
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| maxBuffer exhausted before truncation | Low | High (OOM) | Set maxBuffer: 5MB; truncation is secondary defense |
+| SESSION_LOCK_REENTRANT if recordGitMetrics runs concurrently | Low | Medium (silent data loss) | Sequential await in async IIFE |
+| git_metrics_recorded event silent loss after terminal state | Low | Low (no session correctness impact) | Confirmed safe by collectAndRecordUsage pattern |
+| TypeScript exhaustive switch breakage from new event kinds | Medium | Low (compile error, caught in CI) | Run npm run build before PR |
+
+## 10. PR Packaging
+
+**estimatedPRCount:** 1 (single PR: `feat/etienneb/git-metrics`)
+
+All slices ship together. No slice is useful without the others (schema + reader + wiring + projection + tests must all land together).
+
+## 11. Follow-Up Tickets
+
+- Console rendering of gitEvidence (display committed diff in session detail panel).
+- Audit of sessions missing git_metrics_recorded (monitoring gap noted in design review).
+- Deprecate and eventually remove legacy `captureConfidence`, `startGitSha`, `endGitSha` from SessionMetricsV2 after gitEvidence is the established path.
+
+## 12. Unresolved Questions
+
+None. All questions resolved during design phases.
+
+**unresolvedUnknownCount:** 0
+**planConfidenceBand:** High

--- a/docs/design/git-metrics-verification.md
+++ b/docs/design/git-metrics-verification.md
@@ -1,0 +1,72 @@
+# Git Metrics -- Final Verification Findings
+
+*Verification of the feat/etienneb/git-metrics implementation.*
+
+---
+
+## Readiness Claims and Proof Matrix
+
+| AC | Claim | Evidence | Strength | Gap |
+|---|---|---|---|---|
+| AC-1 | git_start_recorded written at session start | Code: recordGitStart wired in handleV2StartWorkflow success branch (void, fire-and-forget) | Partial | No integration test; proven by structural analogy to recordTokenCheckpoint |
+| AC-2 | git_metrics_recorded written at completion | Code: recordGitMetrics wired as third await in completion async IIFE | Partial | No integration test |
+| AC-3 | captureConfidence correct values | Projection tests verify all three values readable; computeCaptureConfidence logic reviewed | Partial | computeCaptureConfidence not directly unit-tested |
+| AC-4 | gitEvidence null/non-null in projection | 9 projection tests pass covering all cases | Strong | None |
+| AC-5 | Git ops never block session response | Structural: void recordGitStart / await in async IIFE; both have try/catch | Strong | None |
+| AC-6 | run_completed schema unchanged | run_completed schema in events.ts not modified; all 6360 tests pass | Strong | None |
+| NEW-1 | maxBuffer set on all execFile calls | reader.ts has MAX_BUFFER = 5 * 1024 * 1024 on all 6 execFile calls | Strong | None |
+
+---
+
+## Validation Evidence Summary
+
+- `npm run build`: clean (no TypeScript errors)
+- `npx vitest run` (full suite): 6360 pass, 7 skipped, 0 fail
+- `npx vitest run tests/architecture/v2-import-boundaries.test.ts`: 887 pass
+- `npx vitest run tests/unit/git-metrics-reader.test.ts`: 15 tests pass
+- `npx vitest run tests/unit/git-metrics-projection.test.ts`: 9 tests pass
+
+---
+
+## Severity-Classified Gaps
+
+### Red (blocking)
+None.
+
+### Orange (should fix before shipping)
+None.
+
+### Yellow (accepted tension / follow-up)
+- No integration test for fire-and-forget write path (recordGitStart/recordGitMetrics). Acceptable because the pattern is proven by production usage_recorded and token_checkpoint events.
+- computeCaptureConfidence is private and only tested indirectly through projection reads. Logic is correct by inspection.
+- captureConfidence enum divergence between run_completed and git_metrics_recorded is intentional (backward compat).
+
+---
+
+## Regression / Drift Review
+
+No regressions. Full test suite passes. Architecture boundary tests pass.
+
+One unplanned addition: `src/v2/durable-core/schemas/session/git-evidence.ts` (correct architectural fix for architecture boundary violation discovered during implementation -- same pattern as usage.ts).
+
+---
+
+## Philosophy Alignment
+
+Strong. Explicit domain types, errors as data, pure reader functions, functional core, timeouts as first-class, single source of type truth.
+
+Accepted tensions: dual captureConfidence fields (@deprecated JSDoc added), nullable fields with documented invariants.
+
+---
+
+## Recommended Fixes
+
+None required before shipping. Yellow items are tracked follow-up tickets.
+
+---
+
+## Readiness Verdict
+
+**Ready with Accepted Tensions**
+
+All acceptance criteria are proven strong or partial with structural reasoning. No blocking issues. Yellow gaps are intentional tradeoffs documented in design files.

--- a/src/mcp/git-metrics/index.ts
+++ b/src/mcp/git-metrics/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Engine-side git metrics collection module.
+ *
+ * Provides fire-and-forget functions for capturing authoritative git diff stats
+ * at session start and completion. Follows the established pattern of
+ * collectAndRecordUsage and recordTokenCheckpoint.
+ *
+ * Usage:
+ * - Call recordGitStart() in handleV2StartWorkflow (after session created)
+ * - Call recordGitMetrics() in the completion async IIFE (after recordTokenCheckpoint)
+ */
+
+export { recordGitStart, recordGitMetrics } from './record.js';
+export type { GitEvidence, GitCommittedDiff, GitWorkingTreeState } from './types.js';

--- a/src/mcp/git-metrics/reader.ts
+++ b/src/mcp/git-metrics/reader.ts
@@ -1,0 +1,201 @@
+/**
+ * Pure async git reader functions for engine-side metrics collection.
+ *
+ * Rules:
+ * - All functions use execFile (not exec) -- repoRoot is user-controlled input.
+ * - All functions set explicit timeouts and maxBuffer to prevent runaway processes
+ *   and unbounded memory use on large diffs.
+ * - All functions return null on any failure -- errors are data, never exceptions.
+ * - Zero-change results return zero-valued structs (not null).
+ */
+
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { GitCommittedDiff, GitWorkingTreeState } from './types.js';
+
+const execFile = promisify(execFileCb);
+
+/** Maximum number of lines from git diff --numstat before truncation. */
+const MAX_NUMSTAT_LINES = 10_000;
+
+/** Maximum buffer size for execFile (5MB). Prevents OOM on large diffs. */
+const MAX_BUFFER = 5 * 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// Working tree state
+// ---------------------------------------------------------------------------
+
+/**
+ * Read staged and unstaged file counts from the working tree.
+ * Runs `git diff --cached --numstat` and `git diff --numstat` in parallel.
+ *
+ * @returns null if either command fails or times out.
+ */
+export async function readWorkingTreeState(
+  repoRoot: string,
+  timeoutMs: number,
+): Promise<GitWorkingTreeState | null> {
+  try {
+    const [cached, unstaged] = await Promise.all([
+      execFile('git', ['-C', repoRoot, 'diff', '--cached', '--numstat'], {
+        timeout: timeoutMs,
+        maxBuffer: MAX_BUFFER,
+      }),
+      execFile('git', ['-C', repoRoot, 'diff', '--numstat'], {
+        timeout: timeoutMs,
+        maxBuffer: MAX_BUFFER,
+      }),
+    ]);
+
+    return {
+      stagedFiles: countNumstatLines(cached.stdout),
+      unstagedFiles: countNumstatLines(unstaged.stdout),
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Committed diff
+// ---------------------------------------------------------------------------
+
+/**
+ * Read committed diff stats between startSha and current HEAD.
+ * Runs `git diff startSha..HEAD --numstat --no-renames`.
+ *
+ * @param startSha - The git SHA at session start. If null, returns null immediately.
+ * @returns null if startSha is null, if the command fails, or times out.
+ *          Returns a zero-valued struct if no commits were made.
+ */
+export async function readCommittedDiff(
+  repoRoot: string,
+  startSha: string | null,
+  timeoutMs: number,
+): Promise<GitCommittedDiff | null> {
+  if (!startSha) return null;
+
+  try {
+    const { stdout } = await execFile(
+      'git',
+      ['-C', repoRoot, 'diff', `${startSha}..HEAD`, '--numstat', '--no-renames'],
+      { timeout: timeoutMs, maxBuffer: MAX_BUFFER },
+    );
+
+    return parseNumstat(stdout);
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Commit SHAs + PR ref parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Read commit SHAs between startSha and current HEAD.
+ * Runs `git log --no-merges --first-parent --format=%H startSha..HEAD`.
+ *
+ * @param startSha - The git SHA at session start. If null, returns empty arrays.
+ * @returns { shas, prRefs } -- shas is the list of commit SHAs; prRefs is PR numbers
+ *   parsed from commit message subjects and bodies.
+ */
+export async function readCommitShasAndPrRefs(
+  repoRoot: string,
+  startSha: string | null,
+  timeoutMs: number,
+): Promise<{ shas: readonly string[]; prRefs: readonly number[] } | null> {
+  if (!startSha) return { shas: [], prRefs: [] };
+
+  try {
+    // Use format that separates SHA and message body with a delimiter.
+    // %H = full SHA, %s = subject, %b = body
+    const { stdout: shaOutput } = await execFile(
+      'git',
+      ['-C', repoRoot, 'log', '--no-merges', '--first-parent', '--format=%H', `${startSha}..HEAD`],
+      { timeout: timeoutMs, maxBuffer: MAX_BUFFER },
+    );
+
+    const shas = shaOutput
+      .split('\n')
+      .map((s) => s.trim())
+      .filter((s) => s.length === 40 && /^[0-9a-f]{40}$/.test(s));
+
+    if (shas.length === 0) return { shas: [], prRefs: [] };
+
+    // Parse PR refs from subject + body of each commit.
+    const { stdout: msgOutput } = await execFile(
+      'git',
+      ['-C', repoRoot, 'log', '--no-merges', '--first-parent', '--format=%s%n%b', `${startSha}..HEAD`],
+      { timeout: timeoutMs, maxBuffer: MAX_BUFFER },
+    );
+
+    const prRefs = parsePrRefs(msgOutput);
+
+    return { shas, prRefs };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Count the number of non-empty lines in git numstat output.
+ * Each line represents one file.
+ */
+function countNumstatLines(stdout: string): number {
+  return stdout.split('\n').filter((line) => line.trim().length > 0).length;
+}
+
+/**
+ * Parse `git diff --numstat --no-renames` output into a GitCommittedDiff.
+ * Format per line: `<added>\t<removed>\t<filename>`
+ * Binary files show `-\t-\t<filename>` -- counted as 1 file, 0 lines.
+ *
+ * Truncates at MAX_NUMSTAT_LINES.
+ */
+function parseNumstat(stdout: string): GitCommittedDiff {
+  const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
+
+  const truncated = lines.length > MAX_NUMSTAT_LINES;
+  const effectiveLines = truncated ? lines.slice(0, MAX_NUMSTAT_LINES) : lines;
+
+  let filesChanged = 0;
+  let linesAdded = 0;
+  let linesRemoved = 0;
+
+  for (const line of effectiveLines) {
+    const parts = line.split('\t');
+    if (parts.length < 2) continue;
+    filesChanged++;
+    const added = parseInt(parts[0] ?? '0', 10);
+    const removed = parseInt(parts[1] ?? '0', 10);
+    if (!isNaN(added)) linesAdded += added;
+    if (!isNaN(removed)) linesRemoved += removed;
+  }
+
+  return { filesChanged, linesAdded, linesRemoved, truncated };
+}
+
+/**
+ * Parse PR numbers from git log message text.
+ * Matches: `#123`, `Closes #123`, `Fixes #123`, `Refs #123`, `close #123`, etc.
+ * Returns a deduplicated sorted array of PR numbers.
+ */
+function parsePrRefs(text: string): readonly number[] {
+  const pattern = /(?:closes?|fixes?|refs?)\s+#(\d+)|#(\d+)/gi;
+  const found = new Set<number>();
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    const num = parseInt(match[1] ?? match[2] ?? '', 10);
+    if (!isNaN(num) && num > 0) {
+      found.add(num);
+    }
+  }
+
+  return Array.from(found).sort((a, b) => a - b);
+}

--- a/src/mcp/git-metrics/record.ts
+++ b/src/mcp/git-metrics/record.ts
@@ -1,0 +1,240 @@
+/**
+ * Fire-and-forget git metrics recorders.
+ *
+ * These functions follow the same pattern as collectAndRecordUsage and
+ * recordTokenCheckpoint in src/mcp/handlers/v2-execution/index.ts:
+ * - Acquire a fresh session gate lock (never block on the main lock)
+ * - Re-read session events to extract required context (repoRoot, startSha, runId)
+ * - Append a new event fire-and-forget
+ * - Never throw; all errors are caught and logged
+ *
+ * WHY standalone functions (not inside the lock chain): git I/O runs after the
+ * session lock is released. Acquiring a fresh lock per function, sequentially,
+ * prevents SESSION_LOCK_REENTRANT errors.
+ */
+
+import type { V2ToolContext } from '../types.js';
+import type { SessionId } from '../../v2/durable-core/ids/index.js';
+import { EVENT_KIND } from '../../v2/durable-core/constants.js';
+import { buildSessionIndex } from '../../v2/durable-core/session-index.js';
+import { asSortedEventLog } from '../../v2/durable-core/sorted-event-log.js';
+import { okAsync } from 'neverthrow';
+import {
+  readWorkingTreeState,
+  readCommittedDiff,
+  readCommitShasAndPrRefs,
+} from './reader.js';
+
+// Timeouts per operation (ms)
+const DIFF_TIMEOUT_MS = 10_000;
+const STATUS_TIMEOUT_MS = 5_000;
+
+type SessionStore = V2ToolContext['v2']['sessionStore'];
+type Gate = V2ToolContext['v2']['gate'];
+type IdFactory = V2ToolContext['v2']['idFactory'];
+
+// ---------------------------------------------------------------------------
+// recordGitStart
+// ---------------------------------------------------------------------------
+
+/**
+ * Capture baseline working-tree state at session start.
+ *
+ * Appends a `git_start_recorded` event. Fires after start_workflow returns,
+ * before any agent interaction. Uses the repoRoot passed directly (available
+ * at session start from input.workspacePath).
+ *
+ * Must never throw or reject.
+ */
+export async function recordGitStart(
+  sessionId: SessionId,
+  repoRoot: string | null | undefined,
+  sessionStore: SessionStore,
+  gate: Gate,
+  idFactory: IdFactory,
+): Promise<void> {
+  if (!repoRoot) return;
+
+  try {
+    const workingTree = await readWorkingTreeState(repoRoot, STATUS_TIMEOUT_MS);
+    if (workingTree === null) return; // not a git repo or git not installed
+
+    await gate.withHealthySessionLock(sessionId, (lock) =>
+      sessionStore.load(sessionId).andThen((truth) => {
+        const sortedResult = asSortedEventLog(truth.events);
+        if (sortedResult.isErr()) return okAsync(undefined as void);
+        const index = buildSessionIndex(sortedResult.value);
+
+        const event = {
+          v: 1 as const,
+          eventId: idFactory.mintEventId(),
+          eventIndex: index.nextEventIndex,
+          sessionId: String(sessionId),
+          kind: EVENT_KIND.GIT_START_RECORDED,
+          dedupeKey: `git-start-recorded:${String(sessionId)}`,
+          scope: undefined,
+          data: {
+            repoRoot,
+            stagedFiles: workingTree.stagedFiles,
+            unstagedFiles: workingTree.unstagedFiles,
+          },
+          timestampMs: Date.now(),
+        } as const;
+
+        return sessionStore.append(lock, { events: [event], snapshotPins: [] }, truth);
+      })
+    ).match(
+      () => { /* success */ },
+      (err) => {
+        console.warn(`[workrail:git] Could not write git_start_recorded for ${String(sessionId)}: ${JSON.stringify(err)}`);
+      }
+    );
+  } catch (err: unknown) {
+    console.warn(`[workrail:git] Unexpected error in recordGitStart for ${String(sessionId)}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// recordGitMetrics
+// ---------------------------------------------------------------------------
+
+/**
+ * Capture committed diff and final working-tree state at session completion.
+ *
+ * Re-reads the session store to extract repoRoot and startSha from session events
+ * (same pattern as collectAndRecordUsage re-reading workspacePath). Appends a
+ * `git_metrics_recorded` event.
+ *
+ * Must never throw or reject.
+ */
+export async function recordGitMetrics(
+  sessionId: SessionId,
+  sessionStore: SessionStore,
+  gate: Gate,
+  idFactory: IdFactory,
+): Promise<void> {
+  try {
+    // Re-read session events to extract repoRoot, startSha, and runId.
+    const loadResult = await sessionStore.load(sessionId);
+    if (loadResult.isErr()) return;
+
+    const events = loadResult.value.events;
+    if (events.length === 0) return;
+
+    let repoRoot: string | null = null;
+    let startSha: string | null = null;
+    let runId: string | null = null;
+
+    for (const e of events) {
+      if (e.kind === 'observation_recorded') {
+        if (e.data.key === 'repo_root') repoRoot = e.data.value.value;
+        if (e.data.key === 'git_head_sha') startSha = e.data.value.value;
+      }
+      if (e.kind === EVENT_KIND.RUN_COMPLETED) {
+        runId = e.scope.runId;
+      }
+      if (repoRoot && startSha && runId) break;
+    }
+
+    if (!repoRoot || !runId) return;
+
+    // Run all git operations in parallel (independent commands).
+    const [committedDiff, commitResult, workingTree] = await Promise.all([
+      readCommittedDiff(repoRoot, startSha, DIFF_TIMEOUT_MS),
+      readCommitShasAndPrRefs(repoRoot, startSha, STATUS_TIMEOUT_MS),
+      readWorkingTreeState(repoRoot, STATUS_TIMEOUT_MS),
+    ]);
+
+    const commitShas = commitResult?.shas ?? [];
+    const prRefs = commitResult?.prRefs ?? [];
+
+    // Compute endSha from commitShas: if there are commits, the last one in
+    // chronological order is the new HEAD. We rely on git rev-parse HEAD
+    // only when startSha is null (no commits made = endSha stays as startSha).
+    // For simplicity, read endSha from the run_completed event's data.
+    let endSha: string | null = null;
+    for (const e of events) {
+      if (e.kind === EVENT_KIND.RUN_COMPLETED) {
+        endSha = e.data.endGitSha;
+        break;
+      }
+    }
+
+    // Compute captureConfidence.
+    const captureConfidence = computeCaptureConfidence({
+      startSha,
+      endSha,
+      commitShas,
+      committedDiff,
+    });
+
+    await gate.withHealthySessionLock(sessionId, (lock) =>
+      sessionStore.load(sessionId).andThen((truth) => {
+        const sortedResult = asSortedEventLog(truth.events);
+        if (sortedResult.isErr()) return okAsync(undefined as void);
+        const index = buildSessionIndex(sortedResult.value);
+
+        const event = {
+          v: 1 as const,
+          eventId: idFactory.mintEventId(),
+          eventIndex: index.nextEventIndex,
+          sessionId: String(sessionId),
+          kind: EVENT_KIND.GIT_METRICS_RECORDED,
+          dedupeKey: `git-metrics-recorded:${String(sessionId)}`,
+          scope: { runId },
+          data: {
+            startSha,
+            endSha,
+            commitShas: Array.from(commitShas),
+            prRefs: Array.from(prRefs),
+            filesChanged: committedDiff?.filesChanged ?? null,
+            linesAdded: committedDiff?.linesAdded ?? null,
+            linesRemoved: committedDiff?.linesRemoved ?? null,
+            truncated: committedDiff?.truncated ?? false,
+            stagedFiles: workingTree?.stagedFiles ?? null,
+            unstagedFiles: workingTree?.unstagedFiles ?? null,
+            captureConfidence,
+          },
+          timestampMs: Date.now(),
+        } as const;
+
+        return sessionStore.append(lock, { events: [event], snapshotPins: [] }, truth);
+      })
+    ).match(
+      () => { /* success */ },
+      (err) => {
+        console.warn(`[workrail:git] Could not write git_metrics_recorded for ${String(sessionId)}: ${JSON.stringify(err)}`);
+      }
+    );
+  } catch (err: unknown) {
+    console.warn(`[workrail:git] Unexpected error in recordGitMetrics for ${String(sessionId)}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function computeCaptureConfidence(args: {
+  startSha: string | null;
+  endSha: string | null;
+  commitShas: readonly string[];
+  committedDiff: import('../../v2/durable-core/schemas/session/git-evidence.js').GitCommittedDiff | null;
+}): 'high' | 'partial' | 'none' {
+  const { startSha, endSha, commitShas, committedDiff } = args;
+
+  if (!startSha || !endSha) return 'none';
+
+  if (commitShas.length > 0 && committedDiff !== null) {
+    return 'high';
+  }
+
+  // endSha is available but either no commits were found or the diff failed.
+  if (endSha !== startSha || commitShas.length > 0) {
+    return 'partial';
+  }
+
+  // startSha === endSha and no commits -- no changes were made.
+  // Report as partial rather than none: we have valid SHAs but no diff data.
+  return 'partial';
+}

--- a/src/mcp/git-metrics/types.ts
+++ b/src/mcp/git-metrics/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Git metrics types for engine-side authoritative diff collection.
+ *
+ * WHY re-export from durable-core: GitEvidence is a shared type used by both
+ * the projections layer (session-metrics.ts) and the MCP git-metrics module.
+ * The architecture lock forbids projections from importing from MCP, so the
+ * canonical definition lives in durable-core (same pattern as ClientUsage/TokenSnapshot).
+ *
+ * See src/v2/durable-core/schemas/session/git-evidence.ts for the authoritative definition.
+ */
+
+export type {
+  GitEvidence,
+  GitCommittedDiff,
+  GitWorkingTreeState,
+} from '../../v2/durable-core/schemas/session/git-evidence.js';

--- a/src/mcp/handlers/v2-advance-core/outcome-success.ts
+++ b/src/mcp/handlers/v2-advance-core/outcome-success.ts
@@ -269,12 +269,9 @@ export function buildSuccessOutcome(args: {
         // The port runs git rev-parse HEAD and git log --no-merges --first-parent in parallel,
         // capturing both the end SHA and the branch-local commits produced during this session.
         const agentCommitShas: readonly string[] = commitShas;
-        // WHY endGitSha !== null && agentCommitShas.length > 0:
-        // agentCommitShas (from git log startSha..HEAD) is the authoritative commit list.
-        // The previous condition `agentCommitShas.length > 0 ? 'high' : 'none'` was permanently
-        // broken since PR #903 -- commitShas was always empty. This fix produces correct values:
-        // 'high' when we actually found commits between startSha and endSha,
-        // 'none' in all other cases (no git, no repo, no commits made).
+        // WHY endGitSha !== null guard: if gitSnapshot cannot resolve the end SHA
+        // (git rev-parse failed), captureConfidence should be 'none' even if commit
+        // SHAs were somehow present -- we cannot confirm the end state was captured.
         const captureConfidence: 'high' | 'none' = (endGitSha !== null && agentCommitShas.length > 0) ? 'high' : 'none';
         extraEventsToAppend.push(buildRunCompletedEvent({
           sessionId: String(sessionId),

--- a/src/mcp/handlers/v2-advance-core/outcome-success.ts
+++ b/src/mcp/handlers/v2-advance-core/outcome-success.ts
@@ -269,7 +269,13 @@ export function buildSuccessOutcome(args: {
         // The port runs git rev-parse HEAD and git log --no-merges --first-parent in parallel,
         // capturing both the end SHA and the branch-local commits produced during this session.
         const agentCommitShas: readonly string[] = commitShas;
-        const captureConfidence: 'high' | 'none' = agentCommitShas.length > 0 ? 'high' : 'none';
+        // WHY endGitSha !== null && agentCommitShas.length > 0:
+        // agentCommitShas (from git log startSha..HEAD) is the authoritative commit list.
+        // The previous condition `agentCommitShas.length > 0 ? 'high' : 'none'` was permanently
+        // broken since PR #903 -- commitShas was always empty. This fix produces correct values:
+        // 'high' when we actually found commits between startSha and endSha,
+        // 'none' in all other cases (no git, no repo, no commits made).
+        const captureConfidence: 'high' | 'none' = (endGitSha !== null && agentCommitShas.length > 0) ? 'high' : 'none';
         extraEventsToAppend.push(buildRunCompletedEvent({
           sessionId: String(sessionId),
           runId: String(runId),

--- a/src/mcp/handlers/v2-execution/index.ts
+++ b/src/mcp/handlers/v2-execution/index.ts
@@ -36,6 +36,7 @@ import { isSnapshotCapable } from '../../client-usage/types.js';
 import { EVENT_KIND } from '../../../v2/durable-core/constants.js';
 import { buildSessionIndex } from '../../../v2/durable-core/session-index.js';
 import { asSortedEventLog } from '../../../v2/durable-core/sorted-event-log.js';
+import { recordGitStart, recordGitMetrics } from '../../git-metrics/index.js';
 
 /** Unified result for continue_workflow — envelope present on rehydrate with pending step. */
 interface ContinueWorkflowResult {
@@ -96,6 +97,13 @@ export async function handleV2StartWorkflow(
       // Fire-and-forget: snapshot conversation tokens at workflow start.
       void recordTokenCheckpoint(
         result.sessionId, 'start', input.workspacePath,
+        guard.ctx.v2.sessionStore, guard.ctx.v2.gate, guard.ctx.v2.idFactory,
+      );
+      // Fire-and-forget: capture baseline working-tree dirty state at session start.
+      // WHY fire-and-forget (not await): must never block the MCP response.
+      // WHY here (not inside executeStartWorkflow): git I/O belongs outside the session lock.
+      void recordGitStart(
+        result.sessionId, input.workspacePath,
         guard.ctx.v2.sessionStore, guard.ctx.v2.gate, guard.ctx.v2.idFactory,
       );
       return success(attachV2ExecutionRenderMetadata({
@@ -474,6 +482,9 @@ export function executeContinueWorkflow(
                 void (async () => {
                   await collectAndRecordUsage(sessionId, sessionStore, gate, idFactory);
                   await recordTokenCheckpoint(sessionId, 'end', undefined, sessionStore, gate, idFactory);
+                  // WHY sequential (not concurrent): acquires the same session gate lock.
+                  // WHY here (not inside outcome-success.ts): git diff runs outside the session lock.
+                  await recordGitMetrics(sessionId, sessionStore, gate, idFactory);
                 })();
               }
               return { response };

--- a/src/v2/durable-core/constants.ts
+++ b/src/v2/durable-core/constants.ts
@@ -278,6 +278,8 @@ export const EVENT_KIND = {
   REVIEW_DRAFT_SUBMITTED: 'review_draft_submitted',
   USAGE_RECORDED: 'usage_recorded',
   TOKEN_CHECKPOINT: 'token_checkpoint',
+  GIT_START_RECORDED: 'git_start_recorded',
+  GIT_METRICS_RECORDED: 'git_metrics_recorded',
 } as const;
 
 export type EventKindV1 = typeof EVENT_KIND[keyof typeof EVENT_KIND];

--- a/src/v2/durable-core/schemas/session/events.ts
+++ b/src/v2/durable-core/schemas/session/events.ts
@@ -431,6 +431,56 @@ export const DomainEventV1Schema = z.discriminatedUnion('kind', [
       turns: z.number().int().nonnegative(),
     }),
   }),
+  /**
+   * git_start_recorded: baseline working-tree state captured fire-and-forget after
+   * start_workflow succeeds. Records staged and unstaged file counts at the moment
+   * the agent began working, enabling detection of pre-existing dirty state.
+   *
+   * WHY scope: undefined (same as observation_recorded): fires before any run_started
+   * event, so no runId is available yet.
+   *
+   * WHY separate from git_metrics_recorded: start-time dirty state is only observable
+   * at session start; it cannot be retroactively captured at session completion.
+   */
+  DomainEventEnvelopeV1Schema.extend({
+    kind: z.literal('git_start_recorded'),
+    scope: z.undefined(),
+    data: z.object({
+      repoRoot: z.string().min(1),
+      stagedFiles: z.number().int().nonnegative(),
+      unstagedFiles: z.number().int().nonnegative(),
+    }),
+  }),
+  /**
+   * git_metrics_recorded: authoritative committed diff and working-tree state captured
+   * fire-and-forget after session completion (isComplete === true). Replaces agent-reported
+   * metrics_* context_set values as the canonical source for lines/files changed.
+   *
+   * WHY a separate event (not part of run_completed): git diff runs after the session lock
+   * is released. run_completed fires inside the lock; git_metrics_recorded fires after it.
+   *
+   * WHY captureConfidence: 'high'|'partial'|'none': distinct from run_completed's
+   * 'high'|'none' -- partial means endSha is available but diff failed or was truncated.
+   */
+  DomainEventEnvelopeV1Schema.extend({
+    kind: z.literal('git_metrics_recorded'),
+    scope: z.object({ runId: z.string().min(1) }),
+    data: z.object({
+      startSha: z.string().nullable(),
+      endSha: z.string().nullable(),
+      commitShas: z.array(z.string()),
+      prRefs: z.array(z.number().int().positive()),
+      /** null means the diff command failed or timed out; zero-change is a zero-valued struct. */
+      filesChanged: z.number().int().nonnegative().nullable(),
+      linesAdded: z.number().int().nonnegative().nullable(),
+      linesRemoved: z.number().int().nonnegative().nullable(),
+      truncated: z.boolean(),
+      /** null means the status command failed. */
+      stagedFiles: z.number().int().nonnegative().nullable(),
+      unstagedFiles: z.number().int().nonnegative().nullable(),
+      captureConfidence: z.enum(['high', 'partial', 'none']),
+    }),
+  }),
 ]);
 
 export type DomainEventV1 = z.infer<typeof DomainEventV1Schema>;

--- a/src/v2/durable-core/schemas/session/git-evidence.ts
+++ b/src/v2/durable-core/schemas/session/git-evidence.ts
@@ -1,0 +1,75 @@
+/**
+ * GitEvidence types: authoritative engine-side git diff data for a completed session.
+ *
+ * WHY here (in durable-core) and not in mcp/git-metrics/types.ts:
+ * projections/session-metrics.ts must not import from the MCP layer
+ * (architecture lock: projections are internal-only, v2-core-design-locks.md Section 6).
+ * Defining the shared types in durable-core makes them accessible to both sides:
+ * - projections/session-metrics.ts (reads git_metrics_recorded events)
+ * - mcp/git-metrics/record.ts (writes git_metrics_recorded events)
+ *
+ * Nullability invariant (applies to all nullable fields):
+ * - null means the corresponding git command failed or timed out.
+ * - Zero-change results are represented as zero-valued structs (not null).
+ *   Example: readWorkingTreeState on a clean repo returns { stagedFiles: 0, unstagedFiles: 0 }.
+ */
+
+/**
+ * Committed diff between startSha and current HEAD.
+ * Derived from `git diff startSha..HEAD --numstat --no-renames`.
+ *
+ * null on GitEvidence.committedDiff means the diff command failed or timed out.
+ */
+export type GitCommittedDiff = {
+  readonly filesChanged: number;
+  readonly linesAdded: number;
+  readonly linesRemoved: number;
+  /**
+   * true when the diff output was truncated to the line limit.
+   * The stats reflect partial data only.
+   */
+  readonly truncated: boolean;
+};
+
+/**
+ * Working tree state: staged and unstaged file counts.
+ * Captured at session start (baseline) and session completion (final state).
+ *
+ * null on GitEvidence.workingTree means the git status command failed or timed out.
+ */
+export type GitWorkingTreeState = {
+  /** Files with staged changes (git diff --cached). */
+  readonly stagedFiles: number;
+  /** Files with unstaged changes (git diff). */
+  readonly unstagedFiles: number;
+};
+
+/**
+ * Authoritative git evidence for a completed session.
+ * Populated from the `git_metrics_recorded` event.
+ *
+ * null on SessionMetricsV2.gitEvidence means no git_metrics_recorded event
+ * exists for this session (session predates the feature, or completed before
+ * the recording fired).
+ */
+export type GitEvidence = {
+  readonly startSha: string | null;
+  readonly endSha: string | null;
+  /** Commits authored between startSha and endSha (exclusive of startSha). */
+  readonly commitShas: readonly string[];
+  /** PR numbers parsed from commit messages (#123, Closes #123, Fixes #123). */
+  readonly prRefs: readonly number[];
+  /**
+   * Committed diff stats between startSha and endSha.
+   * null means the diff command failed or timed out.
+   * Zero-change returns { filesChanged: 0, linesAdded: 0, linesRemoved: 0, truncated: false }.
+   */
+  readonly committedDiff: GitCommittedDiff | null;
+  /**
+   * Working tree state at session completion.
+   * null means the git status command failed or timed out.
+   */
+  readonly workingTree: GitWorkingTreeState | null;
+  /** Authoritative confidence level for the diff data. */
+  readonly captureConfidence: 'high' | 'partial' | 'none';
+};

--- a/src/v2/projections/session-metrics.ts
+++ b/src/v2/projections/session-metrics.ts
@@ -2,6 +2,9 @@ import type { DomainEventV1 } from '../durable-core/schemas/session/index.js';
 import { EVENT_KIND, VALID_METRICS_OUTCOME } from '../durable-core/constants.js';
 import type { MetricsOutcome } from '../durable-core/constants.js';
 import type { ClientUsage, TokenSnapshot } from '../durable-core/schemas/session/usage.js';
+import type { GitEvidence } from '../durable-core/schemas/session/git-evidence.js';
+
+export type { GitEvidence, GitCommittedDiff, GitWorkingTreeState } from '../durable-core/schemas/session/git-evidence.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -25,6 +28,10 @@ export interface SessionMetricsV2 {
   readonly endGitSha: string | null;
   readonly gitBranch: string | null;
   readonly agentCommitShas: readonly string[];
+  /**
+   * @deprecated Always 'none' for sessions since PR #903 (agentCommitShas is always empty).
+   * Use `gitEvidence.captureConfidence` for accurate confidence from engine-side git metrics.
+   */
   readonly captureConfidence: 'high' | 'none';
   /**
    * Wall-clock duration of the run in milliseconds.
@@ -54,6 +61,17 @@ export interface SessionMetricsV2 {
    * checkpoints were written and the delta is computable.
    */
   readonly tokenDelta: TokenSnapshot | null;
+  /**
+   * Authoritative engine-side git diff evidence for this session.
+   *
+   * Populated from the `git_metrics_recorded` event when present.
+   * null when that event is absent (session predates the feature, session
+   * is still in progress, or the fire-and-forget recording failed silently).
+   *
+   * Prefer this field over the legacy startGitSha/endGitSha/agentCommitShas
+   * fields, which are populated from run_completed and have known accuracy issues.
+   */
+  readonly gitEvidence: GitEvidence | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -244,6 +262,45 @@ export function projectSessionMetricsV2(
         }
       : null;
 
+  // Project gitEvidence from git_metrics_recorded event (if present).
+  // Backward compat: null for sessions that predate the git_metrics feature.
+  let gitEvidence: GitEvidence | null = null;
+  for (const e of events) {
+    if (e.kind !== EVENT_KIND.GIT_METRICS_RECORDED) continue;
+    if (e.scope?.runId !== runCompletedRunId) continue;
+    const gd = e.data;
+    const committedDiff =
+      gd.filesChanged !== null && gd.linesAdded !== null && gd.linesRemoved !== null
+        ? {
+            filesChanged: gd.filesChanged,
+            linesAdded: gd.linesAdded,
+            linesRemoved: gd.linesRemoved,
+            truncated: gd.truncated,
+          }
+        : null;
+    const workingTree =
+      gd.stagedFiles !== null && gd.unstagedFiles !== null
+        ? {
+            stagedFiles: gd.stagedFiles,
+            unstagedFiles: gd.unstagedFiles,
+          }
+        : null;
+    gitEvidence = {
+      startSha: typeof gd.startSha === 'string' ? gd.startSha : null,
+      endSha: typeof gd.endSha === 'string' ? gd.endSha : null,
+      commitShas: Array.isArray(gd.commitShas)
+        ? gd.commitShas.filter((s): s is string => typeof s === 'string')
+        : [],
+      prRefs: Array.isArray(gd.prRefs)
+        ? gd.prRefs.filter((n): n is number => typeof n === 'number' && Number.isFinite(n))
+        : [],
+      committedDiff,
+      workingTree,
+      captureConfidence: gd.captureConfidence,
+    };
+    break; // first git_metrics_recorded by event order wins
+  }
+
   return {
     startGitSha,
     endGitSha,
@@ -258,5 +315,6 @@ export function projectSessionMetricsV2(
     linesRemoved,
     usageEvents,
     tokenDelta,
+    gitEvidence,
   };
 }

--- a/src/v2/projections/session-metrics.ts
+++ b/src/v2/projections/session-metrics.ts
@@ -29,8 +29,10 @@ export interface SessionMetricsV2 {
   readonly gitBranch: string | null;
   readonly agentCommitShas: readonly string[];
   /**
-   * @deprecated Always 'none' for sessions since PR #903 (agentCommitShas is always empty).
-   * Use `gitEvidence.captureConfidence` for accurate confidence from engine-side git metrics.
+   * Confidence that git capture succeeded for this session run.
+   * Populated from run_completed; supports 'high' and 'none' only.
+   * For three-level confidence ('high' | 'partial' | 'none') and authoritative
+   * engine-side git evidence, prefer gitEvidence.captureConfidence.
    */
   readonly captureConfidence: 'high' | 'none';
   /**

--- a/tests/unit/git-metrics-projection.test.ts
+++ b/tests/unit/git-metrics-projection.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for the gitEvidence field of projectSessionMetricsV2.
+ *
+ * Tests cover:
+ * - gitEvidence is null when no git_metrics_recorded event is present (backward compat)
+ * - gitEvidence is populated when git_metrics_recorded event is present
+ * - captureConfidence values: high, partial, none
+ * - null committedDiff when diff fields are null (command failed)
+ * - null workingTree when status fields are null (command failed)
+ * - prRefs and commitShas from event data
+ */
+
+import { describe, it, expect } from 'vitest';
+import { projectSessionMetricsV2 } from '../../src/v2/projections/session-metrics.js';
+import type { DomainEventV1 } from '../../src/v2/durable-core/schemas/session/index.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SESSION_ID = 'sess_test123';
+const RUN_ID = 'run_abc';
+
+function makeRunCompletedEvent(opts: {
+  startGitSha?: string | null;
+  endGitSha?: string | null;
+  captureConfidence?: 'high' | 'none';
+}): DomainEventV1 {
+  return {
+    v: 1,
+    eventId: 'evt_rc',
+    eventIndex: 0,
+    sessionId: SESSION_ID,
+    kind: 'run_completed',
+    scope: { runId: RUN_ID },
+    data: {
+      startGitSha: opts.startGitSha ?? null,
+      endGitSha: opts.endGitSha ?? null,
+      gitBranch: 'main',
+      agentCommitShas: [],
+      captureConfidence: opts.captureConfidence ?? 'none',
+      durationMs: 1000,
+    },
+    timestampMs: Date.now(),
+  } as unknown as DomainEventV1;
+}
+
+function makeGitMetricsEvent(opts: {
+  startSha?: string | null;
+  endSha?: string | null;
+  commitShas?: string[];
+  prRefs?: number[];
+  filesChanged?: number | null;
+  linesAdded?: number | null;
+  linesRemoved?: number | null;
+  truncated?: boolean;
+  stagedFiles?: number | null;
+  unstagedFiles?: number | null;
+  captureConfidence?: 'high' | 'partial' | 'none';
+}): DomainEventV1 {
+  return {
+    v: 1,
+    eventId: 'evt_gm',
+    eventIndex: 1,
+    sessionId: SESSION_ID,
+    kind: 'git_metrics_recorded',
+    scope: { runId: RUN_ID },
+    data: {
+      startSha: opts.startSha ?? null,
+      endSha: opts.endSha ?? null,
+      commitShas: opts.commitShas ?? [],
+      prRefs: opts.prRefs ?? [],
+      filesChanged: opts.filesChanged ?? null,
+      linesAdded: opts.linesAdded ?? null,
+      linesRemoved: opts.linesRemoved ?? null,
+      truncated: opts.truncated ?? false,
+      stagedFiles: opts.stagedFiles ?? null,
+      unstagedFiles: opts.unstagedFiles ?? null,
+      captureConfidence: opts.captureConfidence ?? 'none',
+    },
+    timestampMs: Date.now(),
+  } as unknown as DomainEventV1;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('projectSessionMetricsV2 -- gitEvidence field', () => {
+  it('returns null gitEvidence when no git_metrics_recorded event is present (backward compat)', () => {
+    const events: DomainEventV1[] = [makeRunCompletedEvent({})];
+
+    const result = projectSessionMetricsV2(events);
+
+    expect(result).not.toBeNull();
+    expect(result!.gitEvidence).toBeNull();
+  });
+
+  it('returns null when no run_completed event is present', () => {
+    const events: DomainEventV1[] = [];
+
+    const result = projectSessionMetricsV2(events);
+
+    expect(result).toBeNull();
+  });
+
+  it('populates gitEvidence from git_metrics_recorded event', () => {
+    const sha1 = 'a'.repeat(40);
+    const events: DomainEventV1[] = [
+      makeRunCompletedEvent({ startGitSha: 'start123', endGitSha: sha1 }),
+      makeGitMetricsEvent({
+        startSha: 'start123',
+        endSha: sha1,
+        commitShas: [sha1],
+        prRefs: [42],
+        filesChanged: 3,
+        linesAdded: 50,
+        linesRemoved: 10,
+        truncated: false,
+        stagedFiles: 0,
+        unstagedFiles: 0,
+        captureConfidence: 'high',
+      }),
+    ];
+
+    const result = projectSessionMetricsV2(events);
+
+    expect(result).not.toBeNull();
+    expect(result!.gitEvidence).toEqual({
+      startSha: 'start123',
+      endSha: sha1,
+      commitShas: [sha1],
+      prRefs: [42],
+      committedDiff: {
+        filesChanged: 3,
+        linesAdded: 50,
+        linesRemoved: 10,
+        truncated: false,
+      },
+      workingTree: {
+        stagedFiles: 0,
+        unstagedFiles: 0,
+      },
+      captureConfidence: 'high',
+    });
+  });
+
+  it('returns null committedDiff when diff fields are null (git diff failed)', () => {
+    const events: DomainEventV1[] = [
+      makeRunCompletedEvent({}),
+      makeGitMetricsEvent({
+        startSha: 'abc',
+        endSha: 'def',
+        filesChanged: null,
+        linesAdded: null,
+        linesRemoved: null,
+        captureConfidence: 'partial',
+      }),
+    ];
+
+    const result = projectSessionMetricsV2(events);
+
+    expect(result!.gitEvidence).not.toBeNull();
+    expect(result!.gitEvidence!.committedDiff).toBeNull();
+    expect(result!.gitEvidence!.captureConfidence).toBe('partial');
+  });
+
+  it('returns null workingTree when status fields are null (git status failed)', () => {
+    const events: DomainEventV1[] = [
+      makeRunCompletedEvent({}),
+      makeGitMetricsEvent({
+        filesChanged: 2,
+        linesAdded: 5,
+        linesRemoved: 1,
+        stagedFiles: null,
+        unstagedFiles: null,
+        captureConfidence: 'partial',
+      }),
+    ];
+
+    const result = projectSessionMetricsV2(events);
+
+    expect(result!.gitEvidence!.committedDiff).not.toBeNull();
+    expect(result!.gitEvidence!.workingTree).toBeNull();
+  });
+
+  it('reports captureConfidence=none from git_metrics_recorded', () => {
+    const events: DomainEventV1[] = [
+      makeRunCompletedEvent({}),
+      makeGitMetricsEvent({ captureConfidence: 'none' }),
+    ];
+
+    const result = projectSessionMetricsV2(events);
+
+    expect(result!.gitEvidence!.captureConfidence).toBe('none');
+  });
+
+  it('reports captureConfidence=partial from git_metrics_recorded', () => {
+    const events: DomainEventV1[] = [
+      makeRunCompletedEvent({}),
+      makeGitMetricsEvent({ endSha: 'abc', captureConfidence: 'partial' }),
+    ];
+
+    const result = projectSessionMetricsV2(events);
+
+    expect(result!.gitEvidence!.captureConfidence).toBe('partial');
+  });
+
+  it('uses first git_metrics_recorded event when multiple are present', () => {
+    const events: DomainEventV1[] = [
+      makeRunCompletedEvent({}),
+      makeGitMetricsEvent({ captureConfidence: 'high', filesChanged: 10, linesAdded: 100, linesRemoved: 50 }),
+      {
+        ...makeGitMetricsEvent({ captureConfidence: 'none', filesChanged: 0, linesAdded: 0, linesRemoved: 0 }),
+        eventIndex: 2,
+        eventId: 'evt_gm2',
+      } as unknown as DomainEventV1,
+    ];
+
+    const result = projectSessionMetricsV2(events);
+
+    // First event wins
+    expect(result!.gitEvidence!.captureConfidence).toBe('high');
+    expect(result!.gitEvidence!.committedDiff?.filesChanged).toBe(10);
+  });
+
+  it('does not include git_metrics_recorded events from a different runId', () => {
+    const events: DomainEventV1[] = [
+      makeRunCompletedEvent({}),
+      {
+        ...makeGitMetricsEvent({ captureConfidence: 'high', filesChanged: 5, linesAdded: 50, linesRemoved: 10 }),
+        scope: { runId: 'run_different' },
+      } as unknown as DomainEventV1,
+    ];
+
+    const result = projectSessionMetricsV2(events);
+
+    expect(result!.gitEvidence).toBeNull(); // different runId ignored
+  });
+});

--- a/tests/unit/git-metrics-reader.test.ts
+++ b/tests/unit/git-metrics-reader.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for git-metrics reader functions.
+ *
+ * Uses vi.mock to intercept execFile and test reader behavior under:
+ * - success with real git output
+ * - failure (execFile throws)
+ * - output truncation
+ * - PR ref parsing
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock child_process.execFile
+// Must be declared with vi.hoisted so the variable is available when vi.mock
+// factory runs (vi.mock is hoisted to the top of the file by vitest).
+// ---------------------------------------------------------------------------
+
+const { mockExecFile } = vi.hoisted(() => {
+  const mockExecFile = vi.fn();
+  return { mockExecFile };
+});
+
+vi.mock('node:child_process', () => ({
+  execFile: mockExecFile,
+}));
+
+vi.mock('node:util', () => ({
+  promisify: (fn: unknown) => fn,
+}));
+
+import { readWorkingTreeState, readCommittedDiff, readCommitShasAndPrRefs } from '../../src/mcp/git-metrics/reader.js';
+
+function mockSuccess(stdout: string): Promise<{ stdout: string; stderr: string }> {
+  return Promise.resolve({ stdout, stderr: '' });
+}
+
+function mockFailure(message = 'git: command not found'): Promise<never> {
+  return Promise.reject(new Error(message));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// readWorkingTreeState
+// ---------------------------------------------------------------------------
+
+describe('readWorkingTreeState', () => {
+  it('returns staged and unstaged file counts from numstat output', async () => {
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '5\t3\tfile1.ts\n2\t0\tfile2.ts\n', stderr: '' }) // --cached
+      .mockResolvedValueOnce({ stdout: '1\t1\tfile3.ts\n', stderr: '' }); // unstaged
+
+    const result = await readWorkingTreeState('/repo', 5000);
+
+    expect(result).toEqual({ stagedFiles: 2, unstagedFiles: 1 });
+  });
+
+  it('returns { stagedFiles: 0, unstagedFiles: 0 } for a clean working tree', async () => {
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const result = await readWorkingTreeState('/repo', 5000);
+
+    expect(result).toEqual({ stagedFiles: 0, unstagedFiles: 0 });
+  });
+
+  it('returns null when git command fails', async () => {
+    mockExecFile.mockRejectedValueOnce(new Error('not a git repo'));
+
+    const result = await readWorkingTreeState('/repo', 5000);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when git times out', async () => {
+    mockExecFile.mockRejectedValueOnce(Object.assign(new Error('timed out'), { killed: true }));
+
+    const result = await readWorkingTreeState('/repo', 5000);
+
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCommittedDiff
+// ---------------------------------------------------------------------------
+
+describe('readCommittedDiff', () => {
+  it('returns null immediately when startSha is null', async () => {
+    const result = await readCommittedDiff('/repo', null, 10000);
+
+    expect(result).toBeNull();
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('parses numstat output into file/line counts', async () => {
+    // 3 lines: 2 regular files and 1 binary file (- - filename)
+    const stdout = '10\t5\tfile1.ts\n3\t2\tfile2.ts\n-\t-\tbinary.bin\n';
+    mockExecFile.mockResolvedValueOnce({ stdout, stderr: '' });
+
+    const result = await readCommittedDiff('/repo', 'abc123', 10000);
+
+    expect(result).toEqual({
+      filesChanged: 3,
+      linesAdded: 13,
+      linesRemoved: 7,
+      truncated: false,
+    });
+  });
+
+  it('returns zero-valued struct when no files changed', async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const result = await readCommittedDiff('/repo', 'abc123', 10000);
+
+    expect(result).toEqual({
+      filesChanged: 0,
+      linesAdded: 0,
+      linesRemoved: 0,
+      truncated: false,
+    });
+  });
+
+  it('sets truncated=true when output exceeds 10000 lines', async () => {
+    // Generate 10001 numstat lines
+    const lines = Array.from({ length: 10_001 }, (_, i) => `1\t0\tfile${i}.ts`).join('\n');
+    mockExecFile.mockResolvedValueOnce({ stdout: lines, stderr: '' });
+
+    const result = await readCommittedDiff('/repo', 'abc123', 10000);
+
+    expect(result).not.toBeNull();
+    expect(result!.truncated).toBe(true);
+    expect(result!.filesChanged).toBe(10_000); // truncated at limit
+  });
+
+  it('returns null when execFile fails', async () => {
+    mockExecFile.mockRejectedValueOnce(new Error('git diff failed'));
+
+    const result = await readCommittedDiff('/repo', 'abc123', 10000);
+
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCommitShasAndPrRefs
+// ---------------------------------------------------------------------------
+
+describe('readCommitShasAndPrRefs', () => {
+  it('returns empty arrays when startSha is null (no git info available)', async () => {
+    const result = await readCommitShasAndPrRefs('/repo', null, 5000);
+
+    expect(result).toEqual({ shas: [], prRefs: [] });
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('parses commit SHAs from git log --format=%H output', async () => {
+    const sha1 = 'a'.repeat(40);
+    const sha2 = 'b'.repeat(40);
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: `${sha1}\n${sha2}\n`, stderr: '' }) // SHAs
+      .mockResolvedValueOnce({ stdout: 'feat: add feature\n\nCloses #123', stderr: '' }); // messages
+
+    const result = await readCommitShasAndPrRefs('/repo', 'startSha', 5000);
+
+    expect(result).not.toBeNull();
+    expect(result!.shas).toEqual([sha1, sha2]);
+    expect(result!.prRefs).toEqual([123]);
+  });
+
+  it('returns empty arrays when no commits between startSha and HEAD', async () => {
+    mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const result = await readCommitShasAndPrRefs('/repo', 'startSha', 5000);
+
+    expect(result).not.toBeNull();
+    expect(result!.shas).toEqual([]);
+    expect(result!.prRefs).toEqual([]);
+  });
+
+  it('parses PR refs from various message formats', async () => {
+    const sha = 'a'.repeat(40);
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: `${sha}\n`, stderr: '' })
+      .mockResolvedValueOnce({
+        stdout: 'fix: bug\n\nFixes #456\nCloses #789\nRefs #101\n#202',
+        stderr: '',
+      });
+
+    const result = await readCommitShasAndPrRefs('/repo', 'startSha', 5000);
+
+    expect(result).not.toBeNull();
+    expect(result!.prRefs).toEqual([101, 202, 456, 789]); // sorted
+  });
+
+  it('deduplicates PR refs', async () => {
+    const sha = 'a'.repeat(40);
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: `${sha}\n`, stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'fix: bug\n\nCloses #123\n#123\nFixes #123', stderr: '' });
+
+    const result = await readCommitShasAndPrRefs('/repo', 'startSha', 5000);
+
+    expect(result!.prRefs).toEqual([123]); // deduplicated
+  });
+
+  it('returns null when execFile throws', async () => {
+    mockExecFile.mockRejectedValueOnce(new Error('git not found'));
+
+    const result = await readCommitShasAndPrRefs('/repo', 'startSha', 5000);
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds engine-side git metrics collection to replace unreliable agent-self-reported metrics
- Two new domain events: `git_start_recorded` (baseline dirty state at session start) and `git_metrics_recorded` (authoritative committed diff at completion)
- New `src/mcp/git-metrics/` module with pure async reader functions, explicit timeouts, and `maxBuffer` guards
- `SessionMetricsV2.gitEvidence` field populated from the new `git_metrics_recorded` projection
- Fixes `captureConfidence` bug in `outcome-success.ts` that was permanently `'none'` since PR #903
- `run_completed` schema unchanged (additive events only)
- `GitEvidence` types live in `src/v2/durable-core/schemas/session/git-evidence.ts` to satisfy the architecture boundary (projections cannot import from MCP)
- 24 new unit tests: 15 for reader functions (mocked execFile), 9 for projection behavior

## Test plan

- [x] `npm run build` -- clean (no TypeScript errors)
- [x] `npx vitest run` -- 6360 pass, 7 skipped, 0 fail
- [x] `npx vitest run tests/architecture/v2-import-boundaries.test.ts` -- 887 pass
- [x] `npx vitest run tests/unit/git-metrics-reader.test.ts` -- 15 pass
- [x] `npx vitest run tests/unit/git-metrics-projection.test.ts` -- 9 pass

## Key decisions

- `GitEvidence` types defined in `durable-core` (same pattern as `usage.ts` for `ClientUsage`/`TokenSnapshot`) to satisfy the architecture constraint that projections cannot import from MCP
- `captureConfidence: 'partial'` exists only in `git_metrics_recorded`, not `run_completed` (avoids modifying the locked run_completed schema and its superRefine invariant)
- Fire-and-forget sequential `await` in the completion async IIFE (prevents `SESSION_LOCK_REENTRANT`)
- `maxBuffer: 5MB` on all `execFile` calls to prevent OOM on large diffs before line-count truncation kicks in

🤖 Generated with [Claude Code](https://claude.com/claude-code)