### PR TITLE
feat(engine): add language breakdown, step/retry counts, and code churn detection

### DIFF
--- a/console/src/api/types.ts
+++ b/console/src/api/types.ts
@@ -114,6 +114,8 @@ export type GitCommittedDiff = {
   readonly linesAdded: number;
   readonly linesRemoved: number;
   readonly truncated: boolean;
+  readonly changedFilePaths: readonly string[];
+  readonly languageBreakdown: Readonly<Record<string, number>>;
 };
 
 /**
@@ -140,6 +142,8 @@ export type GitEvidence = {
   /** null means the status command failed or timed out. */
   readonly workingTree: GitWorkingTreeState | null;
   readonly captureConfidence: 'high' | 'partial' | 'none';
+  /** null means churn check was not run (git unavailable or no changed files). */
+  readonly churnSignal: { readonly filesRemodified: number; readonly windowDays: number } | null;
 };
 
 export interface SessionMetricsV2 {
@@ -163,6 +167,9 @@ export interface SessionMetricsV2 {
   readonly tokenDelta: TokenSnapshot | null;
   // From git_metrics_recorded event (engine-authoritative git diff, null for old sessions)
   readonly gitEvidence: GitEvidence | null;
+  // From node_created events (step and blocked_attempt counts)
+  readonly stepsCompleted: number;
+  readonly retriesCount: number;
 }
 
 export interface ConsoleSessionSummary {

--- a/package.json
+++ b/package.json
@@ -114,11 +114,13 @@
   },
   "keywords": [
     "mcp",
+    "mcp-server",
     "model-context-protocol",
     "workflow",
-    "orchestration",
-    "ai-assistant",
-    "task-management"
+    "workflow-enforcement",
+    "ai-agents",
+    "claude-code",
+    "step-by-step"
   ],
   "devDependencies": {
     "@duckdb/node-api": "^1.5.2-r.1",

--- a/src/mcp/git-metrics/reader.ts
+++ b/src/mcp/git-metrics/reader.ts
@@ -240,6 +240,15 @@ export async function readChurnSignal(
     return { filesRemodified: 0, windowDays };
   }
 
+  // WHY cap at 100: each file requires a separate git log subprocess. With no cap,
+  // a session touching MAX_NUMSTAT_LINES (10k) files could run 10k sequential
+  // subprocesses. 100 files covers the vast majority of real sessions and keeps
+  // worst-case runtime under ~10 minutes even with full timeouts.
+  const MAX_CHURN_FILES = 100;
+  const filesToCheck = changedFilePaths.length > MAX_CHURN_FILES
+    ? changedFilePaths.slice(0, MAX_CHURN_FILES)
+    : changedFilePaths;
+
   try {
     // Resolve the Unix timestamp of endSha to use as the --after boundary.
     const { stdout: tsOut } = await execFile(
@@ -256,7 +265,7 @@ export async function readChurnSignal(
 
     let filesRemodified = 0;
 
-    for (const filePath of changedFilePaths) {
+    for (const filePath of filesToCheck) {
       try {
         const { stdout } = await execFile(
           'git',

--- a/src/mcp/git-metrics/reader.ts
+++ b/src/mcp/git-metrics/reader.ts
@@ -166,18 +166,29 @@ function parseNumstat(stdout: string): GitCommittedDiff {
   let filesChanged = 0;
   let linesAdded = 0;
   let linesRemoved = 0;
+  const changedFilePaths: string[] = [];
+  const languageBreakdown: Record<string, number> = {};
 
   for (const line of effectiveLines) {
     const parts = line.split('\t');
-    if (parts.length < 2) continue;
+    if (parts.length < 3) continue;
     filesChanged++;
     const added = parseInt(parts[0] ?? '0', 10);
     const removed = parseInt(parts[1] ?? '0', 10);
     if (!isNaN(added)) linesAdded += added;
     if (!isNaN(removed)) linesRemoved += removed;
+
+    const filePath = parts[2] ?? '';
+    changedFilePaths.push(filePath);
+
+    // Extract extension for language breakdown (lowercase, includes dot).
+    // Files with no dot (e.g. 'Makefile') map to empty string.
+    const lastDot = filePath.lastIndexOf('.');
+    const ext = lastDot > 0 ? filePath.slice(lastDot).toLowerCase() : '';
+    languageBreakdown[ext] = (languageBreakdown[ext] ?? 0) + 1;
   }
 
-  return { filesChanged, linesAdded, linesRemoved, truncated };
+  return { filesChanged, linesAdded, linesRemoved, truncated, changedFilePaths, languageBreakdown };
 }
 
 /**
@@ -198,4 +209,68 @@ function parsePrRefs(text: string): readonly number[] {
   }
 
   return Array.from(found).sort((a, b) => a - b);
+}
+
+// ---------------------------------------------------------------------------
+// Code churn detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Check how many of the session's changed files were re-modified by subsequent
+ * commits within `windowDays` after the session's end SHA.
+ *
+ * WHY churn signal: files re-modified shortly after a session indicate the
+ * session's output required follow-up work -- a quality signal.
+ *
+ * @param repoRoot  Workspace path
+ * @param changedFilePaths  Files changed during the session (from committedDiff)
+ * @param endSha  Session's end commit SHA -- used to anchor the after-window
+ * @param windowDays  How many days after session end to look for re-modifications
+ * @param timeoutMs  Per-command timeout
+ * @returns { filesRemodified, windowDays } or null on git failure
+ */
+export async function readChurnSignal(
+  repoRoot: string,
+  changedFilePaths: readonly string[],
+  endSha: string,
+  windowDays: number,
+  timeoutMs: number,
+): Promise<{ readonly filesRemodified: number; readonly windowDays: number } | null> {
+  if (changedFilePaths.length === 0) {
+    return { filesRemodified: 0, windowDays };
+  }
+
+  try {
+    // Resolve the Unix timestamp of endSha to use as the --after boundary.
+    const { stdout: tsOut } = await execFile(
+      'git',
+      ['-C', repoRoot, 'log', '-1', '--format=%ct', endSha],
+      { timeout: timeoutMs, maxBuffer: MAX_BUFFER },
+    );
+    const endTs = parseInt(tsOut.trim(), 10);
+    if (isNaN(endTs)) return null;
+
+    // Compute the after boundary as a local date string git understands.
+    const afterDate = new Date(endTs * 1000).toISOString();
+    const beforeDate = new Date((endTs + windowDays * 86_400) * 1000).toISOString();
+
+    let filesRemodified = 0;
+
+    for (const filePath of changedFilePaths) {
+      try {
+        const { stdout } = await execFile(
+          'git',
+          ['-C', repoRoot, 'log', '--oneline', `--after=${afterDate}`, `--before=${beforeDate}`, '--', filePath],
+          { timeout: timeoutMs, maxBuffer: MAX_BUFFER },
+        );
+        if (stdout.trim().length > 0) filesRemodified++;
+      } catch {
+        // Skip files that error -- partial results are acceptable
+      }
+    }
+
+    return { filesRemodified, windowDays };
+  } catch {
+    return null;
+  }
 }

--- a/src/mcp/git-metrics/record.ts
+++ b/src/mcp/git-metrics/record.ts
@@ -22,6 +22,7 @@ import { okAsync } from 'neverthrow';
 import {
   readWorkingTreeState,
   readCommittedDiff,
+  readChurnSignal,
   readCommitShasAndPrRefs,
 } from './reader.js';
 
@@ -160,6 +161,13 @@ export async function recordGitMetrics(
       }
     }
 
+    // Run churn detection after we have the committed diff (needs changedFilePaths and endSha).
+    const CHURN_WINDOW_DAYS = 7;
+    const churnSignal =
+      endSha && committedDiff && committedDiff.changedFilePaths.length > 0
+        ? await readChurnSignal(repoRoot, committedDiff.changedFilePaths, endSha, CHURN_WINDOW_DAYS, STATUS_TIMEOUT_MS)
+        : null;
+
     // Compute captureConfidence.
     const captureConfidence = computeCaptureConfidence({
       startSha,
@@ -191,9 +199,12 @@ export async function recordGitMetrics(
             linesAdded: committedDiff?.linesAdded ?? null,
             linesRemoved: committedDiff?.linesRemoved ?? null,
             truncated: committedDiff?.truncated ?? false,
+            changedFilePaths: committedDiff?.changedFilePaths ? Array.from(committedDiff.changedFilePaths) : [],
+            languageBreakdown: committedDiff?.languageBreakdown ?? {},
             stagedFiles: workingTree?.stagedFiles ?? null,
             unstagedFiles: workingTree?.unstagedFiles ?? null,
             captureConfidence,
+            churnSignal: churnSignal ?? null,
           },
           timestampMs: Date.now(),
         } as const;

--- a/src/v2/durable-core/schemas/session/events.ts
+++ b/src/v2/durable-core/schemas/session/events.ts
@@ -475,8 +475,12 @@ export const DomainEventV1Schema = z.discriminatedUnion('kind', [
       linesAdded: z.number().int().nonnegative().nullable(),
       linesRemoved: z.number().int().nonnegative().nullable(),
       truncated: z.boolean(),
-      changedFilePaths: z.array(z.string()),
-      languageBreakdown: z.record(z.string(), z.number().int().nonnegative()),
+      // WHY optional().default(): these fields were added after the initial git_metrics_recorded
+      // schema shipped in #1129. Existing events in the session store lack them. Zod requires
+      // optional() to avoid treating missing fields as corruption; default() ensures the
+      // projection always receives a usable zero value rather than undefined.
+      changedFilePaths: z.array(z.string()).optional().default([]),
+      languageBreakdown: z.record(z.string(), z.number().int().nonnegative()).optional().default({}),
       /** null means the status command failed. */
       stagedFiles: z.number().int().nonnegative().nullable(),
       unstagedFiles: z.number().int().nonnegative().nullable(),
@@ -485,7 +489,7 @@ export const DomainEventV1Schema = z.discriminatedUnion('kind', [
       churnSignal: z.object({
         filesRemodified: z.number().int().nonnegative(),
         windowDays: z.number().int().positive(),
-      }).nullable(),
+      }).nullable().optional().default(null),
     }),
   }),
 ]);

--- a/src/v2/durable-core/schemas/session/events.ts
+++ b/src/v2/durable-core/schemas/session/events.ts
@@ -475,10 +475,17 @@ export const DomainEventV1Schema = z.discriminatedUnion('kind', [
       linesAdded: z.number().int().nonnegative().nullable(),
       linesRemoved: z.number().int().nonnegative().nullable(),
       truncated: z.boolean(),
+      changedFilePaths: z.array(z.string()),
+      languageBreakdown: z.record(z.string(), z.number().int().nonnegative()),
       /** null means the status command failed. */
       stagedFiles: z.number().int().nonnegative().nullable(),
       unstagedFiles: z.number().int().nonnegative().nullable(),
       captureConfidence: z.enum(['high', 'partial', 'none']),
+      /** null means churn check was not run. */
+      churnSignal: z.object({
+        filesRemodified: z.number().int().nonnegative(),
+        windowDays: z.number().int().positive(),
+      }).nullable(),
     }),
   }),
 ]);

--- a/src/v2/durable-core/schemas/session/git-evidence.ts
+++ b/src/v2/durable-core/schemas/session/git-evidence.ts
@@ -29,6 +29,18 @@ export type GitCommittedDiff = {
    * The stats reflect partial data only.
    */
   readonly truncated: boolean;
+  /**
+   * Changed file paths from this diff (bounded by the numstat line limit).
+   * Used for churn detection: which files to check for post-session re-modification.
+   */
+  readonly changedFilePaths: readonly string[];
+  /**
+   * File count per extension, derived from changedFilePaths.
+   * Keys are lowercase extensions including the dot (e.g. '.ts', '.swift').
+   * Files with no extension map to '' (empty string).
+   * Empty object when no files changed or diff was unavailable.
+   */
+  readonly languageBreakdown: Readonly<Record<string, number>>;
 };
 
 /**
@@ -72,4 +84,11 @@ export type GitEvidence = {
   readonly workingTree: GitWorkingTreeState | null;
   /** Authoritative confidence level for the diff data. */
   readonly captureConfidence: 'high' | 'partial' | 'none';
+  /**
+   * Code churn signal: files that were re-modified by other commits within
+   * windowDays after this session ended.
+   * null means the churn check was not run (git unavailable or no changed files).
+   * { filesRemodified: 0 } means no churn detected.
+   */
+  readonly churnSignal: { readonly filesRemodified: number; readonly windowDays: number } | null;
 };

--- a/src/v2/projections/session-metrics.ts
+++ b/src/v2/projections/session-metrics.ts
@@ -74,6 +74,18 @@ export interface SessionMetricsV2 {
    * fields, which are populated from run_completed and have known accuracy issues.
    */
   readonly gitEvidence: GitEvidence | null;
+  /**
+   * Number of workflow steps completed in this run.
+   * Derived from node_created events with nodeKind='step'.
+   * 0 for sessions that completed before any steps advanced.
+   */
+  readonly stepsCompleted: number;
+  /**
+   * Number of step retries (blocked_attempt nodes) in this run.
+   * A blocked_attempt is created when a step's output contract is not met
+   * and the engine re-presents the step. High values indicate workflow quality issues.
+   */
+  readonly retriesCount: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -278,6 +290,12 @@ export function projectSessionMetricsV2(
             linesAdded: gd.linesAdded,
             linesRemoved: gd.linesRemoved,
             truncated: gd.truncated,
+            changedFilePaths: Array.isArray(gd.changedFilePaths)
+              ? gd.changedFilePaths.filter((s): s is string => typeof s === 'string')
+              : [],
+            languageBreakdown: (gd.languageBreakdown != null && typeof gd.languageBreakdown === 'object' && !Array.isArray(gd.languageBreakdown))
+              ? gd.languageBreakdown as Record<string, number>
+              : {},
           }
         : null;
     const workingTree =
@@ -285,6 +303,13 @@ export function projectSessionMetricsV2(
         ? {
             stagedFiles: gd.stagedFiles,
             unstagedFiles: gd.unstagedFiles,
+          }
+        : null;
+    const churnSignal =
+      gd.churnSignal != null && typeof gd.churnSignal === 'object'
+        ? {
+            filesRemodified: typeof gd.churnSignal.filesRemodified === 'number' ? gd.churnSignal.filesRemodified : 0,
+            windowDays: typeof gd.churnSignal.windowDays === 'number' ? gd.churnSignal.windowDays : 7,
           }
         : null;
     gitEvidence = {
@@ -299,8 +324,20 @@ export function projectSessionMetricsV2(
       committedDiff,
       workingTree,
       captureConfidence: gd.captureConfidence,
+      churnSignal,
     };
     break; // first git_metrics_recorded by event order wins
+  }
+
+  // Count step and retry nodes from node_created events for the matching runId.
+  let stepsCompleted = 0;
+  let retriesCount = 0;
+  for (const e of events) {
+    if (e.kind !== EVENT_KIND.NODE_CREATED) continue;
+    if (e.scope?.runId !== runCompletedRunId) continue;
+    const nodeKind = e.data.nodeKind;
+    if (nodeKind === 'step') stepsCompleted++;
+    else if (nodeKind === 'blocked_attempt') retriesCount++;
   }
 
   return {
@@ -318,5 +355,7 @@ export function projectSessionMetricsV2(
     usageEvents,
     tokenDelta,
     gitEvidence,
+    stepsCompleted,
+    retriesCount,
   };
 }

--- a/tests/unit/git-metrics-projection.test.ts
+++ b/tests/unit/git-metrics-projection.test.ts
@@ -54,9 +54,12 @@ function makeGitMetricsEvent(opts: {
   linesAdded?: number | null;
   linesRemoved?: number | null;
   truncated?: boolean;
+  changedFilePaths?: string[];
+  languageBreakdown?: Record<string, number>;
   stagedFiles?: number | null;
   unstagedFiles?: number | null;
   captureConfidence?: 'high' | 'partial' | 'none';
+  churnSignal?: { filesRemodified: number; windowDays: number } | null;
 }): DomainEventV1 {
   return {
     v: 1,
@@ -74,10 +77,26 @@ function makeGitMetricsEvent(opts: {
       linesAdded: opts.linesAdded ?? null,
       linesRemoved: opts.linesRemoved ?? null,
       truncated: opts.truncated ?? false,
+      changedFilePaths: opts.changedFilePaths ?? [],
+      languageBreakdown: opts.languageBreakdown ?? {},
       stagedFiles: opts.stagedFiles ?? null,
       unstagedFiles: opts.unstagedFiles ?? null,
       captureConfidence: opts.captureConfidence ?? 'none',
+      churnSignal: opts.churnSignal ?? null,
     },
+    timestampMs: Date.now(),
+  } as unknown as DomainEventV1;
+}
+
+function makeNodeCreatedEvent(nodeKind: 'step' | 'checkpoint' | 'blocked_attempt' | 'gate_checkpoint', eventIndex: number): DomainEventV1 {
+  return {
+    v: 1,
+    eventId: `evt_nc_${eventIndex}`,
+    eventIndex,
+    sessionId: SESSION_ID,
+    kind: 'node_created',
+    scope: { runId: RUN_ID, nodeId: `node_${eventIndex}` },
+    data: { nodeKind, parentNodeId: null, snapshotRef: 'sha256:abc', workflowHash: 'sha256:abc' },
     timestampMs: Date.now(),
   } as unknown as DomainEventV1;
 }
@@ -136,12 +155,15 @@ describe('projectSessionMetricsV2 -- gitEvidence field', () => {
         linesAdded: 50,
         linesRemoved: 10,
         truncated: false,
+        changedFilePaths: [],
+        languageBreakdown: {},
       },
       workingTree: {
         stagedFiles: 0,
         unstagedFiles: 0,
       },
       captureConfidence: 'high',
+      churnSignal: null,
     });
   });
 
@@ -236,5 +258,76 @@ describe('projectSessionMetricsV2 -- gitEvidence field', () => {
     const result = projectSessionMetricsV2(events);
 
     expect(result!.gitEvidence).toBeNull(); // different runId ignored
+  });
+});
+
+describe('projectSessionMetricsV2 -- stepsCompleted and retriesCount', () => {
+  it('returns stepsCompleted=0 and retriesCount=0 when no node_created events', () => {
+    const events: DomainEventV1[] = [makeRunCompletedEvent({})];
+    const result = projectSessionMetricsV2(events);
+    expect(result!.stepsCompleted).toBe(0);
+    expect(result!.retriesCount).toBe(0);
+  });
+
+  it('counts step nodes and blocked_attempt nodes separately', () => {
+    const events: DomainEventV1[] = [
+      makeRunCompletedEvent({}),
+      makeNodeCreatedEvent('step', 2),
+      makeNodeCreatedEvent('step', 3),
+      makeNodeCreatedEvent('step', 4),
+      makeNodeCreatedEvent('blocked_attempt', 5),
+      makeNodeCreatedEvent('checkpoint', 6),
+    ];
+    const result = projectSessionMetricsV2(events);
+    expect(result!.stepsCompleted).toBe(3);
+    expect(result!.retriesCount).toBe(1);
+  });
+
+  it('ignores node_created events from a different runId', () => {
+    const events: DomainEventV1[] = [
+      makeRunCompletedEvent({}),
+      {
+        ...makeNodeCreatedEvent('step', 2),
+        scope: { runId: 'run_different', nodeId: 'node_2' },
+      } as unknown as DomainEventV1,
+    ];
+    const result = projectSessionMetricsV2(events);
+    expect(result!.stepsCompleted).toBe(0);
+  });
+});
+
+describe('projectSessionMetricsV2 -- languageBreakdown and churnSignal', () => {
+  it('surfaces languageBreakdown from committedDiff', () => {
+    const events: DomainEventV1[] = [
+      makeRunCompletedEvent({}),
+      makeGitMetricsEvent({
+        filesChanged: 3,
+        linesAdded: 10,
+        linesRemoved: 5,
+        changedFilePaths: ['src/foo.ts', 'src/bar.ts', 'README.md'],
+        languageBreakdown: { '.ts': 2, '.md': 1 },
+      }),
+    ];
+    const result = projectSessionMetricsV2(events);
+    expect(result!.gitEvidence?.committedDiff?.languageBreakdown).toEqual({ '.ts': 2, '.md': 1 });
+    expect(result!.gitEvidence?.committedDiff?.changedFilePaths).toEqual(['src/foo.ts', 'src/bar.ts', 'README.md']);
+  });
+
+  it('surfaces churnSignal when present', () => {
+    const events: DomainEventV1[] = [
+      makeRunCompletedEvent({}),
+      makeGitMetricsEvent({ churnSignal: { filesRemodified: 2, windowDays: 7 } }),
+    ];
+    const result = projectSessionMetricsV2(events);
+    expect(result!.gitEvidence?.churnSignal).toEqual({ filesRemodified: 2, windowDays: 7 });
+  });
+
+  it('churnSignal is null when not in event', () => {
+    const events: DomainEventV1[] = [
+      makeRunCompletedEvent({}),
+      makeGitMetricsEvent({}),
+    ];
+    const result = projectSessionMetricsV2(events);
+    expect(result!.gitEvidence?.churnSignal).toBeNull();
   });
 });

--- a/tests/unit/git-metrics-projection.test.ts
+++ b/tests/unit/git-metrics-projection.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { projectSessionMetricsV2 } from '../../src/v2/projections/session-metrics.js';
+import { DomainEventV1Schema } from '../../src/v2/durable-core/schemas/session/events.js';
 import type { DomainEventV1 } from '../../src/v2/durable-core/schemas/session/index.js';
 
 // ---------------------------------------------------------------------------
@@ -329,5 +330,47 @@ describe('projectSessionMetricsV2 -- languageBreakdown and churnSignal', () => {
     ];
     const result = projectSessionMetricsV2(events);
     expect(result!.gitEvidence?.churnSignal).toBeNull();
+  });
+});
+
+describe('DomainEventV1Schema backward compat -- git_metrics_recorded', () => {
+  it('parses a pre-#1131 event that lacks changedFilePaths, languageBreakdown, and churnSignal', () => {
+    // Simulates an event written by #1129 code before the new fields were added.
+    // These events are in existing session stores and must not be treated as corrupt.
+    const oldFormatEvent = {
+      v: 1,
+      eventId: 'evt_old',
+      eventIndex: 5,
+      sessionId: 'sess_test',
+      kind: 'git_metrics_recorded',
+      dedupeKey: 'git-metrics-recorded:sess_test',
+      scope: { runId: 'run_1' },
+      data: {
+        startSha: 'abc123',
+        endSha: 'def456',
+        commitShas: ['def456'],
+        prRefs: [],
+        filesChanged: 3,
+        linesAdded: 50,
+        linesRemoved: 10,
+        truncated: false,
+        // changedFilePaths, languageBreakdown, churnSignal intentionally absent
+        stagedFiles: 0,
+        unstagedFiles: 0,
+        captureConfidence: 'high',
+      },
+      timestampMs: Date.now(),
+    };
+
+    const result = DomainEventV1Schema.safeParse(oldFormatEvent);
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      const d = result.data.data as Record<string, unknown>;
+      // Defaults applied by Zod
+      expect(d['changedFilePaths']).toEqual([]);
+      expect(d['languageBreakdown']).toEqual({});
+      expect(d['churnSignal']).toBeNull();
+    }
   });
 });

--- a/tests/unit/git-metrics-reader.test.ts
+++ b/tests/unit/git-metrics-reader.test.ts
@@ -109,6 +109,8 @@ describe('readCommittedDiff', () => {
       linesAdded: 13,
       linesRemoved: 7,
       truncated: false,
+      changedFilePaths: ['file1.ts', 'file2.ts', 'binary.bin'],
+      languageBreakdown: { '.ts': 2, '.bin': 1 },
     });
   });
 
@@ -122,6 +124,8 @@ describe('readCommittedDiff', () => {
       linesAdded: 0,
       linesRemoved: 0,
       truncated: false,
+      changedFilePaths: [],
+      languageBreakdown: {},
     });
   });
 


### PR DESCRIPTION
## Summary

Three additive session metrics enhancements:

- **Language breakdown**: `parseNumstat` now collects file paths and extension counts in the existing loop (zero extra git invocations). `GitCommittedDiff` gains `changedFilePaths` and `languageBreakdown: Record<string, number>` fields.
- **Step count + retry count**: `SessionMetricsV2` gains `stepsCompleted` and `retriesCount`, derived from `node_created` events with `nodeKind='step'` and `nodeKind='blocked_attempt'` respectively. Pure projection, no new events.
- **Code churn detection**: `readChurnSignal()` checks each session-modified file for subsequent commits within a 7-day window after session end. Uses `git log --after/--before` with the endSha timestamp as anchor. Result in `GitEvidence.churnSignal: { filesRemodified, windowDays } | null`.

All changes are additive. `run_completed` schema unchanged. 6 new tests added.

## What changed

- `src/v2/durable-core/schemas/session/git-evidence.ts` -- `GitCommittedDiff` + `GitEvidence` extended
- `src/v2/durable-core/schemas/session/events.ts` -- `git_metrics_recorded` Zod schema extended
- `src/mcp/git-metrics/reader.ts` -- `parseNumstat` extended + `readChurnSignal` added
- `src/mcp/git-metrics/record.ts` -- churn detection wired into `recordGitMetrics`
- `src/v2/projections/session-metrics.ts` -- `stepsCompleted`, `retriesCount`, new `gitEvidence` fields
- `console/src/api/types.ts` -- mirror types updated

## Test plan

- [x] `npx tsc --noEmit` -- clean
- [x] `npx vitest run` -- 6366 pass, 7 skipped, 0 fail
- [x] Language breakdown: asserts `{ '.ts': 2, '.bin': 1 }` from matching numstat input
- [x] Step/retry counts: asserts exact counts from `node_created` events
- [x] ChurnSignal: asserts `{ filesRemodified: 2, windowDays: 7 }` and null paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)