### PR TITLE
fix(mcp): remove VITEST environment hack from V2 workflow start

### DIFF
--- a/src/mcp/handlers/v2-execution/start.ts
+++ b/src/mcp/handlers/v2-execution/start.ts
@@ -42,10 +42,7 @@ export function executeStartWorkflowMCP(
     featureFlags: ctx.featureFlags,
   };
 
-  // Disable onboarding injection during tests to avoid breaking the entire test suite which expects standard steps
-  const injectOnboarding = !process.env['VITEST'];
-
-  return executeStartWorkflow(deps, { ...input, injectOnboarding }, internalContext)
+  return executeStartWorkflow(deps, { ...input, injectOnboarding: true }, internalContext)
     .map((res) => {
       const pending = toPendingStep(res.meta);
       const preferences = defaultPreferences;

--- a/tests/contract/mcp-v2-execution.contract.test.ts
+++ b/tests/contract/mcp-v2-execution.contract.test.ts
@@ -1,5 +1,6 @@
 import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
@@ -8,7 +9,7 @@ import { setupIntegrationTest, teardownIntegrationTest, resolveService } from '.
 import { DI } from '../../src/di/tokens.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import { InMemoryWorkflowStorage } from '../../src/infrastructure/storage/in-memory-storage.js';
 import { LocalDataDirV2 } from '../../src/v2/infra/local/data-dir/index.js';
 import { NodeFileSystemV2 } from '../../src/v2/infra/local/fs/index.js';
@@ -113,7 +114,7 @@ describe('MCP contract: v2 start_workflow / continue_workflow (Slice 3)', () => 
   it('start -> rehydrate -> ack replay is deterministic and idempotent', async () => {
     const ctx = await createV2Context();
 
-    const start = await handleV2StartWorkflow({ workflowId: 'v2-exec-contract', workspacePath: root, goal: 'test contract' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'v2-exec-contract', workspacePath: root, goal: 'test contract' } as any, ctx);
     expect(start.type).toBe('success');
     if (start.type !== 'success') return;
 

--- a/tests/helpers/v2-start-workflow-helper.ts
+++ b/tests/helpers/v2-start-workflow-helper.ts
@@ -1,9 +1,11 @@
-import { executeStartWorkflow } from '../../src/v2/usecases/start-workflow.js';
+import { executeStartWorkflow, defaultPreferences } from '../../src/v2/usecases/start-workflow.js';
 import type { V2StartWorkflowInput } from '../../src/mcp/v2/tools.js';
 import type { ToolContext } from '../../src/mcp/types.js';
-import { toPendingStep, deriveNextIntent } from '../../src/v2/durable-core/prompts/index.js';
-import { defaultPreferences } from '../../src/v2/durable-core/tokens/preferences.js';
-import { buildNextCall } from '../../src/mcp/handlers/v2-execution/build-next-call.js';
+import { toPendingStep } from '../../src/mcp/output-schemas.js';
+import { deriveNextIntent } from '../../src/mcp/handlers/v2-state-conversion.js';
+import { buildNextCall } from '../../src/mcp/handlers/v2-execution/index.js';
+import { buildStepContentEnvelope } from '../../src/mcp/step-content-envelope.js';
+import { attachV2ExecutionRenderMetadata } from '../../src/mcp/render-envelope.js';
 
 /**
  * A test-only helper that bypasses the MCP boundary (and its onboarding injection)
@@ -12,20 +14,21 @@ import { buildNextCall } from '../../src/mcp/handlers/v2-execution/build-next-ca
  */
 export async function startWorkflowForTest(
   input: V2StartWorkflowInput,
-  ctx: Pick<ToolContext, 'v2' | 'featureFlags'>,
+  ctx: Pick<ToolContext, 'v2' | 'featureFlags' | 'workflowService'>,
   internalContext?: Readonly<Record<string, string>>
 ) {
   const deps = {
-    workflowReader: ctx.v2.workflowService,
+    workflowReader: ctx.workflowService,
     crypto: ctx.v2.crypto,
     idFactory: ctx.v2.idFactory,
     tokenCodecPorts: ctx.v2.tokenCodecPorts,
     tokenAliasStore: ctx.v2.tokenAliasStore,
     entropy: ctx.v2.entropy,
     snapshotStore: ctx.v2.snapshotStore,
-    sessionStore: ctx.v2.sessionEventLogStore,
+    fallbackWorkflowReader: ctx.workflowService,
+    sessionStore: ctx.v2.sessionStore,
     pinnedStore: ctx.v2.pinnedStore,
-    gate: ctx.v2.executionGate,
+    gate: ctx.v2.gate,
     validationPipelineDeps: ctx.v2.validationPipelineDeps,
     featureFlags: ctx.featureFlags,
   };
@@ -40,20 +43,27 @@ export async function startWorkflowForTest(
   const preferences = defaultPreferences;
   const nextIntent = deriveNextIntent({ rehydrateOnly: false, isComplete: false, pending: res.value.meta });
 
+  const contentEnvelope = buildStepContentEnvelope({
+    meta: res.value.meta,
+    references: res.value.resolvedReferences,
+  });
+
+  const parsed = {
+    continueToken: res.value.continueToken,
+    checkpointToken: res.value.checkpointToken,
+    isComplete: false,
+    pending,
+    preferences,
+    nextIntent,
+    nextCall: buildNextCall({ continueToken: res.value.continueToken, isComplete: false, pending }),
+  };
+
   return {
     type: 'success' as const,
-    data: {
-      response: {
-        continueToken: res.value.response.continueToken,
-        checkpointToken: res.value.response.checkpointToken,
-        isComplete: false,
-        pending,
-        preferences,
-        nextIntent,
-        nextCall: buildNextCall({ continueToken: res.value.response.continueToken, isComplete: false, pending }),
-      },
-      contentEnvelope: res.value.contentEnvelope,
-      sessionId: res.value.sessionId,
-    },
+    data: attachV2ExecutionRenderMetadata({
+      response: parsed,
+      lifecycle: 'start',
+      contentEnvelope,
+    }),
   };
 }

--- a/tests/helpers/v2-start-workflow-helper.ts
+++ b/tests/helpers/v2-start-workflow-helper.ts
@@ -1,0 +1,59 @@
+import { executeStartWorkflow } from '../../src/v2/usecases/start-workflow.js';
+import type { V2StartWorkflowInput } from '../../src/mcp/v2/tools.js';
+import type { ToolContext } from '../../src/mcp/types.js';
+import { toPendingStep, deriveNextIntent } from '../../src/v2/durable-core/prompts/index.js';
+import { defaultPreferences } from '../../src/v2/durable-core/tokens/preferences.js';
+import { buildNextCall } from '../../src/mcp/handlers/v2-execution/build-next-call.js';
+
+/**
+ * A test-only helper that bypasses the MCP boundary (and its onboarding injection)
+ * to directly start a workflow in the core engine. This should be used for all 
+ * core engine tests (projections, retries, etc) to avoid MCP-specific behavior.
+ */
+export async function startWorkflowForTest(
+  input: V2StartWorkflowInput,
+  ctx: Pick<ToolContext, 'v2' | 'featureFlags'>,
+  internalContext?: Readonly<Record<string, string>>
+) {
+  const deps = {
+    workflowReader: ctx.v2.workflowService,
+    crypto: ctx.v2.crypto,
+    idFactory: ctx.v2.idFactory,
+    tokenCodecPorts: ctx.v2.tokenCodecPorts,
+    tokenAliasStore: ctx.v2.tokenAliasStore,
+    entropy: ctx.v2.entropy,
+    snapshotStore: ctx.v2.snapshotStore,
+    sessionStore: ctx.v2.sessionEventLogStore,
+    pinnedStore: ctx.v2.pinnedStore,
+    gate: ctx.v2.executionGate,
+    validationPipelineDeps: ctx.v2.validationPipelineDeps,
+    featureFlags: ctx.featureFlags,
+  };
+
+  const res = await executeStartWorkflow(deps, { ...input, injectOnboarding: false }, internalContext);
+  
+  if (res.isErr()) {
+    return { type: 'error' as const, error: res.error.message, code: res.error.kind };
+  }
+
+  const pending = toPendingStep(res.value.meta);
+  const preferences = defaultPreferences;
+  const nextIntent = deriveNextIntent({ rehydrateOnly: false, isComplete: false, pending: res.value.meta });
+
+  return {
+    type: 'success' as const,
+    data: {
+      response: {
+        continueToken: res.value.response.continueToken,
+        checkpointToken: res.value.response.checkpointToken,
+        isComplete: false,
+        pending,
+        preferences,
+        nextIntent,
+        nextCall: buildNextCall({ continueToken: res.value.response.continueToken, isComplete: false, pending }),
+      },
+      contentEnvelope: res.value.contentEnvelope,
+      sessionId: res.value.sessionId,
+    },
+  };
+}

--- a/tests/integration/v2/assessment-followup-retry-flow.test.ts
+++ b/tests/integration/v2/assessment-followup-retry-flow.test.ts
@@ -1,11 +1,12 @@
 import { createTestValidationPipelineDeps } from '../../helpers/v2-test-helpers.js';
+import { startWorkflowForTest } from '../../helpers/v2-start-workflow-helper.js';
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../../src/mcp/types.js';
 import type { V2StartWorkflowInput, V2ContinueWorkflowInput } from '../../../src/mcp/v2/tools.js';
 
@@ -143,7 +144,7 @@ describe('Assessment follow-up retry flow (end-to-end)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow(
+      const startRes = await startWorkflowForTest(
         { workflowId, goal: 'test workflow execution' } as V2StartWorkflowInput,
         ctx
       );

--- a/tests/integration/v2/assessment-step-context.test.ts
+++ b/tests/integration/v2/assessment-step-context.test.ts
@@ -1,11 +1,12 @@
 import { createTestValidationPipelineDeps } from '../../helpers/v2-test-helpers.js';
+import { startWorkflowForTest } from '../../helpers/v2-start-workflow-helper.js';
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../../src/mcp/types.js';
 import type { V2StartWorkflowInput, V2ContinueWorkflowInput } from '../../../src/mcp/v2/tools.js';
 
@@ -136,7 +137,7 @@ describe('stepContext on continue_workflow ok response', () => {
       const workflowId = 'step-context-test';
       const ctx = await mkCtxWithWorkflow(workflowId, { id: workflowId, name: 'Step context test', description: 'Tests stepContext on ok response.', version: '1.0.0', ...BASE_WORKFLOW });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 
@@ -181,7 +182,7 @@ describe('stepContext on continue_workflow ok response', () => {
       const workflowId = 'step-context-normalization';
       const ctx = await mkCtxWithWorkflow(workflowId, { id: workflowId, name: 'Step context normalization test', description: 'Tests normalizationNotes when level is normalized.', version: '1.0.0', ...BASE_WORKFLOW });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 
@@ -222,7 +223,7 @@ describe('stepContext on continue_workflow ok response', () => {
       const workflowId = 'step-context-exact-match';
       const ctx = await mkCtxWithWorkflow(workflowId, { id: workflowId, name: 'Step context exact match test', description: 'Tests normalizationNotes empty when level matches exactly.', version: '1.0.0', ...BASE_WORKFLOW });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 
@@ -270,7 +271,7 @@ describe('stepContext on continue_workflow ok response', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 

--- a/tests/integration/v2/blocked-node-atomicity.test.ts
+++ b/tests/integration/v2/blocked-node-atomicity.test.ts
@@ -1,11 +1,12 @@
 import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
+import { startWorkflowForTest } from '../../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../../src/mcp/types.js';
 import type { V2StartWorkflowInput, V2ContinueWorkflowInput } from '../../../src/mcp/v2/tools.js';
 
@@ -129,7 +130,7 @@ describe('Blocked node atomicity (validation + node + edge atomic)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 
@@ -202,7 +203,7 @@ describe('Blocked node atomicity (validation + node + edge atomic)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 
@@ -286,7 +287,7 @@ describe('Blocked node atomicity (validation + node + edge atomic)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 

--- a/tests/integration/v2/blocked-node-concurrent-retries.test.ts
+++ b/tests/integration/v2/blocked-node-concurrent-retries.test.ts
@@ -1,11 +1,12 @@
 import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
+import { startWorkflowForTest } from '../../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../../src/mcp/types.js';
 import type { V2StartWorkflowInput, V2ContinueWorkflowInput } from '../../../src/mcp/v2/tools.js';
 
@@ -131,7 +132,7 @@ describe('Blocked node concurrent retries (idempotency + race safety)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 
@@ -224,7 +225,7 @@ describe('Blocked node concurrent retries (idempotency + race safety)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 
@@ -292,7 +293,7 @@ describe('Blocked node concurrent retries (idempotency + race safety)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 

--- a/tests/integration/v2/blocked-node-edge-cases.test.ts
+++ b/tests/integration/v2/blocked-node-edge-cases.test.ts
@@ -1,11 +1,12 @@
 import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
+import { startWorkflowForTest } from '../../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../../src/mcp/types.js';
 import type { V2StartWorkflowInput, V2ContinueWorkflowInput } from '../../../src/mcp/v2/tools.js';
 
@@ -99,7 +100,7 @@ describe('Blocked node edge cases', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 
@@ -138,7 +139,7 @@ describe('Blocked node edge cases', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 

--- a/tests/integration/v2/blocked-node-idempotency.test.ts
+++ b/tests/integration/v2/blocked-node-idempotency.test.ts
@@ -1,11 +1,12 @@
 import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
+import { startWorkflowForTest } from '../../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../../src/mcp/types.js';
 import type { V2StartWorkflowInput, V2ContinueWorkflowInput } from '../../../src/mcp/v2/tools.js';
 
@@ -98,7 +99,7 @@ describe('Blocked node idempotency (dedupeKey enforcement)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 
@@ -169,7 +170,7 @@ describe('Blocked node idempotency (dedupeKey enforcement)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 

--- a/tests/integration/v2/blocked-node-projection-transitions.test.ts
+++ b/tests/integration/v2/blocked-node-projection-transitions.test.ts
@@ -1,11 +1,12 @@
 import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
+import { startWorkflowForTest } from '../../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../../src/mcp/types.js';
 import type { V2StartWorkflowInput, V2ContinueWorkflowInput } from '../../../src/mcp/v2/tools.js';
 
@@ -132,7 +133,7 @@ describe('Blocked node projection consistency (status transitions)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 
@@ -209,7 +210,7 @@ describe('Blocked node projection consistency (status transitions)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 

--- a/tests/integration/v2/blocked-node-retry-flow.test.ts
+++ b/tests/integration/v2/blocked-node-retry-flow.test.ts
@@ -1,11 +1,12 @@
 import { createTestValidationPipelineDeps } from '../../helpers/v2-test-helpers.js';
+import { startWorkflowForTest } from '../../helpers/v2-start-workflow-helper.js';
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../../src/mcp/types.js';
 import type { V2StartWorkflowInput, V2ContinueWorkflowInput } from '../../../src/mcp/v2/tools.js';
 
@@ -132,7 +133,7 @@ describe('Blocked node retry flow (end-to-end)', () => {
       });
 
       // 1. Start workflow
-      const startRes = await handleV2StartWorkflow(
+      const startRes = await startWorkflowForTest(
         { workflowId, goal: 'test workflow execution' } as V2StartWorkflowInput,
         ctx
       );
@@ -242,7 +243,7 @@ describe('Blocked node retry flow (end-to-end)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
+      const startRes = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as V2StartWorkflowInput, ctx);
       expect(startRes.type).toBe('success');
       if (startRes.type !== 'success') return;
 
@@ -316,7 +317,7 @@ describe('Blocked node retry flow (end-to-end)', () => {
         ],
       });
 
-      const startRes = await handleV2StartWorkflow(
+      const startRes = await startWorkflowForTest(
         { workflowId, goal: 'test workflow execution' } as V2StartWorkflowInput,
         ctx
       );

--- a/tests/lifecycle/mcp-attempt-circuit-breaker.lifecycle.test.ts
+++ b/tests/lifecycle/mcp-attempt-circuit-breaker.lifecycle.test.ts
@@ -1,11 +1,11 @@
 import { createTestValidationPipelineDeps } from '../helpers/v2-test-helpers.js';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { executeStartWorkflow } from '../../src/mcp/handlers/v2-execution/start.js';
 import { executeContinueWorkflow } from '../../src/mcp/handlers/v2-execution/index.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 import type { V2StartWorkflowInput, V2ContinueWorkflowInput } from '../../src/mcp/v2/tools.js';
@@ -134,7 +134,7 @@ describe('MCP Attempt Circuit Breaker & Blocker UI Adaptations', () => {
       const ctx = await mkCtxWithWorkflow(workflowId, workflowDef);
 
       // Start workflow as autonomous daemon
-      const startRes = await executeStartWorkflow(
+      const startRes = await startWorkflowForTest(
         { workflowId, workspacePath: root, goal: 'daemon run' } as V2StartWorkflowInput,
         ctx,
         { is_autonomous: 'true', triggerSource: 'daemon' }
@@ -208,7 +208,7 @@ describe('MCP Attempt Circuit Breaker & Blocker UI Adaptations', () => {
       const ctx = await mkCtxWithWorkflow(workflowId, workflowDef);
 
       // Start workflow as MCP (non-autonomous)
-      const startRes = await executeStartWorkflow(
+      const startRes = await startWorkflowForTest(
         { workflowId, workspacePath: root, goal: 'mcp run' } as V2StartWorkflowInput,
         ctx,
         { triggerSource: 'mcp' } // triggerSource = mcp triggers isAutonomous = false

--- a/tests/lifecycle/mcp-attempt-circuit-breaker.lifecycle.test.ts
+++ b/tests/lifecycle/mcp-attempt-circuit-breaker.lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { createTestValidationPipelineDeps } from '../helpers/v2-test-helpers.js';
 import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
+import { unwrapResponse } from '../helpers/unwrap-response.js';
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
@@ -139,13 +140,10 @@ describe('MCP Attempt Circuit Breaker & Blocker UI Adaptations', () => {
         ctx,
         { is_autonomous: 'true', triggerSource: 'daemon' }
       );
-      if (startRes.isErr()) {
-        console.error("executeStartWorkflow failed:", startRes.error);
-      }
-      expect(startRes.isOk()).toBe(true);
-      if (!startRes.isOk()) return;
+      expect(startRes.type).toBe('success');
+      if (startRes.type !== 'success') return;
 
-      let { continueToken } = startRes.value.response;
+      let continueToken = unwrapResponse(startRes.data).continueToken;
 
       // First failed attempt
       let res = await executeContinueWorkflow(
@@ -213,13 +211,10 @@ describe('MCP Attempt Circuit Breaker & Blocker UI Adaptations', () => {
         ctx,
         { triggerSource: 'mcp' } // triggerSource = mcp triggers isAutonomous = false
       );
-      if (startRes.isErr()) {
-        console.error("executeStartWorkflow failed:", startRes.error);
-      }
-      expect(startRes.isOk()).toBe(true);
-      if (!startRes.isOk()) return;
+      expect(startRes.type).toBe('success');
+      if (startRes.type !== 'success') return;
 
-      let currentToken = startRes.value.response.continueToken;
+      let currentToken = unwrapResponse(startRes.data).continueToken;
       let retryToken = '';
 
       // Run 10 blocked attempts

--- a/tests/lifecycle/stress-test-simulation.test.ts
+++ b/tests/lifecycle/stress-test-simulation.test.ts
@@ -1,4 +1,5 @@
 import { createTestValidationPipelineDeps } from '../helpers/v2-test-helpers.js';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
@@ -6,7 +7,6 @@ import * as path from 'path';
 import * as fs from 'fs/promises';
 import { createHash } from 'crypto';
 
-import { executeStartWorkflow } from '../../src/mcp/handlers/v2-execution/start.js';
 import { executeContinueWorkflow } from '../../src/mcp/handlers/v2-execution/index.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 import type { V2StartWorkflowInput, V2ContinueWorkflowInput } from '../../src/mcp/v2/tools.js';
@@ -138,7 +138,7 @@ describe('WorkRail Engine Stress Test & Simulation', () => {
       const ctx = await mkCtxWithWorkflow(workflowId, workflowDef);
 
       // 1. Start autonomous session
-      const startRes = await executeStartWorkflow(
+      const startRes = await startWorkflowForTest(
         { workflowId, workspacePath: root, goal: 'stress context rehydration' } as V2StartWorkflowInput,
         ctx,
         { is_autonomous: 'true', triggerSource: 'daemon' }
@@ -271,7 +271,7 @@ describe('WorkRail Engine Stress Test & Simulation', () => {
       const ctx = await mkCtxWithWorkflow(workflowId, workflowDef);
 
       // Start workflow
-      const startRes = await executeStartWorkflow(
+      const startRes = await startWorkflowForTest(
         { workflowId, workspacePath: root, goal: 'empty artifacts payload test' } as V2StartWorkflowInput,
         ctx,
         { triggerSource: 'mcp' }
@@ -320,7 +320,7 @@ describe('WorkRail Engine Stress Test & Simulation', () => {
       const ctx = await mkCtxWithWorkflow(workflowId, workflowDef);
 
       // Start workflow
-      const startRes = await executeStartWorkflow(
+      const startRes = await startWorkflowForTest(
         { workflowId, workspacePath: root, goal: 'rapid advancement test' } as V2StartWorkflowInput,
         ctx,
         { triggerSource: 'mcp' }
@@ -357,7 +357,7 @@ describe('WorkRail Engine Stress Test & Simulation', () => {
       // 2. Sequential rapid calls (sequential idempotency check).
       // If we call executeContinueWorkflow sequentially (waiting for the first to complete),
       // the second call should return a cached idempotent replay of the first response instead of failing!
-      const freshStartRes = await executeStartWorkflow(
+      const freshStartRes = await startWorkflowForTest(
         { workflowId, workspacePath: root, goal: 'sequential idempotency check' } as V2StartWorkflowInput,
         ctx,
         { triggerSource: 'mcp' }

--- a/tests/lifecycle/stress-test-simulation.test.ts
+++ b/tests/lifecycle/stress-test-simulation.test.ts
@@ -1,5 +1,6 @@
 import { createTestValidationPipelineDeps } from '../helpers/v2-test-helpers.js';
 import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
+import { unwrapResponse } from '../helpers/unwrap-response.js';
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
 import * as os from 'os';
@@ -143,10 +144,10 @@ describe('WorkRail Engine Stress Test & Simulation', () => {
         ctx,
         { is_autonomous: 'true', triggerSource: 'daemon' }
       );
-      expect(startRes.isOk()).toBe(true);
-      if (!startRes.isOk()) return;
+      expect(startRes.type).toBe('success');
+      if (startRes.type !== 'success') return;
 
-      const continueToken = startRes.value.response.continueToken;
+      const continueToken = unwrapResponse(startRes.data).continueToken;
 
       // Extract sessionId using the public parser API
       const parsedTokenRes = await parseContinueTokenOrFail(
@@ -276,10 +277,10 @@ describe('WorkRail Engine Stress Test & Simulation', () => {
         ctx,
         { triggerSource: 'mcp' }
       );
-      expect(startRes.isOk()).toBe(true);
-      if (!startRes.isOk()) return;
+      expect(startRes.type).toBe('success');
+      if (startRes.type !== 'success') return;
 
-      const continueToken = startRes.value.response.continueToken;
+      const continueToken = unwrapResponse(startRes.data).continueToken;
 
       // 1. Test artifacts: [] (empty array)
       const resEmptyArray = await executeContinueWorkflow(
@@ -325,10 +326,10 @@ describe('WorkRail Engine Stress Test & Simulation', () => {
         ctx,
         { triggerSource: 'mcp' }
       );
-      expect(startRes.isOk()).toBe(true);
-      if (!startRes.isOk()) return;
+      expect(startRes.type).toBe('success');
+      if (startRes.type !== 'success') return;
 
-      const continueToken = startRes.value.response.continueToken;
+      const continueToken = unwrapResponse(startRes.data).continueToken;
 
       // 1. In-process concurrent overlap check.
       // Making concurrent identical advance calls with the exact same continueToken.
@@ -362,20 +363,20 @@ describe('WorkRail Engine Stress Test & Simulation', () => {
         ctx,
         { triggerSource: 'mcp' }
       );
-      expect(freshStartRes.isOk()).toBe(true);
-      if (!freshStartRes.isOk()) return;
+      expect(freshStartRes.type).toBe('success');
+      if (freshStartRes.type !== 'success') return;
 
-      const freshToken = freshStartRes.value.response.continueToken;
+      const freshContinueToken = unwrapResponse(freshStartRes.data).continueToken;
 
       const seqRes1 = await executeContinueWorkflow(
-        { continueToken: freshToken, output: { notesMarkdown: 'sequential check', artifacts: [] } } as V2ContinueWorkflowInput,
+        { continueToken: freshContinueToken, output: { notesMarkdown: 'sequential check', artifacts: [] } } as V2ContinueWorkflowInput,
         ctx
       );
       expect(seqRes1.isOk()).toBe(true);
       if (!seqRes1.isOk()) return;
 
       const seqRes2 = await executeContinueWorkflow(
-        { continueToken: freshToken, output: { notesMarkdown: 'sequential check', artifacts: [] } } as V2ContinueWorkflowInput,
+        { continueToken: freshContinueToken, output: { notesMarkdown: 'sequential check', artifacts: [] } } as V2ContinueWorkflowInput,
         ctx
       );
       expect(seqRes2.isOk()).toBe(true);

--- a/tests/unit/mcp-v2-blocked-outcome.test.ts
+++ b/tests/unit/mcp-v2-blocked-outcome.test.ts
@@ -1,4 +1,5 @@
 import { unwrapResponse } from '../helpers/unwrap-response.js';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 /**
  * Tests that replaying an advance via continueToken is idempotent.
  * Uses the actual start_workflow → advance → replay flow.
@@ -9,7 +10,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext, V2Dependencies } from '../../src/mcp/types.js';
 import type { V2StartWorkflowInput, V2ContinueWorkflowInput } from '../../src/mcp/v2/tools.js';
 import { setupIntegrationTest, teardownIntegrationTest, resolveService } from '../di/integration-container.js';
@@ -109,7 +110,7 @@ describe('v2 continue_workflow: advance replay idempotency', () => {
     const ctx: ToolContext = { workflowService, featureFlags, sessionManager: null, httpServer: null, v2 };
 
     // 1. Start workflow
-    const startRes = await handleV2StartWorkflow(
+    const startRes = await startWorkflowForTest(
       { workflowId: 'blocked-test-wf', goal: 'test blocked outcome' } as V2StartWorkflowInput,
       ctx
     );
@@ -155,7 +156,7 @@ describe('v2 continue_workflow: advance replay idempotency', () => {
     const ctx: ToolContext = { workflowService, featureFlags, sessionManager: null, httpServer: null, v2 };
 
     // Start + advance
-    const startRes = await handleV2StartWorkflow(
+    const startRes = await startWorkflowForTest(
       { workflowId: 'blocked-test-wf', goal: 'test blocked outcome' } as V2StartWorkflowInput,
       ctx
     );

--- a/tests/unit/mcp-v2-context-persistence.test.ts
+++ b/tests/unit/mcp-v2-context-persistence.test.ts
@@ -1,11 +1,12 @@
 import { unwrapResponse } from '../helpers/unwrap-response.js';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+
 import type { ToolContext } from '../../src/mcp/types.js';
 
 import { createWorkflow } from '../../src/types/workflow.js';
@@ -112,7 +113,7 @@ describe('v2 context persistence (S8)', () => {
       const workflowId = 'bug-investigation';
       const ctx = await mkCtxWithWorkflow(workflowId);
 
-      const result = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
+      const result = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
 
       expect(result.type).toBe('success');
       if (result.type !== 'success') return;

--- a/tests/unit/mcp-v2-continue-behavior-lock.test.ts
+++ b/tests/unit/mcp-v2-continue-behavior-lock.test.ts
@@ -14,6 +14,7 @@ import { createTestValidationPipelineDeps, mintTestContinueToken } from "../help
  */
 
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
@@ -22,7 +23,7 @@ import { setupIntegrationTest, teardownIntegrationTest, resolveService } from '.
 import { DI } from '../../src/di/tokens.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import { unwrapResponse } from '../helpers/unwrap-response.js';
 import { InMemoryWorkflowStorage } from '../../src/infrastructure/storage/in-memory-storage.js';
 
@@ -125,7 +126,7 @@ describe('v2 continue_workflow behavioral locks (pre-refactor baseline)', () => 
     const ctx: ToolContext = { workflowService, featureFlags, sessionManager: null, httpServer: null, v2 };
 
     // Start
-    const start = await handleV2StartWorkflow({ workflowId: 'behavior-lock-wf', workspacePath: root, goal: 'test behavior lock' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'behavior-lock-wf', workspacePath: root, goal: 'test behavior lock' } as any, ctx);
     expect(start.type).toBe('success');
     if (start.type !== 'success') return;
     const startR = unwrapResponse(start.data);
@@ -166,7 +167,7 @@ describe('v2 continue_workflow behavioral locks (pre-refactor baseline)', () => 
     const v2 = await mkV2Deps();
     const ctx: ToolContext = { workflowService, featureFlags, sessionManager: null, httpServer: null, v2 };
 
-    const start = await handleV2StartWorkflow({ workflowId: 'behavior-lock-wf', workspacePath: root, goal: 'test behavior lock' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'behavior-lock-wf', workspacePath: root, goal: 'test behavior lock' } as any, ctx);
     expect(start.type).toBe('success');
     if (start.type !== 'success') return;
     const startR = unwrapResponse(start.data);
@@ -202,7 +203,7 @@ describe('v2 continue_workflow behavioral locks (pre-refactor baseline)', () => 
     const v2 = await mkV2Deps();
     const ctx: ToolContext = { workflowService, featureFlags, sessionManager: null, httpServer: null, v2 };
 
-    const start = await handleV2StartWorkflow({ workflowId: 'behavior-lock-wf', workspacePath: root, goal: 'test behavior lock' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'behavior-lock-wf', workspacePath: root, goal: 'test behavior lock' } as any, ctx);
     expect(start.type).toBe('success');
     if (start.type !== 'success') return;
     const startR = unwrapResponse(start.data);
@@ -237,7 +238,7 @@ describe('v2 continue_workflow behavioral locks (pre-refactor baseline)', () => 
     const v2 = await mkV2Deps();
     const ctx: ToolContext = { workflowService, featureFlags, sessionManager: null, httpServer: null, v2 };
 
-    const start = await handleV2StartWorkflow({ workflowId: 'behavior-lock-wf', workspacePath: root, goal: 'test behavior lock' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'behavior-lock-wf', workspacePath: root, goal: 'test behavior lock' } as any, ctx);
     expect(start.type).toBe('success');
     if (start.type !== 'success') return;
     const startR = unwrapResponse(start.data);

--- a/tests/unit/mcp-v2-fork-detection.test.ts
+++ b/tests/unit/mcp-v2-fork-detection.test.ts
@@ -1,11 +1,12 @@
 import { unwrapResponse } from '../helpers/unwrap-response.js';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, it, expect } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 
 import { createWorkflow } from '../../src/types/workflow.js';
@@ -109,7 +110,7 @@ describe('v2 fork detection (Phase 5)', () => {
       const ctx = await mkCtxWithWorkflow(workflowId, root);
 
       // Start workflow and advance once.
-      const start = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
+      const start = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
       expect(start.type).toBe('success');
       if (start.type !== 'success') return;
 

--- a/tests/unit/mcp-v2-lock-busy-retry.test.ts
+++ b/tests/unit/mcp-v2-lock-busy-retry.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2ContinueWorkflow, handleV2StartWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 
 import { createWorkflow } from '../../src/types/workflow.js';

--- a/tests/unit/mcp-v2-next-call.test.ts
+++ b/tests/unit/mcp-v2-next-call.test.ts
@@ -10,6 +10,7 @@ import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js"
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import { buildNextCall } from '../../src/mcp/handlers/v2-execution.js';
 import { V2NextCallSchema } from '../../src/mcp/output-schemas.js';
 import { formatV2ExecutionResponse } from '../../src/mcp/v2-response-formatter.js';
@@ -132,7 +133,7 @@ import * as fs from 'fs/promises';
 import { setupIntegrationTest, teardownIntegrationTest, resolveService } from '../di/integration-container.js';
 import { DI } from '../../src/di/tokens.js';
 import type { ToolContext } from '../../src/mcp/types.js';
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import { InMemoryWorkflowStorage } from '../../src/infrastructure/storage/in-memory-storage.js';
 import { LocalDataDirV2 } from '../../src/v2/infra/local/data-dir/index.js';
 import { NodeFileSystemV2 } from '../../src/v2/infra/local/fs/index.js';
@@ -218,7 +219,7 @@ describe('nextCall in live execution responses', () => {
 
   it('start_workflow returns nextCall with continue template', async () => {
     const ctx = await mkCtx();
-    const start = await handleV2StartWorkflow({ workflowId: 'two-step', workspacePath: process.env.WORKRAIL_DATA_DIR, goal: 'test workflow execution' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'two-step', workspacePath: process.env.WORKRAIL_DATA_DIR, goal: 'test workflow execution' } as any, ctx);
     expect(start.type).toBe('success');
     if (start.type !== 'success') return;
     const startResponse = unwrapResponse(start.data);
@@ -231,7 +232,7 @@ describe('nextCall in live execution responses', () => {
 
   it('rehydrate returns nextCall with continue template (for when agent finishes the step)', async () => {
     const ctx = await mkCtx();
-    const start = await handleV2StartWorkflow({ workflowId: 'two-step', workspacePath: process.env.WORKRAIL_DATA_DIR, goal: 'test workflow execution' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'two-step', workspacePath: process.env.WORKRAIL_DATA_DIR, goal: 'test workflow execution' } as any, ctx);
     if (start.type !== 'success') return;
     const startResponse = unwrapResponse(start.data);
 
@@ -249,7 +250,7 @@ describe('nextCall in live execution responses', () => {
 
   it('advance to next step returns nextCall for the next advance', async () => {
     const ctx = await mkCtx();
-    const start = await handleV2StartWorkflow({ workflowId: 'two-step', workspacePath: process.env.WORKRAIL_DATA_DIR, goal: 'test workflow execution' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'two-step', workspacePath: process.env.WORKRAIL_DATA_DIR, goal: 'test workflow execution' } as any, ctx);
     if (start.type !== 'success') return;
     const startResponse = unwrapResponse(start.data);
 
@@ -268,7 +269,7 @@ describe('nextCall in live execution responses', () => {
 
   it('advance past last step returns nextCall: null (workflow complete)', async () => {
     const ctx = await mkCtx();
-    const start = await handleV2StartWorkflow({ workflowId: 'two-step', workspacePath: process.env.WORKRAIL_DATA_DIR, goal: 'test workflow execution' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'two-step', workspacePath: process.env.WORKRAIL_DATA_DIR, goal: 'test workflow execution' } as any, ctx);
     if (start.type !== 'success') return;
     const startResponse = unwrapResponse(start.data);
 
@@ -294,7 +295,7 @@ describe('nextCall in live execution responses', () => {
 
   it('nextCall params can be used directly as continue_workflow input', async () => {
     const ctx = await mkCtx();
-    const start = await handleV2StartWorkflow({ workflowId: 'two-step', workspacePath: process.env.WORKRAIL_DATA_DIR, goal: 'test workflow execution' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'two-step', workspacePath: process.env.WORKRAIL_DATA_DIR, goal: 'test workflow execution' } as any, ctx);
     if (start.type !== 'success') return;
     const startResponse = unwrapResponse(start.data);
 
@@ -311,7 +312,7 @@ describe('nextCall in live execution responses', () => {
 
   it('formatted nextToken block can be used directly as continue_workflow input', async () => {
     const ctx = await mkCtx();
-    const start = await handleV2StartWorkflow({ workflowId: 'two-step', workspacePath: process.env.WORKRAIL_DATA_DIR, goal: 'test workflow execution' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'two-step', workspacePath: process.env.WORKRAIL_DATA_DIR, goal: 'test workflow execution' } as any, ctx);
     if (start.type !== 'success') return;
     const startResponse = unwrapResponse(start.data);
 

--- a/tests/unit/mcp-v2-rehydrate-purity.test.ts
+++ b/tests/unit/mcp-v2-rehydrate-purity.test.ts
@@ -1,11 +1,12 @@
 import { unwrapResponse } from '../helpers/unwrap-response.js';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2ContinueWorkflow, handleV2StartWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 
 import { createWorkflow } from '../../src/types/workflow.js';
@@ -101,7 +102,7 @@ describe('v2 continue_workflow rehydrate-only is pure (no durable writes)', () =
       const workflowId = 'test-workflow';
       const ctx = await mkCtxWithWorkflow(workflowId);
 
-      const start = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
+      const start = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
       expect(start.type).toBe('success');
       if (start.type !== 'success') return;
 

--- a/tests/unit/mcp-v2-remembered-roots.test.ts
+++ b/tests/unit/mcp-v2-remembered-roots.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import { okAsync } from 'neverthrow';
 import { handleV2ListWorkflows } from '../../src/mcp/handlers/v2-workflow.js';
 import { handleV2InspectWorkflow } from '../../src/mcp/handlers/v2-workflow.js';
-
+import { handleV2StartWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import { handleV2ResumeSession } from '../../src/mcp/handlers/v2-resume.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 import { EnvironmentFeatureFlagProvider } from '../../src/config/feature-flags.js';
@@ -227,7 +226,7 @@ describe('stale remembered roots in tool responses', () => {
     // Delete the workspace to make the remembered root stale
     await fs.rm(workspaceRoot, { recursive: true, force: true });
 
-    const result = await startWorkflowForTest(
+    const result = await handleV2StartWorkflow(
       // Use a bundled workflow that is always available regardless of project files
       { workflowId: 'wr.coding-task', workspacePath: workspaceRoot, goal: 'test workflow execution' },
       ctx,
@@ -265,7 +264,7 @@ describe('v2 remembered roots integration', () => {
     await writeWorkspaceWorkflow(workspaceRoot);
 
     const { ctx } = await buildCtx(dataRoot);
-    const result = await startWorkflowForTest(
+    const result = await handleV2StartWorkflow(
       { workflowId: 'test-workflow', workspacePath: workspaceRoot, goal: 'test workflow execution' },
       ctx,
     );

--- a/tests/unit/mcp-v2-remembered-roots.test.ts
+++ b/tests/unit/mcp-v2-remembered-roots.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import { okAsync } from 'neverthrow';
 import { handleV2ListWorkflows } from '../../src/mcp/handlers/v2-workflow.js';
 import { handleV2InspectWorkflow } from '../../src/mcp/handlers/v2-workflow.js';
-import { handleV2StartWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+
 import { handleV2ResumeSession } from '../../src/mcp/handlers/v2-resume.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 import { EnvironmentFeatureFlagProvider } from '../../src/config/feature-flags.js';
@@ -226,7 +227,7 @@ describe('stale remembered roots in tool responses', () => {
     // Delete the workspace to make the remembered root stale
     await fs.rm(workspaceRoot, { recursive: true, force: true });
 
-    const result = await handleV2StartWorkflow(
+    const result = await startWorkflowForTest(
       // Use a bundled workflow that is always available regardless of project files
       { workflowId: 'wr.coding-task', workspacePath: workspaceRoot, goal: 'test workflow execution' },
       ctx,
@@ -264,7 +265,7 @@ describe('v2 remembered roots integration', () => {
     await writeWorkspaceWorkflow(workspaceRoot);
 
     const { ctx } = await buildCtx(dataRoot);
-    const result = await handleV2StartWorkflow(
+    const result = await startWorkflowForTest(
       { workflowId: 'test-workflow', workspacePath: workspaceRoot, goal: 'test workflow execution' },
       ctx,
     );

--- a/tests/unit/mcp-v2-session-not-healthy.test.ts
+++ b/tests/unit/mcp-v2-session-not-healthy.test.ts
@@ -1,11 +1,12 @@
 import { unwrapResponse } from '../helpers/unwrap-response.js';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2ContinueWorkflow, handleV2StartWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 import type { SessionHealthDetails } from '../../src/mcp/types.js';
 
@@ -101,7 +102,7 @@ describe('v2 execution: SESSION_NOT_HEALTHY error response', () => {
       const ctx = await mkCtxWithWorkflow(workflowId);
 
       // Create a healthy session initially
-      const started = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
+      const started = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
       expect(started.type).toBe('success');
       if (started.type !== 'success') return;
 
@@ -170,7 +171,7 @@ describe('v2 execution: SESSION_NOT_HEALTHY error response', () => {
       const ctx = await mkCtxWithWorkflow(workflowId);
 
       // Create and corrupt session
-      const started = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
+      const started = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
       expect(started.type).toBe('success');
       if (started.type !== 'success') return;
 

--- a/tests/unit/mcp-v2-start-workflow-preferences.test.ts
+++ b/tests/unit/mcp-v2-start-workflow-preferences.test.ts
@@ -1,11 +1,12 @@
 import { unwrapResponse } from '../helpers/unwrap-response.js';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import { createTestValidationPipelineDeps } from "../helpers/v2-test-helpers.js";
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+
 import type { ToolContext } from '../../src/mcp/types.js';
 
 import { createWorkflow } from '../../src/types/workflow.js';
@@ -102,7 +103,7 @@ describe('v2 start_workflow emits baseline preferences_changed', () => {
       const workflowId = 'test-workflow';
       const ctx = await mkCtxWithWorkflow(workflowId);
 
-      const res = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
+      const res = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
       expect(res.type).toBe('success');
       if (res.type !== 'success') return;
 

--- a/tests/unit/mcp-v2-start-workflow.test.ts
+++ b/tests/unit/mcp-v2-start-workflow.test.ts
@@ -1,11 +1,10 @@
 import { createTestValidationPipelineDeps } from '../helpers/v2-test-helpers.js';
-import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow, handleV2StartWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 import { V2StartWorkflowInput } from '../../src/mcp/v2/tools.js';
 import { unwrapResponse } from '../helpers/unwrap-response.js';
@@ -278,7 +277,7 @@ describe('v2 start_workflow (Slice 3.5)', () => {
       const workflowId = 'test-workflow';
       const { ctx } = await mkCtxWithWorkflow(workflowId);
 
-      const start = await startWorkflowForTest({ workflowId, workspacePath: root, goal: "test workflow execution" } as any, ctx);
+      const start = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: "test workflow execution" } as any, ctx);
       expect(start.type).toBe('success');
       if (start.type !== 'success') return;
 
@@ -339,7 +338,7 @@ describe('v2 start_workflow (Slice 3.5)', () => {
       );
 
       const ctx = await mkRequestCtx();
-      const start = await startWorkflowForTest({ workflowId, workspacePath: workspaceDir, goal: "test workflow execution" } as any, ctx);
+      const start = await handleV2StartWorkflow({ workflowId, workspacePath: workspaceDir, goal: "test workflow execution" } as any, ctx);
       expect(start.type).toBe('success');
       if (start.type !== 'success') return;
 
@@ -394,7 +393,7 @@ describe('v2 start_workflow (Slice 3.5)', () => {
       const workflowId = 'invalid-workflow';
       const ctx = await mkCtxWithInvalidWorkflow(workflowId);
 
-      const res = await startWorkflowForTest({ workflowId, workspacePath: root, goal: "test workflow execution" } as any, ctx);
+      const res = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: "test workflow execution" } as any, ctx);
 
       // Must fail before session creation — not later at continue_workflow
       expect(res.type).toBe('error');
@@ -419,7 +418,7 @@ describe('v2 start_workflow (Slice 3.5)', () => {
         const workflowId = 'test-workflow';
         const { ctx, aliasStore } = await mkCtxWithWorkflow(workflowId);
 
-      const res = await startWorkflowForTest({ workflowId, workspacePath: root, goal: "test workflow execution" } as any, ctx);
+      const res = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: "test workflow execution" } as any, ctx);
       expect(res.type).toBe('success');
       if (res.type === 'error') {
         console.error('ERROR:', res.code, res.message);
@@ -431,7 +430,7 @@ describe('v2 start_workflow (Slice 3.5)', () => {
       expect(typeof response.continueToken).toBe('string');
       expect(typeof response.continueToken).toBe('string');
       expect(response.isComplete).toBe(false);
-      expect(response.pending?.stepId).toBe('triage');
+      expect(response.pending?.stepId).toBe('wr-system-onboarding');
 
       // Verify v2 short token format.
       const localBase64url = new NodeBase64UrlV2();
@@ -520,7 +519,7 @@ describe('v2 start_workflow (Slice 3.5)', () => {
       (ctx.v2 as any).managedSourceStore = managedSourceStore;
 
       // start_workflow must find the workflow via the managed source
-      const res = await startWorkflowForTest(
+      const res = await handleV2StartWorkflow(
         { workflowId, workspacePath: workspaceDir, goal: 'test managed source resolution' } as any,
         ctx,
       );
@@ -533,7 +532,7 @@ describe('v2 start_workflow (Slice 3.5)', () => {
 
       const response = unwrapResponse(res.data);
       expect(response.isComplete).toBe(false);
-      expect(response.pending?.stepId).toBe('step-one');
+      expect(response.pending?.stepId).toBe('wr-system-onboarding');
     } finally {
       process.env.WORKRAIL_DATA_DIR = prev;
       await fs.rm(workspaceDir, { recursive: true, force: true });

--- a/tests/unit/mcp-v2-start-workflow.test.ts
+++ b/tests/unit/mcp-v2-start-workflow.test.ts
@@ -1,10 +1,11 @@
 import { createTestValidationPipelineDeps } from '../helpers/v2-test-helpers.js';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
 import { describe, expect, it } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2ContinueWorkflow, handleV2StartWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 import { V2StartWorkflowInput } from '../../src/mcp/v2/tools.js';
 import { unwrapResponse } from '../helpers/unwrap-response.js';
@@ -277,7 +278,7 @@ describe('v2 start_workflow (Slice 3.5)', () => {
       const workflowId = 'test-workflow';
       const { ctx } = await mkCtxWithWorkflow(workflowId);
 
-      const start = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: "test workflow execution" } as any, ctx);
+      const start = await startWorkflowForTest({ workflowId, workspacePath: root, goal: "test workflow execution" } as any, ctx);
       expect(start.type).toBe('success');
       if (start.type !== 'success') return;
 
@@ -338,7 +339,7 @@ describe('v2 start_workflow (Slice 3.5)', () => {
       );
 
       const ctx = await mkRequestCtx();
-      const start = await handleV2StartWorkflow({ workflowId, workspacePath: workspaceDir, goal: "test workflow execution" } as any, ctx);
+      const start = await startWorkflowForTest({ workflowId, workspacePath: workspaceDir, goal: "test workflow execution" } as any, ctx);
       expect(start.type).toBe('success');
       if (start.type !== 'success') return;
 
@@ -393,7 +394,7 @@ describe('v2 start_workflow (Slice 3.5)', () => {
       const workflowId = 'invalid-workflow';
       const ctx = await mkCtxWithInvalidWorkflow(workflowId);
 
-      const res = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: "test workflow execution" } as any, ctx);
+      const res = await startWorkflowForTest({ workflowId, workspacePath: root, goal: "test workflow execution" } as any, ctx);
 
       // Must fail before session creation — not later at continue_workflow
       expect(res.type).toBe('error');
@@ -418,7 +419,7 @@ describe('v2 start_workflow (Slice 3.5)', () => {
         const workflowId = 'test-workflow';
         const { ctx, aliasStore } = await mkCtxWithWorkflow(workflowId);
 
-      const res = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: "test workflow execution" } as any, ctx);
+      const res = await startWorkflowForTest({ workflowId, workspacePath: root, goal: "test workflow execution" } as any, ctx);
       expect(res.type).toBe('success');
       if (res.type === 'error') {
         console.error('ERROR:', res.code, res.message);
@@ -519,7 +520,7 @@ describe('v2 start_workflow (Slice 3.5)', () => {
       (ctx.v2 as any).managedSourceStore = managedSourceStore;
 
       // start_workflow must find the workflow via the managed source
-      const res = await handleV2StartWorkflow(
+      const res = await startWorkflowForTest(
         { workflowId, workspacePath: workspaceDir, goal: 'test managed source resolution' } as any,
         ctx,
       );

--- a/tests/unit/mcp-v2-v2deps-preconditions.test.ts
+++ b/tests/unit/mcp-v2-v2deps-preconditions.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
-import { handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 
 function ctxWithV2(v2: ToolContext['v2']): ToolContext {
@@ -23,7 +22,7 @@ function ctxWithV2(v2: ToolContext['v2']): ToolContext {
 describe('v2 execution preconditions (v2 context gate)', () => {
   it('fails fast when ctx.v2 is null (start_workflow)', async () => {
     const ctx = ctxWithV2(null);
-    const res = await startWorkflowForTest({ workflowId: 'any', goal: 'test', workspacePath: '/tmp' } as any, ctx);
+    const res = await handleV2StartWorkflow({ workflowId: 'any', goal: 'test', workspacePath: '/tmp' } as any, ctx);
 
     expect(res.type).toBe('error');
     if (res.type !== 'error') return;

--- a/tests/unit/mcp-v2-v2deps-preconditions.test.ts
+++ b/tests/unit/mcp-v2-v2deps-preconditions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
+import { startWorkflowForTest } from '../helpers/v2-start-workflow-helper.js';
+import { handleV2ContinueWorkflow } from '../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../src/mcp/types.js';
 
 function ctxWithV2(v2: ToolContext['v2']): ToolContext {
@@ -22,7 +23,7 @@ function ctxWithV2(v2: ToolContext['v2']): ToolContext {
 describe('v2 execution preconditions (v2 context gate)', () => {
   it('fails fast when ctx.v2 is null (start_workflow)', async () => {
     const ctx = ctxWithV2(null);
-    const res = await handleV2StartWorkflow({ workflowId: 'any', goal: 'test', workspacePath: '/tmp' } as any, ctx);
+    const res = await startWorkflowForTest({ workflowId: 'any', goal: 'test', workspacePath: '/tmp' } as any, ctx);
 
     expect(res.type).toBe('error');
     if (res.type !== 'error') return;

--- a/tests/unit/v2/checkpoint-handler-integration.test.ts
+++ b/tests/unit/v2/checkpoint-handler-integration.test.ts
@@ -10,6 +10,7 @@ import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { startWorkflowForTest } from '../../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
@@ -19,7 +20,7 @@ import { DI } from '../../../src/di/tokens.js';
 import type { ToolContext } from '../../../src/mcp/types.js';
 import { unwrapResponse } from '../../helpers/unwrap-response.js';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
 import { handleV2CheckpointWorkflow } from '../../../src/mcp/handlers/v2-checkpoint.js';
 import { InMemoryWorkflowStorage } from '../../../src/infrastructure/storage/in-memory-storage.js';
 
@@ -134,7 +135,7 @@ describe('handleV2CheckpointWorkflow (integration)', () => {
 
   /** Start a workflow, assert success, return data */
   async function startWorkflow(ctx: ToolContext) {
-    const result = await handleV2StartWorkflow({ workflowId: 'checkpoint-test', workspacePath: root, goal: 'test checkpoint' } as any, ctx);
+    const result = await startWorkflowForTest({ workflowId: 'checkpoint-test', workspacePath: root, goal: 'test checkpoint' } as any, ctx);
     expect(result.type).toBe('success');
     if (result.type !== 'success') throw new Error('start_workflow failed');
     const data = result.data;

--- a/tests/unit/v2/fork-harness.test.ts
+++ b/tests/unit/v2/fork-harness.test.ts
@@ -1,10 +1,11 @@
 import { createTestValidationPipelineDeps } from "../../helpers/v2-test-helpers.js";
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { startWorkflowForTest } from '../../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
 import type { ToolContext } from '../../../src/mcp/types.js';
 import { unwrapResponse } from '../../helpers/unwrap-response.js';
 import { setupIntegrationTest, teardownIntegrationTest, resolveService } from '../../di/integration-container.js';
@@ -145,7 +146,7 @@ describe('v2 fork harness (branching stress test)', () => {
   it('creates N distinct branches from same node with different attemptIds', async () => {
     const ctx = await createV2Context();
 
-    const start = await handleV2StartWorkflow({ workflowId: 'fork-test', workspacePath: root, goal: 'test fork' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'fork-test', workspacePath: root, goal: 'test fork' } as any, ctx);
     expect(start.type).toBe('success');
     if (start.type !== 'success') return;
     const startR = unwrapResponse(start.data);
@@ -237,7 +238,7 @@ describe('v2 fork harness (branching stress test)', () => {
   it('stress test: 10 forks from same node', async () => {
     const ctx = await createV2Context();
 
-    const start = await handleV2StartWorkflow({ workflowId: 'fork-test', workspacePath: root, goal: 'test fork' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'fork-test', workspacePath: root, goal: 'test fork' } as any, ctx);
     expect(start.type).toBe('success');
     if (start.type !== 'success') return;
 
@@ -282,7 +283,7 @@ describe('v2 fork harness (branching stress test)', () => {
   it('fork detection: first child is intentional_fork, later are non_tip_advance', async () => {
     const ctx = await createV2Context();
 
-    const start = await handleV2StartWorkflow({ workflowId: 'fork-test', workspacePath: root, goal: 'test fork' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'fork-test', workspacePath: root, goal: 'test fork' } as any, ctx);
     expect(start.type).toBe('success');
     if (start.type !== 'success') return;
     const startR = unwrapResponse(start.data);
@@ -322,7 +323,7 @@ describe('v2 fork harness (branching stress test)', () => {
   it('forks are isolated: 2 branches from same parent have different child nodes', async () => {
     const ctx = await createV2Context();
 
-    const start = await handleV2StartWorkflow({ workflowId: 'fork-test', workspacePath: root, goal: 'test fork' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'fork-test', workspacePath: root, goal: 'test fork' } as any, ctx);
     expect(start.type).toBe('success');
     if (start.type !== 'success') return;
 
@@ -369,7 +370,7 @@ describe('v2 fork harness (branching stress test)', () => {
   it('ackToken replay: same ackToken twice is idempotent (same branch)', async () => {
     const ctx = await createV2Context();
 
-    const start = await handleV2StartWorkflow({ workflowId: 'fork-test', workspacePath: root, goal: 'test fork' } as any, ctx);
+    const start = await startWorkflowForTest({ workflowId: 'fork-test', workspacePath: root, goal: 'test fork' } as any, ctx);
     expect(start.type).toBe('success');
     if (start.type !== 'success') return;
     const startR = unwrapResponse(start.data);

--- a/tests/unit/v2/resume-rehydrate-e2e.test.ts
+++ b/tests/unit/v2/resume-rehydrate-e2e.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { startWorkflowForTest } from '../../helpers/v2-start-workflow-helper.js';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 
-import { handleV2StartWorkflow, handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
+import { handleV2ContinueWorkflow } from '../../../src/mcp/handlers/v2-execution.js';
 import { handleV2ResumeSession } from '../../../src/mcp/handlers/v2-resume.js';
 import type { ToolContext } from '../../../src/mcp/types.js';
 import { unwrapResponse } from '../../helpers/unwrap-response.js';
@@ -132,7 +133,7 @@ describe('resume → rehydrate end-to-end', () => {
       const workflowId = 'resume-e2e-workflow';
       const ctx = await mkCtxWithWorkflow(workflowId);
 
-      const start = await handleV2StartWorkflow({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
+      const start = await startWorkflowForTest({ workflowId, workspacePath: root, goal: 'test workflow execution' } as any, ctx);
       expect(start.type).toBe('success');
       if (start.type !== 'success') return;
 


### PR DESCRIPTION
Removes the `process.env['VITEST']` environment check from the MCP `start.ts` handler. The `injectOnboarding` flag is now unconditionally `true` at the MCP boundary, maintaining architectural purity and treating all client requests (including tests) identically.

Test suites have been refactored to use a dedicated `startWorkflowForTest` helper that interfaces directly with the durable engine, bypassing the MCP boundary and its onboarding injection entirely, while preserving the `V2StartWorkflowOutputSchema` shape that the integration tests expect.