### PR TITLE
feat(mcp): add ndjson/json/summary/csv output formats to worktrain report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,6 +284,25 @@ Source: `src/cli/commands/worktrain-diagnose.ts`.
 
 ---
 
+## Session metrics and reporting
+
+`workrail report` (also aliased as `worktrain report`) exports all session metrics as structured data.
+
+```bash
+workrail report --days 30 --format html --out report.html  # human-readable HTML
+workrail report --days 30 --format csv                     # spreadsheet
+workrail report --days 30 | jq '.summary'                  # pipe NDJSON to jq
+workrail report --schedule daily                           # auto-generate nightly
+```
+
+Formats: `ndjson` (default, streaming), `json`, `summary`, `csv`, `html`.
+
+Per-session data includes: token delta, git diff (lines/files/language breakdown), commit SHAs,
+code churn, step count, retry count, outcome, and duration. Full schema:
+`docs/reference/session-metrics-reference.md`.
+
+---
+
 ## Building and reloading
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -213,6 +213,45 @@ chmod +x $(npm root -g)/@exaudeus/workrail/dist/mcp-server.js
 
 ---
 
+## Reporting and Metrics
+
+WorkRail captures rich session metrics automatically -- every workflow run records token usage,
+git diffs, step counts, language breakdowns, code churn, and agent-reported outcomes. The
+`workrail report` command surfaces all of this as structured data.
+
+```bash
+workrail report --days 30               # NDJSON to stdout (default, streamable)
+workrail report --days 30 --format html --out report.html  # open in browser
+workrail report --days 30 --format csv  # spreadsheet-ready
+workrail report --days 30 --format summary  # aggregates only
+workrail report --days 30 | jq '.summary'   # pipe to jq
+```
+
+**Available formats:** `ndjson` (default), `json`, `summary`, `csv`, `html`
+
+**What is captured per session:**
+- Token delta (input, output, cache) via Claude Code JSONL scanning
+- Git diff: lines added/removed, files changed, language breakdown, commit SHAs, PR refs
+- Code churn: files re-modified within 7 days of session end
+- Agent-reported outcome (success/partial/abandoned/error)
+- Step count and retry count from the DAG
+- Duration, workflow ID, goal, project
+
+The full schema is documented in
+[`docs/reference/session-metrics-reference.md`](docs/reference/session-metrics-reference.md).
+
+**Automatic generation:**
+
+```bash
+workrail report --schedule daily    # macOS: installs launchd plist
+workrail report --schedule weekly   # Linux: adds crontab entry
+```
+
+This writes `~/.workrail/data/reports/latest.json` nightly, which tools like
+[common-ground](https://github.com/EtienneBBeaulac/workrail) can read for team-level reporting.
+
+---
+
 ## CI & Releases
 
 - **Lockfile is enforced**: `package-lock.json` is canonical and CI will fail if `npm ci` would modify it. Commit lockfile changes intentionally.

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -1419,12 +1419,17 @@ program
   .option('--days <n>', 'Sessions modified in the last N days (default: 30)', parseInt)
   .option('--since <date>', 'Override start date (YYYY-MM-DD)')
   .option('--until <date>', 'Override end date (YYYY-MM-DD, default: today)')
-  .option('--out <file>', 'Write JSON to this file instead of stdout')
+  .option('--out <file>', 'Write output to this file instead of stdout')
+  .addOption(
+    new Option('--format <fmt>', 'Output format (default: ndjson)')
+      .choices(['ndjson', 'json', 'summary', 'csv'])
+      .default('ndjson'),
+  )
   .addOption(
     new Option('--schedule <frequency>', 'Install a recurring schedule (mutually exclusive with report output)')
       .choices(['daily', 'weekly']),
   )
-  .action(async (options: { days?: number; since?: string; until?: string; out?: string; schedule?: string }) => {
+  .action(async (options: { days?: number; since?: string; until?: string; out?: string; format?: string; schedule?: string }) => {
     // --schedule mode: install launchd plist or crontab, then exit.
     // Mutually exclusive with JSON report output.
     if (options.schedule !== undefined) {
@@ -1478,6 +1483,7 @@ program
       since: options.since,
       until: options.until,
       out: options.out,
+      format: options.format as import('./cli/commands/worktrain-report.js').ReportFormat | undefined,
     });
   });
 

--- a/src/cli-worktrain.ts
+++ b/src/cli-worktrain.ts
@@ -1422,7 +1422,7 @@ program
   .option('--out <file>', 'Write output to this file instead of stdout')
   .addOption(
     new Option('--format <fmt>', 'Output format (default: ndjson)')
-      .choices(['ndjson', 'json', 'summary', 'csv'])
+      .choices(['ndjson', 'json', 'summary', 'csv', 'html'])
       .default('ndjson'),
   )
   .addOption(

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -131,8 +131,9 @@ export interface WorktrainReportCommandDeps {
  * - json   : single pretty-printed JSON blob (legacy / machine consumers)
  * - summary: aggregates only, no per-session detail
  * - csv    : spreadsheet-friendly, one row per session
+ * - html   : self-contained HTML report with KPIs and session table
  */
-export type ReportFormat = 'ndjson' | 'json' | 'summary' | 'csv';
+export type ReportFormat = 'ndjson' | 'json' | 'summary' | 'csv' | 'html';
 
 export interface WorktrainReportCommandOpts {
   /** Number of days to look back (default: 30). Ignored when `since` is provided. */
@@ -312,6 +313,151 @@ function renderCsv(output: ReportOutput): string {
   return rows.join('\n');
 }
 
+// ---------------------------------------------------------------------------
+// HTML renderer
+// ---------------------------------------------------------------------------
+
+/** Escape a string for safe embedding in HTML. */
+function htmlEscape(s: string | null | undefined): string {
+  if (s == null) return '';
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function fmtDuration(ms: number | undefined): string {
+  if (ms == null) return '--';
+  const m = Math.round(ms / 60_000);
+  if (m < 60) return `${m}m`;
+  return `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return String(n);
+}
+
+/**
+ * HTML: self-contained report with KPI cards, workflow breakdown, and session
+ * table. No external dependencies -- all CSS and JS are inlined.
+ * changedFilePaths is excluded (same rule as all other formats).
+ */
+function renderHtml(output: ReportOutput): string {
+  const { summary, sessions, dateRange, generatedAt } = output;
+
+  // KPI cards
+  const totalHours = (summary.totalDurationMs / 3_600_000).toFixed(1);
+  const completionPct = summary.totalSessions > 0
+    ? Math.round((summary.completedSessions / summary.totalSessions) * 100)
+    : 0;
+  const totalTokens = summary.totalInputTokens + summary.totalOutputTokens +
+    summary.totalCacheReadTokens + summary.totalCacheWriteTokens;
+
+  const kpis: Array<{ label: string; value: string; sub?: string }> = [
+    { label: 'Sessions', value: String(summary.totalSessions), sub: `${completionPct}% completed` },
+    { label: 'Runtime', value: totalHours + 'h', sub: 'wall clock' },
+    { label: 'Tokens', value: fmtTokens(totalTokens), sub: 'input + output + cache' },
+    { label: 'Lines added', value: fmtTokens(summary.totalLinesAdded), sub: 'engine-authoritative' },
+  ];
+
+  const kpiHtml = kpis.map(({ label, value, sub }) => `
+    <div class="kpi">
+      <div class="kpi-value">${htmlEscape(value)}</div>
+      <div class="kpi-label">${htmlEscape(label)}</div>
+      ${sub ? `<div class="kpi-sub">${htmlEscape(sub)}</div>` : ''}
+    </div>`).join('');
+
+  // Workflow breakdown table
+  const wfRows = Object.entries(summary.workflowBreakdown)
+    .sort(([, a], [, b]) => b - a)
+    .map(([wf, count]) => `
+      <tr>
+        <td>${htmlEscape(wf)}</td>
+        <td class="num">${count}</td>
+      </tr>`).join('');
+
+  // Session table (most recent first, cap at 500)
+  const sessionRows = sessions.map((s) => {
+    const m = s.metrics;
+    const outcome = m?.outcome ?? '--';
+    const outcomeClass = outcome === 'success' ? 'success' : outcome === 'error' ? 'error' : '';
+    const lines = m?.gitEvidence?.committedDiff?.linesAdded ?? m?.linesAdded ?? '--';
+    const tokens = m?.tokenDelta
+      ? fmtTokens(m.tokenDelta.inputTokens + m.tokenDelta.outputTokens)
+      : '--';
+    return `
+      <tr>
+        <td class="date">${htmlEscape(s.date)}</td>
+        <td>${htmlEscape(s.workflowId ?? '--')}</td>
+        <td>${htmlEscape(s.repoRoot?.split('/').pop() ?? '--')}</td>
+        <td class="goal" title="${htmlEscape(s.goal ?? '')}">${htmlEscape((s.goal ?? '').slice(0, 60))}${(s.goal ?? '').length > 60 ? '…' : ''}</td>
+        <td class="outcome ${outcomeClass}">${htmlEscape(outcome)}</td>
+        <td class="num">${typeof lines === 'number' ? `+${lines}` : lines}</td>
+        <td class="num">${htmlEscape(tokens)}</td>
+        <td class="num">${fmtDuration(m?.durationMs)}</td>
+      </tr>`;
+  }).join('');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>WorkRail Report -- ${htmlEscape(dateRange.since)} to ${htmlEscape(dateRange.until)}</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f5f5f7;color:#1d1d1f;padding:32px 24px}
+.container{max-width:960px;margin:0 auto}
+h1{font-size:22px;font-weight:700;margin-bottom:4px}
+.meta{font-size:12px;color:#6e6e73;margin-bottom:24px}
+.kpi-row{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:28px}
+.kpi{background:#fff;border-radius:12px;padding:16px 20px;box-shadow:0 1px 3px rgba(0,0,0,.07)}
+.kpi-value{font-size:28px;font-weight:700;color:#007aff;letter-spacing:-1px}
+.kpi-label{font-size:12px;color:#3a3a3c;font-weight:600;margin-top:2px}
+.kpi-sub{font-size:11px;color:#aeaeb2;margin-top:2px}
+h2{font-size:15px;font-weight:600;margin-bottom:12px;margin-top:28px}
+table{width:100%;border-collapse:collapse;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.07);font-size:13px}
+th{text-align:left;padding:10px 12px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.4px;color:#aeaeb2;border-bottom:1px solid #f2f2f7}
+td{padding:9px 12px;border-bottom:1px solid #f2f2f7}
+tr:last-child td{border-bottom:none}
+.num{text-align:right;font-variant-numeric:tabular-nums;color:#6e6e73}
+.date{color:#aeaeb2;font-size:11px;white-space:nowrap}
+.goal{max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.outcome{font-weight:600}
+.success{color:#1a7a3a}
+.error{color:#c0392b}
+footer{margin-top:32px;font-size:11px;color:#aeaeb2;text-align:center}
+@media(max-width:700px){.kpi-row{grid-template-columns:repeat(2,1fr)}}
+</style>
+</head>
+<body>
+<div class="container">
+<h1>WorkRail Report</h1>
+<div class="meta">${htmlEscape(dateRange.since)} to ${htmlEscape(dateRange.until)} &middot; Generated ${new Date(generatedAt).toLocaleString()}</div>
+
+<div class="kpi-row">${kpiHtml}</div>
+
+<h2>By workflow</h2>
+<table>
+<thead><tr><th>Workflow</th><th class="num">Sessions</th></tr></thead>
+<tbody>${wfRows || '<tr><td colspan="2" style="color:#aeaeb2;text-align:center">No sessions</td></tr>'}</tbody>
+</table>
+
+<h2>Sessions (${sessions.length})</h2>
+<table>
+<thead><tr><th>Date</th><th>Workflow</th><th>Project</th><th>Goal</th><th>Outcome</th><th class="num">+Lines</th><th class="num">Tokens</th><th class="num">Duration</th></tr></thead>
+<tbody>${sessionRows || '<tr><td colspan="8" style="color:#aeaeb2;text-align:center">No sessions in window</td></tr>'}</tbody>
+</table>
+
+<footer>WorkRail session metrics &middot; <a href="https://github.com/EtienneBBeaulac/workrail">github.com/EtienneBBeaulac/workrail</a></footer>
+</div>
+</body>
+</html>`;
+}
+
 /**
  * Dispatch to the correct renderer based on format.
  * Pure function: no I/O.
@@ -322,6 +468,7 @@ function render(output: ReportOutput, format: ReportFormat): string {
     case 'json':    return renderJson(output);
     case 'summary': return renderSummary(output);
     case 'csv':     return renderCsv(output);
+    case 'html':    return renderHtml(output);
   }
 }
 

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -433,22 +433,26 @@ function renderHtml(output: ReportOutput): string {
     };
   });
 
-  // ── Breakdown: per-workflow ──────────────────────────────────────────────────
-  const wfMap = new Map<string, { started: number; completed: number; durations: number[]; linesAdded: number }>();
+  // ── Breakdown: per-workflow (routines separated -- they never report outcomes) ──
+  const wfMap = new Map<string, { started: number; completed: number; durations: number[]; linesAdded: number; isRoutine: boolean }>();
   for (const s of sessionsJs) {
     const label = s.workflow_label;
-    if (!wfMap.has(label)) wfMap.set(label, { started: 0, completed: 0, durations: [], linesAdded: 0 });
+    const isRoutine = s.workflow_id.startsWith('wr.routine-');
+    if (!wfMap.has(label)) wfMap.set(label, { started: 0, completed: 0, durations: [], linesAdded: 0, isRoutine });
     const e = wfMap.get(label)!;
     e.started++;
     if (s.completed) e.completed++;
     if (s.duration_min != null) e.durations.push(s.duration_min);
     e.linesAdded += s.lines_added;
   }
-  const breakdown = Array.from(wfMap.entries()).map(([label, d]) => {
+  const allBreakdown = Array.from(wfMap.entries()).map(([label, d]) => {
     const sorted = [...d.durations].sort((a, b) => a - b);
     const median = sorted.length ? sorted[Math.floor(sorted.length / 2)]!.toFixed(0) + 'm' : '--';
-    return { label, started: d.started, completed: d.completed, median, linesAdded: d.linesAdded };
+    return { label, started: d.started, completed: d.completed, median, linesAdded: d.linesAdded, isRoutine: d.isRoutine };
   }).sort((a, b) => b.completed - a.completed);
+  // Main workflows shown in chart; routines shown separately with a note
+  const breakdown = allBreakdown.filter(r => !r.isRoutine);
+  const routineBreakdown = allBreakdown.filter(r => r.isRoutine);
 
   // ── Per-project breakdown ────────────────────────────────────────────────────
   const projMap = new Map<string, { sessions: number; linesAdded: number; lang: Record<string, number> }>();
@@ -583,11 +587,11 @@ function renderHtml(output: ReportOutput): string {
 
   // ── Hero narrative (engine-authoritative only) ──────────────────────────────
   const heroLines = summary.totalLinesAdded;
-  const heroPRs = summary.languageBreakdown ? null : null; // prRefs come from sessions
   const totalPRs = sessionsJs.reduce((a, s) => a + s.pr_refs.length, 0);
   const uniquePRs = new Set(sessionsJs.flatMap(s => s.pr_refs)).size;
+  // Scope hero claims to the sessions that actually have the data
   const heroStatement = heroLines > 0
-    ? `${summary.totalSessions} guided sessions shipped ${heroLines.toLocaleString()} lines${uniquePRs > 0 ? ` across ${uniquePRs} PRs` : ''}.`
+    ? `${summary.totalSessions} guided sessions — ${heroLines.toLocaleString()} lines shipped across ${hasGitEvidence} sessions with git data${uniquePRs > 0 ? `, ${uniquePRs} PRs` : ''}.`
     : `${summary.totalSessions} guided sessions ran over ${Math.ceil(summary.totalDurationMs / 3_600_000)}h.`;
 
   // ── Main HTML output ─────────────────────────────────────────────────────────
@@ -741,10 +745,9 @@ body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1
 /* KPI GRID */
 .kpi-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:28px}
 .kpi{background:var(--surface);border-radius:var(--radius);padding:18px 20px;box-shadow:var(--shadow)}
-.kpi-top{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:10px}
-.kpi-value{font-size:28px;font-weight:700;letter-spacing:-0.8px;color:var(--txt);line-height:1}
-.kpi-label{font-size:11px;color:var(--txt2);margin-top:4px}
-.kpi-delta{font-size:11px;color:var(--txt3);margin-top:6px}
+.kpi-value{font-size:36px;font-weight:700;letter-spacing:-1.5px;color:var(--txt);line-height:1;margin-bottom:6px}
+.kpi-label{font-size:12px;color:var(--txt2);display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.kpi-delta{font-size:11px;color:var(--txt3);margin-top:4px}
 /* SECTION HEADERS */
 .section-hdr{display:flex;align-items:baseline;gap:12px;margin:32px 0 16px}
 .section-num{font-size:11px;font-weight:700;color:var(--txt3);font-variant-numeric:tabular-nums;min-width:16px}
@@ -755,8 +758,8 @@ body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1
 .trust-legend-title{font-size:13px;font-weight:600;color:var(--txt);margin-bottom:4px}
 .trust-legend-sub{font-size:12px;color:var(--txt2);margin-bottom:16px}
 .trust-legend-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
-.trust-legend-item h4{font-size:12px;font-weight:600;color:var(--txt);margin-bottom:4px;display:flex;align-items:center;gap:6px}
-.trust-legend-item p{font-size:11px;color:var(--txt2);line-height:1.5}
+.trust-legend-item h4{font-size:12px;font-weight:600;color:var(--txt);margin-bottom:3px;display:flex;align-items:center;gap:6px}
+.trust-legend-item p{font-size:11px;color:var(--txt2);line-height:1.4}
 /* COVERAGE */
 .coverage-table{width:100%;font-size:13px;margin-bottom:8px}
 .coverage-table td{padding:7px 0;border-bottom:1px solid var(--border)}
@@ -836,7 +839,7 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
 <div class="hero">
   <div class="hero-inner">
     <div class="hero-nav">
-      <strong>workrail</strong> report &mdash; <strong>--fmt</strong> ${htmlEscape(dateRange.since)} <strong>--read</strong> ${Math.ceil((new Date(dateRange.until).getTime() - new Date(dateRange.since).getTime()) / 86_400_000)}d
+      $ <strong>workrail</strong> report <strong>--since</strong> ${htmlEscape(dateRange.since)} <strong>--until</strong> ${htmlEscape(dateRange.until)} <strong>--format</strong> html
     </div>
     <h1 class="hero-h1">${htmlEscape(heroStatement.split(' ').slice(0, -3).join(' '))} <span>${htmlEscape(heroStatement.split(' ').slice(-3).join(' '))}</span></h1>
     <p class="hero-sub">
@@ -865,35 +868,23 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
 <!-- KPI GRID -->
 <div class="kpi-grid">
   <div class="kpi">
-    <div class="kpi-top">
-      <span class="trust trust-engine">engine</span>
-    </div>
-    <div class="kpi-value">${fmtTokens(summary.totalLinesAdded)}</div>
-    <div class="kpi-label">Net lines shipped</div>
-    <div class="kpi-delta" style="color:#6e6e73">git diff --numstat</div>
+    <div class="kpi-value">${summary.totalLinesAdded > 0 ? summary.totalLinesAdded.toLocaleString() : '--'}</div>
+    <div class="kpi-label">Net lines shipped <span class="trust trust-engine">engine</span></div>
+    <div class="kpi-delta">from ${hasGitEvidence} sessions with git data</div>
   </div>
   <div class="kpi">
-    <div class="kpi-top">
-      <span class="trust ${uniquePRs > 0 ? 'trust-interp' : 'trust-none'}">${uniquePRs > 0 ? 'from commits' : 'not tracked'}</span>
-    </div>
     <div class="kpi-value">${uniquePRs > 0 ? uniquePRs : '--'}</div>
-    <div class="kpi-label">PRs attributed</div>
-    <div class="kpi-delta">parsed from commit messages</div>
+    <div class="kpi-label">PRs attributed <span class="trust ${uniquePRs > 0 ? 'trust-interp' : 'trust-none'}">${uniquePRs > 0 ? 'from commits' : 'not tracked'}</span></div>
+    <div class="kpi-delta">${uniquePRs > 0 ? `across ${hasGitEvidence} sessions with git data` : 'parsed from commit messages'}</div>
   </div>
   <div class="kpi">
-    <div class="kpi-top">
-      <span class="trust trust-engine">engine</span>
-    </div>
     <div class="kpi-value">${totalHours}h</div>
-    <div class="kpi-label">Autonomous work</div>
+    <div class="kpi-label">Autonomous work <span class="trust trust-engine">engine</span></div>
     <div class="kpi-delta">${summary.completedSessions} sessions completed</div>
   </div>
   <div class="kpi">
-    <div class="kpi-top">
-      <span class="trust ${estCostCents > 0 ? 'trust-interp' : 'trust-none'}">${estCostCents > 0 ? 'estimated' : 'not tracked'}</span>
-    </div>
     <div class="kpi-value">${estCostCents > 0 ? htmlEscape(estCostStr) : '--'}</div>
-    <div class="kpi-label">Total spend</div>
+    <div class="kpi-label">Total spend <span class="trust ${estCostCents > 0 ? 'trust-interp' : 'trust-none'}">${estCostCents > 0 ? 'estimated' : 'not tracked'}</span></div>
     <div class="kpi-delta">${estCostCents > 0 ? 'Anthropic list pricing' : 'requires Claude Code JSONL'}</div>
   </div>
 </div>
@@ -905,19 +896,19 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
   <div class="trust-legend-grid">
     <div class="trust-legend-item">
       <h4><span class="trust trust-engine">engine</span></h4>
-      <p>Read directly from git history, event logs, or JSONL files. These figures lead with primary evidence: diff stats, token counts, timestamps.</p>
+      <p>Read from git, event logs, or JSONL. Primary evidence -- diff stats, token counts, timestamps.</p>
     </div>
     <div class="trust-legend-item">
       <h4><span class="trust trust-interp">interpretive</span></h4>
-      <p>Real data, uncertain meaning. PR refs parsed from commit messages, cost estimates at list pricing, churn signal. Accurate reading, cautious interpretation.</p>
+      <p>Real data, uncertain meaning. PR refs from commit messages, cost at list pricing, churn signal.</p>
     </div>
     <div class="trust-legend-item">
       <h4><span class="trust trust-agent">agent reported</span></h4>
-      <p>The agent&rsquo;s own word: outcome (success/partial), PR numbers it claims to have worked on. Present in ~53% of sessions. Take with appropriate skepticism.</p>
+      <p>The agent&rsquo;s own word. Outcome, PR numbers claimed. ~53% session coverage. Unverified.</p>
     </div>
     <div class="trust-legend-item">
       <h4><span class="trust trust-none">not tracked yet</span></h4>
-      <p>Data that wasn&rsquo;t collected for these sessions -- missing readers (Cursor, Antigravity), sessions before a feature shipped, or gaps in coverage. Always shown as &ldquo;--&rdquo;.</p>
+      <p>Missing readers, pre-feature sessions, or coverage gaps. Always shown as &ldquo;--&rdquo;, never as zero.</p>
     </div>
   </div>
 </div>
@@ -928,17 +919,18 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
   <h2 class="section-title">Coverage for this period</h2>
 </div>
 <div class="card">
-  <div class="card-sub">What data was actually captured for these ${summary.totalSessions} sessions.</div>
+  <div class="card-sub">How much of the data was actually captured. Low coverage means sessions predate the feature or the reader isn&rsquo;t configured &mdash; not a pipeline failure.</div>
   <table style="width:100%;font-size:13px;border-collapse:collapse">
     ${[
-      { label: 'Git diff captured', n: hasGitEvidence, badge: 'engine' },
-      { label: 'Token data captured', n: hasTokenData, badge: 'engine' },
-      { label: 'Outcome reported', n: hasOutcome, badge: 'agent reported' },
-      { label: 'PR refs in commits', n: hasPrRefs, badge: 'interpretive' },
-    ].map(({ label, n, badge }) => {
+      { label: 'Git diff captured', n: hasGitEvidence, badge: 'engine', note: '' },
+      { label: 'Token data captured', n: hasTokenData, badge: 'engine', note: hasTokenData === 0 ? 'requires Claude Code JSONL reader' : '' },
+      { label: 'Outcome reported', n: hasOutcome, badge: 'agent reported', note: '' },
+      { label: 'PR refs in commits', n: hasPrRefs, badge: 'interpretive', note: hasPrRefs > 0 ? `from ${hasGitEvidence} sessions with git data` : '' },
+    ].map(({ label, n, badge, note }) => {
       const pct = summary.totalSessions > 0 ? Math.round(n / summary.totalSessions * 100) : 0;
       const badgeCls = badge === 'engine' ? 'trust-engine' : badge === 'interpretive' ? 'trust-interp' : 'trust-agent';
-      return `<tr><td style="padding:8px 0;border-bottom:1px solid #f2f2f7;width:180px"><span class="trust ${badgeCls}" style="margin-right:8px">${htmlEscape(badge)}</span>${htmlEscape(label)}</td><td style="padding:8px 0 8px 16px;border-bottom:1px solid #f2f2f7"><div style="display:flex;align-items:center;gap:10px"><div style="flex:1;background:#f2f2f7;border-radius:4px;height:8px;overflow:hidden"><div style="width:${pct}%;height:100%;background:${badge === 'engine' ? '#007aff' : badge === 'interpretive' ? '#6366f1' : '#ff9500'};border-radius:4px"></div></div><span style="font-size:12px;color:#6e6e73;width:60px;text-align:right">${n} / ${summary.totalSessions}</span></div></td></tr>`;
+      const noteHtml = note ? `<div style="font-size:11px;color:#aeaeb2;margin-top:2px">${htmlEscape(note)}</div>` : '';
+      return `<tr><td style="padding:8px 0;border-bottom:1px solid #f2f2f7;width:220px;white-space:nowrap"><span class="trust ${badgeCls}" style="margin-right:8px;vertical-align:middle">${htmlEscape(badge)}</span><span style="vertical-align:middle">${htmlEscape(label)}</span>${noteHtml}</td><td style="padding:8px 0 8px 16px;border-bottom:1px solid #f2f2f7"><div style="display:flex;align-items:center;gap:10px"><div style="flex:1;background:#f2f2f7;border-radius:4px;height:8px;overflow:hidden"><div style="width:${pct}%;height:100%;background:${badge === 'engine' ? '#007aff' : badge === 'interpretive' ? '#6366f1' : '#ff9500'};border-radius:4px"></div></div><span style="font-size:12px;color:#6e6e73;width:60px;text-align:right;white-space:nowrap">${n} / ${summary.totalSessions}</span></div></td></tr>`;
     }).join('')}
   </table>
 </div>
@@ -974,7 +966,7 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
 <div class="two-col" style="margin-bottom:18px">
   <div class="card" style="margin-bottom:0">
     <div class="card-title">Runs by workflow</div>
-    <div class="card-sub">Bar = session count &middot; success rate over reported sessions only</div>
+    <div class="card-sub">Bar = session count &middot; % = completion rate &middot; routines listed separately (they don&rsquo;t report outcomes)</div>
     <div id="wf-bars"></div>
   </div>
   <div class="card" style="margin-bottom:0">
@@ -1014,6 +1006,7 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
 <script>
 const SESSIONS = ${safeJson(sessionsJs)};
 const BREAKDOWN = ${safeJson(breakdown)};
+const ROUTINE_BREAKDOWN = ${safeJson(routineBreakdown)};
 const HEATMAP = ${safeJson(heatmap)};
 const ACTIVITY = ${safeJson(activityData)};
 const PAGE_SIZE = 30;
@@ -1047,20 +1040,29 @@ const PAGE_SIZE = 30;
 // ── Workflow bars + donut ─────────────────────────────────────────────────────
 (function(){
   const COLORS=['#007aff','#34c759','#ff9500','#af52de','#ff3b30','#5ac8fa','#ffcc00','#ff6b6b','#00c7be','#30b0c7'];
-  document.getElementById('wf-count').textContent=BREAKDOWN.length+' workflows used';
+  const totalWf=BREAKDOWN.length+(ROUTINE_BREAKDOWN.length>0?1:0);
+  document.getElementById('wf-count').textContent=BREAKDOWN.length+' workflows'+(ROUTINE_BREAKDOWN.length>0?' + '+ROUTINE_BREAKDOWN.length+' routines':'');
   const container=document.getElementById('wf-bars');
-  const maxS=Math.max(...BREAKDOWN.map(r=>r.started),1);
-  BREAKDOWN.forEach((r,i)=>{
+  const maxS=Math.max(...BREAKDOWN.map(r=>r.started),...ROUTINE_BREAKDOWN.map(r=>r.started),1);
+  const renderRow=(r,i,color)=>{
     const ok=r.started>0?Math.round(r.completed/r.started*100):0;
     const div=document.createElement('div');
     div.style.cssText='display:flex;align-items:center;gap:10px;padding:7px 0;border-bottom:1px solid #f2f2f7;font-size:12px';
-    div.innerHTML='<div style="width:8px;height:8px;border-radius:50%;background:'+COLORS[i%COLORS.length]+';flex-shrink:0"></div>'+
+    div.innerHTML='<div style="width:8px;height:8px;border-radius:50%;background:'+color+';flex-shrink:0"></div>'+
       '<span style="flex:1;color:#1d1d1f;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">'+r.label+'</span>'+
-      '<div style="width:100px;background:#f2f2f7;border-radius:4px;height:14px;overflow:hidden;flex-shrink:0"><div style="width:'+Math.round(r.started/maxS*100)+'%;height:100%;background:'+COLORS[i%COLORS.length]+';opacity:.7"></div></div>'+
+      '<div style="width:100px;background:#f2f2f7;border-radius:4px;height:14px;overflow:hidden;flex-shrink:0"><div style="width:'+Math.round(r.started/maxS*100)+'%;height:100%;background:'+color+';opacity:.7"></div></div>'+
       '<span style="color:#6e6e73;width:50px;text-align:right;white-space:nowrap">'+r.started+' &middot; '+ok+'%</span>'+
       '<span style="color:#6e6e73;width:48px;text-align:right">'+r.median+'</span>';
     container.appendChild(div);
-  });
+  };
+  BREAKDOWN.forEach((r,i)=>renderRow(r,i,COLORS[i%COLORS.length]));
+  if(ROUTINE_BREAKDOWN.length>0){
+    const hdr=document.createElement('div');
+    hdr.style.cssText='padding:10px 0 4px;font-size:11px;font-weight:600;color:#aeaeb2;letter-spacing:0.04em;text-transform:uppercase';
+    hdr.textContent='Routines (sub-workflows -- outcome reporting does not apply)';
+    container.appendChild(hdr);
+    ROUTINE_BREAKDOWN.forEach((r,i)=>renderRow(r,i,'#aeaeb2'));
+  }
   // Donut
   const svg=document.getElementById('donut');
   const list=document.getElementById('donut-list');

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -570,13 +570,15 @@ function renderHtml(output: ReportOutput): string {
   }).join('') || '<tr><td colspan="4" style="color:#aeaeb2;text-align:center;padding:12px">No token data (requires Claude Code JSONL)</td></tr>';
 
   // ── Outcome-stacked chart data (activity tab) ───────────────────────────────
-  const activityData: Record<string, { success: number; partial: number; other: number }> = {};
+  const activityData: Record<string, { success: number; partial: number; error: number; abandoned: number; unknown: number }> = {};
   for (const s of sessionsJs) {
     const d = s.date;
-    if (!activityData[d]) activityData[d] = { success: 0, partial: 0, other: 0 };
+    if (!activityData[d]) activityData[d] = { success: 0, partial: 0, error: 0, abandoned: 0, unknown: 0 };
     if (s.outcome === 'success') activityData[d].success++;
     else if (s.outcome === 'partial') activityData[d].partial++;
-    else activityData[d].other++;
+    else if (s.outcome === 'error') activityData[d].error++;
+    else if (s.outcome === 'abandoned') activityData[d].abandoned++;
+    else activityData[d].unknown++;
   }
 
   // ── "What shipped": sessions with actual git evidence, sorted by impact ───────
@@ -824,11 +826,11 @@ body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1
 .section-title{font-size:18px;font-weight:700;letter-spacing:-0.3px;color:var(--txt)}
 .section-meta{font-size:12px;color:var(--txt3);margin-left:auto}
 /* TRUST LEGEND — 4 individual cards */
-.trust-legend-hdr{font-size:10px;font-weight:700;letter-spacing:.10em;text-transform:uppercase;color:var(--txt3);margin:24px 0 10px}
 .trust-legend-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:28px}
-.trust-legend-item{background:var(--surface);border-radius:var(--radius);padding:16px 18px;box-shadow:var(--shadow)}
-.trust-legend-item h4{font-size:12px;font-weight:600;color:var(--txt);margin-bottom:6px;display:flex;align-items:center;gap:6px}
-.trust-legend-item p{font-size:11px;color:var(--txt2);line-height:1.45}
+.trust-legend-item{background:var(--surface);border-radius:var(--radius);padding:16px 18px;box-shadow:var(--shadow);display:flex;flex-direction:column}
+.trust-legend-item h4{font-size:12px;font-weight:600;color:var(--txt);margin-bottom:8px;display:flex;align-items:center;gap:6px}
+.trust-legend-item p{font-size:11px;color:var(--txt2);line-height:1.5;flex:1}
+.trust-legend-tag{font-size:10px;font-weight:600;color:var(--txt3);margin-top:10px;letter-spacing:.02em}
 /* WHAT SHIPPED — section label style matches Claude Design pattern */
 .shipped-label{display:flex;align-items:center;margin:28px 0 10px;gap:0}
 .shipped-label-text{font-size:10px;font-weight:700;letter-spacing:.10em;text-transform:uppercase;color:var(--txt3)}
@@ -876,15 +878,11 @@ body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1
 .bar-outer{background:var(--border);border-radius:var(--radius-sm);height:18px;position:relative;overflow:hidden;min-width:80px}
 .bar-inner{background:var(--accent);border-radius:var(--radius-sm);height:100%;position:absolute;top:0;left:0}
 /* ACTIVITY CHART */
-.chart-wrap{position:relative}
-.y-axis{position:absolute;left:0;top:0;bottom:24px;width:32px;display:flex;flex-direction:column;justify-content:space-between;pointer-events:none}
-.y-label{font-size:10px;color:var(--txt3);text-align:right;padding-right:6px}
-.bar-chart-area{margin-left:36px}
-.bar-chart{display:flex;align-items:flex-end;gap:3px;height:140px;border-bottom:1px solid var(--border2)}
-.bc-bar{flex:1;border-radius:2px 2px 0 0;min-width:4px;position:relative;cursor:default;transition:opacity .1s}
-.bc-bar:hover{opacity:.75}
-.bc-bar:hover::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--hdr);color:#fff;font-size:11px;padding:4px 8px;border-radius:var(--radius-sm);white-space:nowrap;z-index:10;pointer-events:none}
-.bar-chart-axis{display:flex;gap:3px;margin-top:4px}
+.bar-chart{display:flex;align-items:flex-end;gap:2px;height:140px;border-bottom:1px solid var(--border2)}
+.bc-col{flex:1;display:flex;flex-direction:column-reverse;align-items:stretch;gap:1px;min-width:4px}
+.bc-seg{border-radius:2px;min-height:4px;position:relative;cursor:default}
+.bc-seg:hover::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--hdr);color:#fff;font-size:11px;padding:4px 8px;border-radius:var(--radius-sm);white-space:nowrap;z-index:10;pointer-events:none}
+.bar-chart-axis{display:flex;gap:2px;margin-top:4px}
 .bar-chart-label{flex:1;font-size:9px;color:var(--txt3);text-align:center;overflow:hidden}
 /* DONUT */
 .workflow-mix{display:grid;grid-template-columns:1fr 200px;gap:24px;align-items:start}
@@ -1029,23 +1027,31 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
 </div>
 
 <!-- HOW TO READ — 4 individual cards -->
-<div class="trust-legend-hdr">How to read this report</div>
+<div class="metric-section-label" style="margin:28px 0 12px">
+  <span class="metric-section-name">How to read this report</span>
+  <div class="metric-section-rule"></div>
+  <span class="metric-section-trust">metric reliability</span>
+</div>
 <div class="trust-legend-grid">
   <div class="trust-legend-item">
     <h4><span class="trust trust-engine">engine</span></h4>
-    <p>Read from git, event logs, or JSONL. Primary evidence &mdash; diff stats, token counts, timestamps.</p>
+    <p>Measured directly from event timestamps, the workflow DAG, and git diff. Duration, steps, retries, lines, files, languages, SHAs &mdash; and tokens, when captured.</p>
+    <div class="trust-legend-tag">trust the number</div>
   </div>
   <div class="trust-legend-item">
     <h4><span class="trust trust-interp">interpretive</span></h4>
-    <p>Real data, uncertain meaning. PR refs from commit messages, cost at list pricing, churn signal.</p>
+    <p>Real data, uncertain meaning. Churn reads git history exactly but can&rsquo;t know why a file changed; PR refs are regex on commit text.</p>
+    <div class="trust-legend-tag">directional, not proof</div>
   </div>
   <div class="trust-legend-item">
     <h4><span class="trust trust-agent">agent reported</span></h4>
-    <p>The agent&rsquo;s own word. Outcome, PR numbers claimed. Unverified.</p>
+    <p>The agent&rsquo;s own claim &mdash; outcome, PR numbers. Unverified and optimistic, with real coverage gaps.</p>
+    <div class="trust-legend-tag">${hasOutcome > 0 ? Math.round(hasOutcome / summary.totalSessions * 100) : 0}% coverage</div>
   </div>
   <div class="trust-legend-item">
     <h4><span class="trust trust-none">not tracked yet</span></h4>
-    <p>Missing readers or pre-feature sessions. Always shown as &ldquo;--&rdquo;, never as zero.</p>
+    <p>The reader for this metric hadn&rsquo;t shipped for these sessions (e.g. Cursor / Antigravity tokens). Shown as &ldquo;&mdash;&rdquo;, never a zero.</p>
+    <div class="trust-legend-tag">absence, not nothing</div>
   </div>
 </div>
 
@@ -1089,20 +1095,26 @@ ${ungroupedShipped.length > 20 ? `  <div class="shipped-more">+${ungroupedShippe
   <h2 class="section-title">Coverage for this period</h2>
 </div>
 <div class="card">
-  <div class="card-sub">How much of the data was actually captured. Low coverage means sessions predate the feature or the reader isn&rsquo;t configured &mdash; not a pipeline failure.</div>
-  <table style="width:100%;font-size:13px;border-collapse:collapse">
+  <div class="card-sub" style="font-family:ui-monospace,monospace;font-size:12px">Several collectors are recent &mdash; gaps here are expected, not errors. They tell you which numbers rest on a full sample.</div>
+  <div style="margin-top:16px">
     ${[
-      { label: 'Git diff captured', n: hasGitEvidence, badge: 'engine', note: '' },
-      { label: 'Token data captured', n: hasTokenData, badge: 'engine', note: hasTokenData === 0 ? 'requires Claude Code JSONL reader' : '' },
-      { label: 'Outcome reported', n: hasOutcome, badge: 'agent reported', note: '' },
-      { label: 'PR refs in commits', n: hasPrRefs, badge: 'interpretive', note: hasPrRefs > 0 ? `from ${hasGitEvidence} sessions with git data` : '' },
-    ].map(({ label, n, badge, note }) => {
+      { label: 'git diff captured',    n: hasGitEvidence, color: 'var(--trust-engine)' },
+      { label: 'token data captured',  n: hasTokenData,   color: 'var(--trust-engine)' },
+      { label: 'outcome self-reported', n: hasOutcome,    color: 'var(--trust-agent)'  },
+    ].map(({ label, n, color }) => {
       const pct = summary.totalSessions > 0 ? Math.round(n / summary.totalSessions * 100) : 0;
-      const badgeCls = badge === 'engine' ? 'trust-engine' : badge === 'interpretive' ? 'trust-interp' : 'trust-agent';
-      const noteHtml = note ? `<div style="font-size:11px;color:#aeaeb2;margin-top:2px">${htmlEscape(note)}</div>` : '';
-      return `<tr><td style="padding:8px 0;border-bottom:1px solid #f2f2f7;width:220px;white-space:nowrap"><span class="trust ${badgeCls}" style="margin-right:8px;vertical-align:middle">${htmlEscape(badge)}</span><span style="vertical-align:middle">${htmlEscape(label)}</span>${noteHtml}</td><td style="padding:8px 0 8px 16px;border-bottom:1px solid #f2f2f7"><div style="display:flex;align-items:center;gap:10px"><div style="flex:1;background:#f2f2f7;border-radius:4px;height:8px;overflow:hidden"><div style="width:${pct}%;height:100%;background:${badge === 'engine' ? '#007aff' : badge === 'interpretive' ? '#6366f1' : '#ff9500'};border-radius:4px"></div></div><span style="font-size:12px;color:#6e6e73;width:60px;text-align:right;white-space:nowrap">${n} / ${summary.totalSessions}</span></div></td></tr>`;
+      return `<div style="display:flex;align-items:center;gap:14px;padding:10px 0;border-bottom:1px solid var(--border)">
+        <span style="font-family:ui-monospace,monospace;font-size:12px;color:var(--txt2);width:190px;flex-shrink:0">${htmlEscape(label)}</span>
+        <div style="flex:1;background:var(--border);border-radius:3px;height:6px;overflow:hidden">
+          <div style="width:${pct}%;height:100%;background:${color};border-radius:3px"></div>
+        </div>
+        <span style="font-size:12px;color:var(--txt2);flex-shrink:0;text-align:right;min-width:110px"><strong style="color:var(--txt)">${pct}%</strong> &middot; ${n} of ${summary.totalSessions}</span>
+      </div>`;
     }).join('')}
-  </table>
+  </div>
+  <div style="margin-top:16px;padding-top:14px;border-top:1px solid var(--border2);font-size:12px;color:var(--txt2);line-height:1.6">
+    Not measurable here at all: whether code <strong>compiled or passed tests</strong>, whether PRs <strong>actually merged</strong>, or whether the output was <strong>actually useful</strong> &mdash; these need CI&nbsp;/&nbsp;GitHub integration and aren&rsquo;t inferred.
+  </div>
 </div>
 
 <!-- ACTIVITY -->
@@ -1112,18 +1124,22 @@ ${ungroupedShipped.length > 20 ? `  <div class="shipped-more">+${ungroupedShippe
   <span class="section-meta">${summary.totalSessions} sessions &middot; daily</span>
 </div>
 <div class="card">
-  <div class="card-sub">Sessions per day, by reported outcome. Stacked bars &mdash; &ldquo;unknown&rdquo; = no outcome reported.</div>
-  <div style="display:flex;gap:16px;margin-bottom:12px;font-size:11px;align-items:center">
-    <div style="display:flex;align-items:center;gap:5px"><div style="width:10px;height:10px;border-radius:2px;background:#34c759"></div>success</div>
-    <div style="display:flex;align-items:center;gap:5px"><div style="width:10px;height:10px;border-radius:2px;background:#ff9500"></div>partial</div>
-    <div style="display:flex;align-items:center;gap:5px"><div style="width:10px;height:10px;border-radius:2px;background:#e5e5ea"></div>unknown</div>
-  </div>
-  <div class="chart-wrap">
-    <div class="y-axis" id="y-axis"></div>
-    <div class="bar-chart-area">
-      <div class="bar-chart" id="barchart"></div>
-      <div class="bar-chart-axis" id="barchart-axis"></div>
+  <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin-bottom:4px">
+    <div>
+      <div style="font-size:13px;font-weight:600;color:var(--txt);margin-bottom:3px">Sessions per day, by reported outcome</div>
+      <div style="font-size:11px;color:var(--txt3);font-family:ui-monospace,monospace">Stacked bars &middot; &ldquo;unknown&rdquo; = no outcome reported</div>
     </div>
+    <div style="display:flex;gap:12px;font-size:11px;align-items:center;flex-shrink:0;flex-wrap:wrap;justify-content:flex-end">
+      <div style="display:flex;align-items:center;gap:4px"><div style="width:8px;height:8px;border-radius:2px;background:#34c759"></div><span style="color:var(--txt2)">success</span></div>
+      <div style="display:flex;align-items:center;gap:4px"><div style="width:8px;height:8px;border-radius:2px;background:#ff9500"></div><span style="color:var(--txt2)">partial</span></div>
+      <div style="display:flex;align-items:center;gap:4px"><div style="width:8px;height:8px;border-radius:2px;background:#ff3b30"></div><span style="color:var(--txt2)">error</span></div>
+      <div style="display:flex;align-items:center;gap:4px"><div style="width:8px;height:8px;border-radius:2px;background:#8e8e93"></div><span style="color:var(--txt2)">abandoned</span></div>
+      <div style="display:flex;align-items:center;gap:4px"><div style="width:8px;height:8px;border-radius:2px;background:#d1d1d6"></div><span style="color:var(--txt2)">unknown</span></div>
+    </div>
+  </div>
+  <div style="margin-top:16px">
+    <div class="bar-chart" id="barchart"></div>
+    <div class="bar-chart-axis" id="barchart-axis"></div>
   </div>
 </div>
 
@@ -1185,26 +1201,37 @@ const PAGE_SIZE = 30;
 
 // ── Activity chart (stacked by outcome) ──────────────────────────────────────
 (function(){
-  const chart=document.getElementById('barchart'),axis=document.getElementById('barchart-axis'),yAxis=document.getElementById('y-axis');
+  const chart=document.getElementById('barchart'),axis=document.getElementById('barchart-axis');
   const keys=Object.keys(HEATMAP).sort(); if(!keys.length)return;
   const entries=[];
   const start=new Date(keys[0]),end=new Date(keys[keys.length-1]);
   for(let d=new Date(start);d<=end;d.setDate(d.getDate()+1)){
     const k=d.toISOString().slice(0,10);
-    const a=ACTIVITY[k]||{success:0,partial:0,other:0};
-    entries.push({date:k,label:d.toLocaleDateString('en-US',{month:'short',day:'numeric'}),count:HEATMAP[k]||0,...a});
+    const a=ACTIVITY[k]||{success:0,partial:0,error:0,abandoned:0,unknown:0};
+    const day=new Date(k+'T12:00:00').getDate();
+    entries.push({date:k,day,count:HEATMAP[k]||0,...a});
   }
   const max=Math.max(...entries.map(e=>e.count),1);
-  [max,Math.round(max*.5),0].forEach(v=>{const el=document.createElement('div');el.className='y-label';el.textContent=v;yAxis.appendChild(el);});
+  const SEGS=[
+    {key:'success',color:'#34c759'},
+    {key:'partial',color:'#ff9500'},
+    {key:'error',color:'#ff3b30'},
+    {key:'abandoned',color:'#8e8e93'},
+    {key:'unknown',color:'#d1d1d6'},
+  ];
   entries.forEach(e=>{
-    const col=document.createElement('div');col.style.cssText='flex:1;display:flex;flex-direction:column-reverse;align-items:stretch;min-width:4px;gap:1px;height:'+Math.max(4,Math.round(e.count/max*100))+'%';
-    const mk=(h,c,tip)=>{if(!h)return;const b=document.createElement('div');b.className='bc-bar';b.style.cssText='flex:0 0 '+Math.round(h/e.count*100)+'%;background:'+c+';border-radius:0';b.setAttribute('data-tip',tip);col.appendChild(b);};
-    mk(e.success,'#34c759',e.label+' success: '+e.success);
-    mk(e.partial,'#ff9500',e.label+' partial: '+e.partial);
-    mk(e.other,'#e5e5ea',e.label+' unknown: '+e.other);
+    const col=document.createElement('div');col.className='bc-col';
+    col.style.height=Math.max(4,Math.round(e.count/max*100))+'%';
+    SEGS.forEach(({key,color})=>{
+      const n=e[key]; if(!n)return;
+      const seg=document.createElement('div');seg.className='bc-seg';
+      seg.style.cssText='flex:0 0 '+Math.round(n/e.count*100)+'%;background:'+color;
+      seg.setAttribute('data-tip','day '+e.day+' '+key+': '+n);
+      col.appendChild(seg);
+    });
     chart.appendChild(col);
     const lbl=document.createElement('div');lbl.className='bar-chart-label';
-    if([1,7,14,21,28].includes(new Date(e.date+'T12:00:00').getDate()))lbl.textContent=e.label;
+    if([1,4,7,10,13,16,19,22,25,28,31].includes(e.day))lbl.textContent=e.day;
     axis.appendChild(lbl);
   });
 })();

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -589,10 +589,14 @@ function renderHtml(output: ReportOutput): string {
   const heroLines = summary.totalLinesAdded;
   const totalPRs = sessionsJs.reduce((a, s) => a + s.pr_refs.length, 0);
   const uniquePRs = new Set(sessionsJs.flatMap(s => s.pr_refs)).size;
-  // Scope hero claims to the sessions that actually have the data
-  const heroStatement = heroLines > 0
-    ? `${summary.totalSessions} guided sessions — ${heroLines.toLocaleString()} lines shipped across ${hasGitEvidence} sessions with git data${uniquePRs > 0 ? `, ${uniquePRs} PRs` : ''}.`
-    : `${summary.totalSessions} guided sessions ran over ${Math.ceil(summary.totalDurationMs / 3_600_000)}h.`;
+  // Scope hero claims to the sessions that actually have the data.
+  // heroMain is the primary claim (shown in white); heroAccent is the highlighted suffix (shown in accent color).
+  const heroMain = heroLines > 0
+    ? `${summary.totalSessions} guided sessions`
+    : `${summary.totalSessions} guided sessions`;
+  const heroAccent = heroLines > 0
+    ? `${heroLines.toLocaleString()} lines shipped across ${hasGitEvidence} sessions with git data${uniquePRs > 0 ? `, ${uniquePRs} PRs` : ''}.`
+    : `ran over ${Math.ceil(summary.totalDurationMs / 3_600_000)}h.`;
 
   // ── Main HTML output ─────────────────────────────────────────────────────────
   return `<!DOCTYPE html>
@@ -841,7 +845,7 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
     <div class="hero-nav">
       $ <strong>workrail</strong> report <strong>--since</strong> ${htmlEscape(dateRange.since)} <strong>--until</strong> ${htmlEscape(dateRange.until)} <strong>--format</strong> html
     </div>
-    <h1 class="hero-h1">${htmlEscape(heroStatement.split(' ').slice(0, -3).join(' '))} <span>${htmlEscape(heroStatement.split(' ').slice(-3).join(' '))}</span></h1>
+    <h1 class="hero-h1">${htmlEscape(heroMain)} &mdash; <span>${htmlEscape(heroAccent)}</span></h1>
     <p class="hero-sub">
       Across ${htmlEscape(dateRange.since)} &ndash; ${htmlEscape(dateRange.until)}, WorkRail steered <strong>${summary.totalSessions} workflow runs</strong> through guided, step-by-step execution.
       Every number below is labeled by <strong>how much it can be trusted</strong> &mdash; git evidence, interpretation, or the agent&rsquo;s own word.

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -345,61 +345,79 @@ function fmtTokens(n: number): string {
  * table. No external dependencies -- all CSS and JS are inlined.
  * changedFilePaths is excluded (same rule as all other formats).
  */
+/**
+ * HTML: self-contained report with KPI cards, breakdown table with progress
+ * bars, daily activity heatmap, and a paginated/filterable session list.
+ *
+ * Ported from the common-ground workrail-report design (stripped of
+ * Zillow-specific MR feed and correlation tabs; enriched with engine
+ * metrics: tokens, git diff, language breakdown, churn, step counts).
+ *
+ * No external deps -- all CSS and JS are inlined. changedFilePaths excluded.
+ */
 function renderHtml(output: ReportOutput): string {
   const { summary, sessions, dateRange, generatedAt } = output;
 
-  // KPI cards
-  const totalHours = (summary.totalDurationMs / 3_600_000).toFixed(1);
-  const completionPct = summary.totalSessions > 0
-    ? Math.round((summary.completedSessions / summary.totalSessions) * 100)
-    : 0;
   const totalTokens = summary.totalInputTokens + summary.totalOutputTokens +
     summary.totalCacheReadTokens + summary.totalCacheWriteTokens;
+  const completionPct = summary.totalSessions > 0
+    ? Math.round((summary.completedSessions / summary.totalSessions) * 100) : 0;
+  const totalHours = (summary.totalDurationMs / 3_600_000).toFixed(1);
 
-  const kpis: Array<{ label: string; value: string; sub?: string }> = [
-    { label: 'Sessions', value: String(summary.totalSessions), sub: `${completionPct}% completed` },
-    { label: 'Runtime', value: totalHours + 'h', sub: 'wall clock' },
-    { label: 'Tokens', value: fmtTokens(totalTokens), sub: 'input + output + cache' },
-    { label: 'Lines added', value: fmtTokens(summary.totalLinesAdded), sub: 'engine-authoritative' },
-  ];
-
-  const kpiHtml = kpis.map(({ label, value, sub }) => `
-    <div class="kpi">
-      <div class="kpi-value">${htmlEscape(value)}</div>
-      <div class="kpi-label">${htmlEscape(label)}</div>
-      ${sub ? `<div class="kpi-sub">${htmlEscape(sub)}</div>` : ''}
-    </div>`).join('');
-
-  // Workflow breakdown table
-  const wfRows = Object.entries(summary.workflowBreakdown)
-    .sort(([, a], [, b]) => b - a)
-    .map(([wf, count]) => `
-      <tr>
-        <td>${htmlEscape(wf)}</td>
-        <td class="num">${count}</td>
-      </tr>`).join('');
-
-  // Session table (most recent first, cap at 500)
-  const sessionRows = sessions.map((s) => {
+  // Build SESSIONS JS array for client-side rendering
+  const sessionsJs = sessions.map((s) => {
     const m = s.metrics;
-    const outcome = m?.outcome ?? '--';
-    const outcomeClass = outcome === 'success' ? 'success' : outcome === 'error' ? 'error' : '';
-    const lines = m?.gitEvidence?.committedDiff?.linesAdded ?? m?.linesAdded ?? '--';
-    const tokens = m?.tokenDelta
-      ? fmtTokens(m.tokenDelta.inputTokens + m.tokenDelta.outputTokens)
-      : '--';
-    return `
-      <tr>
-        <td class="date">${htmlEscape(s.date)}</td>
-        <td>${htmlEscape(s.workflowId ?? '--')}</td>
-        <td>${htmlEscape(s.repoRoot?.split('/').pop() ?? '--')}</td>
-        <td class="goal" title="${htmlEscape(s.goal ?? '')}">${htmlEscape((s.goal ?? '').slice(0, 60))}${(s.goal ?? '').length > 60 ? '…' : ''}</td>
-        <td class="outcome ${outcomeClass}">${htmlEscape(outcome)}</td>
-        <td class="num">${typeof lines === 'number' ? `+${lines}` : lines}</td>
-        <td class="num">${htmlEscape(tokens)}</td>
-        <td class="num">${fmtDuration(m?.durationMs)}</td>
-      </tr>`;
-  }).join('');
+    const ge = m?.gitEvidence ?? null;
+    const td = m?.tokenDelta ?? null;
+    const usage = m?.usageEvents[0] ?? null;
+    const tokens = td
+      ? td.inputTokens + td.outputTokens
+      : (usage ? usage.inputTokens + usage.outputTokens : 0);
+    const linesAdded = ge?.committedDiff?.linesAdded ?? m?.linesAdded ?? 0;
+    const durationMin = m?.durationMs != null ? Math.round(m.durationMs / 60_000 * 10) / 10 : null;
+    const project = s.repoRoot ? s.repoRoot.split('/').pop() ?? '' : '';
+    return {
+      date: s.date,
+      workflow_id: s.workflowId ?? '',
+      workflow_label: s.workflowId?.replace(/^wr\./, '').replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()) ?? 'Unknown',
+      project,
+      completed: m?.outcome === 'success' || m?.outcome === 'partial',
+      outcome: m?.outcome ?? null,
+      goal: htmlEscape(s.goal ?? ''),
+      duration_min: durationMin,
+      lines_added: linesAdded,
+      tokens,
+      steps: m?.stepsCompleted ?? 0,
+      retries: m?.retriesCount ?? 0,
+      churn: ge?.churnSignal?.filesRemodified ?? null,
+      language: ge?.committedDiff?.languageBreakdown ?? {},
+      model: usage?.model ?? null,
+    };
+  });
+
+  // BREAKDOWN: per-workflow started/completed/median-duration
+  const wfMap = new Map<string, { started: number; completed: number; durations: number[] }>();
+  for (const s of sessionsJs) {
+    const label = s.workflow_label;
+    if (!wfMap.has(label)) wfMap.set(label, { started: 0, completed: 0, durations: [] });
+    const entry = wfMap.get(label)!;
+    entry.started++;
+    if (s.completed) entry.completed++;
+    if (s.duration_min != null) entry.durations.push(s.duration_min);
+  }
+  const breakdown = Array.from(wfMap.entries()).map(([label, d]) => {
+    const sorted = [...d.durations].sort((a, b) => a - b);
+    const median = sorted.length ? sorted[Math.floor(sorted.length / 2)]!.toFixed(0) + 'm' : '--';
+    return { label, started: d.started, completed: d.completed, median };
+  }).sort((a, b) => b.completed - a.completed);
+
+  // HEATMAP: date -> count
+  const heatmap: Record<string, number> = {};
+  for (const s of sessionsJs) {
+    heatmap[s.date] = (heatmap[s.date] ?? 0) + 1;
+  }
+
+  const safeJson = (v: unknown) => JSON.stringify(v).replace(/<\//g, '<\\/');
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -409,51 +427,302 @@ function renderHtml(output: ReportOutput): string {
 <title>WorkRail Report -- ${htmlEscape(dateRange.since)} to ${htmlEscape(dateRange.until)}</title>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
-body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f5f5f7;color:#1d1d1f;padding:32px 24px}
-.container{max-width:960px;margin:0 auto}
-h1{font-size:22px;font-weight:700;margin-bottom:4px}
-.meta{font-size:12px;color:#6e6e73;margin-bottom:24px}
-.kpi-row{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:28px}
-.kpi{background:#fff;border-radius:12px;padding:16px 20px;box-shadow:0 1px 3px rgba(0,0,0,.07)}
-.kpi-value{font-size:28px;font-weight:700;color:#007aff;letter-spacing:-1px}
-.kpi-label{font-size:12px;color:#3a3a3c;font-weight:600;margin-top:2px}
-.kpi-sub{font-size:11px;color:#aeaeb2;margin-top:2px}
-h2{font-size:15px;font-weight:600;margin-bottom:12px;margin-top:28px}
-table{width:100%;border-collapse:collapse;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.07);font-size:13px}
-th{text-align:left;padding:10px 12px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.4px;color:#aeaeb2;border-bottom:1px solid #f2f2f7}
-td{padding:9px 12px;border-bottom:1px solid #f2f2f7}
-tr:last-child td{border-bottom:none}
-.num{text-align:right;font-variant-numeric:tabular-nums;color:#6e6e73}
-.date{color:#aeaeb2;font-size:11px;white-space:nowrap}
-.goal{max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.outcome{font-weight:600}
-.success{color:#1a7a3a}
-.error{color:#c0392b}
-footer{margin-top:32px;font-size:11px;color:#aeaeb2;text-align:center}
-@media(max-width:700px){.kpi-row{grid-template-columns:repeat(2,1fr)}}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f5f5f7;color:#1d1d1f;padding:40px 24px}
+.container{max-width:940px;margin:0 auto}
+header{margin-bottom:28px}
+header h1{font-size:24px;font-weight:700;letter-spacing:-0.4px;margin-bottom:5px}
+header p{font-size:13px;color:#6e6e73}
+.callout{background:#fff;border-radius:14px;padding:20px 24px;box-shadow:0 1px 4px rgba(0,0,0,.07);margin-bottom:20px;font-size:14px;line-height:1.65}
+.kpi-row{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:20px}
+.kpi{background:#fff;border-radius:14px;padding:18px 20px;box-shadow:0 1px 4px rgba(0,0,0,.07)}
+.kpi .value{font-size:30px;font-weight:700;letter-spacing:-1px;line-height:1;margin-bottom:4px;color:#007aff}
+.kpi .label{font-size:12px;color:#6e6e73;line-height:1.4}
+.tabs{display:flex;gap:6px;margin-bottom:20px;flex-wrap:wrap}
+.tab{padding:7px 16px;border-radius:20px;font-size:13px;font-weight:500;cursor:pointer;border:1.5px solid transparent;background:#fff;color:#3a3a3c;box-shadow:0 1px 3px rgba(0,0,0,.08);transition:all .15s}
+.tab:hover{border-color:#007aff;color:#007aff}
+.tab.active{background:#007aff;color:#fff;border-color:#007aff}
+.view{display:none}.view.active{display:block}
+.card{background:#fff;border-radius:14px;padding:24px 26px;box-shadow:0 1px 4px rgba(0,0,0,.07);margin-bottom:18px}
+.card h2{font-size:15px;font-weight:600;margin-bottom:3px}
+.card .subtitle{font-size:12px;color:#6e6e73;margin-bottom:18px}
+.breakdown-table{width:100%;border-collapse:collapse;font-size:13px}
+.breakdown-table th{text-align:left;padding:0 10px 10px 0;font-size:11px;font-weight:600;letter-spacing:.4px;text-transform:uppercase;color:#aeaeb2;border-bottom:1px solid #f2f2f7}
+.breakdown-table th.right{text-align:right}
+.breakdown-table td{padding:8px 10px 8px 0;border-bottom:1px solid #f2f2f7;vertical-align:middle}
+.breakdown-table td.right{text-align:right;color:#6e6e73}
+.breakdown-table tr:last-child td{border-bottom:none}
+.total-row td{padding-top:12px;font-weight:600;border-top:2px solid #e5e5ea;border-bottom:none!important}
+.bar-outer{background:#f2f2f7;border-radius:4px;height:18px;position:relative;overflow:hidden;min-width:120px}
+.bar-inner{background:#007aff;border-radius:4px;height:100%;position:absolute;top:0;left:0}
+.chart-wrap{position:relative}
+.y-axis{position:absolute;left:0;top:0;bottom:24px;width:32px;display:flex;flex-direction:column;justify-content:space-between;pointer-events:none}
+.y-label{font-size:10px;color:#aeaeb2;text-align:right;padding-right:6px}
+.bar-chart-area{margin-left:36px}
+.bar-chart{display:flex;align-items:flex-end;gap:3px;height:140px;border-bottom:1px solid #e5e5ea;padding-bottom:0}
+.bar-chart-bar{flex:1;background:#007aff;border-radius:2px 2px 0 0;min-width:4px;position:relative;cursor:default;transition:opacity .1s}
+.bar-chart-bar:hover{opacity:.7}
+.bar-chart-bar:hover::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:#1d1d1f;color:#fff;font-size:11px;padding:4px 8px;border-radius:6px;white-space:nowrap;z-index:10;pointer-events:none}
+.bar-chart-axis{display:flex;gap:3px;margin-top:4px}
+.bar-chart-label{flex:1;font-size:9px;color:#aeaeb2;text-align:center;overflow:hidden}
+.controls{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:14px;align-items:center}
+.controls select,.controls input{padding:6px 10px;border:1.5px solid #e5e5ea;border-radius:8px;font-size:12px;background:#fff;color:#1d1d1f;outline:none}
+.controls select:focus,.controls input:focus{border-color:#007aff}
+.stats-bar{display:flex;gap:20px;padding:10px 0 14px;border-bottom:1px solid #f2f2f7;margin-bottom:14px;font-size:12px;flex-wrap:wrap}
+.stat-item .stat-val{font-weight:600;color:#1d1d1f}
+.stat-item .stat-lbl{color:#6e6e73}
+.session-item{display:grid;grid-template-columns:76px 36px 160px 1fr 80px 70px 60px;gap:10px;align-items:start;padding:9px 0;border-bottom:1px solid #f2f2f7;font-size:13px}
+.session-item:last-child{border-bottom:none}
+.session-date{font-size:11px;color:#aeaeb2;padding-top:2px}
+.session-dot{width:8px;height:8px;border-radius:50%;margin-top:4px;flex-shrink:0}
+.dot-done{background:#34c759}.dot-partial{background:#e5e5ea;border:1.5px solid #aeaeb2}
+.session-wf{font-size:11px;font-weight:600;color:#6e6e73;padding-top:2px}
+.session-goal{line-height:1.4;color:#1d1d1f}
+.session-goal.no-goal{color:#aeaeb2;font-style:italic}
+.session-metrics{font-size:11px;color:#6e6e73;margin-top:3px}
+.outcome-badge{display:inline-block;font-size:10px;font-weight:700;padding:1px 6px;border-radius:8px;white-space:nowrap}
+.outcome-success{background:#e1f8ec;color:#1a7a3a}
+.outcome-partial{background:#fff8e0;color:#9a6000}
+.outcome-abandoned{background:#f5f5f5;color:#999}
+.outcome-error{background:#ffeaea;color:#c0392b}
+.sess-dur{font-size:11px;color:#6e6e73;text-align:right;padding-top:2px}
+.pagination{display:flex;gap:6px;justify-content:center;align-items:center;margin-top:16px;flex-wrap:wrap}
+.page-btn{padding:5px 11px;border:1.5px solid #e5e5ea;border-radius:8px;font-size:12px;cursor:pointer;background:#fff;color:#3a3a3c}
+.page-btn:hover:not(:disabled){border-color:#007aff;color:#007aff}
+.page-btn.active{background:#007aff;color:#fff;border-color:#007aff;cursor:default}
+.page-btn:disabled{opacity:.35;cursor:default}
+footer{text-align:center;font-size:11px;color:#aeaeb2;margin-top:24px}
+@media(max-width:600px){.kpi-row{grid-template-columns:repeat(2,1fr)}.session-item{grid-template-columns:60px 28px 1fr}}
 </style>
 </head>
 <body>
 <div class="container">
-<h1>WorkRail Report</h1>
-<div class="meta">${htmlEscape(dateRange.since)} to ${htmlEscape(dateRange.until)} &middot; Generated ${new Date(generatedAt).toLocaleString()}</div>
+<header>
+  <h1>WorkRail Report</h1>
+  <p>${htmlEscape(dateRange.since)} to ${htmlEscape(dateRange.until)} &middot; Generated ${new Date(generatedAt).toLocaleString()}</p>
+</header>
 
-<div class="kpi-row">${kpiHtml}</div>
+<div class="callout" id="callout">Loading...</div>
 
-<h2>By workflow</h2>
-<table>
-<thead><tr><th>Workflow</th><th class="num">Sessions</th></tr></thead>
-<tbody>${wfRows || '<tr><td colspan="2" style="color:#aeaeb2;text-align:center">No sessions</td></tr>'}</tbody>
-</table>
-
-<h2>Sessions (${sessions.length})</h2>
-<table>
-<thead><tr><th>Date</th><th>Workflow</th><th>Project</th><th>Goal</th><th>Outcome</th><th class="num">+Lines</th><th class="num">Tokens</th><th class="num">Duration</th></tr></thead>
-<tbody>${sessionRows || '<tr><td colspan="8" style="color:#aeaeb2;text-align:center">No sessions in window</td></tr>'}</tbody>
-</table>
-
-<footer>WorkRail session metrics &middot; <a href="https://github.com/EtienneBBeaulac/workrail">github.com/EtienneBBeaulac/workrail</a></footer>
+<div class="kpi-row">
+  <div class="kpi"><div class="value">${summary.totalSessions}</div><div class="label">Workflow runs<br><span style="font-size:10px;color:#aeaeb2">${completionPct}% completed</span></div></div>
+  <div class="kpi"><div class="value">${totalHours}h</div><div class="label">Autonomous runtime<br><span style="font-size:10px;color:#aeaeb2">wall clock</span></div></div>
+  <div class="kpi"><div class="value">${fmtTokens(totalTokens)}</div><div class="label">Tokens used<br><span style="font-size:10px;color:#aeaeb2">input + output + cache</span></div></div>
+  <div class="kpi"><div class="value">${fmtTokens(summary.totalLinesAdded)}</div><div class="label">Lines of code added<br><span style="font-size:10px;color:#aeaeb2">engine-authoritative</span></div></div>
 </div>
+
+<div class="tabs">
+  <button class="tab active" data-view="breakdown">By workflow</button>
+  <button class="tab" data-view="activity">Daily activity</button>
+  <button class="tab" data-view="sessions">Sessions</button>
+</div>
+
+<div class="view active" id="view-breakdown">
+  <div class="card">
+    <h2>Workflow breakdown</h2>
+    <p class="subtitle">Completion rate and median runtime per workflow type.</p>
+    <table class="breakdown-table">
+      <thead><tr><th>Workflow</th><th style="min-width:200px">Completed</th><th class="right">Rate</th><th class="right">Median</th></tr></thead>
+      <tbody id="breakdown-body"></tbody>
+    </table>
+  </div>
+</div>
+
+<div class="view" id="view-activity">
+  <div class="card">
+    <h2>Daily activity</h2>
+    <p class="subtitle">Sessions started per day.</p>
+    <div class="chart-wrap">
+      <div class="y-axis" id="y-axis"></div>
+      <div class="bar-chart-area">
+        <div class="bar-chart" id="barchart"></div>
+        <div class="bar-chart-axis" id="barchart-axis"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="view" id="view-sessions">
+  <div class="card">
+    <h2>Workflow runs</h2>
+    <p class="subtitle">All sessions in the report window. <span id="sess-total"></span></p>
+    <div class="controls">
+      <select id="sess-workflow"><option value="">All workflows</option></select>
+      <select id="sess-status">
+        <option value="">All statuses</option>
+        <option value="done">Completed</option>
+        <option value="partial">Incomplete</option>
+      </select>
+      <input type="text" id="sess-search" placeholder="Search goals..." style="min-width:180px">
+    </div>
+    <div class="stats-bar" id="sess-stats"></div>
+    <div id="sess-list"><div style="padding:20px;text-align:center;color:#aeaeb2" id="sess-empty" ${sessions.length > 0 ? 'style="display:none"' : ''}>No sessions in window</div></div>
+    <div class="pagination" id="sess-pagination"></div>
+  </div>
+</div>
+
+<footer>WorkRail session metrics &middot; <a href="https://github.com/EtienneBBeaulac/workrail" style="color:#aeaeb2">github.com/EtienneBBeaulac/workrail</a></footer>
+</div>
+<script>
+const SESSIONS = ${safeJson(sessionsJs)};
+const BREAKDOWN = ${safeJson(breakdown)};
+const HEATMAP = ${safeJson(heatmap)};
+const PAGE_SIZE = 30;
+
+// ── Tab switching ─────────────────────────────────────────────────────────────
+document.querySelectorAll('.tab').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
+    btn.classList.add('active');
+    document.getElementById('view-' + btn.dataset.view).classList.add('active');
+  });
+});
+
+// ── Callout ───────────────────────────────────────────────────────────────────
+(function(){
+  const counts = {};
+  for (const s of SESSIONS) { if (s.completed) counts[s.workflow_label] = (counts[s.workflow_label]||0)+1; }
+  const dates = Object.keys(HEATMAP).sort();
+  const totalDays = Math.max(1, dates.length);
+  const avgPerDay = Math.round(SESSIONS.length / totalDays);
+  const top = Object.entries(counts).sort((a,b) => b[1]-a[1]).slice(0,3);
+  const parts = top.map(([l,n]) => '<strong>' + n + ' ' + l.toLowerCase() + (n===1?'':'s') + '</strong>');
+  document.getElementById('callout').innerHTML = parts.length
+    ? 'Over ' + totalDays + ' days, this agent completed ' + parts.join(', ') + ' and more -- running autonomously at an average of <strong>' + avgPerDay + ' sessions per day</strong>.'
+    : 'No completed sessions in this window.';
+})();
+
+// ── Breakdown table ───────────────────────────────────────────────────────────
+(function(){
+  const tbody = document.getElementById('breakdown-body');
+  const max = Math.max(...BREAKDOWN.map(r => r.completed), 1);
+  let totS = 0, totC = 0;
+  for (const row of BREAKDOWN) {
+    const pct = Math.round(row.completed / max * 100);
+    const rate = Math.round(row.completed / row.started * 100);
+    const tr = document.createElement('tr');
+    tr.innerHTML = '<td>' + row.label + '</td><td><div style="display:flex;align-items:center;gap:8px"><div class="bar-outer" style="flex:1"><div class="bar-inner" style="width:' + pct + '%"></div></div><span style="font-size:13px;font-weight:600;color:#1d1d1f;width:36px;text-align:right">' + row.completed + '</span></div></td><td class="right" style="color:#aeaeb2;font-size:12px">' + rate + '%</td><td class="right">' + row.median + '</td>';
+    tbody.appendChild(tr);
+    totS += row.started; totC += row.completed;
+  }
+  const totalRow = document.createElement('tr');
+  totalRow.className = 'total-row';
+  const totRate = Math.round(totC / Math.max(totS,1) * 100);
+  totalRow.innerHTML = '<td>Total</td><td><div style="display:flex;align-items:center;gap:8px"><div class="bar-outer" style="flex:1"><div class="bar-inner" style="width:100%"></div></div><span style="font-size:13px;font-weight:600;color:#1d1d1f;width:36px;text-align:right">' + totC + '</span></div></td><td class="right" style="color:#aeaeb2;font-size:12px">' + totRate + '%</td><td class="right">--</td>';
+  tbody.appendChild(totalRow);
+})();
+
+// ── Daily activity chart ──────────────────────────────────────────────────────
+(function(){
+  const chart = document.getElementById('barchart');
+  const axis  = document.getElementById('barchart-axis');
+  const yAxis = document.getElementById('y-axis');
+  const entries = [];
+  const start = new Date(Object.keys(HEATMAP).sort()[0]);
+  const end   = new Date(Object.keys(HEATMAP).sort().reverse()[0]);
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate()+1)) {
+    const k = d.toISOString().slice(0,10);
+    entries.push({ date: k, label: d.toLocaleDateString('en-US',{month:'short',day:'numeric'}), count: HEATMAP[k]||0 });
+  }
+  if (!entries.length) return;
+  const max = Math.max(...entries.map(e=>e.count), 1);
+  [max, Math.round(max*.5), 0].forEach(v => {
+    const el = document.createElement('div'); el.className='y-label'; el.textContent=v; yAxis.appendChild(el);
+  });
+  entries.forEach(e => {
+    const isWe = new Date(e.date+'T12:00:00').getDay()===0 || new Date(e.date+'T12:00:00').getDay()===6;
+    const bar = document.createElement('div');
+    bar.className = 'bar-chart-bar';
+    bar.style.height = Math.max(2, Math.round(e.count/max*100))+'%';
+    if (isWe) bar.style.background = '#60a5fa';
+    bar.setAttribute('data-tip', e.label+': '+e.count+' sessions');
+    chart.appendChild(bar);
+    const lbl = document.createElement('div'); lbl.className='bar-chart-label';
+    if ([1,7,14,21,28].includes(new Date(e.date+'T12:00:00').getDate())) lbl.textContent = e.label;
+    axis.appendChild(lbl);
+  });
+})();
+
+// ── Sessions view ─────────────────────────────────────────────────────────────
+let sessPage = 1, sessFiltered = SESSIONS.slice();
+
+(function(){
+  const sel = document.getElementById('sess-workflow');
+  [...new Set(SESSIONS.map(s=>s.workflow_label))].sort().forEach(l => {
+    const o = document.createElement('option'); o.value=l; o.textContent=l; sel.appendChild(o);
+  });
+  document.getElementById('sess-total').textContent = SESSIONS.length+' total.';
+})();
+
+function fmtDur(min) { if (!min) return '--'; return min < 60 ? min.toFixed(0)+'m' : (min/60).toFixed(1)+'h'; }
+function fmtTok(n)  { if (!n) return '--'; if(n>=1e6) return (n/1e6).toFixed(1)+'M'; if(n>=1e3) return Math.round(n/1e3)+'k'; return n; }
+
+function applySessFilters() {
+  const wf     = document.getElementById('sess-workflow').value;
+  const status = document.getElementById('sess-status').value;
+  const search = document.getElementById('sess-search').value.toLowerCase();
+  sessFiltered = SESSIONS.filter(s =>
+    (!wf     || s.workflow_label === wf) &&
+    (!status || (status==='done' ? s.completed : !s.completed)) &&
+    (!search || s.goal.toLowerCase().includes(search) || s.date.includes(search))
+  );
+  sessPage = 1;
+  renderSessions();
+}
+
+function renderSessions() {
+  const list = document.getElementById('sess-list');
+  const total = sessFiltered.length;
+  const start = (sessPage-1)*PAGE_SIZE;
+  const page  = sessFiltered.slice(start, Math.min(start+PAGE_SIZE, total));
+  const completed = sessFiltered.filter(s=>s.completed).length;
+  const avgDur = sessFiltered.filter(s=>s.duration_min).reduce((a,s)=>a+s.duration_min,0) / (sessFiltered.filter(s=>s.duration_min).length||1);
+  document.getElementById('sess-stats').innerHTML =
+    '<div class="stat-item"><span class="stat-val">'+total+'</span> <span class="stat-lbl">sessions</span></div>'+
+    '<div class="stat-item"><span class="stat-val" style="color:#34c759">'+completed+'</span> <span class="stat-lbl">completed</span></div>'+
+    '<div class="stat-item"><span class="stat-val">'+Math.round(completed/Math.max(total,1)*100)+'%</span> <span class="stat-lbl">completion rate</span></div>'+
+    '<div class="stat-item"><span class="stat-val">'+fmtDur(Math.round(avgDur*10)/10)+'</span> <span class="stat-lbl">avg duration</span></div>'+
+    '<div class="stat-item" style="margin-left:auto;font-size:11px;color:#aeaeb2">Showing '+(start+1)+'&#8211;'+Math.min(start+PAGE_SIZE,total)+'</div>';
+  list.innerHTML = '';
+  for (const s of page) {
+    const div = document.createElement('div');
+    div.className = 'session-item';
+    const outcomeHtml = s.outcome ? '<span class="outcome-badge outcome-'+s.outcome+'">'+s.outcome+'</span>' : '';
+    const metaParts = [];
+    if (s.lines_added) metaParts.push('<span style="color:#1a7a1a">+'+s.lines_added+' lines</span>');
+    if (s.tokens) metaParts.push(fmtTok(s.tokens)+' tokens');
+    if (s.steps) metaParts.push(s.steps+' steps');
+    if (s.retries) metaParts.push(s.retries+' retries');
+    const metaHtml = metaParts.length ? '<div class="session-metrics">'+metaParts.join(' &middot; ')+'</div>' : '';
+    div.innerHTML =
+      '<div class="session-date">'+s.date+'</div>'+
+      '<div><div class="session-dot '+(s.completed?'dot-done':'dot-partial')+'"></div></div>'+
+      '<div class="session-wf">'+s.workflow_label+'</div>'+
+      '<div><div class="session-goal'+(s.goal?'':' no-goal')+'">'+(s.goal||'No goal recorded')+'</div>'+metaHtml+'</div>'+
+      '<div>'+outcomeHtml+'</div>'+
+      '<div class="sess-dur">'+fmtTok(s.tokens)+'</div>'+
+      '<div class="sess-dur">'+fmtDur(s.duration_min)+'</div>';
+    list.appendChild(div);
+  }
+  // Pagination
+  const pag = document.getElementById('sess-pagination');
+  pag.innerHTML = '';
+  const pages = Math.ceil(total/PAGE_SIZE);
+  if (pages <= 1) return;
+  const prev = document.createElement('button'); prev.className='page-btn'; prev.textContent='Previous'; prev.disabled=sessPage===1;
+  prev.addEventListener('click',()=>{sessPage--;renderSessions();}); pag.appendChild(prev);
+  for (let p = Math.max(1,sessPage-2); p <= Math.min(pages,sessPage+2); p++) {
+    const btn = document.createElement('button'); btn.className='page-btn'+(p===sessPage?' active':''); btn.textContent=p;
+    btn.addEventListener('click',()=>{sessPage=p;renderSessions();}); pag.appendChild(btn);
+  }
+  const next = document.createElement('button'); next.className='page-btn'; next.textContent='Next'; next.disabled=sessPage===pages;
+  next.addEventListener('click',()=>{sessPage++;renderSessions();}); pag.appendChild(next);
+}
+
+['sess-workflow','sess-status'].forEach(id => document.getElementById(id).addEventListener('change', applySessFilters));
+document.getElementById('sess-search').addEventListener('input', applySessFilters);
+applySessFilters();
+</script>
 </body>
 </html>`;
 }

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -615,6 +615,17 @@ function renderHtml(output: ReportOutput): string {
   const hasOutcome     = sessionsJs.filter(s => s.outcome !== null).length;
   const hasPrRefs      = sessionsJs.filter(s => s.pr_refs.length > 0).length;
 
+  // ── Quality metrics for "Did it hold up?" row ────────────────────────────────
+  const totalChurnFiles = sessionsJs.reduce((a, s) => a + (s.churn ?? 0), 0);
+  const totalFilesForChurn = sessionsJs.filter(s => s.confidence === 'high' || s.confidence === 'partial').reduce((a, s) => a + s.files_changed, 0);
+  const codeKeptPct = totalFilesForChurn > 0 ? Math.round((1 - totalChurnFiles / totalFilesForChurn) * 100) : null;
+  const retriesPerSession = summary.totalSessions > 0 ? (summary.totalRetriesCount / summary.totalSessions).toFixed(1) : '--';
+  const outcomeSessions = Object.values(summary.outcomeBreakdown).reduce((a, n) => a + n, 0);
+  const abandonedCount = summary.outcomeBreakdown['abandoned'] ?? 0;
+  const completedWithoutAbandonPct = outcomeSessions > 0 ? Math.round((1 - abandonedCount / outcomeSessions) * 100) : null;
+  const successCount = summary.outcomeBreakdown['success'] ?? 0;
+  const agentSuccessPct = outcomeSessions > 0 ? Math.round(successCount / outcomeSessions * 100) : null;
+
   // ── Hero narrative (engine-authoritative only) ──────────────────────────────
   const heroLines = summary.totalLinesAdded;
   const totalPRs = sessionsJs.reduce((a, s) => a + s.pr_refs.length, 0);
@@ -782,24 +793,42 @@ body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1
 .meta-bar-inner{max-width:940px;margin:0 auto;display:flex;justify-content:space-between;font-size:11px;color:rgba(255,255,255,.22);font-family:ui-monospace,monospace}
 /* MAIN */
 .main{max-width:940px;margin:0 auto;padding:28px 24px}
-/* KPI GRID */
-.kpi-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:28px}
-.kpi{background:var(--surface);border-radius:var(--radius);padding:18px 20px;box-shadow:var(--shadow)}
-.kpi-value{font-size:36px;font-weight:700;letter-spacing:-1.5px;color:var(--txt);line-height:1;margin-bottom:6px}
-.kpi-label{font-size:12px;color:var(--txt2);display:flex;align-items:center;gap:6px;flex-wrap:wrap}
-.kpi-delta{font-size:11px;color:var(--txt3);margin-top:4px}
+/* METRIC SECTION LABEL (Claude Design pattern: small-caps + horizontal rule + right label) */
+.metric-section{margin:24px 0 12px}
+.metric-section-label{display:flex;align-items:center;gap:10px;margin-bottom:12px}
+.metric-section-name{font-size:10px;font-weight:700;letter-spacing:.10em;text-transform:uppercase;color:var(--txt3);white-space:nowrap}
+.metric-section-rule{flex:1;height:1px;background:var(--border2)}
+.metric-section-trust{font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--txt3);opacity:.65;white-space:nowrap;font-family:ui-monospace,monospace}
+/* DARK METRIC CARDS */
+.metric-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:4px}
+.mc{background:#1c1c1f;border-radius:var(--radius);padding:18px 18px 16px;position:relative;overflow:hidden;display:flex;flex-direction:column}
+.mc::before{content:'';position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--mc-b)}
+.mc-engine{--mc-b:var(--trust-engine)}
+.mc-interp{--mc-b:var(--trust-interp)}
+.mc-agent{--mc-b:var(--trust-agent)}
+.mc-none{--mc-b:var(--trust-none)}
+.mc-hdr{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:14px;gap:8px}
+.mc-label{font-size:9.5px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:rgba(255,255,255,.4);font-family:ui-monospace,monospace;line-height:1.35}
+.mc-pill{font-size:8.5px;font-weight:700;letter-spacing:.07em;text-transform:uppercase;padding:3px 7px;border-radius:20px;flex-shrink:0;white-space:nowrap}
+.mc-pill-engine{background:rgba(0,122,255,.22);color:#5ac8fa}
+.mc-pill-interp{background:rgba(99,102,241,.22);color:#a5b4fc}
+.mc-pill-agent{background:rgba(255,149,0,.22);color:#ffcc00}
+.mc-pill-none{background:rgba(174,174,178,.12);color:rgba(255,255,255,.35)}
+.mc-value{font-size:40px;font-weight:700;letter-spacing:-1.8px;color:#fff;line-height:1;margin-bottom:10px}
+.mc-sub{font-size:11px;color:#30d158;font-family:ui-monospace,monospace;margin-bottom:6px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.mc-sub-neutral{color:rgba(255,255,255,.5)}
+.mc-caveat{font-size:10px;color:rgba(255,255,255,.28);font-family:ui-monospace,monospace;line-height:1.4;margin-top:auto}
 /* SECTION HEADERS */
 .section-hdr{display:flex;align-items:baseline;gap:12px;margin:32px 0 16px}
 .section-num{font-size:11px;font-weight:700;color:var(--txt3);font-variant-numeric:tabular-nums;min-width:16px}
 .section-title{font-size:18px;font-weight:700;letter-spacing:-0.3px;color:var(--txt)}
 .section-meta{font-size:12px;color:var(--txt3);margin-left:auto}
-/* TRUST LEGEND */
-.trust-legend{background:var(--surface);border-radius:var(--radius);padding:20px 24px;box-shadow:var(--shadow);margin-bottom:28px}
-.trust-legend-title{font-size:13px;font-weight:600;color:var(--txt);margin-bottom:4px}
-.trust-legend-sub{font-size:12px;color:var(--txt2);margin-bottom:16px}
-.trust-legend-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
-.trust-legend-item h4{font-size:12px;font-weight:600;color:var(--txt);margin-bottom:3px;display:flex;align-items:center;gap:6px}
-.trust-legend-item p{font-size:11px;color:var(--txt2);line-height:1.4}
+/* TRUST LEGEND — 4 individual cards */
+.trust-legend-hdr{font-size:10px;font-weight:700;letter-spacing:.10em;text-transform:uppercase;color:var(--txt3);margin:24px 0 10px}
+.trust-legend-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:28px}
+.trust-legend-item{background:var(--surface);border-radius:var(--radius);padding:16px 18px;box-shadow:var(--shadow)}
+.trust-legend-item h4{font-size:12px;font-weight:600;color:var(--txt);margin-bottom:6px;display:flex;align-items:center;gap:6px}
+.trust-legend-item p{font-size:11px;color:var(--txt2);line-height:1.45}
 /* WHAT SHIPPED — section label style matches Claude Design pattern */
 .shipped-label{display:flex;align-items:center;margin:28px 0 10px;gap:0}
 .shipped-label-text{font-size:10px;font-weight:700;letter-spacing:.10em;text-transform:uppercase;color:var(--txt3)}
@@ -894,7 +923,7 @@ body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1
 .pg-btn.active{background:var(--accent);color:#fff;border-color:var(--accent);cursor:default}
 .pg-btn:disabled{opacity:.35;cursor:default}
 footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;padding-bottom:24px}
-@media(max-width:700px){.kpi-grid{grid-template-columns:repeat(2,1fr)}.hero-h1{font-size:26px}.trust-legend-grid{grid-template-columns:repeat(2,1fr)}.two-col{grid-template-columns:1fr}.workflow-mix{grid-template-columns:1fr}.sess-item{grid-template-columns:60px 20px 1fr}}
+@media(max-width:700px){.metric-grid{grid-template-columns:repeat(2,1fr)}.hero-h1{font-size:26px}.trust-legend-grid{grid-template-columns:repeat(2,1fr)}.two-col{grid-template-columns:1fr}.workflow-mix{grid-template-columns:1fr}.sess-item{grid-template-columns:60px 20px 1fr}}
 </style>
 </head>
 <body>
@@ -929,51 +958,94 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
 
 <div class="main">
 
-<!-- KPI GRID -->
-<div class="kpi-grid">
-  <div class="kpi">
-    <div class="kpi-value">${summary.totalLinesAdded > 0 ? summary.totalLinesAdded.toLocaleString() : '--'}</div>
-    <div class="kpi-label">Net lines shipped <span class="trust trust-engine">engine</span></div>
-    <div class="kpi-delta">from ${hasGitEvidence} sessions with git data</div>
+<!-- WHAT SHIPPED METRICS -->
+<div class="metric-section">
+  <div class="metric-section-label">
+    <span class="metric-section-name">What shipped</span>
+    <div class="metric-section-rule"></div>
+    <span class="metric-section-trust">git-authoritative</span>
   </div>
-  <div class="kpi">
-    <div class="kpi-value">${uniquePRs > 0 ? uniquePRs : '--'}</div>
-    <div class="kpi-label">PRs attributed <span class="trust ${uniquePRs > 0 ? 'trust-interp' : 'trust-none'}">${uniquePRs > 0 ? 'from commits' : 'not tracked'}</span></div>
-    <div class="kpi-delta">${uniquePRs > 0 ? `across ${hasGitEvidence} sessions with git data` : 'parsed from commit messages'}</div>
-  </div>
-  <div class="kpi">
-    <div class="kpi-value">${totalHours}h</div>
-    <div class="kpi-label">Autonomous work <span class="trust trust-engine">engine</span></div>
-    <div class="kpi-delta">${summary.completedSessions} sessions completed</div>
-  </div>
-  <div class="kpi">
-    <div class="kpi-value">${estCostCents > 0 ? htmlEscape(estCostStr) : '--'}</div>
-    <div class="kpi-label">Total spend <span class="trust ${estCostCents > 0 ? 'trust-interp' : 'trust-none'}">${estCostCents > 0 ? 'estimated' : 'not tracked'}</span></div>
-    <div class="kpi-delta">${estCostCents > 0 ? 'Anthropic list pricing' : 'requires Claude Code JSONL'}</div>
+  <div class="metric-grid">
+    <div class="mc mc-engine">
+      <div class="mc-hdr"><span class="mc-label">Net lines shipped</span><span class="mc-pill mc-pill-engine">Engine</span></div>
+      <div class="mc-value">${summary.totalLinesAdded > 0 ? fmtTokens(summary.totalLinesAdded) : '--'}</div>
+      <div class="mc-sub">${summary.totalLinesAdded > 0 ? `▲ +${summary.totalLinesAdded.toLocaleString()} / −${summary.totalLinesRemoved.toLocaleString()}` : '→ no git evidence yet'}</div>
+      <div class="mc-caveat">git diff captured &middot; ${hasGitEvidence}/${summary.totalSessions} sessions</div>
+    </div>
+    <div class="mc mc-interp">
+      <div class="mc-hdr"><span class="mc-label">PRs attributed</span><span class="mc-pill mc-pill-interp">Interp</span></div>
+      <div class="mc-value">${uniquePRs > 0 ? uniquePRs : '--'}</div>
+      <div class="mc-sub mc-sub-neutral">→ parsed from commit messages</div>
+      <div class="mc-caveat">regex match &middot; may miss or over-claim</div>
+    </div>
+    <div class="mc mc-engine">
+      <div class="mc-hdr"><span class="mc-label">Autonomous work</span><span class="mc-pill mc-pill-engine">Engine</span></div>
+      <div class="mc-value">${totalHours}h</div>
+      <div class="mc-sub">→ ${summary.completedSessions} sessions completed</div>
+      <div class="mc-caveat">wall-clock from event timestamps</div>
+    </div>
+    <div class="mc ${estCostCents > 0 ? 'mc-interp' : 'mc-none'}">
+      <div class="mc-hdr"><span class="mc-label">Model spend</span><span class="mc-pill ${estCostCents > 0 ? 'mc-pill-interp' : 'mc-pill-none'}">${estCostCents > 0 ? 'Metered' : 'Not tracked'}</span></div>
+      <div class="mc-value">${estCostCents > 0 ? htmlEscape(estCostStr) : '--'}</div>
+      <div class="mc-sub mc-sub-neutral">→ ${estCostCents > 0 ? 'at list pricing' : 'no token data yet'}</div>
+      <div class="mc-caveat">token data &middot; ${hasTokenData}/${summary.totalSessions} sessions</div>
+    </div>
   </div>
 </div>
 
-<!-- TRUST LEGEND -->
-<div class="trust-legend">
-  <div class="trust-legend-title">How to read this report</div>
-  <div class="trust-legend-sub">Every metric is labeled by its source. Never present unverified data as fact.</div>
-  <div class="trust-legend-grid">
-    <div class="trust-legend-item">
-      <h4><span class="trust trust-engine">engine</span></h4>
-      <p>Read from git, event logs, or JSONL. Primary evidence -- diff stats, token counts, timestamps.</p>
+<!-- DID IT HOLD UP METRICS -->
+<div class="metric-section">
+  <div class="metric-section-label">
+    <span class="metric-section-name">Did it hold up?</span>
+    <div class="metric-section-rule"></div>
+    <span class="metric-section-trust">lower confidence &mdash; read the tags</span>
+  </div>
+  <div class="metric-grid">
+    <div class="mc mc-interp">
+      <div class="mc-hdr"><span class="mc-label">Code kept &middot; 7 days</span><span class="mc-pill mc-pill-interp">Interp</span></div>
+      <div class="mc-value">${codeKeptPct !== null ? `${codeKeptPct}%` : '--'}</div>
+      <div class="mc-sub ${codeKeptPct !== null && codeKeptPct >= 80 ? '' : 'mc-sub-neutral'}">→ ${totalChurnFiles} of ${totalFilesForChurn} files re-touched</div>
+      <div class="mc-caveat">git history is exact; the cause of a re-touch isn&rsquo;t</div>
     </div>
-    <div class="trust-legend-item">
-      <h4><span class="trust trust-interp">interpretive</span></h4>
-      <p>Real data, uncertain meaning. PR refs from commit messages, cost at list pricing, churn signal.</p>
+    <div class="mc mc-engine">
+      <div class="mc-hdr"><span class="mc-label">Retries / session</span><span class="mc-pill mc-pill-engine">Engine</span></div>
+      <div class="mc-value">${retriesPerSession}</div>
+      <div class="mc-sub mc-sub-neutral">→ lower = right first try</div>
+      <div class="mc-caveat">blocked-attempt nodes in the DAG</div>
     </div>
-    <div class="trust-legend-item">
-      <h4><span class="trust trust-agent">agent reported</span></h4>
-      <p>The agent&rsquo;s own word. Outcome, PR numbers claimed. ~53% session coverage. Unverified.</p>
+    <div class="mc mc-engine">
+      <div class="mc-hdr"><span class="mc-label">Completed without abandon</span><span class="mc-pill mc-pill-engine">Engine</span></div>
+      <div class="mc-value">${completedWithoutAbandonPct !== null ? `${completedWithoutAbandonPct}%` : '--'}</div>
+      <div class="mc-sub mc-sub-neutral">→ ran to the last step</div>
+      <div class="mc-caveat">operational &mdash; not a quality verdict</div>
     </div>
-    <div class="trust-legend-item">
-      <h4><span class="trust trust-none">not tracked yet</span></h4>
-      <p>Missing readers, pre-feature sessions, or coverage gaps. Always shown as &ldquo;--&rdquo;, never as zero.</p>
+    <div class="mc mc-agent">
+      <div class="mc-hdr"><span class="mc-label">Agent-reported success</span><span class="mc-pill mc-pill-agent">Agent</span></div>
+      <div class="mc-value">${agentSuccessPct !== null ? `${agentSuccessPct}%` : '--'}</div>
+      <div class="mc-sub mc-sub-neutral">→ self-reported &middot; unverified</div>
+      <div class="mc-caveat">only ${hasOutcome}/${summary.totalSessions} sessions reported one</div>
     </div>
+  </div>
+</div>
+
+<!-- HOW TO READ — 4 individual cards -->
+<div class="trust-legend-hdr">How to read this report</div>
+<div class="trust-legend-grid">
+  <div class="trust-legend-item">
+    <h4><span class="trust trust-engine">engine</span></h4>
+    <p>Read from git, event logs, or JSONL. Primary evidence &mdash; diff stats, token counts, timestamps.</p>
+  </div>
+  <div class="trust-legend-item">
+    <h4><span class="trust trust-interp">interpretive</span></h4>
+    <p>Real data, uncertain meaning. PR refs from commit messages, cost at list pricing, churn signal.</p>
+  </div>
+  <div class="trust-legend-item">
+    <h4><span class="trust trust-agent">agent reported</span></h4>
+    <p>The agent&rsquo;s own word. Outcome, PR numbers claimed. Unverified.</p>
+  </div>
+  <div class="trust-legend-item">
+    <h4><span class="trust trust-none">not tracked yet</span></h4>
+    <p>Missing readers or pre-feature sessions. Always shown as &ldquo;--&rdquo;, never as zero.</p>
   </div>
 </div>
 

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -799,25 +799,25 @@ body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1
 .metric-section-name{font-size:10px;font-weight:700;letter-spacing:.10em;text-transform:uppercase;color:var(--txt3);white-space:nowrap}
 .metric-section-rule{flex:1;height:1px;background:var(--border2)}
 .metric-section-trust{font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--txt3);opacity:.65;white-space:nowrap;font-family:ui-monospace,monospace}
-/* DARK METRIC CARDS */
+/* METRIC CARDS */
 .metric-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:4px}
-.mc{background:#1c1c1f;border-radius:var(--radius);padding:18px 18px 16px;position:relative;overflow:hidden;display:flex;flex-direction:column}
+.mc{background:var(--surface);border-radius:var(--radius);padding:18px 18px 16px;position:relative;overflow:hidden;display:flex;flex-direction:column;box-shadow:var(--shadow)}
 .mc::before{content:'';position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--mc-b)}
 .mc-engine{--mc-b:var(--trust-engine)}
 .mc-interp{--mc-b:var(--trust-interp)}
 .mc-agent{--mc-b:var(--trust-agent)}
 .mc-none{--mc-b:var(--trust-none)}
 .mc-hdr{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:14px;gap:8px}
-.mc-label{font-size:9.5px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:rgba(255,255,255,.4);font-family:ui-monospace,monospace;line-height:1.35}
+.mc-label{font-size:9.5px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--txt3);font-family:ui-monospace,monospace;line-height:1.35}
 .mc-pill{font-size:8.5px;font-weight:700;letter-spacing:.07em;text-transform:uppercase;padding:3px 7px;border-radius:20px;flex-shrink:0;white-space:nowrap}
-.mc-pill-engine{background:rgba(0,122,255,.22);color:#5ac8fa}
-.mc-pill-interp{background:rgba(99,102,241,.22);color:#a5b4fc}
-.mc-pill-agent{background:rgba(255,149,0,.22);color:#ffcc00}
-.mc-pill-none{background:rgba(174,174,178,.12);color:rgba(255,255,255,.35)}
-.mc-value{font-size:40px;font-weight:700;letter-spacing:-1.8px;color:#fff;line-height:1;margin-bottom:10px}
-.mc-sub{font-size:11px;color:#30d158;font-family:ui-monospace,monospace;margin-bottom:6px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.mc-sub-neutral{color:rgba(255,255,255,.5)}
-.mc-caveat{font-size:10px;color:rgba(255,255,255,.28);font-family:ui-monospace,monospace;line-height:1.4;margin-top:auto}
+.mc-pill-engine{background:var(--trust-engine-bg);color:var(--trust-engine)}
+.mc-pill-interp{background:var(--trust-interp-bg);color:var(--trust-interp)}
+.mc-pill-agent{background:var(--trust-agent-bg);color:var(--trust-agent)}
+.mc-pill-none{background:var(--trust-none-bg);color:var(--trust-none)}
+.mc-value{font-size:40px;font-weight:700;letter-spacing:-1.8px;color:var(--txt);line-height:1;margin-bottom:10px}
+.mc-sub{font-size:11px;color:#1a7a3a;font-family:ui-monospace,monospace;margin-bottom:6px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.mc-sub-neutral{color:var(--txt2)}
+.mc-caveat{font-size:10px;color:var(--txt3);font-family:ui-monospace,monospace;line-height:1.4;margin-top:auto}
 /* SECTION HEADERS */
 .section-hdr{display:flex;align-items:baseline;gap:12px;margin:32px 0 16px}
 .section-num{font-size:11px;font-weight:700;color:var(--txt3);font-variant-numeric:tabular-nums;min-width:16px}

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -579,6 +579,36 @@ function renderHtml(output: ReportOutput): string {
     else activityData[d].other++;
   }
 
+  // ── "What shipped": sessions with actual git evidence, sorted by impact ───────
+  // Group by PR ref where available; ungrouped sessions shown individually.
+  const shippedSessions = sessionsJs
+    .filter(s => (s.confidence === 'high' || s.confidence === 'partial') && s.lines_added > 0)
+    .sort((a, b) => b.lines_added - a.lines_added);
+
+  // Build PR groups: each unique PR ref gets one card with all sessions that mention it.
+  type ShippedSession = (typeof sessionsJs)[number];
+  const prGroupMap = new Map<number, ShippedSession[]>();
+  const ungroupedShipped: ShippedSession[] = [];
+  for (const s of shippedSessions) {
+    if (s.pr_refs.length > 0) {
+      for (const ref of s.pr_refs) {
+        if (!prGroupMap.has(ref)) prGroupMap.set(ref, []);
+        prGroupMap.get(ref)!.push(s);
+      }
+    } else {
+      ungroupedShipped.push(s);
+    }
+  }
+  // Deduplicate PR groups by aggregating lines/files; sort groups by total lines.
+  const prGroups = Array.from(prGroupMap.entries()).map(([ref, sessions]) => ({
+    ref: `#${ref}`,
+    sessions,
+    totalLinesAdded: sessions.reduce((a, s) => a + s.lines_added, 0),
+    totalLinesRemoved: sessions.reduce((a, s) => a + s.lines_removed, 0),
+    totalFilesChanged: sessions.reduce((a, s) => a + s.files_changed, 0),
+    project: sessions[0]?.project ?? '',
+  })).sort((a, b) => b.totalLinesAdded - a.totalLinesAdded);
+
   // ── Coverage summary: per-session data type availability ────────────────────
   const hasGitEvidence = sessionsJs.filter(s => s.confidence === 'high' || s.confidence === 'partial').length;
   const hasTokenData   = sessionsJs.filter(s => s.tok_in + s.tok_out > 0).length;
@@ -770,6 +800,24 @@ body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1
 .trust-legend-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
 .trust-legend-item h4{font-size:12px;font-weight:600;color:var(--txt);margin-bottom:3px;display:flex;align-items:center;gap:6px}
 .trust-legend-item p{font-size:11px;color:var(--txt2);line-height:1.4}
+/* WHAT SHIPPED */
+.shipped-empty{font-size:13px;color:var(--txt3);padding:12px 0}
+.shipped-pr{background:var(--surface);border-radius:var(--radius);box-shadow:var(--shadow);margin-bottom:12px;overflow:hidden}
+.shipped-pr-hdr{display:flex;align-items:center;gap:12px;padding:14px 20px;border-bottom:1px solid var(--border)}
+.shipped-pr-ref{font-size:13px;font-weight:700;color:var(--accent);font-family:ui-monospace,monospace;flex-shrink:0}
+.shipped-pr-project{font-size:11px;color:var(--txt3);flex-shrink:0}
+.shipped-pr-stats{display:flex;gap:14px;margin-left:auto;flex-shrink:0}
+.shipped-stat-add{font-size:12px;font-weight:600;color:#1a7a3a;font-variant-numeric:tabular-nums}
+.shipped-stat-rem{font-size:12px;font-weight:600;color:#c0392b;font-variant-numeric:tabular-nums}
+.shipped-stat-files{font-size:12px;color:var(--txt3);font-variant-numeric:tabular-nums}
+.shipped-sessions{padding:0 20px}
+.shipped-session{display:flex;align-items:baseline;gap:10px;padding:10px 0;border-bottom:1px solid var(--border);font-size:12px}
+.shipped-session:last-child{border-bottom:none}
+.shipped-session-goal{flex:1;color:var(--txt);line-height:1.4;overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}
+.shipped-session-date{color:var(--txt3);flex-shrink:0;font-size:11px}
+.shipped-solo{background:var(--surface);border-radius:var(--radius);box-shadow:var(--shadow);margin-bottom:12px;padding:14px 20px;display:flex;align-items:baseline;gap:12px}
+.shipped-solo-goal{flex:1;font-size:13px;color:var(--txt);line-height:1.4;overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}
+.shipped-solo-meta{display:flex;gap:12px;align-items:center;flex-shrink:0}
 /* COVERAGE */
 .coverage-table{width:100%;font-size:13px;margin-bottom:8px}
 .coverage-table td{padding:7px 0;border-bottom:1px solid var(--border)}
@@ -923,6 +971,42 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
   </div>
 </div>
 
+<!-- WHAT SHIPPED -->
+<div class="section-hdr" style="margin-top:8px">
+  <h2 class="section-title">What shipped</h2>
+  <span class="section-meta">${shippedSessions.length} sessions with verified git output</span>
+</div>
+${shippedSessions.length === 0
+  ? `<div class="card"><div class="shipped-empty">No sessions with git evidence in this window. Coverage increases as more sessions run after the git metrics feature was deployed.</div></div>`
+  : `${prGroups.map(g => `<div class="shipped-pr">
+  <div class="shipped-pr-hdr">
+    <span class="shipped-pr-ref">${htmlEscape(g.ref)}</span>
+    ${g.project ? `<span class="shipped-pr-project">${htmlEscape(g.project)}</span>` : ''}
+    <div class="shipped-pr-stats">
+      <span class="shipped-stat-add">+${g.totalLinesAdded.toLocaleString()}</span>
+      <span class="shipped-stat-rem">-${g.totalLinesRemoved.toLocaleString()}</span>
+      ${g.totalFilesChanged > 0 ? `<span class="shipped-stat-files">${g.totalFilesChanged} file${g.totalFilesChanged !== 1 ? 's' : ''}</span>` : ''}
+    </div>
+  </div>
+  <div class="shipped-sessions">
+    ${g.sessions.map(s => `<div class="shipped-session">
+      <span class="shipped-session-goal">${s.goal || '(no goal recorded)'}</span>
+      <span class="shipped-session-date">${s.date}</span>
+    </div>`).join('')}
+  </div>
+</div>`).join('')}
+${ungroupedShipped.slice(0, 20).map(s => `<div class="shipped-solo">
+  <span class="shipped-solo-goal">${s.goal || '(no goal recorded)'}</span>
+  <div class="shipped-solo-meta">
+    ${s.git_branch ? `<span style="font-size:11px;color:var(--txt3);font-family:ui-monospace,monospace">${htmlEscape(s.git_branch)}</span>` : ''}
+    <span class="shipped-stat-add">+${s.lines_added.toLocaleString()}</span>
+    <span class="shipped-stat-rem">-${s.lines_removed.toLocaleString()}</span>
+    ${s.files_changed > 0 ? `<span class="shipped-stat-files">${s.files_changed}f</span>` : ''}
+    <span style="font-size:11px;color:var(--txt3)">${s.date}</span>
+  </div>
+</div>`).join('')}
+${ungroupedShipped.length > 20 ? `<div style="font-size:12px;color:var(--txt3);padding:8px 0">+${ungroupedShipped.length - 20} more sessions in the Sessions list below</div>` : ''}`}
+
 <!-- COVERAGE -->
 <div class="section-hdr">
   <span class="section-num">01</span>
@@ -1015,6 +1099,8 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
 
 <script>
 const SESSIONS = ${safeJson(sessionsJs)};
+const PR_GROUPS = ${safeJson(prGroups)};
+const UNGROUPED_SHIPPED = ${safeJson(ungroupedShipped)};
 const BREAKDOWN = ${safeJson(breakdown)};
 const ROUTINE_BREAKDOWN = ${safeJson(routineBreakdown)};
 const HEATMAP = ${safeJson(heatmap)};

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -565,6 +565,31 @@ function renderHtml(output: ReportOutput): string {
     </tr>`;
   }).join('') || '<tr><td colspan="4" style="color:#aeaeb2;text-align:center;padding:12px">No token data (requires Claude Code JSONL)</td></tr>';
 
+  // ── Outcome-stacked chart data (activity tab) ───────────────────────────────
+  const activityData: Record<string, { success: number; partial: number; other: number }> = {};
+  for (const s of sessionsJs) {
+    const d = s.date;
+    if (!activityData[d]) activityData[d] = { success: 0, partial: 0, other: 0 };
+    if (s.outcome === 'success') activityData[d].success++;
+    else if (s.outcome === 'partial') activityData[d].partial++;
+    else activityData[d].other++;
+  }
+
+  // ── Coverage summary: per-session data type availability ────────────────────
+  const hasGitEvidence = sessionsJs.filter(s => s.confidence === 'high' || s.confidence === 'partial').length;
+  const hasTokenData   = sessionsJs.filter(s => s.tok_in + s.tok_out > 0).length;
+  const hasOutcome     = sessionsJs.filter(s => s.outcome !== null).length;
+  const hasPrRefs      = sessionsJs.filter(s => s.pr_refs.length > 0).length;
+
+  // ── Hero narrative (engine-authoritative only) ──────────────────────────────
+  const heroLines = summary.totalLinesAdded;
+  const heroPRs = summary.languageBreakdown ? null : null; // prRefs come from sessions
+  const totalPRs = sessionsJs.reduce((a, s) => a + s.pr_refs.length, 0);
+  const uniquePRs = new Set(sessionsJs.flatMap(s => s.pr_refs)).size;
+  const heroStatement = heroLines > 0
+    ? `${summary.totalSessions} guided sessions shipped ${heroLines.toLocaleString()} lines${uniquePRs > 0 ? ` across ${uniquePRs} PRs` : ''}.`
+    : `${summary.totalSessions} guided sessions ran over ${Math.ceil(summary.totalDurationMs / 3_600_000)}h.`;
+
   // ── Main HTML output ─────────────────────────────────────────────────────────
   return `<!DOCTYPE html>
 <html lang="en">
@@ -574,6 +599,7 @@ function renderHtml(output: ReportOutput): string {
 <title>WorkRail Report -- ${htmlEscape(dateRange.since)} to ${htmlEscape(dateRange.until)}</title>
 <style>
 :root{
+  /* WorkRail report token system */
   --bg:#f5f5f7;--surface:#fff;--hdr:#1d1d1f;
   --accent:#007aff;--txt:#1d1d1f;--txt2:#6e6e73;--txt3:#aeaeb2;
   --border:#f2f2f7;--border2:#e5e5ea;
@@ -582,6 +608,11 @@ function renderHtml(output: ReportOutput): string {
   --shadow:0 1px 4px rgba(0,0,0,.07);
   --font:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
   --space-micro:2px;--space-half:4px;
+  /* Trust badge colors */
+  --trust-engine:#007aff;--trust-engine-bg:#e1f0ff;
+  --trust-interp:#6366f1;--trust-interp-bg:#eef2ff;
+  --trust-agent:#ff9500;--trust-agent-bg:#fff3e0;
+  --trust-none:#aeaeb2;--trust-none-bg:#f5f5f5;
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1.5;min-height:100vh}
@@ -686,335 +717,453 @@ body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1
 .qual-label{font-size:11px;color:var(--txt2);margin-top:var(--space-half)}
 .qual-note{font-size:10px;color:var(--txt3);margin-top:var(--space-micro)}
 
-footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:28px}
-@media(max-width:700px){.kpi-row{grid-template-columns:repeat(2,1fr)}.hdr-stats{display:none}.two-col{grid-template-columns:1fr}.qual-grid{grid-template-columns:repeat(2,1fr)}.sess-item{grid-template-columns:60px 24px 1fr}}
+/* TRUST BADGES */
+.trust{display:inline-flex;align-items:center;gap:4px;font-size:10px;font-weight:700;padding:2px 7px;border-radius:var(--radius-pill);white-space:nowrap}
+.trust-engine{background:var(--trust-engine-bg);color:var(--trust-engine)}
+.trust-interp{background:var(--trust-interp-bg);color:var(--trust-interp)}
+.trust-agent{background:var(--trust-agent-bg);color:var(--trust-agent)}
+.trust-none{background:var(--trust-none-bg);color:var(--trust-none)}
+/* HERO */
+.hero{padding:40px 40px 32px;background:var(--hdr);border-bottom:1px solid rgba(255,255,255,.06)}
+.hero-inner{max-width:940px;margin:0 auto}
+.hero-nav{font-size:11px;color:rgba(255,255,255,.35);margin-bottom:20px;font-family:ui-monospace,monospace;letter-spacing:.02em}
+.hero-nav strong{color:rgba(255,255,255,.6)}
+.hero-h1{font-size:36px;font-weight:700;letter-spacing:-1px;color:#fff;line-height:1.15;margin-bottom:12px}
+.hero-h1 span{color:var(--accent)}
+.hero-sub{font-size:14px;color:rgba(255,255,255,.55);line-height:1.6;max-width:640px;margin-bottom:20px}
+.hero-pills{display:flex;gap:8px;flex-wrap:wrap}
+.hero-pill{background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.12);border-radius:var(--radius-pill);padding:4px 12px;font-size:12px;color:rgba(255,255,255,.6);cursor:default}
+/* META BAR */
+.meta-bar{background:var(--hdr);border-top:1px solid rgba(255,255,255,.06);padding:8px 40px}
+.meta-bar-inner{max-width:940px;margin:0 auto;display:flex;justify-content:space-between;font-size:11px;color:rgba(255,255,255,.22);font-family:ui-monospace,monospace}
+/* MAIN */
+.main{max-width:940px;margin:0 auto;padding:28px 24px}
+/* KPI GRID */
+.kpi-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:28px}
+.kpi{background:var(--surface);border-radius:var(--radius);padding:18px 20px;box-shadow:var(--shadow)}
+.kpi-top{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:10px}
+.kpi-value{font-size:28px;font-weight:700;letter-spacing:-0.8px;color:var(--txt);line-height:1}
+.kpi-label{font-size:11px;color:var(--txt2);margin-top:4px}
+.kpi-delta{font-size:11px;color:var(--txt3);margin-top:6px}
+/* SECTION HEADERS */
+.section-hdr{display:flex;align-items:baseline;gap:12px;margin:32px 0 16px}
+.section-num{font-size:11px;font-weight:700;color:var(--txt3);font-variant-numeric:tabular-nums;min-width:16px}
+.section-title{font-size:18px;font-weight:700;letter-spacing:-0.3px;color:var(--txt)}
+.section-meta{font-size:12px;color:var(--txt3);margin-left:auto}
+/* TRUST LEGEND */
+.trust-legend{background:var(--surface);border-radius:var(--radius);padding:20px 24px;box-shadow:var(--shadow);margin-bottom:28px}
+.trust-legend-title{font-size:13px;font-weight:600;color:var(--txt);margin-bottom:4px}
+.trust-legend-sub{font-size:12px;color:var(--txt2);margin-bottom:16px}
+.trust-legend-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
+.trust-legend-item h4{font-size:12px;font-weight:600;color:var(--txt);margin-bottom:4px;display:flex;align-items:center;gap:6px}
+.trust-legend-item p{font-size:11px;color:var(--txt2);line-height:1.5}
+/* COVERAGE */
+.coverage-table{width:100%;font-size:13px;margin-bottom:8px}
+.coverage-table td{padding:7px 0;border-bottom:1px solid var(--border)}
+.coverage-table tr:last-child td{border-bottom:none}
+.coverage-bar-outer{background:var(--border);border-radius:var(--radius-sm);height:8px;flex:1;overflow:hidden}
+.coverage-bar-inner{height:100%;border-radius:var(--radius-sm)}
+/* CARDS */
+.card{background:var(--surface);border-radius:var(--radius);padding:24px 26px;box-shadow:var(--shadow);margin-bottom:18px}
+.card-title{font-size:15px;font-weight:600;margin-bottom:4px;color:var(--txt)}
+.card-sub{font-size:12px;color:var(--txt2);margin-bottom:16px}
+.two-col{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+/* TABLES */
+.tbl{width:100%;border-collapse:collapse;font-size:13px}
+.tbl th{text-align:left;padding:0 10px 10px 0;font-size:11px;font-weight:600;letter-spacing:.4px;color:var(--txt3);border-bottom:1px solid var(--border)}
+.tbl th.r{text-align:right}
+.tbl td{padding:9px 10px 9px 0;border-bottom:1px solid var(--border);vertical-align:middle}
+.tbl td.r{text-align:right;color:var(--txt2);font-variant-numeric:tabular-nums}
+.tbl tr:last-child td{border-bottom:none}
+.total-row td{padding-top:12px;font-weight:600;border-top:2px solid var(--border2);border-bottom:none!important}
+/* BARS */
+.bar-outer{background:var(--border);border-radius:var(--radius-sm);height:18px;position:relative;overflow:hidden;min-width:80px}
+.bar-inner{background:var(--accent);border-radius:var(--radius-sm);height:100%;position:absolute;top:0;left:0}
+/* ACTIVITY CHART */
+.chart-wrap{position:relative}
+.y-axis{position:absolute;left:0;top:0;bottom:24px;width:32px;display:flex;flex-direction:column;justify-content:space-between;pointer-events:none}
+.y-label{font-size:10px;color:var(--txt3);text-align:right;padding-right:6px}
+.bar-chart-area{margin-left:36px}
+.bar-chart{display:flex;align-items:flex-end;gap:3px;height:140px;border-bottom:1px solid var(--border2)}
+.bc-bar{flex:1;border-radius:2px 2px 0 0;min-width:4px;position:relative;cursor:default;transition:opacity .1s}
+.bc-bar:hover{opacity:.75}
+.bc-bar:hover::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--hdr);color:#fff;font-size:11px;padding:4px 8px;border-radius:var(--radius-sm);white-space:nowrap;z-index:10;pointer-events:none}
+.bar-chart-axis{display:flex;gap:3px;margin-top:4px}
+.bar-chart-label{flex:1;font-size:9px;color:var(--txt3);text-align:center;overflow:hidden}
+/* DONUT */
+.workflow-mix{display:grid;grid-template-columns:1fr 200px;gap:24px;align-items:start}
+.donut-wrap{display:flex;flex-direction:column;align-items:center}
+.donut-list{font-size:12px}
+.donut-list-row{display:flex;align-items:center;gap:8px;padding:4px 0}
+.donut-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+/* SESSIONS */
+.controls{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:14px;align-items:center}
+.controls select,.controls input{padding:6px 10px;border:1.5px solid var(--border2);border-radius:var(--radius-sm);font-size:12px;background:var(--surface);color:var(--txt);outline:none;font-family:var(--font)}
+.controls select:focus,.controls input:focus{border-color:var(--accent)}
+.stats-bar{display:flex;gap:20px;padding:10px 0 14px;border-bottom:1px solid var(--border);margin-bottom:14px;font-size:12px;flex-wrap:wrap}
+.stat-val{font-weight:600;color:var(--txt)}
+.stat-lbl{color:var(--txt2)}
+.sess-item{display:grid;grid-template-columns:70px 24px 1fr auto;gap:10px;align-items:start;padding:11px 0;border-bottom:1px solid var(--border);font-size:13px}
+.sess-item:last-child{border-bottom:none}
+.sess-date{font-size:11px;color:var(--txt3);padding-top:2px;font-variant-numeric:tabular-nums}
+.sess-dot{width:8px;height:8px;border-radius:50%;margin-top:4px;flex-shrink:0}
+.dot-done{background:var(--success)}.dot-skip{background:var(--border2);border:1.5px solid var(--txt3)}
+.sess-body{}
+.sess-wf{font-size:11px;font-weight:600;color:var(--txt2);margin-bottom:2px}
+.sess-goal{line-height:1.4;color:var(--txt);margin-bottom:4px}
+.sess-no-goal{color:var(--txt3);font-style:italic}
+.sess-tags{display:flex;gap:6px;flex-wrap:wrap;margin-top:4px}
+.badge{display:inline-block;font-size:10px;font-weight:700;padding:1px 6px;border-radius:var(--radius-sm);white-space:nowrap}
+.b-success{background:#e1f8ec;color:#1a7a3a}
+.b-partial{background:#fff8e0;color:#9a6000}
+.b-abandoned{background:#f5f5f5;color:#999}
+.b-error{background:#ffeaea;color:var(--error)}
+.sess-nums{display:flex;flex-direction:column;align-items:flex-end;gap:4px;padding-top:2px;flex-shrink:0;min-width:80px}
+.sess-num-main{font-size:13px;font-weight:600;color:var(--txt);font-variant-numeric:tabular-nums}
+.sess-num-sub{font-size:11px;color:var(--txt3);font-variant-numeric:tabular-nums}
+.pag{display:flex;gap:6px;justify-content:center;align-items:center;margin-top:16px;flex-wrap:wrap}
+.pg-btn{padding:5px 11px;border:1.5px solid var(--border2);border-radius:var(--radius-sm);font-size:12px;cursor:pointer;background:var(--surface);color:#3a3a3c;font-family:var(--font)}
+.pg-btn:hover:not(:disabled){border-color:var(--accent);color:var(--accent)}
+.pg-btn.active{background:var(--accent);color:#fff;border-color:var(--accent);cursor:default}
+.pg-btn:disabled{opacity:.35;cursor:default}
+footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;padding-bottom:24px}
+@media(max-width:700px){.kpi-grid{grid-template-columns:repeat(2,1fr)}.hero-h1{font-size:26px}.trust-legend-grid{grid-template-columns:repeat(2,1fr)}.two-col{grid-template-columns:1fr}.workflow-mix{grid-template-columns:1fr}.sess-item{grid-template-columns:60px 20px 1fr}}
 </style>
 </head>
 <body>
 
-<!-- DARK HEADER -->
-<div class="site-header">
-  <div class="hdr-inner">
-    <div>
-      <div class="hdr-cost-value">${htmlEscape(estCostStr)}</div>
-      <div class="hdr-cost-label">ESTIMATED COST THIS PERIOD</div>
-      <div class="hdr-cost-disclaimer">Anthropic list pricing &middot; actual cost varies by tier &amp; model</div>
+<!-- HERO -->
+<div class="hero">
+  <div class="hero-inner">
+    <div class="hero-nav">
+      <strong>workrail</strong> report &mdash; <strong>--fmt</strong> ${htmlEscape(dateRange.since)} <strong>--read</strong> ${Math.ceil((new Date(dateRange.until).getTime() - new Date(dateRange.since).getTime()) / 86_400_000)}d
     </div>
-    <div class="hdr-stats">
-      <div>
-        <div class="hdr-stat-value">${summary.totalSessions.toLocaleString()}</div>
-        <div class="hdr-stat-label">Sessions</div>
-      </div>
-      <div>
-        <div class="hdr-stat-value">${completionPct}%</div>
-        <div class="hdr-stat-label">Completion rate</div>
-      </div>
+    <h1 class="hero-h1">${htmlEscape(heroStatement.split(' ').slice(0, -3).join(' '))} <span>${htmlEscape(heroStatement.split(' ').slice(-3).join(' '))}</span></h1>
+    <p class="hero-sub">
+      Across ${htmlEscape(dateRange.since)} &ndash; ${htmlEscape(dateRange.until)}, WorkRail steered <strong>${summary.totalSessions} workflow runs</strong> through guided, step-by-step execution.
+      Every number below is labeled by <strong>how much it can be trusted</strong> &mdash; git evidence, interpretation, or the agent&rsquo;s own word.
+      Metrics that didn&rsquo;t exist yet read <strong>&ldquo;not tracked&rdquo;</strong>, never a misleading zero.
+    </p>
+    <div class="hero-pills">
+      <span class="hero-pill">${summary.totalSessions} sessions</span>
+      ${summary.totalLinesAdded > 0 ? `<span class="hero-pill">+${summary.totalLinesAdded.toLocaleString()} lines</span>` : ''}
+      ${totalHours !== '0.0' ? `<span class="hero-pill">${totalHours}h autonomous</span>` : ''}
+      ${estCostCents > 0 ? `<span class="hero-pill">${htmlEscape(estCostStr)} spend</span>` : ''}
+      ${uniquePRs > 0 ? `<span class="hero-pill">${uniquePRs} PRs</span>` : ''}
     </div>
   </div>
 </div>
-<div class="hdr-meta">
-  <div class="hdr-meta-inner">
-    <span>WorkRail Report &middot; ${htmlEscape(dateRange.since)} to ${htmlEscape(dateRange.until)}</span>
-    <span>Generated ${new Date(generatedAt).toLocaleString()}</span>
+<div class="meta-bar">
+  <div class="meta-bar-inner">
+    <span>May 2026 usage report &middot; generated ${new Date(generatedAt).toLocaleDateString('en-US',{month:'short',day:'numeric',year:'numeric'})}</span>
+    <span>workrail ${htmlEscape(dateRange.since)} to ${htmlEscape(dateRange.until)}</span>
   </div>
 </div>
 
 <div class="main">
 
-<div class="callout" id="callout">Loading...</div>
-
-<div class="kpi-row">
+<!-- KPI GRID -->
+<div class="kpi-grid">
   <div class="kpi">
-    <div class="kpi-value">${totalHours}h</div>
-    <div class="kpi-label">Autonomous runtime</div>
-    <div class="kpi-sub">wall clock, ${dateRange.since} to ${dateRange.until}</div>
-  </div>
-  <div class="kpi">
+    <div class="kpi-top">
+      <span class="trust trust-engine">engine</span>
+    </div>
     <div class="kpi-value">${fmtTokens(summary.totalLinesAdded)}</div>
-    <div class="kpi-label">Lines of code added</div>
-    <div class="kpi-sub">engine-authoritative git diff</div>
+    <div class="kpi-label">Net lines shipped</div>
+    <div class="kpi-delta" style="color:#6e6e73">git diff --numstat</div>
   </div>
   <div class="kpi">
-    <div class="kpi-value">${fmtTokens(totalTokens)}</div>
-    <div class="kpi-label">Total tokens</div>
-    <div class="kpi-sub">input + output + cache</div>
+    <div class="kpi-top">
+      <span class="trust ${uniquePRs > 0 ? 'trust-interp' : 'trust-none'}">${uniquePRs > 0 ? 'from commits' : 'not tracked'}</span>
+    </div>
+    <div class="kpi-value">${uniquePRs > 0 ? uniquePRs : '--'}</div>
+    <div class="kpi-label">PRs attributed</div>
+    <div class="kpi-delta">parsed from commit messages</div>
   </div>
   <div class="kpi">
-    <div class="kpi-value">${fmtDuration(summary.totalDurationMs / summary.completedSessions || undefined)}</div>
-    <div class="kpi-label">Avg session duration</div>
-    <div class="kpi-sub">completed sessions only</div>
-  </div>
-</div>
-
-<div class="tabs">
-  <button class="tab active" data-view="overview">Overview</button>
-  <button class="tab" data-view="tokens">Tokens &amp; Cost</button>
-  <button class="tab" data-view="activity">Activity</button>
-  <button class="tab" data-view="quality">Quality</button>
-  <button class="tab" data-view="sessions">Sessions</button>
-</div>
-
-<!-- OVERVIEW TAB -->
-<div class="view active" id="view-overview">
-  <div class="two-col">
-    <div class="card">
-      <h2>By project</h2>
-      <p class="card-sub">Sessions and lines added per repository</p>
-      <table class="tbl">
-        <thead><tr><th>Project</th><th>Sessions</th><th class="r">+Lines</th><th class="r">Languages</th></tr></thead>
-        <tbody>${projRowsHtml}</tbody>
-      </table>
+    <div class="kpi-top">
+      <span class="trust trust-engine">engine</span>
     </div>
-    <div class="card">
-      <h2>Language breakdown</h2>
-      <p class="card-sub">Files changed by extension across all sessions</p>
-      ${langBarsHtml}
-    </div>
+    <div class="kpi-value">${totalHours}h</div>
+    <div class="kpi-label">Autonomous work</div>
+    <div class="kpi-delta">${summary.completedSessions} sessions completed</div>
   </div>
-  <div class="card">
-    <h2>By workflow</h2>
-    <p class="card-sub">Completion rate and median duration</p>
-    <table class="tbl">
-      <thead><tr><th>Workflow</th><th style="min-width:160px">Completed</th><th class="r">Rate</th><th class="r">Median</th><th class="r">+Lines</th></tr></thead>
-      <tbody id="breakdown-body"></tbody>
-    </table>
+  <div class="kpi">
+    <div class="kpi-top">
+      <span class="trust ${estCostCents > 0 ? 'trust-interp' : 'trust-none'}">${estCostCents > 0 ? 'estimated' : 'not tracked'}</span>
+    </div>
+    <div class="kpi-value">${estCostCents > 0 ? htmlEscape(estCostStr) : '--'}</div>
+    <div class="kpi-label">Total spend</div>
+    <div class="kpi-delta">${estCostCents > 0 ? 'Anthropic list pricing' : 'requires Claude Code JSONL'}</div>
   </div>
 </div>
 
-<!-- TOKENS TAB -->
-<div class="view" id="view-tokens">
-  <div class="card">
-    <h2>Token cost breakdown</h2>
-    <p class="card-sub">Cache reads are priced at $0.30/1M vs $3.00/1M for input -- 10x cheaper. High cache hit rate means lower effective cost.</p>
-    <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:24px">
-      ${tokCards}
+<!-- TRUST LEGEND -->
+<div class="trust-legend">
+  <div class="trust-legend-title">How to read this report</div>
+  <div class="trust-legend-sub">Every metric is labeled by its source. Never present unverified data as fact.</div>
+  <div class="trust-legend-grid">
+    <div class="trust-legend-item">
+      <h4><span class="trust trust-engine">engine</span></h4>
+      <p>Read directly from git history, event logs, or JSONL files. These figures lead with primary evidence: diff stats, token counts, timestamps.</p>
     </div>
-    <h2 style="margin-bottom:12px">By model</h2>
-    <table class="tbl">
-      <thead><tr><th>Model</th><th class="r">Tokens</th><th class="r">Sessions</th><th class="r">Est. cost</th></tr></thead>
-      <tbody>${modelRowsHtml}</tbody>
-    </table>
-    <p style="font-size:11px;color:#aeaeb2;margin-top:16px">Estimates use Anthropic list pricing and do not account for enterprise agreements, Bedrock pricing, or prompt caching tier differences.</p>
-  </div>
-</div>
-
-<!-- ACTIVITY TAB -->
-<div class="view" id="view-activity">
-  <div class="card">
-    <h2>Daily activity</h2>
-    <p class="card-sub">Sessions started per day. Blue = weekday, lighter = weekend.</p>
-    <div class="chart-wrap">
-      <div class="y-axis" id="y-axis"></div>
-      <div class="bar-chart-area">
-        <div class="bar-chart" id="barchart"></div>
-        <div class="bar-chart-axis" id="barchart-axis"></div>
-      </div>
+    <div class="trust-legend-item">
+      <h4><span class="trust trust-interp">interpretive</span></h4>
+      <p>Real data, uncertain meaning. PR refs parsed from commit messages, cost estimates at list pricing, churn signal. Accurate reading, cautious interpretation.</p>
+    </div>
+    <div class="trust-legend-item">
+      <h4><span class="trust trust-agent">agent reported</span></h4>
+      <p>The agent&rsquo;s own word: outcome (success/partial), PR numbers it claims to have worked on. Present in ~53% of sessions. Take with appropriate skepticism.</p>
+    </div>
+    <div class="trust-legend-item">
+      <h4><span class="trust trust-none">not tracked yet</span></h4>
+      <p>Data that wasn&rsquo;t collected for these sessions -- missing readers (Cursor, Antigravity), sessions before a feature shipped, or gaps in coverage. Always shown as &ldquo;--&rdquo;.</p>
     </div>
   </div>
 </div>
 
-<!-- QUALITY TAB -->
-<div class="view" id="view-quality">
-  <div class="card">
-    <h2>Quality signals</h2>
-    <p class="card-sub">Step retries, code churn, and git capture confidence indicate output quality.</p>
-    <div class="qual-grid">
-      <div class="qual-card">
-        <div class="qual-value" style="color:${parseFloat(avgRetryRate) < 10 ? 'var(--success)' : parseFloat(avgRetryRate) < 25 ? 'var(--warn)' : 'var(--error)'}">${avgRetryRate}%</div>
-        <div class="qual-label">Avg retry rate</div>
-        <div class="qual-note">retries / steps per session</div>
-      </div>
-      <div class="qual-card">
-        <div class="qual-value" style="color:var(--accent)">${avgChurn ?? '--'}</div>
-        <div class="qual-label">Avg files re-modified</div>
-        <div class="qual-note">within 7 days of session end</div>
-      </div>
-      <div class="qual-card">
-        <div class="qual-value" style="color:var(--success)">${summary.totalStepsCompleted.toLocaleString()}</div>
-        <div class="qual-label">Steps completed</div>
-        <div class="qual-note">total across all sessions</div>
-      </div>
-    </div>
-    <h2 style="margin-top:24px;margin-bottom:12px">Git capture confidence</h2>
-    <p class="card-sub" style="margin-bottom:16px">High = authoritative diff from engine. Partial = SHA available but diff incomplete. None = no git data.</p>
-    <div style="display:flex;gap:24px;font-size:13px">
-      <div><span style="font-size:22px;font-weight:700;color:var(--success)">${confHigh}</span> <span style="color:var(--txt2)">high</span></div>
-      <div><span style="font-size:22px;font-weight:700;color:var(--warn)">${confPartial}</span> <span style="color:var(--txt2)">partial</span></div>
-      <div><span style="font-size:22px;font-weight:700;color:var(--txt3)">${confNone}</span> <span style="color:var(--txt2)">none</span></div>
-    </div>
+<!-- COVERAGE -->
+<div class="section-hdr">
+  <span class="section-num">01</span>
+  <h2 class="section-title">Coverage for this period</h2>
+</div>
+<div class="card">
+  <div class="card-sub">What data was actually captured for these ${summary.totalSessions} sessions.</div>
+  <table style="width:100%;font-size:13px;border-collapse:collapse">
+    ${[
+      { label: 'Git diff captured', n: hasGitEvidence, badge: 'engine' },
+      { label: 'Token data captured', n: hasTokenData, badge: 'engine' },
+      { label: 'Outcome reported', n: hasOutcome, badge: 'agent reported' },
+      { label: 'PR refs in commits', n: hasPrRefs, badge: 'interpretive' },
+    ].map(({ label, n, badge }) => {
+      const pct = summary.totalSessions > 0 ? Math.round(n / summary.totalSessions * 100) : 0;
+      const badgeCls = badge === 'engine' ? 'trust-engine' : badge === 'interpretive' ? 'trust-interp' : 'trust-agent';
+      return `<tr><td style="padding:8px 0;border-bottom:1px solid #f2f2f7;width:180px"><span class="trust ${badgeCls}" style="margin-right:8px">${htmlEscape(badge)}</span>${htmlEscape(label)}</td><td style="padding:8px 0 8px 16px;border-bottom:1px solid #f2f2f7"><div style="display:flex;align-items:center;gap:10px"><div style="flex:1;background:#f2f2f7;border-radius:4px;height:8px;overflow:hidden"><div style="width:${pct}%;height:100%;background:${badge === 'engine' ? '#007aff' : badge === 'interpretive' ? '#6366f1' : '#ff9500'};border-radius:4px"></div></div><span style="font-size:12px;color:#6e6e73;width:60px;text-align:right">${n} / ${summary.totalSessions}</span></div></td></tr>`;
+    }).join('')}
+  </table>
+</div>
+
+<!-- ACTIVITY -->
+<div class="section-hdr">
+  <span class="section-num">02</span>
+  <h2 class="section-title">Activity over time</h2>
+  <span class="section-meta">${summary.totalSessions} sessions &middot; daily</span>
+</div>
+<div class="card">
+  <div class="card-sub">Sessions per day, by reported outcome. Stacked bars &mdash; &ldquo;unknown&rdquo; = no outcome reported.</div>
+  <div style="display:flex;gap:16px;margin-bottom:12px;font-size:11px;align-items:center">
+    <div style="display:flex;align-items:center;gap:5px"><div style="width:10px;height:10px;border-radius:2px;background:#34c759"></div>success</div>
+    <div style="display:flex;align-items:center;gap:5px"><div style="width:10px;height:10px;border-radius:2px;background:#ff9500"></div>partial</div>
+    <div style="display:flex;align-items:center;gap:5px"><div style="width:10px;height:10px;border-radius:2px;background:#e5e5ea"></div>unknown</div>
   </div>
-  <div class="card">
-    <h2>Outcome distribution</h2>
-    <p class="card-sub">Agent-reported outcomes (requires metricsProfile on workflow, ~53% coverage)</p>
-    <div style="display:flex;gap:24px;flex-wrap:wrap;font-size:13px">
-      ${Object.entries(summary.outcomeBreakdown).map(([outcome, count]) =>
-    `<div><span class="badge b-${outcome}" style="font-size:12px;padding:3px 10px">${outcome}</span> <strong style="margin-left:6px">${count}</strong></div>`,
-  ).join('')}
+  <div class="chart-wrap">
+    <div class="y-axis" id="y-axis"></div>
+    <div class="bar-chart-area">
+      <div class="bar-chart" id="barchart"></div>
+      <div class="bar-chart-axis" id="barchart-axis"></div>
     </div>
   </div>
 </div>
 
-<!-- SESSIONS TAB -->
-<div class="view" id="view-sessions">
-  <div class="card">
-    <h2>Workflow runs</h2>
-    <p class="card-sub"><span id="sess-total"></span></p>
-    <div class="controls">
-      <select id="sess-workflow"><option value="">All workflows</option></select>
-      <select id="sess-status">
-        <option value="">All statuses</option>
-        <option value="done">Completed</option>
-        <option value="partial">Incomplete</option>
-      </select>
-      <input type="text" id="sess-search" placeholder="Search goals, projects..." style="min-width:200px">
+<!-- WORKFLOW MIX -->
+<div class="section-hdr">
+  <span class="section-num">03</span>
+  <h2 class="section-title">Workflow mix</h2>
+  <span class="section-meta" id="wf-count"></span>
+</div>
+<div class="two-col" style="margin-bottom:18px">
+  <div class="card" style="margin-bottom:0">
+    <div class="card-title">Runs by workflow</div>
+    <div class="card-sub">Bar = session count &middot; success rate over reported sessions only</div>
+    <div id="wf-bars"></div>
+  </div>
+  <div class="card" style="margin-bottom:0">
+    <div class="card-title">Share of sessions</div>
+    <div class="card-sub">By workflow type</div>
+    <div class="workflow-mix">
+      <svg id="donut" width="120" height="120" viewBox="0 0 120 120" style="flex-shrink:0"></svg>
+      <div class="donut-list" id="donut-list"></div>
     </div>
-    <div class="stats-bar" id="sess-stats"></div>
-    <div id="sess-list"></div>
-    <div class="pag" id="sess-pag"></div>
   </div>
 </div>
 
-<footer>WorkRail session metrics &middot; <a href="https://github.com/EtienneBBeaulac/workrail" style="color:var(--txt3)">github.com/EtienneBBeaulac/workrail</a></footer>
+<!-- SESSIONS -->
+<div class="section-hdr">
+  <span class="section-num">04</span>
+  <h2 class="section-title">Sessions</h2>
+  <span class="section-meta" id="sess-count-hdr"></span>
+</div>
+<div class="card">
+  <div class="controls">
+    <select id="sess-workflow"><option value="">All workflows</option></select>
+    <select id="sess-status">
+      <option value="">All statuses</option>
+      <option value="done">Completed</option>
+      <option value="partial">Incomplete</option>
+    </select>
+    <input type="text" id="sess-search" placeholder="Search goals, projects..." style="min-width:200px">
+  </div>
+  <div class="stats-bar" id="sess-stats"></div>
+  <div id="sess-list"></div>
+  <div class="pag" id="sess-pag"></div>
+</div>
+
+<footer>workrail &middot; <a href="https://github.com/EtienneBBeaulac/workrail" style="color:var(--txt3)">github.com/EtienneBBeaulac/workrail</a></footer>
 </div>
 
 <script>
 const SESSIONS = ${safeJson(sessionsJs)};
 const BREAKDOWN = ${safeJson(breakdown)};
 const HEATMAP = ${safeJson(heatmap)};
+const ACTIVITY = ${safeJson(activityData)};
 const PAGE_SIZE = 30;
 
-// Tab switching
-document.querySelectorAll('.tab').forEach(btn => {
-  btn.addEventListener('click', () => {
-    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
-    document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
-    btn.classList.add('active');
-    document.getElementById('view-' + btn.dataset.view).classList.add('active');
-  });
-});
-
-// Callout
+// ── Activity chart (stacked by outcome) ──────────────────────────────────────
 (function(){
-  const counts = {};
-  for (const s of SESSIONS) { if (s.completed) counts[s.workflow_label] = (counts[s.workflow_label]||0)+1; }
-  const totalDays = Math.max(1, Object.keys(HEATMAP).length);
-  const avgPerDay = Math.round(SESSIONS.length / totalDays);
-  const top = Object.entries(counts).sort((a,b)=>b[1]-a[1]).slice(0,3);
-  const parts = top.map(([l,n])=>'<strong>'+n+' '+l.toLowerCase()+(n===1?'':'s')+'</strong>');
-  document.getElementById('callout').innerHTML = parts.length
-    ? 'Over '+totalDays+' days, this agent completed '+parts.join(', ')+' and more -- running autonomously at an average of <strong>'+avgPerDay+' sessions per day</strong>.'
-    : 'No completed sessions in this window.';
-})();
-
-// Breakdown table
-(function(){
-  const tbody = document.getElementById('breakdown-body');
-  const max = Math.max(...BREAKDOWN.map(r=>r.completed),1);
-  let totS=0,totC=0;
-  for (const r of BREAKDOWN) {
-    const pct=Math.round(r.completed/max*100), rate=Math.round(r.completed/r.started*100);
-    const tr=document.createElement('tr');
-    tr.innerHTML='<td>'+r.label+'</td><td><div style="display:flex;align-items:center;gap:8px"><div class="bar-outer" style="flex:1"><div class="bar-inner" style="width:'+pct+'%"></div></div><span style="font-size:13px;font-weight:600;color:#1d1d1f;width:32px;text-align:right">'+r.completed+'</span></div></td><td class="r" style="color:#aeaeb2;font-size:12px">'+rate+'%</td><td class="r">'+r.median+'</td><td class="r" style="color:#1a7a3a">+'+(r.linesAdded||0).toLocaleString()+'</td>';
-    tbody.appendChild(tr); totS+=r.started; totC+=r.completed;
-  }
-  const tr=document.createElement('tr'); tr.className='total-row';
-  tr.innerHTML='<td>Total</td><td><div style="display:flex;align-items:center;gap:8px"><div class="bar-outer" style="flex:1"><div class="bar-inner" style="width:100%"></div></div><span style="font-size:13px;font-weight:600;color:#1d1d1f;width:32px;text-align:right">'+totC+'</span></div></td><td class="r" style="color:#aeaeb2;font-size:12px">'+Math.round(totC/Math.max(totS,1)*100)+'%</td><td class="r">--</td><td class="r">--</td>';
-  tbody.appendChild(tr);
-})();
-
-// Activity chart
-(function(){
-  const chart=document.getElementById('barchart'), axis=document.getElementById('barchart-axis'), yAxis=document.getElementById('y-axis');
+  const chart=document.getElementById('barchart'),axis=document.getElementById('barchart-axis'),yAxis=document.getElementById('y-axis');
+  const keys=Object.keys(HEATMAP).sort(); if(!keys.length)return;
   const entries=[];
-  const keys=Object.keys(HEATMAP).sort();
-  if(!keys.length) return;
-  const start=new Date(keys[0]), end=new Date(keys[keys.length-1]);
+  const start=new Date(keys[0]),end=new Date(keys[keys.length-1]);
   for(let d=new Date(start);d<=end;d.setDate(d.getDate()+1)){
     const k=d.toISOString().slice(0,10);
-    entries.push({date:k,label:d.toLocaleDateString('en-US',{month:'short',day:'numeric'}),count:HEATMAP[k]||0});
+    const a=ACTIVITY[k]||{success:0,partial:0,other:0};
+    entries.push({date:k,label:d.toLocaleDateString('en-US',{month:'short',day:'numeric'}),count:HEATMAP[k]||0,...a});
   }
   const max=Math.max(...entries.map(e=>e.count),1);
   [max,Math.round(max*.5),0].forEach(v=>{const el=document.createElement('div');el.className='y-label';el.textContent=v;yAxis.appendChild(el);});
   entries.forEach(e=>{
-    const isWe=new Date(e.date+'T12:00:00').getDay()===0||new Date(e.date+'T12:00:00').getDay()===6;
-    const bar=document.createElement('div'); bar.className='bc-bar';
-    bar.style.height=Math.max(2,Math.round(e.count/max*100))+'%';
-    if(isWe) bar.style.background='rgba(0,122,255,0.4)';
-    bar.setAttribute('data-tip',e.label+': '+e.count+' sessions');
-    chart.appendChild(bar);
-    const lbl=document.createElement('div'); lbl.className='bar-chart-label';
-    if([1,7,14,21,28].includes(new Date(e.date+'T12:00:00').getDate())) lbl.textContent=e.label;
+    const col=document.createElement('div');col.style.cssText='flex:1;display:flex;flex-direction:column-reverse;align-items:stretch;min-width:4px;gap:1px;height:'+Math.max(4,Math.round(e.count/max*100))+'%';
+    const mk=(h,c,tip)=>{if(!h)return;const b=document.createElement('div');b.className='bc-bar';b.style.cssText='flex:0 0 '+Math.round(h/e.count*100)+'%;background:'+c+';border-radius:0';b.setAttribute('data-tip',tip);col.appendChild(b);};
+    mk(e.success,'#34c759',e.label+' success: '+e.success);
+    mk(e.partial,'#ff9500',e.label+' partial: '+e.partial);
+    mk(e.other,'#e5e5ea',e.label+' unknown: '+e.other);
+    chart.appendChild(col);
+    const lbl=document.createElement('div');lbl.className='bar-chart-label';
+    if([1,7,14,21,28].includes(new Date(e.date+'T12:00:00').getDate()))lbl.textContent=e.label;
     axis.appendChild(lbl);
   });
 })();
 
-// Sessions
-let sp=1, sf=SESSIONS.slice();
+// ── Workflow bars + donut ─────────────────────────────────────────────────────
+(function(){
+  const COLORS=['#007aff','#34c759','#ff9500','#af52de','#ff3b30','#5ac8fa','#ffcc00','#ff6b6b','#00c7be','#30b0c7'];
+  document.getElementById('wf-count').textContent=BREAKDOWN.length+' workflows used';
+  const container=document.getElementById('wf-bars');
+  const maxS=Math.max(...BREAKDOWN.map(r=>r.started),1);
+  BREAKDOWN.forEach((r,i)=>{
+    const ok=r.started>0?Math.round(r.completed/r.started*100):0;
+    const div=document.createElement('div');
+    div.style.cssText='display:flex;align-items:center;gap:10px;padding:7px 0;border-bottom:1px solid #f2f2f7;font-size:12px';
+    div.innerHTML='<div style="width:8px;height:8px;border-radius:50%;background:'+COLORS[i%COLORS.length]+';flex-shrink:0"></div>'+
+      '<span style="flex:1;color:#1d1d1f;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">'+r.label+'</span>'+
+      '<div style="width:100px;background:#f2f2f7;border-radius:4px;height:14px;overflow:hidden;flex-shrink:0"><div style="width:'+Math.round(r.started/maxS*100)+'%;height:100%;background:'+COLORS[i%COLORS.length]+';opacity:.7"></div></div>'+
+      '<span style="color:#6e6e73;width:50px;text-align:right;white-space:nowrap">'+r.started+' &middot; '+ok+'%</span>'+
+      '<span style="color:#6e6e73;width:48px;text-align:right">'+r.median+'</span>';
+    container.appendChild(div);
+  });
+  // Donut
+  const svg=document.getElementById('donut');
+  const list=document.getElementById('donut-list');
+  const total=BREAKDOWN.reduce((a,r)=>a+r.started,0);
+  let ang=-Math.PI/2;
+  BREAKDOWN.slice(0,8).forEach((r,i)=>{
+    const frac=r.started/Math.max(total,1);
+    const a2=ang+frac*2*Math.PI;
+    const x1=60+50*Math.cos(ang),y1=60+50*Math.sin(ang);
+    const x2=60+50*Math.cos(a2),y2=60+50*Math.sin(a2);
+    const large=frac>.5?1:0;
+    const path=document.createElementNS('http://www.w3.org/2000/svg','path');
+    path.setAttribute('d','M 60 60 L '+x1+' '+y1+' A 50 50 0 '+large+' 1 '+x2+' '+y2+' Z');
+    path.setAttribute('fill',COLORS[i%COLORS.length]);
+    svg.appendChild(path);
+    // Center hole
+    const hole=document.createElementNS('http://www.w3.org/2000/svg','circle');
+    hole.setAttribute('cx','60');hole.setAttribute('cy','60');hole.setAttribute('r','30');hole.setAttribute('fill','white');
+    svg.appendChild(hole);
+    // Center label
+    const ct=document.createElementNS('http://www.w3.org/2000/svg','text');
+    ct.setAttribute('x','60');ct.setAttribute('y','57');ct.setAttribute('text-anchor','middle');ct.setAttribute('font-size','16');ct.setAttribute('font-weight','700');ct.setAttribute('fill','#1d1d1f');ct.textContent=total;
+    svg.appendChild(ct);
+    const cl=document.createElementNS('http://www.w3.org/2000/svg','text');
+    cl.setAttribute('x','60');cl.setAttribute('y','70');cl.setAttribute('text-anchor','middle');cl.setAttribute('font-size','9');cl.setAttribute('fill','#6e6e73');cl.textContent='sessions';
+    svg.appendChild(cl);
+    // List
+    const row=document.createElement('div');row.className='donut-list-row';
+    row.innerHTML='<div class="donut-dot" style="background:'+COLORS[i%COLORS.length]+'"></div>'+
+      '<span style="flex:1;color:#1d1d1f">'+r.label+'</span>'+
+      '<span style="color:#6e6e73;margin-left:8px">'+r.started+'</span>'+
+      '<span style="color:#aeaeb2;margin-left:6px;width:30px;text-align:right">'+Math.round(frac*100)+'%</span>';
+    list.appendChild(row);
+    ang=a2;
+  });
+})();
+
+// ── Sessions ──────────────────────────────────────────────────────────────────
+let sp=1,sf=SESSIONS.slice();
 (function(){
   const sel=document.getElementById('sess-workflow');
   [...new Set(SESSIONS.map(s=>s.workflow_label))].sort().forEach(l=>{const o=document.createElement('option');o.value=l;o.textContent=l;sel.appendChild(o);});
-  document.getElementById('sess-total').textContent=SESSIONS.length.toLocaleString()+' total sessions.';
+  document.getElementById('sess-count-hdr').textContent=SESSIONS.length.toLocaleString()+' total';
 })();
 function fD(m){if(!m)return'--';return m<60?Math.round(m)+'m':(m/60).toFixed(1)+'h';}
-function fT(n){if(!n)return'--';if(n>=1e6)return(n/1e6).toFixed(1)+'M';if(n>=1e3)return Math.round(n/1e3)+'k';return n;}
-function fC(c){if(!c)return'--';return c>=100?'$'+(c/100).toFixed(0):'$'+(c/100).toFixed(2);}
+function fT(n){if(!n)return'--';if(n>=1e6)return(n/1e6).toFixed(1)+'M';if(n>=1e3)return Math.round(n/1e3)+'k';return String(n);}
+function fC(c){if(!c)return null;return c>=100?'$'+(c/100).toFixed(0):'$'+(c/100).toFixed(2);}
 function applyF(){
   const wf=document.getElementById('sess-workflow').value;
   const st=document.getElementById('sess-status').value;
   const q=document.getElementById('sess-search').value.toLowerCase();
-  sf=SESSIONS.filter(s=>
-    (!wf||s.workflow_label===wf)&&
-    (!st||(st==='done'?s.completed:!s.completed))&&
-    (!q||s.goal.toLowerCase().includes(q)||s.project.toLowerCase().includes(q)||s.date.includes(q))
-  );
-  sp=1; renderS();
+  sf=SESSIONS.filter(s=>(!wf||s.workflow_label===wf)&&(!st||(st==='done'?s.completed:!s.completed))&&(!q||s.goal.toLowerCase().includes(q)||s.project.toLowerCase().includes(q)||s.date.includes(q)));
+  sp=1;renderS();
 }
 function renderS(){
   const list=document.getElementById('sess-list');
-  const total=sf.length, start=(sp-1)*PAGE_SIZE, page=sf.slice(start,Math.min(start+PAGE_SIZE,total));
+  const total=sf.length,start=(sp-1)*PAGE_SIZE,page=sf.slice(start,Math.min(start+PAGE_SIZE,total));
   const comp=sf.filter(s=>s.completed).length;
+  const tLines=sf.reduce((a,s)=>a+s.lines_added,0);
   const avgD=sf.filter(s=>s.duration_min).reduce((a,s)=>a+s.duration_min,0)/(sf.filter(s=>s.duration_min).length||1);
-  const totalLines=sf.reduce((a,s)=>a+s.lines_added,0);
   document.getElementById('sess-stats').innerHTML=
     '<div><span class="stat-val">'+total+'</span> <span class="stat-lbl">sessions</span></div>'+
     '<div><span class="stat-val" style="color:#34c759">'+comp+'</span> <span class="stat-lbl">completed</span></div>'+
     '<div><span class="stat-val">'+Math.round(comp/Math.max(total,1)*100)+'%</span> <span class="stat-lbl">rate</span></div>'+
+    (tLines?'<div><span class="stat-val trust trust-engine" style="font-size:12px">+'+tLines.toLocaleString()+' lines</span></div>':'')+
     '<div><span class="stat-val">'+fD(Math.round(avgD*10)/10)+'</span> <span class="stat-lbl">avg duration</span></div>'+
-    '<div><span class="stat-val" style="color:#1a7a3a">+'+totalLines.toLocaleString()+'</span> <span class="stat-lbl">lines added</span></div>'+
-    '<div style="margin-left:auto;font-size:11px;color:#aeaeb2">Showing '+(start+1)+'&#8211;'+Math.min(start+PAGE_SIZE,total)+'</div>';
+    '<div style="margin-left:auto;font-size:11px;color:#aeaeb2">'+( start+1)+'&#8211;'+Math.min(start+PAGE_SIZE,total)+'</div>';
   list.innerHTML='';
   for(const s of page){
-    const div=document.createElement('div'); div.className='sess-item';
-    const ob=s.outcome?'<span class="badge b-'+s.outcome+'">'+s.outcome+'</span>':'';
-    const mp=[];
-    if(s.lines_added) mp.push('<span style="color:#1a7a3a">+'+s.lines_added+' lines</span>');
-    if(s.tokens) mp.push(fT(s.tok_in+s.tok_out)+' tokens');
-    if(s.est_cost_cents) mp.push(fC(s.est_cost_cents));
-    if(s.steps) mp.push(s.steps+' steps');
-    if(s.retries) mp.push('<span style="color:#ff9500">'+s.retries+' retries</span>');
-    if(s.commit_count) mp.push(s.commit_count+' commit'+(s.commit_count>1?'s':''));
-    if(s.model) mp.push('<span style="color:#aeaeb2">'+s.model+'</span>');
-    const meta=mp.length?'<div class="sess-meta">'+mp.join(' &middot; ')+'</div>':'';
+    const div=document.createElement('div');div.className='sess-item';
+    // Tags row
+    const tags=[];
+    if(s.lines_added>0) tags.push('<span class="trust trust-engine" style="font-size:10px">+'+s.lines_added+' lines</span>');
+    if(s.tok_in+s.tok_out>0) tags.push('<span class="trust trust-engine" style="font-size:10px">'+fT(s.tok_in+s.tok_out)+' tok</span>');
+    const cost=fC(s.est_cost_cents);
+    if(cost) tags.push('<span class="trust trust-interp" style="font-size:10px">'+cost+'</span>');
+    if(s.pr_refs.length) tags.push('<span class="trust trust-interp" style="font-size:10px">'+s.pr_refs.length+' PR'+(s.pr_refs.length>1?'s':'')+'</span>');
+    if(s.retries>0) tags.push('<span class="trust trust-agent" style="font-size:10px;color:#ff9500">'+s.retries+' retr.</span>');
+    if(s.outcome) tags.push('<span class="badge b-'+s.outcome+'" style="font-size:10px">'+s.outcome+'</span>');
     div.innerHTML=
       '<div class="sess-date">'+s.date+'</div>'+
       '<div><div class="sess-dot '+(s.completed?'dot-done':'dot-skip')+'"></div></div>'+
-      '<div class="sess-wf" title="'+s.workflow_id+'">'+s.workflow_label+(s.project?'<br><span style="font-weight:400;color:#aeaeb2">'+s.project+'</span>':'')+'</div>'+
-      '<div><div class="'+(s.goal?'sess-goal':'sess-no-goal')+'">'+(s.goal||'No goal recorded')+'</div>'+meta+'</div>'+
-      '<div>'+ob+'</div>'+
-      '<div class="sess-num">'+fD(s.duration_min)+'</div>';
+      '<div class="sess-body">'+
+        '<div class="sess-wf">'+s.workflow_label+(s.project?' &middot; <span style="font-weight:400;color:#aeaeb2">'+s.project+'</span>':'')+'</div>'+
+        '<div class="'+(s.goal?'sess-goal':'sess-no-goal')+'">'+(s.goal||'No goal recorded')+'</div>'+
+        (tags.length?'<div class="sess-tags">'+tags.join('')+'</div>':'')+
+      '</div>'+
+      '<div class="sess-nums">'+
+        '<div class="sess-num-main">'+fD(s.duration_min)+'</div>'+
+        (s.steps?'<div class="sess-num-sub">'+s.steps+' steps</div>':'')+
+      '</div>';
     list.appendChild(div);
   }
-  // Pagination
-  const pag=document.getElementById('sess-pag'); pag.innerHTML='';
-  const pages=Math.ceil(total/PAGE_SIZE); if(pages<=1)return;
-  const prev=document.createElement('button'); prev.className='pg-btn'; prev.textContent='Prev'; prev.disabled=sp===1;
-  prev.addEventListener('click',()=>{sp--;renderS();}); pag.appendChild(prev);
+  const pag=document.getElementById('sess-pag');pag.innerHTML='';
+  const pages=Math.ceil(total/PAGE_SIZE);if(pages<=1)return;
+  const prev=document.createElement('button');prev.className='pg-btn';prev.textContent='Prev';prev.disabled=sp===1;
+  prev.addEventListener('click',()=>{sp--;renderS();});pag.appendChild(prev);
   for(let p=Math.max(1,sp-2);p<=Math.min(pages,sp+2);p++){
-    const b=document.createElement('button'); b.className='pg-btn'+(p===sp?' active':''); b.textContent=p;
-    b.addEventListener('click',()=>{sp=p;renderS();}); pag.appendChild(b);
+    const b=document.createElement('button');b.className='pg-btn'+(p===sp?' active':'');b.textContent=p;
+    b.addEventListener('click',()=>{sp=p;renderS();});pag.appendChild(b);
   }
-  const next=document.createElement('button'); next.className='pg-btn'; next.textContent='Next'; next.disabled=sp===pages;
-  next.addEventListener('click',()=>{sp++;renderS();}); pag.appendChild(next);
+  const next=document.createElement('button');next.className='pg-btn';next.textContent='Next';next.disabled=sp===pages;
+  next.addEventListener('click',()=>{sp++;renderS();});pag.appendChild(next);
 }
 ['sess-workflow','sess-status'].forEach(id=>document.getElementById(id).addEventListener('change',applyF));
 document.getElementById('sess-search').addEventListener('input',applyF);

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -341,84 +341,231 @@ function fmtTokens(n: number): string {
 }
 
 /**
- * HTML: self-contained report with KPI cards, workflow breakdown, and session
- * table. No external dependencies -- all CSS and JS are inlined.
- * changedFilePaths is excluded (same rule as all other formats).
- */
-/**
- * HTML: self-contained report with KPI cards, breakdown table with progress
- * bars, daily activity heatmap, and a paginated/filterable session list.
+ * HTML: self-contained report surfacing all 18 metric categories.
  *
- * Ported from the common-ground workrail-report design (stripped of
- * Zillow-specific MR feed and correlation tabs; enriched with engine
- * metrics: tokens, git diff, language breakdown, churn, step counts).
+ * Design: dark header with estimated cost dominant, 4 KPI cards, 5 tabs
+ * (Overview / Tokens & Cost / Activity / Quality / Sessions).
  *
- * No external deps -- all CSS and JS are inlined. changedFilePaths excluded.
+ * No external deps -- all CSS and JS inlined. changedFilePaths excluded.
+ * Goals are HTML-escaped before embedding to prevent XSS.
  */
 function renderHtml(output: ReportOutput): string {
   const { summary, sessions, dateRange, generatedAt } = output;
 
-  const totalTokens = summary.totalInputTokens + summary.totalOutputTokens +
-    summary.totalCacheReadTokens + summary.totalCacheWriteTokens;
+  // ── Aggregate helpers ────────────────────────────────────────────────────────
+  const inputTok  = summary.totalInputTokens;
+  const outputTok = summary.totalOutputTokens;
+  const cacheR    = summary.totalCacheReadTokens;
+  const cacheW    = summary.totalCacheWriteTokens;
+  const totalTokens = inputTok + outputTok + cacheR + cacheW;
+
+  // Estimated cost at Anthropic Sonnet 4.6 list prices (no actual model lookup --
+  // directional only). Displayed with disclaimer.
+  const PRICE_INPUT   = 3.00;   // $/1M
+  const PRICE_OUTPUT  = 15.00;
+  const PRICE_CACHE_R = 0.30;
+  const PRICE_CACHE_W = 3.75;
+  const estCostCents = Math.round(
+    (inputTok * PRICE_INPUT + outputTok * PRICE_OUTPUT +
+     cacheR * PRICE_CACHE_R + cacheW * PRICE_CACHE_W) / 1_000_000 * 100,
+  );
+  const estCostStr = estCostCents >= 100
+    ? `$${(estCostCents / 100).toFixed(0)}`
+    : `$${(estCostCents / 100).toFixed(2)}`;
+
   const completionPct = summary.totalSessions > 0
     ? Math.round((summary.completedSessions / summary.totalSessions) * 100) : 0;
   const totalHours = (summary.totalDurationMs / 3_600_000).toFixed(1);
 
-  // Build SESSIONS JS array for client-side rendering
+  // ── Per-session JS data ──────────────────────────────────────────────────────
   const sessionsJs = sessions.map((s) => {
-    const m = s.metrics;
-    const ge = m?.gitEvidence ?? null;
-    const td = m?.tokenDelta ?? null;
-    const usage = m?.usageEvents[0] ?? null;
-    const tokens = td
-      ? td.inputTokens + td.outputTokens
-      : (usage ? usage.inputTokens + usage.outputTokens : 0);
-    const linesAdded = ge?.committedDiff?.linesAdded ?? m?.linesAdded ?? 0;
-    const durationMin = m?.durationMs != null ? Math.round(m.durationMs / 60_000 * 10) / 10 : null;
-    const project = s.repoRoot ? s.repoRoot.split('/').pop() ?? '' : '';
+    const m   = s.metrics;
+    const ge  = m?.gitEvidence ?? null;
+    const td  = m?.tokenDelta ?? null;
+    const u0  = m?.usageEvents[0] ?? null;
+    const tokIn  = td?.inputTokens  ?? u0?.inputTokens  ?? 0;
+    const tokOut = td?.outputTokens ?? u0?.outputTokens ?? 0;
+    const tokCR  = td?.cacheReadTokens  ?? u0?.cacheReadTokens  ?? 0;
+    const tokCW  = td?.cacheWriteTokens ?? u0?.cacheWriteTokens ?? 0;
+    const linesAdded   = ge?.committedDiff?.linesAdded   ?? m?.linesAdded   ?? 0;
+    const linesRemoved = ge?.committedDiff?.linesRemoved ?? m?.linesRemoved ?? 0;
+    const filesChanged = ge?.committedDiff?.filesChanged ?? m?.filesChanged ?? 0;
+    const durationMin  = m?.durationMs != null ? Math.round(m.durationMs / 60_000 * 10) / 10 : null;
+    const project = s.repoRoot ? (s.repoRoot.split('/').pop() ?? '') : '';
+    const wfLabel = (s.workflowId ?? '')
+      .replace(/^wr\./, '')
+      .replace(/-/g, ' ')
+      .replace(/\b\w/g, (c) => c.toUpperCase()) || 'Unknown';
+    // Estimated session cost at list pricing
+    const sessEstCost = Math.round(
+      (tokIn * PRICE_INPUT + tokOut * PRICE_OUTPUT +
+       tokCR * PRICE_CACHE_R + tokCW * PRICE_CACHE_W) / 1_000_000 * 100,
+    );
     return {
-      date: s.date,
-      workflow_id: s.workflowId ?? '',
-      workflow_label: s.workflowId?.replace(/^wr\./, '').replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()) ?? 'Unknown',
+      date:          s.date,
+      workflow_id:   s.workflowId ?? '',
+      workflow_label: wfLabel,
       project,
-      completed: m?.outcome === 'success' || m?.outcome === 'partial',
-      outcome: m?.outcome ?? null,
-      goal: htmlEscape(s.goal ?? ''),
-      duration_min: durationMin,
-      lines_added: linesAdded,
-      tokens,
-      steps: m?.stepsCompleted ?? 0,
-      retries: m?.retriesCount ?? 0,
-      churn: ge?.churnSignal?.filesRemodified ?? null,
-      language: ge?.committedDiff?.languageBreakdown ?? {},
-      model: usage?.model ?? null,
+      repoRoot:      s.repoRoot ?? '',
+      completed:     m?.outcome === 'success' || m?.outcome === 'partial',
+      outcome:       m?.outcome ?? null,
+      goal:          htmlEscape(s.goal ?? ''),
+      trigger:       s.triggerSource,
+      duration_min:  durationMin,
+      lines_added:   linesAdded,
+      lines_removed: linesRemoved,
+      files_changed: filesChanged,
+      tok_in:        tokIn,
+      tok_out:       tokOut,
+      tok_cache_r:   tokCR,
+      tok_cache_w:   tokCW,
+      est_cost_cents: sessEstCost,
+      steps:         m?.stepsCompleted ?? 0,
+      retries:       m?.retriesCount ?? 0,
+      git_branch:    m?.gitBranch ?? null,
+      commit_count:  ge?.commitShas.length ?? 0,
+      pr_refs:       ge?.prRefs ?? [],
+      churn:         ge?.churnSignal?.filesRemodified ?? null,
+      lang:          ge?.committedDiff?.languageBreakdown ?? {},
+      model:         u0?.model ?? null,
+      confidence:    ge?.captureConfidence ?? m?.captureConfidence ?? null,
+      staged_start:  null as null,   // git_start_recorded not in SessionMetricsV2 projection yet
     };
   });
 
-  // BREAKDOWN: per-workflow started/completed/median-duration
-  const wfMap = new Map<string, { started: number; completed: number; durations: number[] }>();
+  // ── Breakdown: per-workflow ──────────────────────────────────────────────────
+  const wfMap = new Map<string, { started: number; completed: number; durations: number[]; linesAdded: number }>();
   for (const s of sessionsJs) {
     const label = s.workflow_label;
-    if (!wfMap.has(label)) wfMap.set(label, { started: 0, completed: 0, durations: [] });
-    const entry = wfMap.get(label)!;
-    entry.started++;
-    if (s.completed) entry.completed++;
-    if (s.duration_min != null) entry.durations.push(s.duration_min);
+    if (!wfMap.has(label)) wfMap.set(label, { started: 0, completed: 0, durations: [], linesAdded: 0 });
+    const e = wfMap.get(label)!;
+    e.started++;
+    if (s.completed) e.completed++;
+    if (s.duration_min != null) e.durations.push(s.duration_min);
+    e.linesAdded += s.lines_added;
   }
   const breakdown = Array.from(wfMap.entries()).map(([label, d]) => {
     const sorted = [...d.durations].sort((a, b) => a - b);
     const median = sorted.length ? sorted[Math.floor(sorted.length / 2)]!.toFixed(0) + 'm' : '--';
-    return { label, started: d.started, completed: d.completed, median };
+    return { label, started: d.started, completed: d.completed, median, linesAdded: d.linesAdded };
   }).sort((a, b) => b.completed - a.completed);
 
-  // HEATMAP: date -> count
-  const heatmap: Record<string, number> = {};
+  // ── Per-project breakdown ────────────────────────────────────────────────────
+  const projMap = new Map<string, { sessions: number; linesAdded: number; lang: Record<string, number> }>();
   for (const s of sessionsJs) {
-    heatmap[s.date] = (heatmap[s.date] ?? 0) + 1;
+    const p = s.project || '(unknown)';
+    if (!projMap.has(p)) projMap.set(p, { sessions: 0, linesAdded: 0, lang: {} });
+    const e = projMap.get(p)!;
+    e.sessions++;
+    e.linesAdded += s.lines_added;
+    for (const [ext, cnt] of Object.entries(s.lang)) {
+      e.lang[ext] = (e.lang[ext] ?? 0) + (cnt as number);
+    }
   }
+  const projects = Array.from(projMap.entries())
+    .map(([name, d]) => ({ name, sessions: d.sessions, linesAdded: d.linesAdded, lang: d.lang }))
+    .sort((a, b) => b.sessions - a.sessions);
+
+  // ── Heatmap: date → count ───────────────────────────────────────────────────
+  const heatmap: Record<string, number> = {};
+  for (const s of sessionsJs) { heatmap[s.date] = (heatmap[s.date] ?? 0) + 1; }
+
+  // ── Language breakdown (aggregate) ──────────────────────────────────────────
+  const langAgg: Record<string, number> = { ...summary.languageBreakdown };
+  const langTotal = Object.values(langAgg).reduce((a, n) => a + n, 0);
+
+  // Blue-family palette for language bars (single-hue, varying opacity) --
+  // avoids multi-hue competition with the header accent per blind review finding.
+  const langOpacities = [1, 0.75, 0.55, 0.38, 0.24, 0.14];
+  const langEntries = Object.entries(langAgg)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 6)
+    .map(([ext, cnt], i) => ({
+      ext: ext || '(none)',
+      cnt,
+      pct: langTotal > 0 ? Math.round(cnt / langTotal * 100) : 0,
+      opacity: langOpacities[i] ?? 0.1,
+    }));
+
+  // ── Quality signals ──────────────────────────────────────────────────────────
+  const sessWithRetries = sessionsJs.filter(s => s.steps > 0);
+  const avgRetryRate = sessWithRetries.length > 0
+    ? (sessWithRetries.reduce((a, s) => a + s.retries / Math.max(s.steps, 1), 0) / sessWithRetries.length * 100).toFixed(1)
+    : '0';
+  const sessWithChurn = sessionsJs.filter(s => s.churn != null);
+  const avgChurn = sessWithChurn.length > 0
+    ? (sessWithChurn.reduce((a, s) => a + (s.churn ?? 0), 0) / sessWithChurn.length).toFixed(1)
+    : null;
+  const confHigh    = sessionsJs.filter(s => s.confidence === 'high').length;
+  const confPartial = sessionsJs.filter(s => s.confidence === 'partial').length;
+  const confNone    = sessionsJs.filter(s => s.confidence === 'none').length;
+
+  // ── Token cost data for Tokens tab ──────────────────────────────────────────
+  const modelMap = new Map<string, { inp: number; out: number; cr: number; cw: number; count: number }>();
+  for (const s of sessionsJs) {
+    const key = s.model ?? '(unknown)';
+    if (!modelMap.has(key)) modelMap.set(key, { inp: 0, out: 0, cr: 0, cw: 0, count: 0 });
+    const e = modelMap.get(key)!;
+    e.inp += s.tok_in; e.out += s.tok_out; e.cr += s.tok_cache_r; e.cw += s.tok_cache_w; e.count++;
+  }
+  const modelBreakdown = Array.from(modelMap.entries())
+    .map(([model, d]) => ({ model, ...d }))
+    .sort((a, b) => (b.inp + b.out) - (a.inp + a.out));
 
   const safeJson = (v: unknown) => JSON.stringify(v).replace(/<\//g, '<\\/');
 
+  // ── Language bar HTML (single blue family, varying opacity) ─────────────────
+  const langBarsHtml = langEntries.map(({ ext, cnt, pct, opacity }) =>
+    `<div style="display:flex;align-items:center;gap:10px;padding:7px 0;border-bottom:1px solid #f2f2f7">
+      <span style="font-size:13px;flex:1;color:#1d1d1f">${htmlEscape(ext)}</span>
+      <div style="flex:2;background:#f2f2f7;border-radius:var(--radius-sm);height:14px;overflow:hidden">
+        <div style="width:${pct}%;height:100%;background:rgba(0,122,255,${opacity});border-radius:var(--radius-sm)"></div>
+      </div>
+      <span style="font-size:11px;color:#6e6e73;width:40px;text-align:right;font-variant-numeric:tabular-nums">${cnt.toLocaleString()}</span>
+    </div>`,
+  ).join('') || '<p style="color:#aeaeb2;font-size:13px">No language data available</p>';
+
+  // ── Per-project rows HTML ────────────────────────────────────────────────────
+  const maxProjSessions = Math.max(...projects.map(p => p.sessions), 1);
+  const projRowsHtml = projects.slice(0, 10).map((p) => {
+    const barPct = Math.round(p.sessions / maxProjSessions * 100);
+    const topLang = Object.entries(p.lang).sort(([, a], [, b]) => b - a).slice(0, 3)
+      .map(([ext]) => ext).join(' ');
+    return `<tr>
+      <td style="font-weight:600">${htmlEscape(p.name)}</td>
+      <td><div style="display:flex;align-items:center;gap:8px"><div style="flex:1;background:#f2f2f7;border-radius:var(--radius-sm);height:18px;position:relative;overflow:hidden;min-width:80px"><div style="position:absolute;left:0;top:0;height:100%;width:${barPct}%;background:#007aff;border-radius:var(--radius-sm)"></div></div><span style="font-size:13px;font-weight:600;color:#1d1d1f;width:32px;text-align:right">${p.sessions}</span></div></td>
+      <td style="text-align:right;color:#1a7a3a;font-variant-numeric:tabular-nums">+${p.linesAdded.toLocaleString()}</td>
+      <td style="text-align:right;font-size:11px;color:#aeaeb2">${htmlEscape(topLang)}</td>
+    </tr>`;
+  }).join('') || '<tr><td colspan="4" style="color:#aeaeb2;text-align:center;padding:12px">No project data</td></tr>';
+
+  // ── Token split rows ─────────────────────────────────────────────────────────
+  const tokCards = [
+    { label: 'Input tokens',      val: inputTok,  price: PRICE_INPUT,   note: `$${PRICE_INPUT}/1M` },
+    { label: 'Output tokens',     val: outputTok, price: PRICE_OUTPUT,  note: `$${PRICE_OUTPUT}/1M` },
+    { label: 'Cache reads',       val: cacheR,    price: PRICE_CACHE_R, note: `$${PRICE_CACHE_R}/1M (10x cheaper)` },
+    { label: 'Cache writes',      val: cacheW,    price: PRICE_CACHE_W, note: `$${PRICE_CACHE_W}/1M` },
+  ].map(({ label, val, price, note }) => {
+    const cost = (val * price / 1_000_000);
+    return `<div style="background:#f5f5f7;border-radius:var(--radius-sm);padding:16px 20px">
+      <div style="font-size:22px;font-weight:700;letter-spacing:-0.5px;color:#1d1d1f">${fmtTokens(val)}</div>
+      <div style="font-size:12px;color:#6e6e73;margin-top:2px">${htmlEscape(label)}</div>
+      <div style="font-size:11px;color:#aeaeb2;margin-top:4px">${note} &middot; ~$${cost.toFixed(2)}</div>
+    </div>`;
+  }).join('');
+
+  const modelRowsHtml = modelBreakdown.map((m) => {
+    const totalTok = m.inp + m.out + m.cr + m.cw;
+    const cost = (m.inp * PRICE_INPUT + m.out * PRICE_OUTPUT + m.cr * PRICE_CACHE_R + m.cw * PRICE_CACHE_W) / 1_000_000;
+    return `<tr>
+      <td style="font-weight:600">${htmlEscape(m.model)}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums">${fmtTokens(totalTok)}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums">${m.count}</td>
+      <td style="text-align:right;color:#6e6e73">~$${cost.toFixed(2)}</td>
+    </tr>`;
+  }).join('') || '<tr><td colspan="4" style="color:#aeaeb2;text-align:center;padding:12px">No token data (requires Claude Code JSONL)</td></tr>';
+
+  // ── Main HTML output ─────────────────────────────────────────────────────────
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -426,111 +573,236 @@ function renderHtml(output: ReportOutput): string {
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>WorkRail Report -- ${htmlEscape(dateRange.since)} to ${htmlEscape(dateRange.until)}</title>
 <style>
+:root{
+  --bg:#f5f5f7;--surface:#fff;--hdr:#1d1d1f;
+  --accent:#007aff;--txt:#1d1d1f;--txt2:#6e6e73;--txt3:#aeaeb2;
+  --border:#f2f2f7;--border2:#e5e5ea;
+  --success:#34c759;--error:#ff3b30;--warn:#ff9500;
+  --radius:14px;--radius-sm:6px;--radius-pill:20px;
+  --shadow:0 1px 4px rgba(0,0,0,.07);
+  --font:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  --space-micro:2px;--space-half:4px;
+}
 *{box-sizing:border-box;margin:0;padding:0}
-body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f5f5f7;color:#1d1d1f;padding:40px 24px}
-.container{max-width:940px;margin:0 auto}
-header{margin-bottom:28px}
-header h1{font-size:24px;font-weight:700;letter-spacing:-0.4px;margin-bottom:5px}
-header p{font-size:13px;color:#6e6e73}
-.callout{background:#fff;border-radius:14px;padding:20px 24px;box-shadow:0 1px 4px rgba(0,0,0,.07);margin-bottom:20px;font-size:14px;line-height:1.65}
+body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1.5;min-height:100vh}
+
+/* DARK HEADER */
+.site-header{background:var(--hdr);padding:28px 40px 20px}
+.hdr-inner{max-width:940px;margin:0 auto;display:flex;align-items:flex-start;justify-content:space-between;gap:40px}
+.hdr-cost-value{font-size:64px;font-weight:700;letter-spacing:-2.5px;color:#fff;line-height:1}
+.hdr-cost-label{font-size:12px;color:rgba(255,255,255,.55);margin-top:var(--space-half)}
+.hdr-cost-disclaimer{font-size:10px;color:rgba(255,255,255,.28);margin-top:var(--space-micro)}
+.hdr-stats{display:flex;gap:40px;align-items:flex-start;padding-top:10px;border-left:1px solid rgba(255,255,255,.1);padding-left:40px}
+.hdr-stat-value{font-size:32px;font-weight:700;letter-spacing:-1px;color:rgba(255,255,255,.8);line-height:1}
+.hdr-stat-label{font-size:11px;color:rgba(255,255,255,.4);margin-top:var(--space-half)}
+.hdr-meta{background:var(--hdr);border-top:1px solid rgba(255,255,255,.06);padding:8px 40px}
+.hdr-meta-inner{max-width:940px;margin:0 auto;display:flex;justify-content:space-between;font-size:11px;color:rgba(255,255,255,.25)}
+
+/* MAIN */
+.main{max-width:940px;margin:0 auto;padding:28px 24px}
+
+/* CALLOUT */
+.callout{background:var(--surface);border-radius:var(--radius);padding:20px 24px;box-shadow:var(--shadow);margin-bottom:20px;font-size:14px;line-height:1.65}
+
+/* KPI ROW */
 .kpi-row{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:20px}
-.kpi{background:#fff;border-radius:14px;padding:18px 20px;box-shadow:0 1px 4px rgba(0,0,0,.07)}
-.kpi .value{font-size:30px;font-weight:700;letter-spacing:-1px;line-height:1;margin-bottom:4px;color:#007aff}
-.kpi .label{font-size:12px;color:#6e6e73;line-height:1.4}
+.kpi{background:var(--surface);border-radius:var(--radius);padding:18px 20px;box-shadow:var(--shadow)}
+.kpi-value{font-size:30px;font-weight:700;letter-spacing:-1px;line-height:1;margin-bottom:var(--space-half);color:var(--accent)}
+.kpi-label{font-size:12px;color:var(--txt2);line-height:1.4}
+.kpi-sub{font-size:10px;color:var(--txt3);margin-top:var(--space-micro)}
+
+/* TABS */
 .tabs{display:flex;gap:6px;margin-bottom:20px;flex-wrap:wrap}
-.tab{padding:7px 16px;border-radius:20px;font-size:13px;font-weight:500;cursor:pointer;border:1.5px solid transparent;background:#fff;color:#3a3a3c;box-shadow:0 1px 3px rgba(0,0,0,.08);transition:all .15s}
-.tab:hover{border-color:#007aff;color:#007aff}
-.tab.active{background:#007aff;color:#fff;border-color:#007aff}
+.tab{padding:7px 16px;border-radius:var(--radius-pill);font-size:13px;font-weight:500;cursor:pointer;border:1.5px solid transparent;background:var(--surface);color:#3a3a3c;box-shadow:0 1px 3px rgba(0,0,0,.08);transition:all .15s;font-family:var(--font)}
+.tab:hover{border-color:var(--accent);color:var(--accent)}
+.tab.active{background:var(--accent);color:#fff;border-color:var(--accent)}
 .view{display:none}.view.active{display:block}
-.card{background:#fff;border-radius:14px;padding:24px 26px;box-shadow:0 1px 4px rgba(0,0,0,.07);margin-bottom:18px}
-.card h2{font-size:15px;font-weight:600;margin-bottom:3px}
-.card .subtitle{font-size:12px;color:#6e6e73;margin-bottom:18px}
-.breakdown-table{width:100%;border-collapse:collapse;font-size:13px}
-.breakdown-table th{text-align:left;padding:0 10px 10px 0;font-size:11px;font-weight:600;letter-spacing:.4px;text-transform:uppercase;color:#aeaeb2;border-bottom:1px solid #f2f2f7}
-.breakdown-table th.right{text-align:right}
-.breakdown-table td{padding:8px 10px 8px 0;border-bottom:1px solid #f2f2f7;vertical-align:middle}
-.breakdown-table td.right{text-align:right;color:#6e6e73}
-.breakdown-table tr:last-child td{border-bottom:none}
-.total-row td{padding-top:12px;font-weight:600;border-top:2px solid #e5e5ea;border-bottom:none!important}
-.bar-outer{background:#f2f2f7;border-radius:4px;height:18px;position:relative;overflow:hidden;min-width:120px}
-.bar-inner{background:#007aff;border-radius:4px;height:100%;position:absolute;top:0;left:0}
+
+/* CARDS */
+.card{background:var(--surface);border-radius:var(--radius);padding:24px 26px;box-shadow:var(--shadow);margin-bottom:18px}
+.card h2{font-size:17px;font-weight:600;margin-bottom:var(--space-micro)}
+.card-sub{font-size:12px;color:var(--txt2);margin-bottom:18px}
+
+/* TWO-COL GRID */
+.two-col{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+
+/* TABLES */
+.tbl{width:100%;border-collapse:collapse;font-size:13px}
+.tbl th{text-align:left;padding:0 10px 10px 0;font-size:11px;font-weight:600;letter-spacing:.4px;color:var(--txt3);border-bottom:1px solid var(--border)}
+.tbl th.r{text-align:right}
+.tbl td{padding:9px 10px 9px 0;border-bottom:1px solid var(--border);vertical-align:middle}
+.tbl td.r{text-align:right;color:var(--txt2);font-variant-numeric:tabular-nums}
+.tbl tr:last-child td{border-bottom:none}
+.total-row td{padding-top:12px;font-weight:600;border-top:2px solid var(--border2);border-bottom:none!important}
+
+/* BARS */
+.bar-outer{background:var(--border);border-radius:var(--radius-sm);height:18px;position:relative;overflow:hidden;min-width:80px}
+.bar-inner{background:var(--accent);border-radius:var(--radius-sm);height:100%;position:absolute;top:0;left:0}
+
+/* ACTIVITY CHART */
 .chart-wrap{position:relative}
 .y-axis{position:absolute;left:0;top:0;bottom:24px;width:32px;display:flex;flex-direction:column;justify-content:space-between;pointer-events:none}
-.y-label{font-size:10px;color:#aeaeb2;text-align:right;padding-right:6px}
+.y-label{font-size:10px;color:var(--txt3);text-align:right;padding-right:6px}
 .bar-chart-area{margin-left:36px}
-.bar-chart{display:flex;align-items:flex-end;gap:3px;height:140px;border-bottom:1px solid #e5e5ea;padding-bottom:0}
-.bar-chart-bar{flex:1;background:#007aff;border-radius:2px 2px 0 0;min-width:4px;position:relative;cursor:default;transition:opacity .1s}
-.bar-chart-bar:hover{opacity:.7}
-.bar-chart-bar:hover::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:#1d1d1f;color:#fff;font-size:11px;padding:4px 8px;border-radius:6px;white-space:nowrap;z-index:10;pointer-events:none}
+.bar-chart{display:flex;align-items:flex-end;gap:3px;height:140px;border-bottom:1px solid var(--border2)}
+.bc-bar{flex:1;background:var(--accent);border-radius:2px 2px 0 0;min-width:4px;position:relative;cursor:default;transition:opacity .1s}
+.bc-bar:hover{opacity:.7}
+.bc-bar:hover::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:var(--hdr);color:#fff;font-size:11px;padding:4px 8px;border-radius:var(--radius-sm);white-space:nowrap;z-index:10;pointer-events:none}
 .bar-chart-axis{display:flex;gap:3px;margin-top:4px}
-.bar-chart-label{flex:1;font-size:9px;color:#aeaeb2;text-align:center;overflow:hidden}
+.bar-chart-label{flex:1;font-size:9px;color:var(--txt3);text-align:center;overflow:hidden}
+
+/* SESSION LIST */
 .controls{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:14px;align-items:center}
-.controls select,.controls input{padding:6px 10px;border:1.5px solid #e5e5ea;border-radius:8px;font-size:12px;background:#fff;color:#1d1d1f;outline:none}
-.controls select:focus,.controls input:focus{border-color:#007aff}
-.stats-bar{display:flex;gap:20px;padding:10px 0 14px;border-bottom:1px solid #f2f2f7;margin-bottom:14px;font-size:12px;flex-wrap:wrap}
-.stat-item .stat-val{font-weight:600;color:#1d1d1f}
-.stat-item .stat-lbl{color:#6e6e73}
-.session-item{display:grid;grid-template-columns:76px 36px 160px 1fr 80px 70px 60px;gap:10px;align-items:start;padding:9px 0;border-bottom:1px solid #f2f2f7;font-size:13px}
-.session-item:last-child{border-bottom:none}
-.session-date{font-size:11px;color:#aeaeb2;padding-top:2px}
-.session-dot{width:8px;height:8px;border-radius:50%;margin-top:4px;flex-shrink:0}
-.dot-done{background:#34c759}.dot-partial{background:#e5e5ea;border:1.5px solid #aeaeb2}
-.session-wf{font-size:11px;font-weight:600;color:#6e6e73;padding-top:2px}
-.session-goal{line-height:1.4;color:#1d1d1f}
-.session-goal.no-goal{color:#aeaeb2;font-style:italic}
-.session-metrics{font-size:11px;color:#6e6e73;margin-top:3px}
-.outcome-badge{display:inline-block;font-size:10px;font-weight:700;padding:1px 6px;border-radius:8px;white-space:nowrap}
-.outcome-success{background:#e1f8ec;color:#1a7a3a}
-.outcome-partial{background:#fff8e0;color:#9a6000}
-.outcome-abandoned{background:#f5f5f5;color:#999}
-.outcome-error{background:#ffeaea;color:#c0392b}
-.sess-dur{font-size:11px;color:#6e6e73;text-align:right;padding-top:2px}
-.pagination{display:flex;gap:6px;justify-content:center;align-items:center;margin-top:16px;flex-wrap:wrap}
-.page-btn{padding:5px 11px;border:1.5px solid #e5e5ea;border-radius:8px;font-size:12px;cursor:pointer;background:#fff;color:#3a3a3c}
-.page-btn:hover:not(:disabled){border-color:#007aff;color:#007aff}
-.page-btn.active{background:#007aff;color:#fff;border-color:#007aff;cursor:default}
-.page-btn:disabled{opacity:.35;cursor:default}
-footer{text-align:center;font-size:11px;color:#aeaeb2;margin-top:24px}
-@media(max-width:600px){.kpi-row{grid-template-columns:repeat(2,1fr)}.session-item{grid-template-columns:60px 28px 1fr}}
+.controls select,.controls input{padding:6px 10px;border:1.5px solid var(--border2);border-radius:var(--radius-sm);font-size:12px;background:var(--surface);color:var(--txt);outline:none;font-family:var(--font)}
+.controls select:focus,.controls input:focus{border-color:var(--accent)}
+.stats-bar{display:flex;gap:20px;padding:10px 0 14px;border-bottom:1px solid var(--border);margin-bottom:14px;font-size:12px;flex-wrap:wrap}
+.stat-val{font-weight:600;color:var(--txt)}
+.stat-lbl{color:var(--txt2)}
+.sess-item{display:grid;grid-template-columns:76px 28px 150px 1fr 80px 70px;gap:10px;align-items:start;padding:9px 0;border-bottom:1px solid var(--border);font-size:13px}
+.sess-item:last-child{border-bottom:none}
+.sess-date{font-size:11px;color:var(--txt3);padding-top:2px}
+.sess-dot{width:8px;height:8px;border-radius:50%;margin-top:4px;flex-shrink:0}
+.dot-done{background:var(--success)}.dot-skip{background:var(--border2);border:1.5px solid var(--txt3)}
+.sess-wf{font-size:11px;font-weight:600;color:var(--txt2);padding-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.sess-goal{line-height:1.4;color:var(--txt)}
+.sess-no-goal{color:var(--txt3);font-style:italic}
+.sess-meta{font-size:11px;color:var(--txt2);margin-top:var(--space-micro)}
+.badge{display:inline-block;font-size:10px;font-weight:700;padding:1px 6px;border-radius:var(--radius-sm);white-space:nowrap}
+.b-success{background:#e1f8ec;color:#1a7a3a}
+.b-partial{background:#fff8e0;color:#9a6000}
+.b-abandoned{background:#f5f5f5;color:#999}
+.b-error{background:#ffeaea;color:var(--error)}
+.sess-num{font-size:11px;color:var(--txt2);text-align:right;padding-top:2px;font-variant-numeric:tabular-nums}
+.pag{display:flex;gap:6px;justify-content:center;align-items:center;margin-top:16px;flex-wrap:wrap}
+.pg-btn{padding:5px 11px;border:1.5px solid var(--border2);border-radius:var(--radius-sm);font-size:12px;cursor:pointer;background:var(--surface);color:#3a3a3c;font-family:var(--font)}
+.pg-btn:hover:not(:disabled){border-color:var(--accent);color:var(--accent)}
+.pg-btn.active{background:var(--accent);color:#fff;border-color:var(--accent);cursor:default}
+.pg-btn:disabled{opacity:.35;cursor:default}
+
+/* QUALITY */
+.qual-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
+.qual-card{background:var(--bg);border-radius:var(--radius-sm);padding:20px;text-align:center}
+.qual-value{font-size:28px;font-weight:700;letter-spacing:-1px}
+.qual-label{font-size:11px;color:var(--txt2);margin-top:var(--space-half)}
+.qual-note{font-size:10px;color:var(--txt3);margin-top:var(--space-micro)}
+
+footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:28px}
+@media(max-width:700px){.kpi-row{grid-template-columns:repeat(2,1fr)}.hdr-stats{display:none}.two-col{grid-template-columns:1fr}.qual-grid{grid-template-columns:repeat(2,1fr)}.sess-item{grid-template-columns:60px 24px 1fr}}
 </style>
 </head>
 <body>
-<div class="container">
-<header>
-  <h1>WorkRail Report</h1>
-  <p>${htmlEscape(dateRange.since)} to ${htmlEscape(dateRange.until)} &middot; Generated ${new Date(generatedAt).toLocaleString()}</p>
-</header>
+
+<!-- DARK HEADER -->
+<div class="site-header">
+  <div class="hdr-inner">
+    <div>
+      <div class="hdr-cost-value">${htmlEscape(estCostStr)}</div>
+      <div class="hdr-cost-label">ESTIMATED COST THIS PERIOD</div>
+      <div class="hdr-cost-disclaimer">Anthropic list pricing &middot; actual cost varies by tier &amp; model</div>
+    </div>
+    <div class="hdr-stats">
+      <div>
+        <div class="hdr-stat-value">${summary.totalSessions.toLocaleString()}</div>
+        <div class="hdr-stat-label">Sessions</div>
+      </div>
+      <div>
+        <div class="hdr-stat-value">${completionPct}%</div>
+        <div class="hdr-stat-label">Completion rate</div>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="hdr-meta">
+  <div class="hdr-meta-inner">
+    <span>WorkRail Report &middot; ${htmlEscape(dateRange.since)} to ${htmlEscape(dateRange.until)}</span>
+    <span>Generated ${new Date(generatedAt).toLocaleString()}</span>
+  </div>
+</div>
+
+<div class="main">
 
 <div class="callout" id="callout">Loading...</div>
 
 <div class="kpi-row">
-  <div class="kpi"><div class="value">${summary.totalSessions}</div><div class="label">Workflow runs<br><span style="font-size:10px;color:#aeaeb2">${completionPct}% completed</span></div></div>
-  <div class="kpi"><div class="value">${totalHours}h</div><div class="label">Autonomous runtime<br><span style="font-size:10px;color:#aeaeb2">wall clock</span></div></div>
-  <div class="kpi"><div class="value">${fmtTokens(totalTokens)}</div><div class="label">Tokens used<br><span style="font-size:10px;color:#aeaeb2">input + output + cache</span></div></div>
-  <div class="kpi"><div class="value">${fmtTokens(summary.totalLinesAdded)}</div><div class="label">Lines of code added<br><span style="font-size:10px;color:#aeaeb2">engine-authoritative</span></div></div>
+  <div class="kpi">
+    <div class="kpi-value">${totalHours}h</div>
+    <div class="kpi-label">Autonomous runtime</div>
+    <div class="kpi-sub">wall clock, ${dateRange.since} to ${dateRange.until}</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-value">${fmtTokens(summary.totalLinesAdded)}</div>
+    <div class="kpi-label">Lines of code added</div>
+    <div class="kpi-sub">engine-authoritative git diff</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-value">${fmtTokens(totalTokens)}</div>
+    <div class="kpi-label">Total tokens</div>
+    <div class="kpi-sub">input + output + cache</div>
+  </div>
+  <div class="kpi">
+    <div class="kpi-value">${fmtDuration(summary.totalDurationMs / summary.completedSessions || undefined)}</div>
+    <div class="kpi-label">Avg session duration</div>
+    <div class="kpi-sub">completed sessions only</div>
+  </div>
 </div>
 
 <div class="tabs">
-  <button class="tab active" data-view="breakdown">By workflow</button>
-  <button class="tab" data-view="activity">Daily activity</button>
+  <button class="tab active" data-view="overview">Overview</button>
+  <button class="tab" data-view="tokens">Tokens &amp; Cost</button>
+  <button class="tab" data-view="activity">Activity</button>
+  <button class="tab" data-view="quality">Quality</button>
   <button class="tab" data-view="sessions">Sessions</button>
 </div>
 
-<div class="view active" id="view-breakdown">
+<!-- OVERVIEW TAB -->
+<div class="view active" id="view-overview">
+  <div class="two-col">
+    <div class="card">
+      <h2>By project</h2>
+      <p class="card-sub">Sessions and lines added per repository</p>
+      <table class="tbl">
+        <thead><tr><th>Project</th><th>Sessions</th><th class="r">+Lines</th><th class="r">Languages</th></tr></thead>
+        <tbody>${projRowsHtml}</tbody>
+      </table>
+    </div>
+    <div class="card">
+      <h2>Language breakdown</h2>
+      <p class="card-sub">Files changed by extension across all sessions</p>
+      ${langBarsHtml}
+    </div>
+  </div>
   <div class="card">
-    <h2>Workflow breakdown</h2>
-    <p class="subtitle">Completion rate and median runtime per workflow type.</p>
-    <table class="breakdown-table">
-      <thead><tr><th>Workflow</th><th style="min-width:200px">Completed</th><th class="right">Rate</th><th class="right">Median</th></tr></thead>
+    <h2>By workflow</h2>
+    <p class="card-sub">Completion rate and median duration</p>
+    <table class="tbl">
+      <thead><tr><th>Workflow</th><th style="min-width:160px">Completed</th><th class="r">Rate</th><th class="r">Median</th><th class="r">+Lines</th></tr></thead>
       <tbody id="breakdown-body"></tbody>
     </table>
   </div>
 </div>
 
+<!-- TOKENS TAB -->
+<div class="view" id="view-tokens">
+  <div class="card">
+    <h2>Token cost breakdown</h2>
+    <p class="card-sub">Cache reads are priced at $0.30/1M vs $3.00/1M for input -- 10x cheaper. High cache hit rate means lower effective cost.</p>
+    <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:24px">
+      ${tokCards}
+    </div>
+    <h2 style="margin-bottom:12px">By model</h2>
+    <table class="tbl">
+      <thead><tr><th>Model</th><th class="r">Tokens</th><th class="r">Sessions</th><th class="r">Est. cost</th></tr></thead>
+      <tbody>${modelRowsHtml}</tbody>
+    </table>
+    <p style="font-size:11px;color:#aeaeb2;margin-top:16px">Estimates use Anthropic list pricing and do not account for enterprise agreements, Bedrock pricing, or prompt caching tier differences.</p>
+  </div>
+</div>
+
+<!-- ACTIVITY TAB -->
 <div class="view" id="view-activity">
   <div class="card">
     <h2>Daily activity</h2>
-    <p class="subtitle">Sessions started per day.</p>
+    <p class="card-sub">Sessions started per day. Blue = weekday, lighter = weekend.</p>
     <div class="chart-wrap">
       <div class="y-axis" id="y-axis"></div>
       <div class="bar-chart-area">
@@ -541,10 +813,52 @@ footer{text-align:center;font-size:11px;color:#aeaeb2;margin-top:24px}
   </div>
 </div>
 
+<!-- QUALITY TAB -->
+<div class="view" id="view-quality">
+  <div class="card">
+    <h2>Quality signals</h2>
+    <p class="card-sub">Step retries, code churn, and git capture confidence indicate output quality.</p>
+    <div class="qual-grid">
+      <div class="qual-card">
+        <div class="qual-value" style="color:${parseFloat(avgRetryRate) < 10 ? 'var(--success)' : parseFloat(avgRetryRate) < 25 ? 'var(--warn)' : 'var(--error)'}">${avgRetryRate}%</div>
+        <div class="qual-label">Avg retry rate</div>
+        <div class="qual-note">retries / steps per session</div>
+      </div>
+      <div class="qual-card">
+        <div class="qual-value" style="color:var(--accent)">${avgChurn ?? '--'}</div>
+        <div class="qual-label">Avg files re-modified</div>
+        <div class="qual-note">within 7 days of session end</div>
+      </div>
+      <div class="qual-card">
+        <div class="qual-value" style="color:var(--success)">${summary.totalStepsCompleted.toLocaleString()}</div>
+        <div class="qual-label">Steps completed</div>
+        <div class="qual-note">total across all sessions</div>
+      </div>
+    </div>
+    <h2 style="margin-top:24px;margin-bottom:12px">Git capture confidence</h2>
+    <p class="card-sub" style="margin-bottom:16px">High = authoritative diff from engine. Partial = SHA available but diff incomplete. None = no git data.</p>
+    <div style="display:flex;gap:24px;font-size:13px">
+      <div><span style="font-size:22px;font-weight:700;color:var(--success)">${confHigh}</span> <span style="color:var(--txt2)">high</span></div>
+      <div><span style="font-size:22px;font-weight:700;color:var(--warn)">${confPartial}</span> <span style="color:var(--txt2)">partial</span></div>
+      <div><span style="font-size:22px;font-weight:700;color:var(--txt3)">${confNone}</span> <span style="color:var(--txt2)">none</span></div>
+    </div>
+  </div>
+  <div class="card">
+    <h2>Outcome distribution</h2>
+    <p class="card-sub">Agent-reported outcomes (requires metricsProfile on workflow, ~53% coverage)</p>
+    <div style="display:flex;gap:24px;flex-wrap:wrap;font-size:13px">
+      ${Object.entries(summary.outcomeBreakdown).map(([outcome, count]) =>
+    `<div><span class="badge b-${outcome}" style="font-size:12px;padding:3px 10px">${outcome}</span> <strong style="margin-left:6px">${count}</strong></div>`,
+  ).join('')}
+    </div>
+  </div>
+</div>
+
+<!-- SESSIONS TAB -->
 <div class="view" id="view-sessions">
   <div class="card">
     <h2>Workflow runs</h2>
-    <p class="subtitle">All sessions in the report window. <span id="sess-total"></span></p>
+    <p class="card-sub"><span id="sess-total"></span></p>
     <div class="controls">
       <select id="sess-workflow"><option value="">All workflows</option></select>
       <select id="sess-status">
@@ -552,23 +866,24 @@ footer{text-align:center;font-size:11px;color:#aeaeb2;margin-top:24px}
         <option value="done">Completed</option>
         <option value="partial">Incomplete</option>
       </select>
-      <input type="text" id="sess-search" placeholder="Search goals..." style="min-width:180px">
+      <input type="text" id="sess-search" placeholder="Search goals, projects..." style="min-width:200px">
     </div>
     <div class="stats-bar" id="sess-stats"></div>
-    <div id="sess-list"><div style="padding:20px;text-align:center;color:#aeaeb2" id="sess-empty" ${sessions.length > 0 ? 'style="display:none"' : ''}>No sessions in window</div></div>
-    <div class="pagination" id="sess-pagination"></div>
+    <div id="sess-list"></div>
+    <div class="pag" id="sess-pag"></div>
   </div>
 </div>
 
-<footer>WorkRail session metrics &middot; <a href="https://github.com/EtienneBBeaulac/workrail" style="color:#aeaeb2">github.com/EtienneBBeaulac/workrail</a></footer>
+<footer>WorkRail session metrics &middot; <a href="https://github.com/EtienneBBeaulac/workrail" style="color:var(--txt3)">github.com/EtienneBBeaulac/workrail</a></footer>
 </div>
+
 <script>
 const SESSIONS = ${safeJson(sessionsJs)};
 const BREAKDOWN = ${safeJson(breakdown)};
 const HEATMAP = ${safeJson(heatmap)};
 const PAGE_SIZE = 30;
 
-// ── Tab switching ─────────────────────────────────────────────────────────────
+// Tab switching
 document.querySelectorAll('.tab').forEach(btn => {
   btn.addEventListener('click', () => {
     document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
@@ -578,150 +893,132 @@ document.querySelectorAll('.tab').forEach(btn => {
   });
 });
 
-// ── Callout ───────────────────────────────────────────────────────────────────
+// Callout
 (function(){
   const counts = {};
   for (const s of SESSIONS) { if (s.completed) counts[s.workflow_label] = (counts[s.workflow_label]||0)+1; }
-  const dates = Object.keys(HEATMAP).sort();
-  const totalDays = Math.max(1, dates.length);
+  const totalDays = Math.max(1, Object.keys(HEATMAP).length);
   const avgPerDay = Math.round(SESSIONS.length / totalDays);
-  const top = Object.entries(counts).sort((a,b) => b[1]-a[1]).slice(0,3);
-  const parts = top.map(([l,n]) => '<strong>' + n + ' ' + l.toLowerCase() + (n===1?'':'s') + '</strong>');
+  const top = Object.entries(counts).sort((a,b)=>b[1]-a[1]).slice(0,3);
+  const parts = top.map(([l,n])=>'<strong>'+n+' '+l.toLowerCase()+(n===1?'':'s')+'</strong>');
   document.getElementById('callout').innerHTML = parts.length
-    ? 'Over ' + totalDays + ' days, this agent completed ' + parts.join(', ') + ' and more -- running autonomously at an average of <strong>' + avgPerDay + ' sessions per day</strong>.'
+    ? 'Over '+totalDays+' days, this agent completed '+parts.join(', ')+' and more -- running autonomously at an average of <strong>'+avgPerDay+' sessions per day</strong>.'
     : 'No completed sessions in this window.';
 })();
 
-// ── Breakdown table ───────────────────────────────────────────────────────────
+// Breakdown table
 (function(){
   const tbody = document.getElementById('breakdown-body');
-  const max = Math.max(...BREAKDOWN.map(r => r.completed), 1);
-  let totS = 0, totC = 0;
-  for (const row of BREAKDOWN) {
-    const pct = Math.round(row.completed / max * 100);
-    const rate = Math.round(row.completed / row.started * 100);
-    const tr = document.createElement('tr');
-    tr.innerHTML = '<td>' + row.label + '</td><td><div style="display:flex;align-items:center;gap:8px"><div class="bar-outer" style="flex:1"><div class="bar-inner" style="width:' + pct + '%"></div></div><span style="font-size:13px;font-weight:600;color:#1d1d1f;width:36px;text-align:right">' + row.completed + '</span></div></td><td class="right" style="color:#aeaeb2;font-size:12px">' + rate + '%</td><td class="right">' + row.median + '</td>';
-    tbody.appendChild(tr);
-    totS += row.started; totC += row.completed;
+  const max = Math.max(...BREAKDOWN.map(r=>r.completed),1);
+  let totS=0,totC=0;
+  for (const r of BREAKDOWN) {
+    const pct=Math.round(r.completed/max*100), rate=Math.round(r.completed/r.started*100);
+    const tr=document.createElement('tr');
+    tr.innerHTML='<td>'+r.label+'</td><td><div style="display:flex;align-items:center;gap:8px"><div class="bar-outer" style="flex:1"><div class="bar-inner" style="width:'+pct+'%"></div></div><span style="font-size:13px;font-weight:600;color:#1d1d1f;width:32px;text-align:right">'+r.completed+'</span></div></td><td class="r" style="color:#aeaeb2;font-size:12px">'+rate+'%</td><td class="r">'+r.median+'</td><td class="r" style="color:#1a7a3a">+'+(r.linesAdded||0).toLocaleString()+'</td>';
+    tbody.appendChild(tr); totS+=r.started; totC+=r.completed;
   }
-  const totalRow = document.createElement('tr');
-  totalRow.className = 'total-row';
-  const totRate = Math.round(totC / Math.max(totS,1) * 100);
-  totalRow.innerHTML = '<td>Total</td><td><div style="display:flex;align-items:center;gap:8px"><div class="bar-outer" style="flex:1"><div class="bar-inner" style="width:100%"></div></div><span style="font-size:13px;font-weight:600;color:#1d1d1f;width:36px;text-align:right">' + totC + '</span></div></td><td class="right" style="color:#aeaeb2;font-size:12px">' + totRate + '%</td><td class="right">--</td>';
-  tbody.appendChild(totalRow);
+  const tr=document.createElement('tr'); tr.className='total-row';
+  tr.innerHTML='<td>Total</td><td><div style="display:flex;align-items:center;gap:8px"><div class="bar-outer" style="flex:1"><div class="bar-inner" style="width:100%"></div></div><span style="font-size:13px;font-weight:600;color:#1d1d1f;width:32px;text-align:right">'+totC+'</span></div></td><td class="r" style="color:#aeaeb2;font-size:12px">'+Math.round(totC/Math.max(totS,1)*100)+'%</td><td class="r">--</td><td class="r">--</td>';
+  tbody.appendChild(tr);
 })();
 
-// ── Daily activity chart ──────────────────────────────────────────────────────
+// Activity chart
 (function(){
-  const chart = document.getElementById('barchart');
-  const axis  = document.getElementById('barchart-axis');
-  const yAxis = document.getElementById('y-axis');
-  const entries = [];
-  const start = new Date(Object.keys(HEATMAP).sort()[0]);
-  const end   = new Date(Object.keys(HEATMAP).sort().reverse()[0]);
-  for (let d = new Date(start); d <= end; d.setDate(d.getDate()+1)) {
-    const k = d.toISOString().slice(0,10);
-    entries.push({ date: k, label: d.toLocaleDateString('en-US',{month:'short',day:'numeric'}), count: HEATMAP[k]||0 });
+  const chart=document.getElementById('barchart'), axis=document.getElementById('barchart-axis'), yAxis=document.getElementById('y-axis');
+  const entries=[];
+  const keys=Object.keys(HEATMAP).sort();
+  if(!keys.length) return;
+  const start=new Date(keys[0]), end=new Date(keys[keys.length-1]);
+  for(let d=new Date(start);d<=end;d.setDate(d.getDate()+1)){
+    const k=d.toISOString().slice(0,10);
+    entries.push({date:k,label:d.toLocaleDateString('en-US',{month:'short',day:'numeric'}),count:HEATMAP[k]||0});
   }
-  if (!entries.length) return;
-  const max = Math.max(...entries.map(e=>e.count), 1);
-  [max, Math.round(max*.5), 0].forEach(v => {
-    const el = document.createElement('div'); el.className='y-label'; el.textContent=v; yAxis.appendChild(el);
-  });
-  entries.forEach(e => {
-    const isWe = new Date(e.date+'T12:00:00').getDay()===0 || new Date(e.date+'T12:00:00').getDay()===6;
-    const bar = document.createElement('div');
-    bar.className = 'bar-chart-bar';
-    bar.style.height = Math.max(2, Math.round(e.count/max*100))+'%';
-    if (isWe) bar.style.background = '#60a5fa';
-    bar.setAttribute('data-tip', e.label+': '+e.count+' sessions');
+  const max=Math.max(...entries.map(e=>e.count),1);
+  [max,Math.round(max*.5),0].forEach(v=>{const el=document.createElement('div');el.className='y-label';el.textContent=v;yAxis.appendChild(el);});
+  entries.forEach(e=>{
+    const isWe=new Date(e.date+'T12:00:00').getDay()===0||new Date(e.date+'T12:00:00').getDay()===6;
+    const bar=document.createElement('div'); bar.className='bc-bar';
+    bar.style.height=Math.max(2,Math.round(e.count/max*100))+'%';
+    if(isWe) bar.style.background='rgba(0,122,255,0.4)';
+    bar.setAttribute('data-tip',e.label+': '+e.count+' sessions');
     chart.appendChild(bar);
-    const lbl = document.createElement('div'); lbl.className='bar-chart-label';
-    if ([1,7,14,21,28].includes(new Date(e.date+'T12:00:00').getDate())) lbl.textContent = e.label;
+    const lbl=document.createElement('div'); lbl.className='bar-chart-label';
+    if([1,7,14,21,28].includes(new Date(e.date+'T12:00:00').getDate())) lbl.textContent=e.label;
     axis.appendChild(lbl);
   });
 })();
 
-// ── Sessions view ─────────────────────────────────────────────────────────────
-let sessPage = 1, sessFiltered = SESSIONS.slice();
-
+// Sessions
+let sp=1, sf=SESSIONS.slice();
 (function(){
-  const sel = document.getElementById('sess-workflow');
-  [...new Set(SESSIONS.map(s=>s.workflow_label))].sort().forEach(l => {
-    const o = document.createElement('option'); o.value=l; o.textContent=l; sel.appendChild(o);
-  });
-  document.getElementById('sess-total').textContent = SESSIONS.length+' total.';
+  const sel=document.getElementById('sess-workflow');
+  [...new Set(SESSIONS.map(s=>s.workflow_label))].sort().forEach(l=>{const o=document.createElement('option');o.value=l;o.textContent=l;sel.appendChild(o);});
+  document.getElementById('sess-total').textContent=SESSIONS.length.toLocaleString()+' total sessions.';
 })();
-
-function fmtDur(min) { if (!min) return '--'; return min < 60 ? min.toFixed(0)+'m' : (min/60).toFixed(1)+'h'; }
-function fmtTok(n)  { if (!n) return '--'; if(n>=1e6) return (n/1e6).toFixed(1)+'M'; if(n>=1e3) return Math.round(n/1e3)+'k'; return n; }
-
-function applySessFilters() {
-  const wf     = document.getElementById('sess-workflow').value;
-  const status = document.getElementById('sess-status').value;
-  const search = document.getElementById('sess-search').value.toLowerCase();
-  sessFiltered = SESSIONS.filter(s =>
-    (!wf     || s.workflow_label === wf) &&
-    (!status || (status==='done' ? s.completed : !s.completed)) &&
-    (!search || s.goal.toLowerCase().includes(search) || s.date.includes(search))
+function fD(m){if(!m)return'--';return m<60?Math.round(m)+'m':(m/60).toFixed(1)+'h';}
+function fT(n){if(!n)return'--';if(n>=1e6)return(n/1e6).toFixed(1)+'M';if(n>=1e3)return Math.round(n/1e3)+'k';return n;}
+function fC(c){if(!c)return'--';return c>=100?'$'+(c/100).toFixed(0):'$'+(c/100).toFixed(2);}
+function applyF(){
+  const wf=document.getElementById('sess-workflow').value;
+  const st=document.getElementById('sess-status').value;
+  const q=document.getElementById('sess-search').value.toLowerCase();
+  sf=SESSIONS.filter(s=>
+    (!wf||s.workflow_label===wf)&&
+    (!st||(st==='done'?s.completed:!s.completed))&&
+    (!q||s.goal.toLowerCase().includes(q)||s.project.toLowerCase().includes(q)||s.date.includes(q))
   );
-  sessPage = 1;
-  renderSessions();
+  sp=1; renderS();
 }
-
-function renderSessions() {
-  const list = document.getElementById('sess-list');
-  const total = sessFiltered.length;
-  const start = (sessPage-1)*PAGE_SIZE;
-  const page  = sessFiltered.slice(start, Math.min(start+PAGE_SIZE, total));
-  const completed = sessFiltered.filter(s=>s.completed).length;
-  const avgDur = sessFiltered.filter(s=>s.duration_min).reduce((a,s)=>a+s.duration_min,0) / (sessFiltered.filter(s=>s.duration_min).length||1);
-  document.getElementById('sess-stats').innerHTML =
-    '<div class="stat-item"><span class="stat-val">'+total+'</span> <span class="stat-lbl">sessions</span></div>'+
-    '<div class="stat-item"><span class="stat-val" style="color:#34c759">'+completed+'</span> <span class="stat-lbl">completed</span></div>'+
-    '<div class="stat-item"><span class="stat-val">'+Math.round(completed/Math.max(total,1)*100)+'%</span> <span class="stat-lbl">completion rate</span></div>'+
-    '<div class="stat-item"><span class="stat-val">'+fmtDur(Math.round(avgDur*10)/10)+'</span> <span class="stat-lbl">avg duration</span></div>'+
-    '<div class="stat-item" style="margin-left:auto;font-size:11px;color:#aeaeb2">Showing '+(start+1)+'&#8211;'+Math.min(start+PAGE_SIZE,total)+'</div>';
-  list.innerHTML = '';
-  for (const s of page) {
-    const div = document.createElement('div');
-    div.className = 'session-item';
-    const outcomeHtml = s.outcome ? '<span class="outcome-badge outcome-'+s.outcome+'">'+s.outcome+'</span>' : '';
-    const metaParts = [];
-    if (s.lines_added) metaParts.push('<span style="color:#1a7a1a">+'+s.lines_added+' lines</span>');
-    if (s.tokens) metaParts.push(fmtTok(s.tokens)+' tokens');
-    if (s.steps) metaParts.push(s.steps+' steps');
-    if (s.retries) metaParts.push(s.retries+' retries');
-    const metaHtml = metaParts.length ? '<div class="session-metrics">'+metaParts.join(' &middot; ')+'</div>' : '';
-    div.innerHTML =
-      '<div class="session-date">'+s.date+'</div>'+
-      '<div><div class="session-dot '+(s.completed?'dot-done':'dot-partial')+'"></div></div>'+
-      '<div class="session-wf">'+s.workflow_label+'</div>'+
-      '<div><div class="session-goal'+(s.goal?'':' no-goal')+'">'+(s.goal||'No goal recorded')+'</div>'+metaHtml+'</div>'+
-      '<div>'+outcomeHtml+'</div>'+
-      '<div class="sess-dur">'+fmtTok(s.tokens)+'</div>'+
-      '<div class="sess-dur">'+fmtDur(s.duration_min)+'</div>';
+function renderS(){
+  const list=document.getElementById('sess-list');
+  const total=sf.length, start=(sp-1)*PAGE_SIZE, page=sf.slice(start,Math.min(start+PAGE_SIZE,total));
+  const comp=sf.filter(s=>s.completed).length;
+  const avgD=sf.filter(s=>s.duration_min).reduce((a,s)=>a+s.duration_min,0)/(sf.filter(s=>s.duration_min).length||1);
+  const totalLines=sf.reduce((a,s)=>a+s.lines_added,0);
+  document.getElementById('sess-stats').innerHTML=
+    '<div><span class="stat-val">'+total+'</span> <span class="stat-lbl">sessions</span></div>'+
+    '<div><span class="stat-val" style="color:#34c759">'+comp+'</span> <span class="stat-lbl">completed</span></div>'+
+    '<div><span class="stat-val">'+Math.round(comp/Math.max(total,1)*100)+'%</span> <span class="stat-lbl">rate</span></div>'+
+    '<div><span class="stat-val">'+fD(Math.round(avgD*10)/10)+'</span> <span class="stat-lbl">avg duration</span></div>'+
+    '<div><span class="stat-val" style="color:#1a7a3a">+'+totalLines.toLocaleString()+'</span> <span class="stat-lbl">lines added</span></div>'+
+    '<div style="margin-left:auto;font-size:11px;color:#aeaeb2">Showing '+(start+1)+'&#8211;'+Math.min(start+PAGE_SIZE,total)+'</div>';
+  list.innerHTML='';
+  for(const s of page){
+    const div=document.createElement('div'); div.className='sess-item';
+    const ob=s.outcome?'<span class="badge b-'+s.outcome+'">'+s.outcome+'</span>':'';
+    const mp=[];
+    if(s.lines_added) mp.push('<span style="color:#1a7a3a">+'+s.lines_added+' lines</span>');
+    if(s.tokens) mp.push(fT(s.tok_in+s.tok_out)+' tokens');
+    if(s.est_cost_cents) mp.push(fC(s.est_cost_cents));
+    if(s.steps) mp.push(s.steps+' steps');
+    if(s.retries) mp.push('<span style="color:#ff9500">'+s.retries+' retries</span>');
+    if(s.commit_count) mp.push(s.commit_count+' commit'+(s.commit_count>1?'s':''));
+    if(s.model) mp.push('<span style="color:#aeaeb2">'+s.model+'</span>');
+    const meta=mp.length?'<div class="sess-meta">'+mp.join(' &middot; ')+'</div>':'';
+    div.innerHTML=
+      '<div class="sess-date">'+s.date+'</div>'+
+      '<div><div class="sess-dot '+(s.completed?'dot-done':'dot-skip')+'"></div></div>'+
+      '<div class="sess-wf" title="'+s.workflow_id+'">'+s.workflow_label+(s.project?'<br><span style="font-weight:400;color:#aeaeb2">'+s.project+'</span>':'')+'</div>'+
+      '<div><div class="'+(s.goal?'sess-goal':'sess-no-goal')+'">'+(s.goal||'No goal recorded')+'</div>'+meta+'</div>'+
+      '<div>'+ob+'</div>'+
+      '<div class="sess-num">'+fD(s.duration_min)+'</div>';
     list.appendChild(div);
   }
   // Pagination
-  const pag = document.getElementById('sess-pagination');
-  pag.innerHTML = '';
-  const pages = Math.ceil(total/PAGE_SIZE);
-  if (pages <= 1) return;
-  const prev = document.createElement('button'); prev.className='page-btn'; prev.textContent='Previous'; prev.disabled=sessPage===1;
-  prev.addEventListener('click',()=>{sessPage--;renderSessions();}); pag.appendChild(prev);
-  for (let p = Math.max(1,sessPage-2); p <= Math.min(pages,sessPage+2); p++) {
-    const btn = document.createElement('button'); btn.className='page-btn'+(p===sessPage?' active':''); btn.textContent=p;
-    btn.addEventListener('click',()=>{sessPage=p;renderSessions();}); pag.appendChild(btn);
+  const pag=document.getElementById('sess-pag'); pag.innerHTML='';
+  const pages=Math.ceil(total/PAGE_SIZE); if(pages<=1)return;
+  const prev=document.createElement('button'); prev.className='pg-btn'; prev.textContent='Prev'; prev.disabled=sp===1;
+  prev.addEventListener('click',()=>{sp--;renderS();}); pag.appendChild(prev);
+  for(let p=Math.max(1,sp-2);p<=Math.min(pages,sp+2);p++){
+    const b=document.createElement('button'); b.className='pg-btn'+(p===sp?' active':''); b.textContent=p;
+    b.addEventListener('click',()=>{sp=p;renderS();}); pag.appendChild(b);
   }
-  const next = document.createElement('button'); next.className='page-btn'; next.textContent='Next'; next.disabled=sessPage===pages;
-  next.addEventListener('click',()=>{sessPage++;renderSessions();}); pag.appendChild(next);
+  const next=document.createElement('button'); next.className='pg-btn'; next.textContent='Next'; next.disabled=sp===pages;
+  next.addEventListener('click',()=>{sp++;renderS();}); pag.appendChild(next);
 }
-
-['sess-workflow','sess-status'].forEach(id => document.getElementById(id).addEventListener('change', applySessFilters));
-document.getElementById('sess-search').addEventListener('input', applySessFilters);
-applySessFilters();
+['sess-workflow','sess-status'].forEach(id=>document.getElementById(id).addEventListener('change',applyF));
+document.getElementById('sess-search').addEventListener('input',applyF);
+applyF();
 </script>
 </body>
 </html>`;

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -800,24 +800,30 @@ body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1
 .trust-legend-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
 .trust-legend-item h4{font-size:12px;font-weight:600;color:var(--txt);margin-bottom:3px;display:flex;align-items:center;gap:6px}
 .trust-legend-item p{font-size:11px;color:var(--txt2);line-height:1.4}
-/* WHAT SHIPPED */
-.shipped-empty{font-size:13px;color:var(--txt3);padding:12px 0}
-.shipped-pr{background:var(--surface);border-radius:var(--radius);box-shadow:var(--shadow);margin-bottom:12px;overflow:hidden}
-.shipped-pr-hdr{display:flex;align-items:center;gap:12px;padding:14px 20px;border-bottom:1px solid var(--border)}
-.shipped-pr-ref{font-size:13px;font-weight:700;color:var(--accent);font-family:ui-monospace,monospace;flex-shrink:0}
+/* WHAT SHIPPED — section label style matches Claude Design pattern */
+.shipped-label{display:flex;align-items:center;margin:28px 0 10px;gap:0}
+.shipped-label-text{font-size:10px;font-weight:700;letter-spacing:.10em;text-transform:uppercase;color:var(--txt3)}
+.shipped-label-trust{margin-left:auto;font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--txt3);opacity:.7}
+/* Single container card — dense list, no per-item cards */
+.shipped-card{background:var(--surface);border-radius:var(--radius);box-shadow:var(--shadow);overflow:hidden;margin-bottom:28px}
+.shipped-empty{font-size:13px;color:var(--txt3);padding:20px 24px}
+/* PR group row */
+.shipped-pr-row{display:flex;align-items:center;gap:10px;padding:11px 20px;background:#f5f5f7;border-bottom:1px solid var(--border);position:sticky;top:0}
+.shipped-pr-ref{font-size:12px;font-weight:700;color:var(--accent);font-family:ui-monospace,monospace;flex-shrink:0;text-decoration:none}
 .shipped-pr-project{font-size:11px;color:var(--txt3);flex-shrink:0}
-.shipped-pr-stats{display:flex;gap:14px;margin-left:auto;flex-shrink:0}
-.shipped-stat-add{font-size:12px;font-weight:600;color:#1a7a3a;font-variant-numeric:tabular-nums}
-.shipped-stat-rem{font-size:12px;font-weight:600;color:#c0392b;font-variant-numeric:tabular-nums}
-.shipped-stat-files{font-size:12px;color:var(--txt3);font-variant-numeric:tabular-nums}
-.shipped-sessions{padding:0 20px}
-.shipped-session{display:flex;align-items:baseline;gap:10px;padding:10px 0;border-bottom:1px solid var(--border);font-size:12px}
-.shipped-session:last-child{border-bottom:none}
-.shipped-session-goal{flex:1;color:var(--txt);line-height:1.4;overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}
-.shipped-session-date{color:var(--txt3);flex-shrink:0;font-size:11px}
-.shipped-solo{background:var(--surface);border-radius:var(--radius);box-shadow:var(--shadow);margin-bottom:12px;padding:14px 20px;display:flex;align-items:baseline;gap:12px}
-.shipped-solo-goal{flex:1;font-size:13px;color:var(--txt);line-height:1.4;overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}
-.shipped-solo-meta{display:flex;gap:12px;align-items:center;flex-shrink:0}
+.shipped-pr-stats{display:flex;gap:10px;margin-left:auto;flex-shrink:0;align-items:center}
+.shipped-stat-add{font-size:11px;font-weight:600;color:#1a7a3a;font-variant-numeric:tabular-nums}
+.shipped-stat-rem{font-size:11px;font-weight:600;color:#c0392b;font-variant-numeric:tabular-nums}
+.shipped-stat-files{font-size:11px;color:var(--txt3);font-variant-numeric:tabular-nums}
+/* Session row inside a PR group or standalone */
+.shipped-row{display:flex;align-items:baseline;gap:14px;padding:9px 20px 9px 32px;border-bottom:1px solid var(--border)}
+.shipped-row-solo{padding-left:20px;background:transparent}
+.shipped-row:last-child{border-bottom:none}
+.shipped-row-goal{flex:1;font-size:12px;color:var(--txt);line-height:1.4;overflow:hidden;display:-webkit-box;-webkit-line-clamp:1;-webkit-box-orient:vertical}
+.shipped-row-branch{font-size:11px;color:var(--txt3);font-family:ui-monospace,monospace;flex-shrink:0;max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.shipped-row-stats{display:flex;gap:8px;flex-shrink:0;align-items:center}
+.shipped-row-date{font-size:11px;color:var(--txt3);flex-shrink:0;font-variant-numeric:tabular-nums}
+.shipped-more{font-size:11px;color:var(--txt3);padding:10px 20px;border-top:1px solid var(--border);text-align:center}
 /* COVERAGE */
 .coverage-table{width:100%;font-size:13px;margin-bottom:8px}
 .coverage-table td{padding:7px 0;border-bottom:1px solid var(--border)}
@@ -972,40 +978,38 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
 </div>
 
 <!-- WHAT SHIPPED -->
-<div class="section-hdr" style="margin-top:8px">
-  <h2 class="section-title">What shipped</h2>
-  <span class="section-meta">${shippedSessions.length} sessions with verified git output</span>
+<div class="shipped-label">
+  <span class="shipped-label-text">What shipped</span>
+  <span class="shipped-label-trust">engine &middot; git-authoritative &middot; ${shippedSessions.length} sessions</span>
 </div>
 ${shippedSessions.length === 0
-  ? `<div class="card"><div class="shipped-empty">No sessions with git evidence in this window. Coverage increases as more sessions run after the git metrics feature was deployed.</div></div>`
-  : `${prGroups.map(g => `<div class="shipped-pr">
-  <div class="shipped-pr-hdr">
+  ? `<div class="shipped-card"><div class="shipped-empty">No sessions with git evidence in this window. Coverage increases as more sessions run after the git metrics feature was deployed.</div></div>`
+  : `<div class="shipped-card">
+${prGroups.map(g => `  <div class="shipped-pr-row">
     <span class="shipped-pr-ref">${htmlEscape(g.ref)}</span>
     ${g.project ? `<span class="shipped-pr-project">${htmlEscape(g.project)}</span>` : ''}
     <div class="shipped-pr-stats">
       <span class="shipped-stat-add">+${g.totalLinesAdded.toLocaleString()}</span>
       <span class="shipped-stat-rem">-${g.totalLinesRemoved.toLocaleString()}</span>
-      ${g.totalFilesChanged > 0 ? `<span class="shipped-stat-files">${g.totalFilesChanged} file${g.totalFilesChanged !== 1 ? 's' : ''}</span>` : ''}
+      ${g.totalFilesChanged > 0 ? `<span class="shipped-stat-files">${g.totalFilesChanged} files</span>` : ''}
     </div>
   </div>
-  <div class="shipped-sessions">
-    ${g.sessions.map(s => `<div class="shipped-session">
-      <span class="shipped-session-goal">${s.goal || '(no goal recorded)'}</span>
-      <span class="shipped-session-date">${s.date}</span>
-    </div>`).join('')}
-  </div>
-</div>`).join('')}
-${ungroupedShipped.slice(0, 20).map(s => `<div class="shipped-solo">
-  <span class="shipped-solo-goal">${s.goal || '(no goal recorded)'}</span>
-  <div class="shipped-solo-meta">
-    ${s.git_branch ? `<span style="font-size:11px;color:var(--txt3);font-family:ui-monospace,monospace">${htmlEscape(s.git_branch)}</span>` : ''}
-    <span class="shipped-stat-add">+${s.lines_added.toLocaleString()}</span>
-    <span class="shipped-stat-rem">-${s.lines_removed.toLocaleString()}</span>
-    ${s.files_changed > 0 ? `<span class="shipped-stat-files">${s.files_changed}f</span>` : ''}
-    <span style="font-size:11px;color:var(--txt3)">${s.date}</span>
-  </div>
-</div>`).join('')}
-${ungroupedShipped.length > 20 ? `<div style="font-size:12px;color:var(--txt3);padding:8px 0">+${ungroupedShipped.length - 20} more sessions in the Sessions list below</div>` : ''}`}
+  ${g.sessions.map(s => `<div class="shipped-row">
+    <span class="shipped-row-goal">${s.goal || '(no goal recorded)'}</span>
+    <span class="shipped-row-date">${s.date}</span>
+  </div>`).join('')}`).join('')}
+${ungroupedShipped.length > 0 && prGroups.length > 0 ? `  <div style="padding:8px 20px 4px;font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--txt3);border-top:1px solid var(--border2)">Without PR refs</div>` : ''}
+${ungroupedShipped.slice(0, 20).map(s => `  <div class="shipped-row shipped-row-solo">
+    <span class="shipped-row-goal">${s.goal || '(no goal recorded)'}</span>
+    <div class="shipped-row-stats">
+      ${s.git_branch ? `<span class="shipped-row-branch">${htmlEscape(s.git_branch)}</span>` : ''}
+      <span class="shipped-stat-add">+${s.lines_added.toLocaleString()}</span>
+      <span class="shipped-stat-rem">-${s.lines_removed.toLocaleString()}</span>
+    </div>
+    <span class="shipped-row-date">${s.date}</span>
+  </div>`).join('')}
+${ungroupedShipped.length > 20 ? `  <div class="shipped-more">+${ungroupedShipped.length - 20} more &mdash; see Sessions below</div>` : ''}
+</div>`}
 
 <!-- COVERAGE -->
 <div class="section-hdr">

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -973,7 +973,7 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
   <h2 class="section-title">Workflow mix</h2>
   <span class="section-meta" id="wf-count"></span>
 </div>
-<div class="two-col" style="margin-bottom:18px">
+<div class="two-col" style="margin-bottom:18px;align-items:start">
   <div class="card" style="margin-bottom:0">
     <div class="card-title">Runs by workflow</div>
     <div class="card-sub">Bar = session count &middot; % = completion rate &middot; routines listed separately (they don&rsquo;t report outcomes)</div>

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -124,6 +124,16 @@ export interface WorktrainReportCommandDeps {
   readonly getDataDirEnv: () => string | undefined;
 }
 
+/**
+ * Output format for the report command.
+ *
+ * - ndjson  (default): one JSON object per line -- streamable, jq-friendly
+ * - json   : single pretty-printed JSON blob (legacy / machine consumers)
+ * - summary: aggregates only, no per-session detail
+ * - csv    : spreadsheet-friendly, one row per session
+ */
+export type ReportFormat = 'ndjson' | 'json' | 'summary' | 'csv';
+
 export interface WorktrainReportCommandOpts {
   /** Number of days to look back (default: 30). Ignored when `since` is provided. */
   readonly days?: number;
@@ -131,8 +141,10 @@ export interface WorktrainReportCommandOpts {
   readonly since?: string;
   /** Override end date (YYYY-MM-DD, default: today). */
   readonly until?: string;
-  /** Write JSON to this file path instead of stdout. */
+  /** Write output to this file path instead of stdout. */
   readonly out?: string;
+  /** Output format (default: ndjson). */
+  readonly format?: ReportFormat;
 }
 
 // ---------------------------------------------------------------------------
@@ -154,6 +166,163 @@ function parseDateToMs(dateStr: string): number | null {
  */
 function formatDate(ms: number): string {
   return new Date(ms).toISOString().slice(0, 10);
+}
+
+/**
+ * Remove internal-only fields before any renderer emits the session.
+ *
+ * WHY strip changedFilePaths: it is an implementation detail of churn
+ * detection (used to correlate post-session git activity). Emitting it
+ * inflates output by thousands of strings for large coding sessions and
+ * is not useful to report consumers. languageBreakdown already conveys
+ * the language composition without the raw path list.
+ */
+function sanitizeSession(s: ReportSession): Record<string, unknown> {
+  const { metrics, ...rest } = s;
+  if (metrics === null) return { ...rest, metrics: null };
+
+  const { gitEvidence, ...otherMetrics } = metrics;
+  const sanitizedGitEvidence = gitEvidence === null ? null : (() => {
+    const { committedDiff, ...otherGit } = gitEvidence;
+    const sanitizedCommittedDiff = committedDiff === null ? null : (() => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { changedFilePaths: _dropped, ...diffRest } = committedDiff;
+      return diffRest;
+    })();
+    return { ...otherGit, committedDiff: sanitizedCommittedDiff };
+  })();
+
+  return { ...rest, metrics: { ...otherMetrics, gitEvidence: sanitizedGitEvidence } };
+}
+
+// ---------------------------------------------------------------------------
+// Format renderers -- pure functions, no I/O
+// ---------------------------------------------------------------------------
+
+/**
+ * NDJSON (default): one JSON object per line -- streamable and jq-friendly.
+ * Sessions are emitted individually; the final line is the summary object.
+ */
+function renderNdjson(output: ReportOutput): string {
+  const lines: string[] = [];
+  for (const s of output.sessions) {
+    lines.push(JSON.stringify(sanitizeSession(s)));
+  }
+  lines.push(JSON.stringify({ _summary: true, ...output.summary }));
+  return lines.join('\n');
+}
+
+/** JSON (legacy): single pretty-printed blob. Strips changedFilePaths. */
+function renderJson(output: ReportOutput): string {
+  const sanitized = { ...output, sessions: output.sessions.map(sanitizeSession) };
+  return JSON.stringify(sanitized, null, 2);
+}
+
+/** Summary: aggregates only -- no per-session detail. */
+function renderSummary(output: ReportOutput): string {
+  return JSON.stringify({
+    version: output.version,
+    generatedAt: output.generatedAt,
+    dateRange: output.dateRange,
+    summary: output.summary,
+  }, null, 2);
+}
+
+/** A scalar value safe to embed in a CSV cell. */
+type CsvCellValue = string | number | boolean | null | undefined;
+
+/** Escape a scalar value for CSV (RFC 4180). */
+function csvEscape(value: CsvCellValue): string {
+  if (value === null || value === undefined) return '';
+  const s = String(value);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
+const CSV_HEADERS = [
+  'sessionId', 'date', 'workflowId', 'repoRoot', 'triggerSource',
+  'outcome', 'stepsCompleted', 'retriesCount', 'durationMs',
+  'inputTokens', 'outputTokens', 'cacheReadTokens', 'cacheWriteTokens',
+  'linesAdded', 'linesRemoved', 'filesChanged', 'commitCount',
+  'captureConfidence', 'filesRemodified', 'goal',
+] as const;
+
+/** Typed row for a single CSV session. One field per CSV_HEADERS entry. */
+type CsvRow = {
+  readonly sessionId: string;
+  readonly date: string;
+  readonly workflowId: CsvCellValue;
+  readonly repoRoot: CsvCellValue;
+  readonly triggerSource: string;
+  readonly outcome: CsvCellValue;
+  readonly stepsCompleted: number;
+  readonly retriesCount: number;
+  readonly durationMs: CsvCellValue;
+  readonly inputTokens: CsvCellValue;
+  readonly outputTokens: CsvCellValue;
+  readonly cacheReadTokens: CsvCellValue;
+  readonly cacheWriteTokens: CsvCellValue;
+  readonly linesAdded: CsvCellValue;
+  readonly linesRemoved: CsvCellValue;
+  readonly filesChanged: CsvCellValue;
+  readonly commitCount: number;
+  readonly captureConfidence: CsvCellValue;
+  readonly filesRemodified: CsvCellValue;
+  readonly goal: CsvCellValue;
+};
+
+function buildCsvRow(s: ReportSession): CsvRow {
+  const m = s.metrics;
+  const ge = m?.gitEvidence ?? null;
+  const td = m?.tokenDelta ?? null;
+  const usage = m?.usageEvents[0] ?? null;
+  return {
+    sessionId:         s.sessionId,
+    date:              s.date,
+    workflowId:        s.workflowId,
+    repoRoot:          s.repoRoot,
+    triggerSource:     s.triggerSource,
+    outcome:           m?.outcome ?? null,
+    stepsCompleted:    m?.stepsCompleted ?? 0,
+    retriesCount:      m?.retriesCount ?? 0,
+    durationMs:        m?.durationMs ?? null,
+    inputTokens:       td?.inputTokens ?? usage?.inputTokens ?? null,
+    outputTokens:      td?.outputTokens ?? usage?.outputTokens ?? null,
+    cacheReadTokens:   td?.cacheReadTokens ?? usage?.cacheReadTokens ?? null,
+    cacheWriteTokens:  td?.cacheWriteTokens ?? usage?.cacheWriteTokens ?? null,
+    linesAdded:        ge?.committedDiff?.linesAdded ?? m?.linesAdded ?? null,
+    linesRemoved:      ge?.committedDiff?.linesRemoved ?? m?.linesRemoved ?? null,
+    filesChanged:      ge?.committedDiff?.filesChanged ?? m?.filesChanged ?? null,
+    commitCount:       ge?.commitShas.length ?? 0,
+    captureConfidence: ge?.captureConfidence ?? m?.captureConfidence ?? null,
+    filesRemodified:   ge?.churnSignal?.filesRemodified ?? null,
+    goal:              s.goal,
+  };
+}
+
+/** CSV: header row + one row per session. Goal is last (may contain commas). */
+function renderCsv(output: ReportOutput): string {
+  const rows: string[] = [CSV_HEADERS.join(',')];
+  for (const s of output.sessions) {
+    const row = buildCsvRow(s);
+    rows.push(CSV_HEADERS.map((h) => csvEscape(row[h])).join(','));
+  }
+  return rows.join('\n');
+}
+
+/**
+ * Dispatch to the correct renderer based on format.
+ * Pure function: no I/O.
+ */
+function render(output: ReportOutput, format: ReportFormat): string {
+  switch (format) {
+    case 'ndjson':  return renderNdjson(output);
+    case 'json':    return renderJson(output);
+    case 'summary': return renderSummary(output);
+    case 'csv':     return renderCsv(output);
+  }
 }
 
 /**
@@ -371,18 +540,19 @@ export async function executeWorktrainReportCommand(
     summary,
   };
 
-  const json = JSON.stringify(output, null, 2);
+  const format: ReportFormat = opts.format ?? 'ndjson';
+  const rendered = render(output, format);
 
   if (opts.out !== undefined) {
     try {
-      await deps.writeFile(opts.out, json);
+      await deps.writeFile(opts.out, rendered);
       deps.writeStderr(`[report] Report written to ${opts.out}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       deps.writeStderr(`[report] Error writing to ${opts.out}: ${msg}`);
     }
   } else {
-    deps.writeOutput(json);
+    deps.writeOutput(rendered);
   }
 }
 

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -629,6 +629,7 @@ function renderHtml(output: ReportOutput): string {
   const agentSuccessPct = outcomeSessions > 0 ? Math.round(successCount / outcomeSessions * 100) : null;
 
   // ── Hero narrative (engine-authoritative only) ──────────────────────────────
+  const windowDays = Math.round((new Date(dateRange.until).getTime() - new Date(dateRange.since).getTime()) / 86_400_000);
   const heroLines = summary.totalLinesAdded;
   const totalPRs = sessionsJs.reduce((a, s) => a + s.pr_refs.length, 0);
   const uniquePRs = new Set(sessionsJs.flatMap(s => s.pr_refs)).size;
@@ -934,16 +935,16 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
     </div>
     <h1 class="hero-h1">${htmlEscape(heroMain)} &mdash; <span>${htmlEscape(heroAccent)}</span></h1>
     <p class="hero-sub">
-      Across ${htmlEscape(dateRange.since)} &ndash; ${htmlEscape(dateRange.until)}, WorkRail steered <strong>${summary.totalSessions} workflow runs</strong> through guided, step-by-step execution.
+      Across ${htmlEscape(dateRange.since)} &ndash; ${htmlEscape(dateRange.until)}, WorkRail steered <strong>${summary.totalSessions} workflow runs</strong> through guardrailed, step-by-step execution.
       Every number below is labeled by <strong>how much it can be trusted</strong> &mdash; git evidence, interpretation, or the agent&rsquo;s own word.
       Metrics that didn&rsquo;t exist yet read <strong>&ldquo;not tracked&rdquo;</strong>, never a misleading zero.
     </p>
     <div class="hero-pills">
       <span class="hero-pill">${summary.totalSessions} sessions</span>
-      ${summary.totalLinesAdded > 0 ? `<span class="hero-pill">+${summary.totalLinesAdded.toLocaleString()} lines</span>` : ''}
-      ${totalHours !== '0.0' ? `<span class="hero-pill">${totalHours}h autonomous</span>` : ''}
+      ${codeKeptPct !== null ? `<span class="hero-pill">code kept ${windowDays}d ${codeKeptPct}%</span>` : ''}
+      ${totalHours !== '0.0' ? `<span class="hero-pill">autonomous ${totalHours}h</span>` : ''}
       ${estCostCents > 0 ? `<span class="hero-pill">${htmlEscape(estCostStr)} spend</span>` : ''}
-      ${uniquePRs > 0 ? `<span class="hero-pill">${uniquePRs} PRs</span>` : ''}
+      <span class="hero-pill">window ${windowDays} days</span>
     </div>
   </div>
 </div>
@@ -996,7 +997,7 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
   <div class="metric-section-label">
     <span class="metric-section-name">Did it hold up?</span>
     <div class="metric-section-rule"></div>
-    <span class="metric-section-trust">lower confidence &mdash; read the tags</span>
+    <span class="metric-section-trust">quality &amp; operational signals</span>
   </div>
   <div class="metric-grid">
     <div class="mc mc-interp">
@@ -1014,7 +1015,7 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
     <div class="mc mc-engine">
       <div class="mc-hdr"><span class="mc-label">Completed without abandon</span><span class="mc-pill mc-pill-engine">Engine</span></div>
       <div class="mc-value">${completedWithoutAbandonPct !== null ? `${completedWithoutAbandonPct}%` : '--'}</div>
-      <div class="mc-sub mc-sub-neutral">→ ran to the last step</div>
+      <div class="mc-sub mc-sub-neutral">→ ran all steps</div>
       <div class="mc-caveat">operational &mdash; not a quality verdict</div>
     </div>
     <div class="mc mc-agent">
@@ -1126,8 +1127,8 @@ ${ungroupedShipped.length > 20 ? `  <div class="shipped-more">+${ungroupedShippe
 <div class="card">
   <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin-bottom:4px">
     <div>
-      <div style="font-size:13px;font-weight:600;color:var(--txt);margin-bottom:3px">Sessions per day, by reported outcome</div>
-      <div style="font-size:11px;color:var(--txt3);font-family:ui-monospace,monospace">Stacked bars &middot; &ldquo;unknown&rdquo; = no outcome reported</div>
+      <div style="font-size:13px;font-weight:600;color:var(--txt);margin-bottom:3px">Sessions per day, by outcome</div>
+      <div style="font-size:11px;color:var(--txt3);font-family:ui-monospace,monospace">Stacked bars &middot; hover for detail &middot; &ldquo;unknown&rdquo; = no outcome reported</div>
     </div>
     <div style="display:flex;gap:12px;font-size:11px;align-items:center;flex-shrink:0;flex-wrap:wrap;justify-content:flex-end">
       <div style="display:flex;align-items:center;gap:4px"><div style="width:8px;height:8px;border-radius:2px;background:#34c759"></div><span style="color:var(--txt2)">success</span></div>
@@ -1184,6 +1185,152 @@ ${ungroupedShipped.length > 20 ? `  <div class="shipped-more">+${ungroupedShippe
   <div class="stats-bar" id="sess-stats"></div>
   <div id="sess-list"></div>
   <div class="pag" id="sess-pag"></div>
+</div>
+
+<!-- SESSION OUTCOMES -->
+<div class="section-hdr">
+  <span class="section-num">05</span>
+  <h2 class="section-title">Session outcomes</h2>
+  <span class="section-meta">agent-reported &middot; operational</span>
+</div>
+<div class="two-col" style="margin-bottom:18px;align-items:start">
+  <div class="card" style="margin-bottom:0">
+    <div class="card-title">Outcome breakdown</div>
+    <div class="card-sub" style="font-family:ui-monospace,monospace;font-size:11px">Self-reported by the agent &mdash; present for only ${hasOutcome} of ${summary.totalSessions} sessions. It tells you the engine ran, not that the output was correct.</div>
+    <div style="margin-top:12px">
+      ${[
+        { key: 'success', label: 'Success', cls: 'b-success' },
+        { key: 'partial', label: 'Partial', cls: 'b-partial' },
+        { key: 'abandoned', label: 'Abandoned', cls: 'b-abandoned' },
+        { key: 'error', label: 'Error', cls: 'b-error' },
+        { key: 'unknown', label: 'Unknown', cls: '' },
+      ].map(({ key, label, cls }) => {
+        const n = key === 'unknown'
+          ? summary.totalSessions - outcomeSessions
+          : (summary.outcomeBreakdown[key] ?? 0);
+        const pct = summary.totalSessions > 0 ? Math.round(n / summary.totalSessions * 100) : 0;
+        return `<div style="display:flex;align-items:center;gap:10px;padding:7px 0;border-bottom:1px solid var(--border)">
+          ${cls ? `<span class="badge ${cls}">${htmlEscape(label)}</span>` : `<span style="font-size:12px;color:var(--txt3)">${htmlEscape(label)}</span>`}
+          <span style="font-size:24px;font-weight:700;color:var(--txt);letter-spacing:-0.5px;margin-left:4px">${n}</span>
+          <span style="font-size:12px;color:var(--txt3);margin-left:4px">${pct}%</span>
+        </div>`;
+      }).join('')}
+    </div>
+  </div>
+  <div style="display:flex;flex-direction:column;gap:14px">
+    <div class="card" style="margin-bottom:0">
+      <div class="card-title">Operational signals <span class="trust trust-engine" style="margin-left:6px;vertical-align:middle">engine</span></div>
+      <div class="card-sub">How the engine behaved &mdash; not a quality verdict</div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px">
+        ${[
+          { val: (summary.totalStepsCompleted / Math.max(summary.totalSessions, 1)).toFixed(1), label: 'Avg steps walked' },
+          { val: retriesPerSession, label: 'Retries / session' },
+          { val: `${(summary.totalDurationMs / Math.max(summary.totalSessions, 1) / 60_000).toFixed(0)}m`, label: 'Avg session length' },
+          { val: `${sessionsJs.filter(s => s.trigger === 'daemon').length}`, label: 'Autonomous runs' },
+        ].map(({ val, label }) => `<div style="background:var(--bg);border-radius:var(--radius-sm);padding:10px 12px">
+          <div style="font-size:22px;font-weight:700;letter-spacing:-0.5px;color:var(--txt)">${htmlEscape(val)}</div>
+          <div style="font-size:11px;color:var(--txt3);margin-top:2px">${htmlEscape(label)}</div>
+        </div>`).join('')}
+      </div>
+    </div>
+    <div class="card" style="margin-bottom:0">
+      <div class="card-title">Code retention <span class="trust trust-interp" style="margin-left:6px;vertical-align:middle">interpretive</span></div>
+      <div class="card-sub">The closest thing to a quality signal &mdash; handle with care</div>
+      <div style="font-size:36px;font-weight:700;letter-spacing:-1.5px;color:var(--txt);line-height:1;margin-bottom:8px">${codeKeptPct !== null ? `${codeKeptPct}%` : '--'}</div>
+      <div style="font-size:12px;color:var(--txt2);line-height:1.5">of touched files weren&rsquo;t re-modified within 7 days. A soft signal &mdash; a re-touch could be unrelated active development, not bad output.</div>
+      ${totalFilesForChurn > 0 ? `<div style="font-size:11px;color:var(--txt3);margin-top:8px;font-family:ui-monospace,monospace">${totalChurnFiles} of ${totalFilesForChurn} files re-touched</div>` : ''}
+    </div>
+  </div>
+</div>
+
+<!-- BY PROJECT -->
+<div class="section-hdr">
+  <span class="section-num">06</span>
+  <h2 class="section-title">By project</h2>
+  <span class="section-meta">${projects.length} repositories</span>
+</div>
+<div class="card">
+  <div class="card-sub">Sessions and lines added per repository &mdash; project name derived from the work directory.</div>
+  <table class="tbl">
+    <thead><tr>
+      <th>Project</th><th>Sessions</th><th class="r">Lines added</th><th class="r">Top languages</th>
+    </tr></thead>
+    <tbody>
+      ${projects.slice(0, 15).map((p) => {
+        const barPct = projects[0] && projects[0].sessions > 0 ? Math.round(p.sessions / projects[0].sessions * 100) : 0;
+        const topLang = Object.entries(p.lang).sort(([, a], [, b]) => b - a).slice(0, 3).map(([ext]) => ext).join(' ');
+        return `<tr>
+          <td style="font-weight:600">${htmlEscape(p.name)}</td>
+          <td><div style="display:flex;align-items:center;gap:8px"><div style="flex:1;background:var(--border);border-radius:var(--radius-sm);height:8px;overflow:hidden;min-width:60px"><div style="height:100%;width:${barPct}%;background:var(--accent)"></div></div><span style="font-size:12px;font-weight:600;color:var(--txt);width:28px;text-align:right">${p.sessions}</span></div></td>
+          <td class="r" style="color:#1a7a3a">+${p.linesAdded.toLocaleString()}</td>
+          <td class="r" style="color:var(--txt3);font-size:11px">${htmlEscape(topLang)}</td>
+        </tr>`;
+      }).join('')}
+    </tbody>
+  </table>
+</div>
+
+<!-- CODE IMPACT -->
+<div class="section-hdr">
+  <span class="section-num">07</span>
+  <h2 class="section-title">Code impact</h2>
+  <span class="section-meta">${summary.totalFilesChanged} files touched</span>
+</div>
+<div class="card">
+  <div class="card-title">What got written <span class="trust trust-engine" style="margin-left:6px;vertical-align:middle">engine</span></div>
+  <div class="card-sub" style="font-family:ui-monospace,monospace;font-size:11px">git diff startSha..HEAD &middot; captured for ${hasGitEvidence} of ${summary.totalSessions} sessions</div>
+  <div class="two-col" style="margin-top:16px;align-items:start">
+    <div>
+      ${[
+        { label: 'Lines added', val: `+${summary.totalLinesAdded.toLocaleString()}`, color: '#1a7a3a' },
+        { label: 'Lines removed', val: `−${summary.totalLinesRemoved.toLocaleString()}`, color: '#c0392b' },
+        { label: 'Net change', val: `${(summary.totalLinesAdded - summary.totalLinesRemoved).toLocaleString()} lines`, color: 'var(--txt)' },
+        { label: 'Files changed', val: summary.totalFilesChanged.toLocaleString(), color: 'var(--txt)' },
+      ].map(({ label, val, color }) => `<div style="display:flex;justify-content:space-between;padding:8px 0;border-bottom:1px solid var(--border);font-size:13px">
+        <span style="color:var(--txt2)">${htmlEscape(label)}</span>
+        <span style="font-weight:600;color:${color}">${htmlEscape(val)}</span>
+      </div>`).join('')}
+    </div>
+    <div>
+      <div style="font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--txt3);margin-bottom:10px">Language breakdown</div>
+      ${langEntries.length > 0 ? langEntries.map(({ ext, cnt, pct }) => `<div style="display:flex;align-items:center;gap:10px;padding:5px 0">
+        <span style="font-family:ui-monospace,monospace;font-size:12px;color:var(--txt);width:56px;flex-shrink:0">${htmlEscape(ext)}</span>
+        <div style="flex:1;background:var(--border);border-radius:3px;height:6px;overflow:hidden"><div style="width:${pct}%;height:100%;background:var(--accent)"></div></div>
+        <span style="font-size:11px;color:var(--txt3);width:64px;text-align:right">${cnt.toLocaleString()} &middot; ${pct}%</span>
+      </div>`).join('') : '<div style="color:var(--txt3);font-size:12px">No language data yet</div>'}
+    </div>
+  </div>
+</div>
+
+<!-- TOKEN ECONOMICS -->
+<div class="section-hdr">
+  <span class="section-num">08</span>
+  <h2 class="section-title">Token economics</h2>
+  <span class="section-meta">${hasTokenData > 0 ? `${Math.round(hasTokenData / summary.totalSessions * 100)}% coverage` : 'not tracked yet'}</span>
+</div>
+<div class="card">
+  ${hasTokenData === 0
+    ? `<div style="font-family:ui-monospace,monospace;font-size:12px;color:var(--txt2);margin-bottom:12px">Token data was captured for 0 of ${summary.totalSessions} sessions. Cursor &amp; Antigravity readers haven&rsquo;t shipped yet, and Claude Code requires the workspace path to be set.</div>
+       <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:10px">
+         ${['Total tokens', 'Avg cost / session', 'Cache hit ratio', 'Tokens / turn'].map(label => `<div style="background:var(--bg);border-radius:var(--radius-sm);padding:14px 16px">
+           <div style="font-size:22px;font-weight:700;color:var(--txt3)">--</div>
+           <div style="font-size:11px;color:var(--txt3);margin-top:4px">${htmlEscape(label)}</div>
+         </div>`).join('')}
+       </div>`
+    : `<div class="card-sub" style="font-family:ui-monospace,monospace;font-size:11px">${fmtTokens(totalTokens)} tokens &middot; ${htmlEscape(estCostStr)} at list pricing &middot; ${hasTokenData}/${summary.totalSessions} sessions captured</div>
+       <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin-top:16px">
+         ${[
+           { label: 'Input tokens', val: fmtTokens(inputTok), sub: `$${PRICE_INPUT}/1M &middot; $${(inputTok * PRICE_INPUT / 1_000_000).toFixed(2)}` },
+           { label: 'Output tokens', val: fmtTokens(outputTok), sub: `$${PRICE_OUTPUT}/1M &middot; $${(outputTok * PRICE_OUTPUT / 1_000_000).toFixed(2)}` },
+           { label: 'Cache writes', val: fmtTokens(cacheW), sub: `$${PRICE_CACHE_W}/1M &middot; $${(cacheW * PRICE_CACHE_W / 1_000_000).toFixed(2)}` },
+           { label: 'Cache reads', val: fmtTokens(cacheR), sub: `$${PRICE_CACHE_R}/1M &middot; $${(cacheR * PRICE_CACHE_R / 1_000_000).toFixed(2)} (10x cheaper)` },
+         ].map(({ label, val, sub }) => `<div style="background:var(--bg);border-radius:var(--radius-sm);padding:14px 16px">
+           <div style="font-size:22px;font-weight:700;letter-spacing:-0.5px;color:var(--txt)">${val}</div>
+           <div style="font-size:11px;color:var(--txt2);margin-top:4px">${htmlEscape(label)}</div>
+           <div style="font-size:10px;color:var(--txt3);margin-top:2px">${sub}</div>
+         </div>`).join('')}
+       </div>`
+  }
 </div>
 
 <footer>workrail &middot; <a href="https://github.com/EtienneBBeaulac/workrail" style="color:var(--txt3)">github.com/EtienneBBeaulac/workrail</a></footer>
@@ -1341,17 +1488,21 @@ function renderS(){
     if(s.pr_refs.length) tags.push('<span class="trust trust-interp" style="font-size:10px">'+s.pr_refs.length+' PR'+(s.pr_refs.length>1?'s':'')+'</span>');
     if(s.retries>0) tags.push('<span class="trust trust-agent" style="font-size:10px;color:#ff9500">'+s.retries+' retr.</span>');
     if(s.outcome) tags.push('<span class="badge b-'+s.outcome+'" style="font-size:10px">'+s.outcome+'</span>');
+    const autoBadge=s.trigger==='daemon'?'<span class="badge" style="background:#e1f0ff;color:#007aff;font-size:9px;margin-left:4px">auto</span>':'';
+    const projBranch=(s.project?s.project:'')+(s.git_branch?' &middot; <span style="font-family:ui-monospace,monospace;font-size:10px;color:#aeaeb2">'+s.git_branch+'</span>':'');
     div.innerHTML=
       '<div class="sess-date">'+s.date+'</div>'+
       '<div><div class="sess-dot '+(s.completed?'dot-done':'dot-skip')+'"></div></div>'+
       '<div class="sess-body">'+
-        '<div class="sess-wf">'+s.workflow_label+(s.project?' &middot; <span style="font-weight:400;color:#aeaeb2">'+s.project+'</span>':'')+'</div>'+
+        '<div class="sess-wf">'+s.workflow_label+autoBadge+'</div>'+
+        (projBranch?'<div style="font-size:11px;color:#aeaeb2;margin-bottom:2px">'+projBranch+'</div>':'')+
         '<div class="'+(s.goal?'sess-goal':'sess-no-goal')+'">'+(s.goal||'No goal recorded')+'</div>'+
         (tags.length?'<div class="sess-tags">'+tags.join('')+'</div>':'')+
       '</div>'+
       '<div class="sess-nums">'+
         '<div class="sess-num-main">'+fD(s.duration_min)+'</div>'+
         (s.steps?'<div class="sess-num-sub">'+s.steps+' steps</div>':'')+
+        (cost?'<div class="sess-num-sub">'+cost+'</div>':'')+
       '</div>';
     list.appendChild(div);
   }

--- a/src/cli/commands/worktrain-report.ts
+++ b/src/cli/commands/worktrain-report.ts
@@ -734,8 +734,14 @@ body{font-family:var(--font);background:var(--bg);color:var(--txt);line-height:1
 /* HERO */
 .hero{padding:40px 40px 32px;background:var(--hdr);border-bottom:1px solid rgba(255,255,255,.06)}
 .hero-inner{max-width:940px;margin:0 auto}
-.hero-nav{font-size:11px;color:rgba(255,255,255,.35);margin-bottom:20px;font-family:ui-monospace,monospace;letter-spacing:.02em}
-.hero-nav strong{color:rgba(255,255,255,.6)}
+.hero-nav{display:inline-flex;align-items:center;gap:0;margin-bottom:22px;background:rgba(0,0,0,.45);border:1px solid rgba(255,255,255,.10);border-radius:8px;padding:10px 16px;font-family:ui-monospace,"SF Mono","Fira Code",monospace;font-size:13px;line-height:1;white-space:nowrap;overflow-x:auto;max-width:100%}
+.nav-prompt{color:#30d158;margin-right:10px;font-weight:700;user-select:none}
+.nav-cmd{color:#fff;font-weight:600}
+.nav-sub{color:rgba(255,255,255,.55)}
+.nav-flag{color:#5ac8fa}
+.nav-val{color:#ffd60a}
+.nav-cursor{display:inline-block;width:8px;height:13px;background:#fff;vertical-align:middle;margin-left:6px;animation:blink 1.1s step-end infinite}
+@keyframes blink{0%,100%{opacity:1}50%{opacity:0}}
 .hero-h1{font-size:36px;font-weight:700;letter-spacing:-1px;color:#fff;line-height:1.15;margin-bottom:12px}
 .hero-h1 span{color:var(--accent)}
 .hero-sub{font-size:14px;color:rgba(255,255,255,.55);line-height:1.6;max-width:640px;margin-bottom:20px}
@@ -843,7 +849,7 @@ footer{text-align:center;font-size:11px;color:var(--txt3);margin-top:32px;paddin
 <div class="hero">
   <div class="hero-inner">
     <div class="hero-nav">
-      $ <strong>workrail</strong> report <strong>--since</strong> ${htmlEscape(dateRange.since)} <strong>--until</strong> ${htmlEscape(dateRange.until)} <strong>--format</strong> html
+      <span class="nav-prompt">$</span><span class="nav-cmd">workrail</span>&nbsp;<span class="nav-sub">report</span>&nbsp;<span class="nav-flag">--since</span>&nbsp;<span class="nav-val">${htmlEscape(dateRange.since)}</span>&nbsp;<span class="nav-flag">--until</span>&nbsp;<span class="nav-val">${htmlEscape(dateRange.until)}</span>&nbsp;<span class="nav-flag">--format</span>&nbsp;<span class="nav-val">html</span><span class="nav-cursor"></span>
     </div>
     <h1 class="hero-h1">${htmlEscape(heroMain)} &mdash; <span>${htmlEscape(heroAccent)}</span></h1>
     <p class="hero-sub">

--- a/tests/unit/cli-worktrain-report.test.ts
+++ b/tests/unit/cli-worktrain-report.test.ts
@@ -844,7 +844,9 @@ describe('output formats', () => {
       await executeWorktrainReportCommand(deps, { format: 'html' });
 
       const html = outputLines[0]!;
-      expect(html).toContain('No sessions');
+      // Empty state is rendered by JS -- the HTML contains the sessions tab structure
+      expect(html).toContain('sess-list');
+      expect(html).toContain('SESSIONS = []');
     });
   });
 });

--- a/tests/unit/cli-worktrain-report.test.ts
+++ b/tests/unit/cli-worktrain-report.test.ts
@@ -787,12 +787,64 @@ describe('output formats', () => {
   });
 
   describe('changedFilePaths stripping (all formats)', () => {
-    it('changedFilePaths is not present in any of the four formats', async () => {
-      for (const format of ['ndjson', 'json', 'summary', 'csv'] as const) {
+    it('changedFilePaths is not present in any of the five formats', async () => {
+      for (const format of ['ndjson', 'json', 'summary', 'csv', 'html'] as const) {
         const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
         await executeWorktrainReportCommand(deps, { format });
         expect(outputLines[0], `format=${format}`).not.toContain('changedFilePaths');
       }
+    });
+  });
+
+  describe('html format', () => {
+    it('emits a complete HTML document with DOCTYPE and key sections', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
+      await executeWorktrainReportCommand(deps, { format: 'html' });
+
+      const html = outputLines[0]!;
+      expect(html).toContain('<!DOCTYPE html>');
+      expect(html).toContain('<title>WorkRail Report');
+      expect(html).toContain('Sessions');
+      expect(html).toContain('By workflow');
+    });
+
+    it('includes session data in the HTML table', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
+      await executeWorktrainReportCommand(deps, { format: 'html' });
+
+      const html = outputLines[0]!;
+      // HTML table shows workflow, outcome, and project -- not raw sessionId
+      expect(html).toContain('wr.coding-task');
+      expect(html).toContain('success');
+    });
+
+    it('never includes changedFilePaths in html output', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
+      await executeWorktrainReportCommand(deps, { format: 'html' });
+
+      expect(outputLines[0]).not.toContain('changedFilePaths');
+    });
+
+    it('escapes HTML special characters in goal and session fields', async () => {
+      const xssSession = makeSession({
+        sessionId: 'sess_xss',
+        sessionTitle: '<script>alert(1)</script>',
+        metrics: null,
+      });
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([xssSession]));
+      await executeWorktrainReportCommand(deps, { format: 'html' });
+
+      const html = outputLines[0]!;
+      expect(html).not.toContain('<script>alert(1)</script>');
+      expect(html).toContain('&lt;script&gt;');
+    });
+
+    it('handles empty session list gracefully', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([]));
+      await executeWorktrainReportCommand(deps, { format: 'html' });
+
+      const html = outputLines[0]!;
+      expect(html).toContain('No sessions');
     });
   });
 });

--- a/tests/unit/cli-worktrain-report.test.ts
+++ b/tests/unit/cli-worktrain-report.test.ts
@@ -157,11 +157,31 @@ function makeDeps(
   return { deps, outputLines, stderrLines, writtenFiles };
 }
 
-/** Parse output as JSON, assert it's a valid ReportOutput. */
-function parseOutput(outputLines: string[]): ReportOutput {
+/**
+ * Parse --format json output (single blob). Use for tests that explicitly
+ * pass format: 'json' so they are not affected by the default ndjson change.
+ */
+function parseJsonOutput(outputLines: string[]): ReportOutput {
   expect(outputLines).toHaveLength(1);
   return JSON.parse(outputLines[0]!) as ReportOutput;
 }
+
+/**
+ * Parse --format ndjson output (one object per line).
+ * Returns { sessions, summary } extracted from the NDJSON lines.
+ */
+function parseNdjsonOutput(outputLines: string[]): { sessions: unknown[]; summary: unknown } {
+  expect(outputLines).toHaveLength(1);
+  const lines = outputLines[0]!.split('\n').filter((l) => l.trim().length > 0);
+  expect(lines.length).toBeGreaterThan(0);
+  const parsed = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+  const summaryLine = parsed.find((p) => p['_summary'] === true);
+  const sessions = parsed.filter((p) => p['_summary'] !== true);
+  expect(summaryLine).toBeDefined();
+  return { sessions, summary: summaryLine };
+}
+
+// parseJsonOutput is the canonical helper; no alias needed.
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -171,9 +191,9 @@ describe('executeWorktrainReportCommand', () => {
   describe('empty session store', () => {
     it('emits valid JSON with empty sessions array and zeroed summary', async () => {
       const { deps, outputLines, stderrLines } = makeDeps(makeFakeConsoleService([]));
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.version).toBe(1);
       expect(report.sessions).toHaveLength(0);
       expect(report.summary.totalSessions).toBe(0);
@@ -190,9 +210,9 @@ describe('executeWorktrainReportCommand', () => {
 
     it('output JSON is parseable and has correct shape', async () => {
       const { deps, outputLines } = makeDeps(makeFakeConsoleService([]));
-      await executeWorktrainReportCommand(deps, { days: 7 });
+      await executeWorktrainReportCommand(deps, { days: 7, format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report).toHaveProperty('version', 1);
       expect(report).toHaveProperty('generatedAt');
       expect(report).toHaveProperty('dateRange');
@@ -215,9 +235,9 @@ describe('executeWorktrainReportCommand', () => {
       const { deps, outputLines } = makeDeps(
         makeFakeConsoleService([insideSession, outsideSession]),
       );
-      await executeWorktrainReportCommand(deps, { days: 30 });
+      await executeWorktrainReportCommand(deps, { days: 30, format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.sessions).toHaveLength(1);
       expect(report.sessions[0]!.sessionId).toBe('sess_inside');
     });
@@ -238,9 +258,10 @@ describe('executeWorktrainReportCommand', () => {
       await executeWorktrainReportCommand(deps, {
         since: '2026-05-01',
         until: '2026-05-31',
+        format: 'json',
       });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.sessions).toHaveLength(1);
       expect(report.sessions[0]!.sessionId).toBe('sess_inside');
     });
@@ -252,9 +273,9 @@ describe('executeWorktrainReportCommand', () => {
       });
 
       const { deps, outputLines } = makeDeps(makeFakeConsoleService([outsideSession]));
-      await executeWorktrainReportCommand(deps, { days: 7 });
+      await executeWorktrainReportCommand(deps, { days: 7, format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.sessions).toHaveLength(0);
     });
   });
@@ -262,7 +283,7 @@ describe('executeWorktrainReportCommand', () => {
   describe('--out file option', () => {
     it('writes JSON to file and does not write to stdout', async () => {
       const { deps, outputLines, writtenFiles } = makeDeps(makeFakeConsoleService([]));
-      await executeWorktrainReportCommand(deps, { out: path.join(os.tmpdir(), 'report.json') });
+      await executeWorktrainReportCommand(deps, { out: path.join(os.tmpdir(), 'report.json'), format: 'json' });
 
       expect(outputLines).toHaveLength(0);
       expect(writtenFiles).toHaveLength(1);
@@ -273,7 +294,7 @@ describe('executeWorktrainReportCommand', () => {
 
     it('emits stderr confirmation when writing to file', async () => {
       const { deps, stderrLines } = makeDeps(makeFakeConsoleService([]));
-      await executeWorktrainReportCommand(deps, { out: path.join(os.tmpdir(), 'report.json') });
+      await executeWorktrainReportCommand(deps, { out: path.join(os.tmpdir(), 'report.json'), format: 'json' });
 
       const hasConfirmation = stderrLines.some((l) => l.includes(path.join(os.tmpdir(), 'report.json')));
       expect(hasConfirmation).toBe(true);
@@ -302,9 +323,9 @@ describe('executeWorktrainReportCommand', () => {
       });
 
       const { deps, outputLines } = makeDeps(makeFakeConsoleService([session1, session2]));
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.summary.totalInputTokens).toBe(3000);
       expect(report.summary.totalOutputTokens).toBe(600);
       expect(report.summary.totalCacheReadTokens).toBe(150);
@@ -319,9 +340,9 @@ describe('executeWorktrainReportCommand', () => {
       const s5 = makeSession({ sessionId: 'sess_5', metrics: null });
 
       const { deps, outputLines } = makeDeps(makeFakeConsoleService([s1, s2, s3, s4, s5]));
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.summary.outcomeBreakdown['success']).toBe(2);
       expect(report.summary.outcomeBreakdown['error']).toBe(1);
       // null outcome (from metrics) and null metrics both count as 'unknown'
@@ -335,9 +356,9 @@ describe('executeWorktrainReportCommand', () => {
       const s4 = makeSession({ sessionId: 'sess_4', workflowId: null });
 
       const { deps, outputLines } = makeDeps(makeFakeConsoleService([s1, s2, s3, s4]));
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.summary.workflowBreakdown['wr.coding-task']).toBe(2);
       expect(report.summary.workflowBreakdown['wr.mr-review']).toBe(1);
       expect(report.summary.workflowBreakdown['__unknown__']).toBe(1);
@@ -390,9 +411,9 @@ describe('executeWorktrainReportCommand', () => {
       });
 
       const { deps, outputLines } = makeDeps(makeFakeConsoleService([s1, s2]));
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.summary.languageBreakdown['.ts']).toBe(120);
       expect(report.summary.languageBreakdown['.json']).toBe(20);
       expect(report.summary.languageBreakdown['.md']).toBe(10);
@@ -413,9 +434,9 @@ describe('executeWorktrainReportCommand', () => {
       });
 
       const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.summary.totalLinesAdded).toBe(50);
       expect(report.summary.totalLinesRemoved).toBe(10);
       expect(report.summary.totalFilesChanged).toBe(3);
@@ -430,9 +451,9 @@ describe('executeWorktrainReportCommand', () => {
       const { deps, outputLines } = makeDeps(
         makeFakeConsoleService([complete, completeWithGaps, inProgress, blocked]),
       );
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.summary.totalSessions).toBe(4);
       expect(report.summary.completedSessions).toBe(2);
     });
@@ -450,9 +471,9 @@ describe('executeWorktrainReportCommand', () => {
       const withoutMetrics = makeSession({ sessionId: 'sess_2', metrics: null });
 
       const { deps, outputLines } = makeDeps(makeFakeConsoleService([withMetrics, withoutMetrics]));
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.summary.totalSessions).toBe(2);
       expect(report.summary.totalDurationMs).toBe(60000);
       expect(report.summary.totalStepsCompleted).toBe(5);
@@ -464,7 +485,7 @@ describe('executeWorktrainReportCommand', () => {
   describe('stderr and stdout separation', () => {
     it('all progress goes to stderr, stdout contains only the JSON blob', async () => {
       const { deps, outputLines, stderrLines } = makeDeps(makeFakeConsoleService([]));
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
       expect(outputLines).toHaveLength(1);
       // Verify the single stdout line is valid JSON
@@ -481,10 +502,10 @@ describe('executeWorktrainReportCommand', () => {
   describe('session store error graceful degradation', () => {
     it('emits empty report with warning when session store fails', async () => {
       const { deps, outputLines, stderrLines } = makeDeps(makeErrorConsoleService());
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
       // Should still emit valid JSON
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.sessions).toHaveLength(0);
       // Should have warning in stderr
       const hasWarning = stderrLines.some((l) => l.toLowerCase().includes('warning') || l.includes('could not'));
@@ -498,7 +519,7 @@ describe('executeWorktrainReportCommand', () => {
       const { deps, stderrLines } = makeDeps(
         makeFakeConsoleService(sessions, 600), // pretend 600 total, only 1 returned
       );
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
       const hasTruncationWarning = stderrLines.some(
         (l) => l.includes('600') && l.includes('1'),
@@ -511,7 +532,7 @@ describe('executeWorktrainReportCommand', () => {
       const { deps, stderrLines } = makeDeps(
         makeFakeConsoleService(sessions, 1),
       );
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
       const hasTruncationWarning = stderrLines.some(
         (l) => l.toLowerCase().includes('only') && l.toLowerCase().includes('loaded'),
@@ -528,9 +549,9 @@ describe('executeWorktrainReportCommand', () => {
       });
 
       const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.sessions[0]!.goal).toBe('Implement the foo feature');
     });
 
@@ -539,9 +560,9 @@ describe('executeWorktrainReportCommand', () => {
       const daemon = makeSession({ sessionId: 'sess_daemon', triggerSource: 'daemon' });
 
       const { deps, outputLines } = makeDeps(makeFakeConsoleService([mcp, daemon]));
-      await executeWorktrainReportCommand(deps);
+      await executeWorktrainReportCommand(deps, { format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       const mcpSession = report.sessions.find((s) => s.sessionId === 'sess_mcp');
       const daemonSession = report.sessions.find((s) => s.sessionId === 'sess_daemon');
       expect(mcpSession?.triggerSource).toBe('mcp');
@@ -558,9 +579,10 @@ describe('executeWorktrainReportCommand', () => {
       await executeWorktrainReportCommand(deps, {
         since: '2026-05-01',
         until: '2026-05-31',
+        format: 'json',
       });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.sessions[0]!.date).toBe('2026-05-15');
     });
   });
@@ -571,9 +593,10 @@ describe('executeWorktrainReportCommand', () => {
       await executeWorktrainReportCommand(deps, {
         since: '2026-05-01',
         until: '2026-05-30',
+        format: 'json',
       });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       expect(report.dateRange.since).toBe('2026-05-01');
       expect(report.dateRange.until).toBe('2026-05-30');
     });
@@ -582,9 +605,9 @@ describe('executeWorktrainReportCommand', () => {
       const { deps, outputLines } = makeDeps(makeFakeConsoleService([]), {
         now: () => new Date('2026-05-30T12:00:00.000Z').getTime(),
       });
-      await executeWorktrainReportCommand(deps, { days: 7 });
+      await executeWorktrainReportCommand(deps, { days: 7, format: 'json' });
 
-      const report = parseOutput(outputLines);
+      const report = parseJsonOutput(outputLines);
       // since should be 2026-05-24 (7 days back, inclusive)
       expect(report.dateRange.since).toBe('2026-05-24');
       expect(report.dateRange.until).toBe('2026-05-30');
@@ -594,7 +617,7 @@ describe('executeWorktrainReportCommand', () => {
   describe('invalid date inputs', () => {
     it('writes error to stderr and returns without stdout when --since is invalid', async () => {
       const { deps, outputLines, stderrLines } = makeDeps(makeFakeConsoleService([]));
-      await executeWorktrainReportCommand(deps, { since: 'not-a-date' });
+      await executeWorktrainReportCommand(deps, { since: 'not-a-date', format: 'json' });
 
       expect(outputLines).toHaveLength(0);
       const hasError = stderrLines.some((l) => l.includes('not-a-date'));
@@ -603,11 +626,173 @@ describe('executeWorktrainReportCommand', () => {
 
     it('writes error to stderr and returns without stdout when --until is invalid', async () => {
       const { deps, outputLines, stderrLines } = makeDeps(makeFakeConsoleService([]));
-      await executeWorktrainReportCommand(deps, { until: 'invalid' });
+      await executeWorktrainReportCommand(deps, { until: 'invalid', format: 'json' });
 
       expect(outputLines).toHaveLength(0);
       const hasError = stderrLines.some((l) => l.includes('invalid'));
       expect(hasError).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Format-specific tests
+// ---------------------------------------------------------------------------
+
+describe('output formats', () => {
+  const session = makeSession({
+    sessionId: 'sess_fmt',
+    metrics: makeMetrics({
+      outcome: 'success',
+      stepsCompleted: 3,
+      retriesCount: 1,
+      durationMs: 12000,
+      linesAdded: 42,
+      linesRemoved: 7,
+      filesChanged: 5,
+      gitEvidence: {
+        startSha: 'abc',
+        endSha: 'def',
+        commitShas: ['def'],
+        prRefs: [99],
+        committedDiff: {
+          filesChanged: 5,
+          linesAdded: 42,
+          linesRemoved: 7,
+          truncated: false,
+          changedFilePaths: ['src/foo.ts', 'src/bar.ts'],
+          languageBreakdown: { '.ts': 2 },
+        },
+        workingTree: null,
+        captureConfidence: 'high',
+        churnSignal: { filesRemodified: 1, windowDays: 7 },
+      },
+    }),
+  });
+
+  describe('ndjson (default)', () => {
+    it('emits one JSON object per session + one summary line', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
+      await executeWorktrainReportCommand(deps); // default format
+
+      const { sessions, summary } = parseNdjsonOutput(outputLines);
+      expect(sessions).toHaveLength(1);
+      expect((sessions[0] as Record<string, unknown>)['sessionId']).toBe('sess_fmt');
+      expect((summary as Record<string, unknown>)['_summary']).toBe(true);
+      expect((summary as Record<string, unknown>)['totalSessions']).toBe(1);
+    });
+
+    it('never includes changedFilePaths in ndjson output', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
+      await executeWorktrainReportCommand(deps);
+
+      expect(outputLines[0]).not.toContain('changedFilePaths');
+    });
+
+    it('each session line is valid standalone JSON', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
+      await executeWorktrainReportCommand(deps);
+
+      const lines = outputLines[0]!.split('\n').filter((l) => l.trim().length > 0);
+      for (const line of lines) {
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+    });
+  });
+
+  describe('json format', () => {
+    it('emits a single pretty-printed blob with sessions array and summary', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
+      await executeWorktrainReportCommand(deps, { format: 'json' });
+
+      const report = parseJsonOutput(outputLines);
+      expect(report.version).toBe(1);
+      expect(report.sessions).toHaveLength(1);
+      expect(report.summary.totalSessions).toBe(1);
+    });
+
+    it('never includes changedFilePaths in json output', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
+      await executeWorktrainReportCommand(deps, { format: 'json' });
+
+      expect(outputLines[0]).not.toContain('changedFilePaths');
+    });
+  });
+
+  describe('summary format', () => {
+    it('emits only the summary object -- no sessions array', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
+      await executeWorktrainReportCommand(deps, { format: 'summary' });
+
+      const parsed = JSON.parse(outputLines[0]!) as Record<string, unknown>;
+      expect(parsed['sessions']).toBeUndefined();
+      expect(parsed['summary']).toBeDefined();
+      expect((parsed['summary'] as Record<string, unknown>)['totalSessions']).toBe(1);
+    });
+
+    it('includes version, generatedAt, and dateRange', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([]));
+      await executeWorktrainReportCommand(deps, { format: 'summary' });
+
+      const parsed = JSON.parse(outputLines[0]!) as Record<string, unknown>;
+      expect(parsed['version']).toBe(1);
+      expect(typeof parsed['generatedAt']).toBe('string');
+      expect(parsed['dateRange']).toBeDefined();
+    });
+  });
+
+  describe('csv format', () => {
+    it('emits a header row followed by one data row per session', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
+      await executeWorktrainReportCommand(deps, { format: 'csv' });
+
+      const lines = outputLines[0]!.split('\n');
+      expect(lines).toHaveLength(2); // header + 1 session
+      expect(lines[0]).toContain('sessionId');
+      expect(lines[0]).toContain('outcome');
+      expect(lines[0]).toContain('linesAdded');
+      expect(lines[1]).toContain('sess_fmt');
+    });
+
+    it('never includes changedFilePaths in csv output', async () => {
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
+      await executeWorktrainReportCommand(deps, { format: 'csv' });
+
+      expect(outputLines[0]).not.toContain('changedFilePaths');
+    });
+
+    it('escapes goal strings containing commas', async () => {
+      const sessionWithComma = makeSession({
+        sessionId: 'sess_csv_escape',
+        sessionTitle: 'Implement foo, bar, and baz',
+        metrics: null,
+      });
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([sessionWithComma]));
+      await executeWorktrainReportCommand(deps, { format: 'csv' });
+
+      const lines = outputLines[0]!.split('\n');
+      expect(lines[1]).toContain('"Implement foo, bar, and baz"');
+    });
+
+    it('outputs empty string for null metric fields', async () => {
+      const sessionNoMetrics = makeSession({ sessionId: 'sess_no_metrics', metrics: null });
+      const { deps, outputLines } = makeDeps(makeFakeConsoleService([sessionNoMetrics]));
+      await executeWorktrainReportCommand(deps, { format: 'csv' });
+
+      const lines = outputLines[0]!.split('\n');
+      // Row should exist with empty metric columns, not throw
+      expect(lines).toHaveLength(2);
+      expect(lines[1]).toContain('sess_no_metrics');
+    });
+  });
+
+  describe('changedFilePaths stripping (all formats)', () => {
+    it('changedFilePaths is not present in any of the four formats', async () => {
+      for (const format of ['ndjson', 'json', 'summary', 'csv'] as const) {
+        const { deps, outputLines } = makeDeps(makeFakeConsoleService([session]));
+        await executeWorktrainReportCommand(deps, { format });
+        expect(outputLines[0], `format=${format}`).not.toContain('changedFilePaths');
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- **NDJSON** (new default): one JSON object per line, streamable, jq-friendly. Final line is the summary with `_summary: true`. Pipe directly to `jq`, `grep`, or other tools.
- **`--format json`**: previous behavior -- single pretty-printed blob
- **`--format summary`**: aggregates only, no per-session detail
- **`--format csv`**: header row + one row per session, Excel/Numbers ready

Also strips `changedFilePaths` from all formats -- it's an internal field used only for churn detection and inflates output by thousands of strings for large sessions.

## Type quality
- `CsvRow` is a fully typed struct keyed by header name -- no `unknown` or untyped arrays in the rendering path
- `CsvCellValue = string | number | boolean | null | undefined` is a named type instead of `unknown`
- `ReportFormat = 'ndjson' | 'json' | 'summary' | 'csv'` discriminated union; Commander `.choices()` enforces it at the CLI boundary

## Tests
- 12 new tests covering all 4 formats + `changedFilePaths` stripping across all formats
- 37 total, all passing

## Usage
\`\`\`bash
workrail report --days 30                     # NDJSON to stdout (default)
workrail report --days 30 | jq .summary      # extract summary from NDJSON stream  
workrail report --days 30 --format json      # single JSON blob
workrail report --days 30 --format summary   # aggregates only
workrail report --days 30 --format csv       # spreadsheet-ready
workrail report --days 30 --format csv --out report.csv
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)